### PR TITLE
Always synthesize the optional params type

### DIFF
--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -44,7 +44,7 @@ func TestCustomNamedRequestIDParamGrouping(t *testing.T) {
 	client := newHeaderClient()
 	result, err := client.CustomNamedRequestIDParamGrouping(context.Background(), HeaderClientCustomNamedRequestIDParamGroupingParameters{
 		FooClientRequestID: "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0",
-	})
+	}, nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.FooRequestID, to.StringPtr("123")); r != "" {
 		t.Fatal(r)

--- a/test/autorest/azurespecialsgroup/zz_generated_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header_client.go
@@ -120,8 +120,10 @@ func (client *HeaderClient) customNamedRequestIDHeadHandleResponse(resp *http.Re
 // If the operation fails it returns an *azcore.ResponseError type.
 // HeaderClientCustomNamedRequestIDParamGroupingParameters - HeaderClientCustomNamedRequestIDParamGroupingParameters contains
 // a group of parameters for the HeaderClient.CustomNamedRequestIDParamGrouping method.
-func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Context, headerClientCustomNamedRequestIDParamGroupingParameters HeaderClientCustomNamedRequestIDParamGroupingParameters) (HeaderClientCustomNamedRequestIDParamGroupingResponse, error) {
-	req, err := client.customNamedRequestIDParamGroupingCreateRequest(ctx, headerClientCustomNamedRequestIDParamGroupingParameters)
+// options - HeaderClientCustomNamedRequestIDParamGroupingOptions contains the optional parameters for the HeaderClient.CustomNamedRequestIDParamGrouping
+// method.
+func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Context, headerClientCustomNamedRequestIDParamGroupingParameters HeaderClientCustomNamedRequestIDParamGroupingParameters, options *HeaderClientCustomNamedRequestIDParamGroupingOptions) (HeaderClientCustomNamedRequestIDParamGroupingResponse, error) {
+	req, err := client.customNamedRequestIDParamGroupingCreateRequest(ctx, headerClientCustomNamedRequestIDParamGroupingParameters, options)
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDParamGroupingResponse{}, err
 	}
@@ -136,7 +138,7 @@ func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Contex
 }
 
 // customNamedRequestIDParamGroupingCreateRequest creates the CustomNamedRequestIDParamGrouping request.
-func (client *HeaderClient) customNamedRequestIDParamGroupingCreateRequest(ctx context.Context, headerClientCustomNamedRequestIDParamGroupingParameters HeaderClientCustomNamedRequestIDParamGroupingParameters) (*policy.Request, error) {
+func (client *HeaderClient) customNamedRequestIDParamGroupingCreateRequest(ctx context.Context, headerClientCustomNamedRequestIDParamGroupingParameters HeaderClientCustomNamedRequestIDParamGroupingParameters, options *HeaderClientCustomNamedRequestIDParamGroupingOptions) (*policy.Request, error) {
 	urlPath := "/azurespecials/customNamedRequestIdParamGrouping"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -119,7 +119,7 @@ func TestGetMultiplePagesFragmentWithGroupingNextLink(t *testing.T) {
 	pager := client.GetMultiplePagesFragmentWithGroupingNextLink(CustomParameterGroup{
 		APIVersion: "1.6",
 		Tenant:     "test_user",
-	})
+	}, nil)
 	count := 0
 	for pager.More() {
 		page, err := pager.NextPage(context.Background())

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -283,11 +283,13 @@ func (client *PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp 
 // If the operation fails it returns an *azcore.ResponseError type.
 // CustomParameterGroup - CustomParameterGroup contains a group of parameters for the PagingClient.GetMultiplePagesFragmentWithGroupingNextLink
 // method.
-func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(customParameterGroup CustomParameterGroup) *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager {
+// options - PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions contains the optional parameters for the PagingClient.GetMultiplePagesFragmentWithGroupingNextLink
+// method.
+func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(customParameterGroup CustomParameterGroup, options *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions) *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager {
 	return &PagingClientGetMultiplePagesFragmentWithGroupingNextLinkPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
-			return client.getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx, customParameterGroup)
+			return client.getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx, customParameterGroup, options)
 		},
 		advancer: func(ctx context.Context, resp PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse) (*policy.Request, error) {
 			return client.nextFragmentWithGroupingCreateRequest(ctx, *resp.ODataProductResult.ODataNextLink, customParameterGroup)
@@ -296,7 +298,7 @@ func (client *PagingClient) GetMultiplePagesFragmentWithGroupingNextLink(customP
 }
 
 // getMultiplePagesFragmentWithGroupingNextLinkCreateRequest creates the GetMultiplePagesFragmentWithGroupingNextLink request.
-func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx context.Context, customParameterGroup CustomParameterGroup) (*policy.Request, error) {
+func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkCreateRequest(ctx context.Context, customParameterGroup CustomParameterGroup, options *PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions) (*policy.Request, error) {
 	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}"
 	if customParameterGroup.Tenant == "" {
 		return nil, errors.New("parameter customParameterGroup.Tenant cannot be empty")
@@ -465,13 +467,13 @@ func (client *PagingClient) getMultiplePagesRetrySecondHandleResponse(resp *http
 
 // GetMultiplePagesWithOffset - A paging operation that includes a nextLink that has 10 pages
 // If the operation fails it returns an *azcore.ResponseError type.
-// PagingClientGetMultiplePagesWithOffsetOptions - PagingClientGetMultiplePagesWithOffsetOptions contains the optional parameters
-// for the PagingClient.GetMultiplePagesWithOffset method.
-func (client *PagingClient) GetMultiplePagesWithOffset(pagingClientGetMultiplePagesWithOffsetOptions PagingClientGetMultiplePagesWithOffsetOptions) *PagingClientGetMultiplePagesWithOffsetPager {
+// options - PagingClientGetMultiplePagesWithOffsetOptions contains the optional parameters for the PagingClient.GetMultiplePagesWithOffset
+// method.
+func (client *PagingClient) GetMultiplePagesWithOffset(options PagingClientGetMultiplePagesWithOffsetOptions) *PagingClientGetMultiplePagesWithOffsetPager {
 	return &PagingClientGetMultiplePagesWithOffsetPager{
 		client: client,
 		requester: func(ctx context.Context) (*policy.Request, error) {
-			return client.getMultiplePagesWithOffsetCreateRequest(ctx, pagingClientGetMultiplePagesWithOffsetOptions)
+			return client.getMultiplePagesWithOffsetCreateRequest(ctx, options)
 		},
 		advancer: func(ctx context.Context, resp PagingClientGetMultiplePagesWithOffsetResponse) (*policy.Request, error) {
 			return runtime.NewRequest(ctx, http.MethodGet, *resp.ProductResult.NextLink)
@@ -480,21 +482,21 @@ func (client *PagingClient) GetMultiplePagesWithOffset(pagingClientGetMultiplePa
 }
 
 // getMultiplePagesWithOffsetCreateRequest creates the GetMultiplePagesWithOffset request.
-func (client *PagingClient) getMultiplePagesWithOffsetCreateRequest(ctx context.Context, pagingClientGetMultiplePagesWithOffsetOptions PagingClientGetMultiplePagesWithOffsetOptions) (*policy.Request, error) {
+func (client *PagingClient) getMultiplePagesWithOffsetCreateRequest(ctx context.Context, options PagingClientGetMultiplePagesWithOffsetOptions) (*policy.Request, error) {
 	urlPath := "/paging/multiple/withpath/{offset}"
-	urlPath = strings.ReplaceAll(urlPath, "{offset}", url.PathEscape(strconv.FormatInt(int64(pagingClientGetMultiplePagesWithOffsetOptions.Offset), 10)))
+	urlPath = strings.ReplaceAll(urlPath, "{offset}", url.PathEscape(strconv.FormatInt(int64(options.Offset), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
-	if pagingClientGetMultiplePagesWithOffsetOptions.ClientRequestID != nil {
-		req.Raw().Header.Set("client-request-id", *pagingClientGetMultiplePagesWithOffsetOptions.ClientRequestID)
+	if options.ClientRequestID != nil {
+		req.Raw().Header.Set("client-request-id", *options.ClientRequestID)
 	}
-	if pagingClientGetMultiplePagesWithOffsetOptions.Maxresults != nil {
-		req.Raw().Header.Set("maxresults", strconv.FormatInt(int64(*pagingClientGetMultiplePagesWithOffsetOptions.Maxresults), 10))
+	if options.Maxresults != nil {
+		req.Raw().Header.Set("maxresults", strconv.FormatInt(int64(*options.Maxresults), 10))
 	}
-	if pagingClientGetMultiplePagesWithOffsetOptions.Timeout != nil {
-		req.Raw().Header.Set("timeout", strconv.FormatInt(int64(*pagingClientGetMultiplePagesWithOffsetOptions.Timeout), 10))
+	if options.Timeout != nil {
+		req.Raw().Header.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -17,7 +17,7 @@ func newParameterGroupingClient() *ParameterGroupingClient {
 // PostMultiParamGroups - Post parameters from multiple different parameter groups
 func TestPostMultiParamGroups(t *testing.T) {
 	client := newParameterGroupingClient()
-	result, err := client.PostMultiParamGroups(context.Background(), nil, nil)
+	result, err := client.PostMultiParamGroups(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
@@ -25,7 +25,7 @@ func TestPostMultiParamGroups(t *testing.T) {
 // PostOptional - Post a bunch of optional parameters grouped
 func TestPostOptional(t *testing.T) {
 	client := newParameterGroupingClient()
-	result, err := client.PostOptional(context.Background(), nil)
+	result, err := client.PostOptional(context.Background(), nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
@@ -36,7 +36,7 @@ func TestPostRequired(t *testing.T) {
 	result, err := client.PostRequired(context.Background(), ParameterGroupingClientPostRequiredParameters{
 		Body: 1234,
 		Path: "path",
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
@@ -44,7 +44,7 @@ func TestPostRequired(t *testing.T) {
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
 func TestPostSharedParameterGroupObject(t *testing.T) {
 	client := newParameterGroupingClient()
-	result, err := client.PostSharedParameterGroupObject(context.Background(), nil)
+	result, err := client.PostSharedParameterGroupObject(context.Background(), nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
@@ -44,8 +44,10 @@ func NewParameterGroupingClient(options *azcore.ClientOptions) *ParameterGroupin
 // method.
 // ParameterGroupingClientPostMultiParamGroupsSecondParamGroup - ParameterGroupingClientPostMultiParamGroupsSecondParamGroup
 // contains a group of parameters for the ParameterGroupingClient.PostMultiParamGroups method.
-func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context, firstParameterGroup *FirstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup *ParameterGroupingClientPostMultiParamGroupsSecondParamGroup) (ParameterGroupingClientPostMultiParamGroupsResponse, error) {
-	req, err := client.postMultiParamGroupsCreateRequest(ctx, firstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup)
+// options - ParameterGroupingClientPostMultiParamGroupsOptions contains the optional parameters for the ParameterGroupingClient.PostMultiParamGroups
+// method.
+func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context, firstParameterGroup *FirstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup *ParameterGroupingClientPostMultiParamGroupsSecondParamGroup, options *ParameterGroupingClientPostMultiParamGroupsOptions) (ParameterGroupingClientPostMultiParamGroupsResponse, error) {
+	req, err := client.postMultiParamGroupsCreateRequest(ctx, firstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup, options)
 	if err != nil {
 		return ParameterGroupingClientPostMultiParamGroupsResponse{}, err
 	}
@@ -60,7 +62,7 @@ func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context,
 }
 
 // postMultiParamGroupsCreateRequest creates the PostMultiParamGroups request.
-func (client *ParameterGroupingClient) postMultiParamGroupsCreateRequest(ctx context.Context, firstParameterGroup *FirstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup *ParameterGroupingClientPostMultiParamGroupsSecondParamGroup) (*policy.Request, error) {
+func (client *ParameterGroupingClient) postMultiParamGroupsCreateRequest(ctx context.Context, firstParameterGroup *FirstParameterGroup, parameterGroupingClientPostMultiParamGroupsSecondParamGroup *ParameterGroupingClientPostMultiParamGroupsSecondParamGroup, options *ParameterGroupingClientPostMultiParamGroupsOptions) (*policy.Request, error) {
 	urlPath := "/parameterGrouping/postMultipleParameterGroups"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -86,10 +88,12 @@ func (client *ParameterGroupingClient) postMultiParamGroupsCreateRequest(ctx con
 
 // PostOptional - Post a bunch of optional parameters grouped
 // If the operation fails it returns an *azcore.ResponseError type.
-// options - ParameterGroupingClientPostOptionalParameters contains a group of parameters for the ParameterGroupingClient.PostOptional
+// ParameterGroupingClientPostOptionalParameters - ParameterGroupingClientPostOptionalParameters contains a group of parameters
+// for the ParameterGroupingClient.PostOptional method.
+// options - ParameterGroupingClientPostOptionalOptions contains the optional parameters for the ParameterGroupingClient.PostOptional
 // method.
-func (client *ParameterGroupingClient) PostOptional(ctx context.Context, options *ParameterGroupingClientPostOptionalParameters) (ParameterGroupingClientPostOptionalResponse, error) {
-	req, err := client.postOptionalCreateRequest(ctx, options)
+func (client *ParameterGroupingClient) PostOptional(ctx context.Context, parameterGroupingClientPostOptionalParameters *ParameterGroupingClientPostOptionalParameters, options *ParameterGroupingClientPostOptionalOptions) (ParameterGroupingClientPostOptionalResponse, error) {
+	req, err := client.postOptionalCreateRequest(ctx, parameterGroupingClientPostOptionalParameters, options)
 	if err != nil {
 		return ParameterGroupingClientPostOptionalResponse{}, err
 	}
@@ -104,19 +108,19 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, options
 }
 
 // postOptionalCreateRequest creates the PostOptional request.
-func (client *ParameterGroupingClient) postOptionalCreateRequest(ctx context.Context, options *ParameterGroupingClientPostOptionalParameters) (*policy.Request, error) {
+func (client *ParameterGroupingClient) postOptionalCreateRequest(ctx context.Context, parameterGroupingClientPostOptionalParameters *ParameterGroupingClientPostOptionalParameters, options *ParameterGroupingClientPostOptionalOptions) (*policy.Request, error) {
 	urlPath := "/parameterGrouping/postOptional"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if options != nil && options.Query != nil {
-		reqQP.Set("query", strconv.FormatInt(int64(*options.Query), 10))
+	if parameterGroupingClientPostOptionalParameters != nil && parameterGroupingClientPostOptionalParameters.Query != nil {
+		reqQP.Set("query", strconv.FormatInt(int64(*parameterGroupingClientPostOptionalParameters.Query), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if options != nil && options.CustomHeader != nil {
-		req.Raw().Header.Set("customHeader", *options.CustomHeader)
+	if parameterGroupingClientPostOptionalParameters != nil && parameterGroupingClientPostOptionalParameters.CustomHeader != nil {
+		req.Raw().Header.Set("customHeader", *parameterGroupingClientPostOptionalParameters.CustomHeader)
 	}
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil
@@ -126,8 +130,10 @@ func (client *ParameterGroupingClient) postOptionalCreateRequest(ctx context.Con
 // If the operation fails it returns an *azcore.ResponseError type.
 // ParameterGroupingClientPostRequiredParameters - ParameterGroupingClientPostRequiredParameters contains a group of parameters
 // for the ParameterGroupingClient.PostRequired method.
-func (client *ParameterGroupingClient) PostRequired(ctx context.Context, parameterGroupingClientPostRequiredParameters ParameterGroupingClientPostRequiredParameters) (ParameterGroupingClientPostRequiredResponse, error) {
-	req, err := client.postRequiredCreateRequest(ctx, parameterGroupingClientPostRequiredParameters)
+// options - ParameterGroupingClientPostRequiredOptions contains the optional parameters for the ParameterGroupingClient.PostRequired
+// method.
+func (client *ParameterGroupingClient) PostRequired(ctx context.Context, parameterGroupingClientPostRequiredParameters ParameterGroupingClientPostRequiredParameters, options *ParameterGroupingClientPostRequiredOptions) (ParameterGroupingClientPostRequiredResponse, error) {
+	req, err := client.postRequiredCreateRequest(ctx, parameterGroupingClientPostRequiredParameters, options)
 	if err != nil {
 		return ParameterGroupingClientPostRequiredResponse{}, err
 	}
@@ -142,7 +148,7 @@ func (client *ParameterGroupingClient) PostRequired(ctx context.Context, paramet
 }
 
 // postRequiredCreateRequest creates the PostRequired request.
-func (client *ParameterGroupingClient) postRequiredCreateRequest(ctx context.Context, parameterGroupingClientPostRequiredParameters ParameterGroupingClientPostRequiredParameters) (*policy.Request, error) {
+func (client *ParameterGroupingClient) postRequiredCreateRequest(ctx context.Context, parameterGroupingClientPostRequiredParameters ParameterGroupingClientPostRequiredParameters, options *ParameterGroupingClientPostRequiredOptions) (*policy.Request, error) {
 	urlPath := "/parameterGrouping/postRequired/{path}"
 	if parameterGroupingClientPostRequiredParameters.Path == "" {
 		return nil, errors.New("parameter parameterGroupingClientPostRequiredParameters.Path cannot be empty")
@@ -166,10 +172,12 @@ func (client *ParameterGroupingClient) postRequiredCreateRequest(ctx context.Con
 
 // PostReservedWords - Post a grouped parameters with reserved words
 // If the operation fails it returns an *azcore.ResponseError type.
-// options - ParameterGroupingClientPostReservedWordsParameters contains a group of parameters for the ParameterGroupingClient.PostReservedWords
+// ParameterGroupingClientPostReservedWordsParameters - ParameterGroupingClientPostReservedWordsParameters contains a group
+// of parameters for the ParameterGroupingClient.PostReservedWords method.
+// options - ParameterGroupingClientPostReservedWordsOptions contains the optional parameters for the ParameterGroupingClient.PostReservedWords
 // method.
-func (client *ParameterGroupingClient) PostReservedWords(ctx context.Context, options *ParameterGroupingClientPostReservedWordsParameters) (ParameterGroupingClientPostReservedWordsResponse, error) {
-	req, err := client.postReservedWordsCreateRequest(ctx, options)
+func (client *ParameterGroupingClient) PostReservedWords(ctx context.Context, parameterGroupingClientPostReservedWordsParameters *ParameterGroupingClientPostReservedWordsParameters, options *ParameterGroupingClientPostReservedWordsOptions) (ParameterGroupingClientPostReservedWordsResponse, error) {
+	req, err := client.postReservedWordsCreateRequest(ctx, parameterGroupingClientPostReservedWordsParameters, options)
 	if err != nil {
 		return ParameterGroupingClientPostReservedWordsResponse{}, err
 	}
@@ -184,18 +192,18 @@ func (client *ParameterGroupingClient) PostReservedWords(ctx context.Context, op
 }
 
 // postReservedWordsCreateRequest creates the PostReservedWords request.
-func (client *ParameterGroupingClient) postReservedWordsCreateRequest(ctx context.Context, options *ParameterGroupingClientPostReservedWordsParameters) (*policy.Request, error) {
+func (client *ParameterGroupingClient) postReservedWordsCreateRequest(ctx context.Context, parameterGroupingClientPostReservedWordsParameters *ParameterGroupingClientPostReservedWordsParameters, options *ParameterGroupingClientPostReservedWordsOptions) (*policy.Request, error) {
 	urlPath := "/parameterGrouping/postReservedWords"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if options != nil && options.From != nil {
-		reqQP.Set("from", *options.From)
+	if parameterGroupingClientPostReservedWordsParameters != nil && parameterGroupingClientPostReservedWordsParameters.From != nil {
+		reqQP.Set("from", *parameterGroupingClientPostReservedWordsParameters.From)
 	}
-	if options != nil && options.Accept != nil {
-		reqQP.Set("accept", *options.Accept)
+	if parameterGroupingClientPostReservedWordsParameters != nil && parameterGroupingClientPostReservedWordsParameters.Accept != nil {
+		reqQP.Set("accept", *parameterGroupingClientPostReservedWordsParameters.Accept)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Accept", "application/json")
@@ -204,9 +212,12 @@ func (client *ParameterGroupingClient) postReservedWordsCreateRequest(ctx contex
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
 // If the operation fails it returns an *azcore.ResponseError type.
-// options - FirstParameterGroup contains a group of parameters for the ParameterGroupingClient.PostMultiParamGroups method.
-func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx context.Context, options *FirstParameterGroup) (ParameterGroupingClientPostSharedParameterGroupObjectResponse, error) {
-	req, err := client.postSharedParameterGroupObjectCreateRequest(ctx, options)
+// FirstParameterGroup - FirstParameterGroup contains a group of parameters for the ParameterGroupingClient.PostMultiParamGroups
+// method.
+// options - ParameterGroupingClientPostSharedParameterGroupObjectOptions contains the optional parameters for the ParameterGroupingClient.PostSharedParameterGroupObject
+// method.
+func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx context.Context, firstParameterGroup *FirstParameterGroup, options *ParameterGroupingClientPostSharedParameterGroupObjectOptions) (ParameterGroupingClientPostSharedParameterGroupObjectResponse, error) {
+	req, err := client.postSharedParameterGroupObjectCreateRequest(ctx, firstParameterGroup, options)
 	if err != nil {
 		return ParameterGroupingClientPostSharedParameterGroupObjectResponse{}, err
 	}
@@ -221,19 +232,19 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 }
 
 // postSharedParameterGroupObjectCreateRequest creates the PostSharedParameterGroupObject request.
-func (client *ParameterGroupingClient) postSharedParameterGroupObjectCreateRequest(ctx context.Context, options *FirstParameterGroup) (*policy.Request, error) {
+func (client *ParameterGroupingClient) postSharedParameterGroupObjectCreateRequest(ctx context.Context, firstParameterGroup *FirstParameterGroup, options *ParameterGroupingClientPostSharedParameterGroupObjectOptions) (*policy.Request, error) {
 	urlPath := "/parameterGrouping/sharedParameterGroupObject"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if options != nil && options.QueryOne != nil {
-		reqQP.Set("query-one", strconv.FormatInt(int64(*options.QueryOne), 10))
+	if firstParameterGroup != nil && firstParameterGroup.QueryOne != nil {
+		reqQP.Set("query-one", strconv.FormatInt(int64(*firstParameterGroup.QueryOne), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if options != nil && options.HeaderOne != nil {
-		req.Raw().Header.Set("header-one", *options.HeaderOne)
+	if firstParameterGroup != nil && firstParameterGroup.HeaderOne != nil {
+		req.Raw().Header.Set("header-one", *firstParameterGroup.HeaderOne)
 	}
 	req.Raw().Header.Set("Accept", "application/json")
 	return req, nil

--- a/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_appendblob_client.go
@@ -44,16 +44,15 @@ func newAppendBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *a
 // If the operation fails it returns an *azcore.ResponseError type.
 // contentLength - The length of the request.
 // body - Initial data
-// appendBlobClientAppendBlockOptions - appendBlobClientAppendBlockOptions contains the optional parameters for the appendBlobClient.AppendBlock
-// method.
+// options - appendBlobClientAppendBlockOptions contains the optional parameters for the appendBlobClient.AppendBlock method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock
 // method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *appendBlobClient) AppendBlock(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, appendBlobClientAppendBlockOptions *appendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (appendBlobClientAppendBlockResponse, error) {
-	req, err := client.appendBlockCreateRequest(ctx, comp, contentLength, body, appendBlobClientAppendBlockOptions, leaseAccessConditions, appendPositionAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *appendBlobClient) AppendBlock(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *appendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (appendBlobClientAppendBlockResponse, error) {
+	req, err := client.appendBlockCreateRequest(ctx, comp, contentLength, body, options, leaseAccessConditions, appendPositionAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return appendBlobClientAppendBlockResponse{}, err
 	}
@@ -68,23 +67,23 @@ func (client *appendBlobClient) AppendBlock(ctx context.Context, comp Enum38, co
 }
 
 // appendBlockCreateRequest creates the AppendBlock request.
-func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, appendBlobClientAppendBlockOptions *appendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *appendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if appendBlobClientAppendBlockOptions != nil && appendBlobClientAppendBlockOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*appendBlobClientAppendBlockOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if appendBlobClientAppendBlockOptions != nil && appendBlobClientAppendBlockOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(appendBlobClientAppendBlockOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
-	if appendBlobClientAppendBlockOptions != nil && appendBlobClientAppendBlockOptions.TransactionalContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(appendBlobClientAppendBlockOptions.TransactionalContentCRC64))
+	if options != nil && options.TransactionalContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(options.TransactionalContentCRC64))
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -123,8 +122,8 @@ func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, co
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if appendBlobClientAppendBlockOptions != nil && appendBlobClientAppendBlockOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *appendBlobClientAppendBlockOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
@@ -206,8 +205,8 @@ func (client *appendBlobClient) appendBlockHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 // sourceURL - Specify a URL to the copy source.
 // contentLength - The length of the request.
-// appendBlobClientAppendBlockFromURLOptions - appendBlobClientAppendBlockFromURLOptions contains the optional parameters
-// for the appendBlobClient.AppendBlockFromURL method.
+// options - appendBlobClientAppendBlockFromURLOptions contains the optional parameters for the appendBlobClient.AppendBlockFromURL
+// method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
@@ -216,8 +215,8 @@ func (client *appendBlobClient) appendBlockHandleResponse(resp *http.Response) (
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, appendBlobClientAppendBlockFromURLOptions *appendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (appendBlobClientAppendBlockFromURLResponse, error) {
-	req, err := client.appendBlockFromURLCreateRequest(ctx, comp, sourceURL, contentLength, appendBlobClientAppendBlockFromURLOptions, cpkInfo, cpkScopeInfo, leaseAccessConditions, appendPositionAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
+func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *appendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (appendBlobClientAppendBlockFromURLResponse, error) {
+	req, err := client.appendBlockFromURLCreateRequest(ctx, comp, sourceURL, contentLength, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, appendPositionAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return appendBlobClientAppendBlockFromURLResponse{}, err
 	}
@@ -232,30 +231,30 @@ func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enu
 }
 
 // appendBlockFromURLCreateRequest creates the AppendBlockFromURL request.
-func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, appendBlobClientAppendBlockFromURLOptions *appendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *appendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*appendBlobClientAppendBlockFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-copy-source", sourceURL)
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.SourceRange != nil {
-		req.Raw().Header.Set("x-ms-source-range", *appendBlobClientAppendBlockFromURLOptions.SourceRange)
+	if options != nil && options.SourceRange != nil {
+		req.Raw().Header.Set("x-ms-source-range", *options.SourceRange)
 	}
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.SourceContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(appendBlobClientAppendBlockFromURLOptions.SourceContentMD5))
+	if options != nil && options.SourceContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(options.SourceContentMD5))
 	}
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.SourceContentcrc64 != nil {
-		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(appendBlobClientAppendBlockFromURLOptions.SourceContentcrc64))
+	if options != nil && options.SourceContentcrc64 != nil {
+		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(options.SourceContentcrc64))
 	}
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(appendBlobClientAppendBlockFromURLOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKey != nil {
 		req.Raw().Header.Set("x-ms-encryption-key", *cpkInfo.EncryptionKey)
@@ -306,8 +305,8 @@ func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Cont
 		req.Raw().Header.Set("x-ms-source-if-none-match", *sourceModifiedAccessConditions.SourceIfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if appendBlobClientAppendBlockFromURLOptions != nil && appendBlobClientAppendBlockFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *appendBlobClientAppendBlockFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -383,15 +382,14 @@ func (client *appendBlobClient) appendBlockFromURLHandleResponse(resp *http.Resp
 // Create - The Create Append Blob operation creates a new append blob.
 // If the operation fails it returns an *azcore.ResponseError type.
 // contentLength - The length of the request.
-// appendBlobClientCreateOptions - appendBlobClientCreateOptions contains the optional parameters for the appendBlobClient.Create
-// method.
+// options - appendBlobClientCreateOptions contains the optional parameters for the appendBlobClient.Create method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *appendBlobClient) Create(ctx context.Context, contentLength int64, appendBlobClientCreateOptions *appendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (appendBlobClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, contentLength, appendBlobClientCreateOptions, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *appendBlobClient) Create(ctx context.Context, contentLength int64, options *appendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (appendBlobClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, contentLength, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return appendBlobClientCreateResponse{}, err
 	}
@@ -406,14 +404,14 @@ func (client *appendBlobClient) Create(ctx context.Context, contentLength int64,
 }
 
 // createCreateRequest creates the Create request.
-func (client *appendBlobClient) createCreateRequest(ctx context.Context, contentLength int64, appendBlobClientCreateOptions *appendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *appendBlobClient) createCreateRequest(ctx context.Context, contentLength int64, options *appendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*appendBlobClientCreateOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-blob-type", "AppendBlob")
@@ -433,8 +431,8 @@ func (client *appendBlobClient) createCreateRequest(ctx context.Context, content
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
 		req.Raw().Header.Set("x-ms-blob-cache-control", *blobHTTPHeaders.BlobCacheControl)
 	}
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.Metadata != nil {
-		for k, v := range appendBlobClientCreateOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -472,20 +470,20 @@ func (client *appendBlobClient) createCreateRequest(ctx context.Context, content
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *appendBlobClientCreateOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *appendBlobClientCreateOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", appendBlobClientCreateOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*appendBlobClientCreateOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if appendBlobClientCreateOptions != nil && appendBlobClientCreateOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*appendBlobClientCreateOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -549,14 +547,13 @@ func (client *appendBlobClient) createHandleResponse(resp *http.Response) (appen
 // Seal - The Seal operation seals the Append Blob to make it read-only. Seal is supported only on version 2019-12-12 version
 // or later.
 // If the operation fails it returns an *azcore.ResponseError type.
-// appendBlobClientSealOptions - appendBlobClientSealOptions contains the optional parameters for the appendBlobClient.Seal
-// method.
+// options - appendBlobClientSealOptions contains the optional parameters for the appendBlobClient.Seal method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock
 // method.
-func (client *appendBlobClient) Seal(ctx context.Context, comp Enum39, appendBlobClientSealOptions *appendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (appendBlobClientSealResponse, error) {
-	req, err := client.sealCreateRequest(ctx, comp, appendBlobClientSealOptions, leaseAccessConditions, modifiedAccessConditions, appendPositionAccessConditions)
+func (client *appendBlobClient) Seal(ctx context.Context, comp Enum39, options *appendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (appendBlobClientSealResponse, error) {
+	req, err := client.sealCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions, appendPositionAccessConditions)
 	if err != nil {
 		return appendBlobClientSealResponse{}, err
 	}
@@ -571,20 +568,20 @@ func (client *appendBlobClient) Seal(ctx context.Context, comp Enum39, appendBlo
 }
 
 // sealCreateRequest creates the Seal request.
-func (client *appendBlobClient) sealCreateRequest(ctx context.Context, comp Enum39, appendBlobClientSealOptions *appendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (*policy.Request, error) {
+func (client *appendBlobClient) sealCreateRequest(ctx context.Context, comp Enum39, options *appendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if appendBlobClientSealOptions != nil && appendBlobClientSealOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*appendBlobClientSealOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if appendBlobClientSealOptions != nil && appendBlobClientSealOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *appendBlobClientSealOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)

--- a/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_blockblob_client.go
@@ -46,15 +46,15 @@ func newBlockBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *bl
 // the most recently uploaded version of the block, whichever list it may
 // belong to.
 // If the operation fails it returns an *azcore.ResponseError type.
-// blockBlobClientCommitBlockListOptions - blockBlobClientCommitBlockListOptions contains the optional parameters for the
-// blockBlobClient.CommitBlockList method.
+// options - blockBlobClientCommitBlockListOptions contains the optional parameters for the blockBlobClient.CommitBlockList
+// method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) CommitBlockList(ctx context.Context, comp Enum34, blocks BlockLookupList, blockBlobClientCommitBlockListOptions *blockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientCommitBlockListResponse, error) {
-	req, err := client.commitBlockListCreateRequest(ctx, comp, blocks, blockBlobClientCommitBlockListOptions, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *blockBlobClient) CommitBlockList(ctx context.Context, comp Enum34, blocks BlockLookupList, options *blockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientCommitBlockListResponse, error) {
+	req, err := client.commitBlockListCreateRequest(ctx, comp, blocks, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return blockBlobClientCommitBlockListResponse{}, err
 	}
@@ -69,15 +69,15 @@ func (client *blockBlobClient) CommitBlockList(ctx context.Context, comp Enum34,
 }
 
 // commitBlockListCreateRequest creates the CommitBlockList request.
-func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context, comp Enum34, blocks BlockLookupList, blockBlobClientCommitBlockListOptions *blockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context, comp Enum34, blocks BlockLookupList, options *blockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientCommitBlockListOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
@@ -95,14 +95,14 @@ func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobContentMD5 != nil {
 		req.Raw().Header.Set("x-ms-blob-content-md5", base64.StdEncoding.EncodeToString(blobHTTPHeaders.BlobContentMD5))
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(blockBlobClientCommitBlockListOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.TransactionalContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(blockBlobClientCommitBlockListOptions.TransactionalContentCRC64))
+	if options != nil && options.TransactionalContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(options.TransactionalContentCRC64))
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.Metadata != nil {
-		for k, v := range blockBlobClientCommitBlockListOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -124,8 +124,8 @@ func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Raw().Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*blockBlobClientCommitBlockListOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -143,20 +143,20 @@ func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientCommitBlockListOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *blockBlobClientCommitBlockListOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", blockBlobClientCommitBlockListOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*blockBlobClientCommitBlockListOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if blockBlobClientCommitBlockListOptions != nil && blockBlobClientCommitBlockListOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*blockBlobClientCommitBlockListOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, runtime.MarshalAsXML(req, blocks)
@@ -227,12 +227,11 @@ func (client *blockBlobClient) commitBlockListHandleResponse(resp *http.Response
 // GetBlockList - The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob
 // If the operation fails it returns an *azcore.ResponseError type.
 // listType - Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists together.
-// blockBlobClientGetBlockListOptions - blockBlobClientGetBlockListOptions contains the optional parameters for the blockBlobClient.GetBlockList
-// method.
+// options - blockBlobClientGetBlockListOptions contains the optional parameters for the blockBlobClient.GetBlockList method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) GetBlockList(ctx context.Context, comp Enum34, listType BlockListType, blockBlobClientGetBlockListOptions *blockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientGetBlockListResponse, error) {
-	req, err := client.getBlockListCreateRequest(ctx, comp, listType, blockBlobClientGetBlockListOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *blockBlobClient) GetBlockList(ctx context.Context, comp Enum34, listType BlockListType, options *blockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientGetBlockListResponse, error) {
+	req, err := client.getBlockListCreateRequest(ctx, comp, listType, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return blockBlobClientGetBlockListResponse{}, err
 	}
@@ -247,19 +246,19 @@ func (client *blockBlobClient) GetBlockList(ctx context.Context, comp Enum34, li
 }
 
 // getBlockListCreateRequest creates the GetBlockList request.
-func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, comp Enum34, listType BlockListType, blockBlobClientGetBlockListOptions *blockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, comp Enum34, listType BlockListType, options *blockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if blockBlobClientGetBlockListOptions != nil && blockBlobClientGetBlockListOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *blockBlobClientGetBlockListOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
 	reqQP.Set("blocklisttype", string(listType))
-	if blockBlobClientGetBlockListOptions != nil && blockBlobClientGetBlockListOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientGetBlockListOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -269,8 +268,8 @@ func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, co
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientGetBlockListOptions != nil && blockBlobClientGetBlockListOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientGetBlockListOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -331,7 +330,7 @@ func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// blockBlobClientPutBlobFromURLOptions - blockBlobClientPutBlobFromURLOptions contains the optional parameters for the blockBlobClient.PutBlobFromURL
+// options - blockBlobClientPutBlobFromURLOptions contains the optional parameters for the blockBlobClient.PutBlobFromURL
 // method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
@@ -340,8 +339,8 @@ func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *blockBlobClient) PutBlobFromURL(ctx context.Context, contentLength int64, copySource string, blockBlobClientPutBlobFromURLOptions *blockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (blockBlobClientPutBlobFromURLResponse, error) {
-	req, err := client.putBlobFromURLCreateRequest(ctx, contentLength, copySource, blockBlobClientPutBlobFromURLOptions, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions, sourceModifiedAccessConditions)
+func (client *blockBlobClient) PutBlobFromURL(ctx context.Context, contentLength int64, copySource string, options *blockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (blockBlobClientPutBlobFromURLResponse, error) {
+	req, err := client.putBlobFromURLCreateRequest(ctx, contentLength, copySource, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return blockBlobClientPutBlobFromURLResponse{}, err
 	}
@@ -356,19 +355,19 @@ func (client *blockBlobClient) PutBlobFromURL(ctx context.Context, contentLength
 }
 
 // putBlobFromURLCreateRequest creates the PutBlobFromURL request.
-func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, contentLength int64, copySource string, blockBlobClientPutBlobFromURLOptions *blockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, contentLength int64, copySource string, options *blockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientPutBlobFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-blob-type", "BlockBlob")
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(blockBlobClientPutBlobFromURLOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobContentType != nil {
@@ -386,8 +385,8 @@ func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
 		req.Raw().Header.Set("x-ms-blob-cache-control", *blobHTTPHeaders.BlobCacheControl)
 	}
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.Metadata != nil {
-		for k, v := range blockBlobClientPutBlobFromURLOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -409,8 +408,8 @@ func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Raw().Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*blockBlobClientPutBlobFromURLOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -443,18 +442,18 @@ func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 		req.Raw().Header.Set("x-ms-source-if-tags", *sourceModifiedAccessConditions.SourceIfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientPutBlobFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.SourceContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(blockBlobClientPutBlobFromURLOptions.SourceContentMD5))
+	if options != nil && options.SourceContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(options.SourceContentMD5))
 	}
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *blockBlobClientPutBlobFromURLOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
 	req.Raw().Header.Set("x-ms-copy-source", copySource)
-	if blockBlobClientPutBlobFromURLOptions != nil && blockBlobClientPutBlobFromURLOptions.CopySourceBlobProperties != nil {
-		req.Raw().Header.Set("x-ms-copy-source-blob-properties", strconv.FormatBool(*blockBlobClientPutBlobFromURLOptions.CopySourceBlobProperties))
+	if options != nil && options.CopySourceBlobProperties != nil {
+		req.Raw().Header.Set("x-ms-copy-source-blob-properties", strconv.FormatBool(*options.CopySourceBlobProperties))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -522,13 +521,12 @@ func (client *blockBlobClient) putBlobFromURLHandleResponse(resp *http.Response)
 // parameter must be the same size for each block.
 // contentLength - The length of the request.
 // body - Initial data
-// blockBlobClientStageBlockOptions - blockBlobClientStageBlockOptions contains the optional parameters for the blockBlobClient.StageBlock
-// method.
+// options - blockBlobClientStageBlockOptions contains the optional parameters for the blockBlobClient.StageBlock method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-func (client *blockBlobClient) StageBlock(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, blockBlobClientStageBlockOptions *blockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (blockBlobClientStageBlockResponse, error) {
-	req, err := client.stageBlockCreateRequest(ctx, comp, blockID, contentLength, body, blockBlobClientStageBlockOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo)
+func (client *blockBlobClient) StageBlock(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *blockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (blockBlobClientStageBlockResponse, error) {
+	req, err := client.stageBlockCreateRequest(ctx, comp, blockID, contentLength, body, options, leaseAccessConditions, cpkInfo, cpkScopeInfo)
 	if err != nil {
 		return blockBlobClientStageBlockResponse{}, err
 	}
@@ -543,7 +541,7 @@ func (client *blockBlobClient) StageBlock(ctx context.Context, comp Enum33, bloc
 }
 
 // stageBlockCreateRequest creates the StageBlock request.
-func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, blockBlobClientStageBlockOptions *blockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
+func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *blockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -551,16 +549,16 @@ func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("blockid", blockID)
-	if blockBlobClientStageBlockOptions != nil && blockBlobClientStageBlockOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientStageBlockOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if blockBlobClientStageBlockOptions != nil && blockBlobClientStageBlockOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(blockBlobClientStageBlockOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
-	if blockBlobClientStageBlockOptions != nil && blockBlobClientStageBlockOptions.TransactionalContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(blockBlobClientStageBlockOptions.TransactionalContentCRC64))
+	if options != nil && options.TransactionalContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(options.TransactionalContentCRC64))
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -578,8 +576,8 @@ func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp
 		req.Raw().Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientStageBlockOptions != nil && blockBlobClientStageBlockOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientStageBlockOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
@@ -642,15 +640,15 @@ func (client *blockBlobClient) stageBlockHandleResponse(resp *http.Response) (bl
 // parameter must be the same size for each block.
 // contentLength - The length of the request.
 // sourceURL - Specify a URL to the copy source.
-// blockBlobClientStageBlockFromURLOptions - blockBlobClientStageBlockFromURLOptions contains the optional parameters for
-// the blockBlobClient.StageBlockFromURL method.
+// options - blockBlobClientStageBlockFromURLOptions contains the optional parameters for the blockBlobClient.StageBlockFromURL
+// method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, blockBlobClientStageBlockFromURLOptions *blockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (blockBlobClientStageBlockFromURLResponse, error) {
-	req, err := client.stageBlockFromURLCreateRequest(ctx, comp, blockID, contentLength, sourceURL, blockBlobClientStageBlockFromURLOptions, cpkInfo, cpkScopeInfo, leaseAccessConditions, sourceModifiedAccessConditions)
+func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *blockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (blockBlobClientStageBlockFromURLResponse, error) {
+	req, err := client.stageBlockFromURLCreateRequest(ctx, comp, blockID, contentLength, sourceURL, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return blockBlobClientStageBlockFromURLResponse{}, err
 	}
@@ -665,7 +663,7 @@ func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum3
 }
 
 // stageBlockFromURLCreateRequest creates the StageBlockFromURL request.
-func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, blockBlobClientStageBlockFromURLOptions *blockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *blockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -673,20 +671,20 @@ func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Contex
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("blockid", blockID)
-	if blockBlobClientStageBlockFromURLOptions != nil && blockBlobClientStageBlockFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientStageBlockFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	req.Raw().Header.Set("x-ms-copy-source", sourceURL)
-	if blockBlobClientStageBlockFromURLOptions != nil && blockBlobClientStageBlockFromURLOptions.SourceRange != nil {
-		req.Raw().Header.Set("x-ms-source-range", *blockBlobClientStageBlockFromURLOptions.SourceRange)
+	if options != nil && options.SourceRange != nil {
+		req.Raw().Header.Set("x-ms-source-range", *options.SourceRange)
 	}
-	if blockBlobClientStageBlockFromURLOptions != nil && blockBlobClientStageBlockFromURLOptions.SourceContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(blockBlobClientStageBlockFromURLOptions.SourceContentMD5))
+	if options != nil && options.SourceContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(options.SourceContentMD5))
 	}
-	if blockBlobClientStageBlockFromURLOptions != nil && blockBlobClientStageBlockFromURLOptions.SourceContentcrc64 != nil {
-		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(blockBlobClientStageBlockFromURLOptions.SourceContentcrc64))
+	if options != nil && options.SourceContentcrc64 != nil {
+		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(options.SourceContentcrc64))
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKey != nil {
 		req.Raw().Header.Set("x-ms-encryption-key", *cpkInfo.EncryptionKey)
@@ -716,8 +714,8 @@ func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Contex
 		req.Raw().Header.Set("x-ms-source-if-none-match", *sourceModifiedAccessConditions.SourceIfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientStageBlockFromURLOptions != nil && blockBlobClientStageBlockFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientStageBlockFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -779,15 +777,14 @@ func (client *blockBlobClient) stageBlockFromURLHandleResponse(resp *http.Respon
 // If the operation fails it returns an *azcore.ResponseError type.
 // contentLength - The length of the request.
 // body - Initial data
-// blockBlobClientUploadOptions - blockBlobClientUploadOptions contains the optional parameters for the blockBlobClient.Upload
-// method.
+// options - blockBlobClientUploadOptions contains the optional parameters for the blockBlobClient.Upload method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, body io.ReadSeekCloser, blockBlobClientUploadOptions *blockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientUploadResponse, error) {
-	req, err := client.uploadCreateRequest(ctx, contentLength, body, blockBlobClientUploadOptions, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *blockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (blockBlobClientUploadResponse, error) {
+	req, err := client.uploadCreateRequest(ctx, contentLength, body, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return blockBlobClientUploadResponse{}, err
 	}
@@ -802,19 +799,19 @@ func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, 
 }
 
 // uploadCreateRequest creates the Upload request.
-func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, blockBlobClientUploadOptions *blockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *blockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*blockBlobClientUploadOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-blob-type", "BlockBlob")
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(blockBlobClientUploadOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobContentType != nil {
@@ -832,8 +829,8 @@ func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
 		req.Raw().Header.Set("x-ms-blob-cache-control", *blobHTTPHeaders.BlobCacheControl)
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.Metadata != nil {
-		for k, v := range blockBlobClientUploadOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -855,8 +852,8 @@ func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 	if cpkScopeInfo != nil && cpkScopeInfo.EncryptionScope != nil {
 		req.Raw().Header.Set("x-ms-encryption-scope", *cpkScopeInfo.EncryptionScope)
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*blockBlobClientUploadOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -874,20 +871,20 @@ func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *blockBlobClientUploadOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *blockBlobClientUploadOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", blockBlobClientUploadOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*blockBlobClientUploadOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if blockBlobClientUploadOptions != nil && blockBlobClientUploadOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*blockBlobClientUploadOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")

--- a/test/storage/2020-06-12/azblob/zz_generated_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_client.go
@@ -45,11 +45,10 @@ func newClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, p
 // blob with zero length and full metadata.
 // If the operation fails it returns an *azcore.ResponseError type.
 // copyID - The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.
-// clientAbortCopyFromURLOptions - clientAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL
-// method.
+// options - clientAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, clientAbortCopyFromURLOptions *clientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (clientAbortCopyFromURLResponse, error) {
-	req, err := client.abortCopyFromURLCreateRequest(ctx, comp, copyActionAbortConstant, copyID, clientAbortCopyFromURLOptions, leaseAccessConditions)
+func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *clientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (clientAbortCopyFromURLResponse, error) {
+	req, err := client.abortCopyFromURLCreateRequest(ctx, comp, copyActionAbortConstant, copyID, options, leaseAccessConditions)
 	if err != nil {
 		return clientAbortCopyFromURLResponse{}, err
 	}
@@ -64,7 +63,7 @@ func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyAct
 }
 
 // abortCopyFromURLCreateRequest creates the AbortCopyFromURL request.
-func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, clientAbortCopyFromURLOptions *clientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *clientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -72,8 +71,8 @@ func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp En
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("copyid", copyID)
-	if clientAbortCopyFromURLOptions != nil && clientAbortCopyFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientAbortCopyFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-copy-action", string(copyActionAbortConstant))
@@ -81,8 +80,8 @@ func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp En
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientAbortCopyFromURLOptions != nil && clientAbortCopyFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientAbortCopyFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -112,10 +111,10 @@ func (client *client) abortCopyFromURLHandleResponse(resp *http.Response) (clien
 
 // AcquireLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientAcquireLeaseOptions - clientAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
+// options - clientAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) AcquireLease(ctx context.Context, comp Enum16, clientAcquireLeaseOptions *clientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientAcquireLeaseResponse, error) {
-	req, err := client.acquireLeaseCreateRequest(ctx, comp, clientAcquireLeaseOptions, modifiedAccessConditions)
+func (client *client) AcquireLease(ctx context.Context, comp Enum16, options *clientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientAcquireLeaseResponse, error) {
+	req, err := client.acquireLeaseCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return clientAcquireLeaseResponse{}, err
 	}
@@ -130,23 +129,23 @@ func (client *client) AcquireLease(ctx context.Context, comp Enum16, clientAcqui
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, clientAcquireLeaseOptions *clientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, options *clientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientAcquireLeaseOptions != nil && clientAcquireLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientAcquireLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "acquire")
-	if clientAcquireLeaseOptions != nil && clientAcquireLeaseOptions.Duration != nil {
-		req.Raw().Header.Set("x-ms-lease-duration", strconv.FormatInt(int64(*clientAcquireLeaseOptions.Duration), 10))
+	if options != nil && options.Duration != nil {
+		req.Raw().Header.Set("x-ms-lease-duration", strconv.FormatInt(int64(*options.Duration), 10))
 	}
-	if clientAcquireLeaseOptions != nil && clientAcquireLeaseOptions.ProposedLeaseID != nil {
-		req.Raw().Header.Set("x-ms-proposed-lease-id", *clientAcquireLeaseOptions.ProposedLeaseID)
+	if options != nil && options.ProposedLeaseID != nil {
+		req.Raw().Header.Set("x-ms-proposed-lease-id", *options.ProposedLeaseID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -164,8 +163,8 @@ func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientAcquireLeaseOptions != nil && clientAcquireLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientAcquireLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -208,10 +207,10 @@ func (client *client) acquireLeaseHandleResponse(resp *http.Response) (clientAcq
 
 // BreakLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientBreakLeaseOptions - clientBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
+// options - clientBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) BreakLease(ctx context.Context, comp Enum16, clientBreakLeaseOptions *clientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientBreakLeaseResponse, error) {
-	req, err := client.breakLeaseCreateRequest(ctx, comp, clientBreakLeaseOptions, modifiedAccessConditions)
+func (client *client) BreakLease(ctx context.Context, comp Enum16, options *clientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientBreakLeaseResponse, error) {
+	req, err := client.breakLeaseCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return clientBreakLeaseResponse{}, err
 	}
@@ -226,20 +225,20 @@ func (client *client) BreakLease(ctx context.Context, comp Enum16, clientBreakLe
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, clientBreakLeaseOptions *clientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, options *clientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientBreakLeaseOptions != nil && clientBreakLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientBreakLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "break")
-	if clientBreakLeaseOptions != nil && clientBreakLeaseOptions.BreakPeriod != nil {
-		req.Raw().Header.Set("x-ms-lease-break-period", strconv.FormatInt(int64(*clientBreakLeaseOptions.BreakPeriod), 10))
+	if options != nil && options.BreakPeriod != nil {
+		req.Raw().Header.Set("x-ms-lease-break-period", strconv.FormatInt(int64(*options.BreakPeriod), 10))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -257,8 +256,8 @@ func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, 
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientBreakLeaseOptions != nil && clientBreakLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientBreakLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -310,10 +309,10 @@ func (client *client) breakLeaseHandleResponse(resp *http.Response) (clientBreak
 // proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 // lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 // string formats.
-// clientChangeLeaseOptions - clientChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
+// options - clientChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, clientChangeLeaseOptions *clientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientChangeLeaseResponse, error) {
-	req, err := client.changeLeaseCreateRequest(ctx, comp, leaseID, proposedLeaseID, clientChangeLeaseOptions, modifiedAccessConditions)
+func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *clientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientChangeLeaseResponse, error) {
+	req, err := client.changeLeaseCreateRequest(ctx, comp, leaseID, proposedLeaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return clientChangeLeaseResponse{}, err
 	}
@@ -328,15 +327,15 @@ func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID stri
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, clientChangeLeaseOptions *clientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *clientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientChangeLeaseOptions != nil && clientChangeLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientChangeLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "change")
@@ -358,8 +357,8 @@ func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16,
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientChangeLeaseOptions != nil && clientChangeLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientChangeLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -406,13 +405,13 @@ func (client *client) changeLeaseHandleResponse(resp *http.Response) (clientChan
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// clientCopyFromURLOptions - clientCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
+// options - clientCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, clientCopyFromURLOptions *clientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientCopyFromURLResponse, error) {
-	req, err := client.copyFromURLCreateRequest(ctx, xmsRequiresSync, copySource, clientCopyFromURLOptions, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
+func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *clientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientCopyFromURLResponse, error) {
+	req, err := client.copyFromURLCreateRequest(ctx, xmsRequiresSync, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return clientCopyFromURLResponse{}, err
 	}
@@ -427,24 +426,24 @@ func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, c
 }
 
 // copyFromURLCreateRequest creates the CopyFromURL request.
-func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, clientCopyFromURLOptions *clientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *clientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientCopyFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-requires-sync", string(xmsRequiresSync))
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.Metadata != nil {
-		for k, v := range clientCopyFromURLOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*clientCopyFromURLOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
 	if sourceModifiedAccessConditions != nil && sourceModifiedAccessConditions.SourceIfModifiedSince != nil {
 		req.Raw().Header.Set("x-ms-source-if-modified-since", sourceModifiedAccessConditions.SourceIfModifiedSince.Format(time.RFC1123))
@@ -478,23 +477,23 @@ func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresS
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientCopyFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.SourceContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(clientCopyFromURLOptions.SourceContentMD5))
+	if options != nil && options.SourceContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(options.SourceContentMD5))
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *clientCopyFromURLOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", clientCopyFromURLOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*clientCopyFromURLOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if clientCopyFromURLOptions != nil && clientCopyFromURLOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*clientCopyFromURLOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -557,14 +556,13 @@ func (client *client) copyFromURLHandleResponse(resp *http.Response) (clientCopy
 
 // CreateSnapshot - The Create Snapshot operation creates a read-only snapshot of a blob
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientCreateSnapshotOptions - clientCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot
-// method.
+// options - clientCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, clientCreateSnapshotOptions *clientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientCreateSnapshotResponse, error) {
-	req, err := client.createSnapshotCreateRequest(ctx, comp, clientCreateSnapshotOptions, cpkInfo, cpkScopeInfo, modifiedAccessConditions, leaseAccessConditions)
+func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, options *clientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientCreateSnapshotResponse, error) {
+	req, err := client.createSnapshotCreateRequest(ctx, comp, options, cpkInfo, cpkScopeInfo, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return clientCreateSnapshotResponse{}, err
 	}
@@ -579,19 +577,19 @@ func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, clientCre
 }
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
-func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum28, clientCreateSnapshotOptions *clientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum28, options *clientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientCreateSnapshotOptions != nil && clientCreateSnapshotOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientCreateSnapshotOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if clientCreateSnapshotOptions != nil && clientCreateSnapshotOptions.Metadata != nil {
-		for k, v := range clientCreateSnapshotOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -626,8 +624,8 @@ func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientCreateSnapshotOptions != nil && clientCreateSnapshotOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientCreateSnapshotOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -690,11 +688,11 @@ func (client *client) createSnapshotHandleResponse(resp *http.Response) (clientC
 // All other operations on a soft-deleted blob or snapshot causes the service to
 // return an HTTP status code of 404 (ResourceNotFound).
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientDeleteOptions - clientDeleteOptions contains the optional parameters for the client.Delete method.
+// options - clientDeleteOptions contains the optional parameters for the client.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Delete(ctx context.Context, clientDeleteOptions *clientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientDeleteResponse, error) {
-	req, err := client.deleteCreateRequest(ctx, clientDeleteOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *client) Delete(ctx context.Context, options *clientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientDeleteResponse, error) {
+	req, err := client.deleteCreateRequest(ctx, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return clientDeleteResponse{}, err
 	}
@@ -709,30 +707,30 @@ func (client *client) Delete(ctx context.Context, clientDeleteOptions *clientDel
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *client) deleteCreateRequest(ctx context.Context, clientDeleteOptions *clientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) deleteCreateRequest(ctx context.Context, options *clientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientDeleteOptions != nil && clientDeleteOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientDeleteOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientDeleteOptions != nil && clientDeleteOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientDeleteOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
-	if clientDeleteOptions != nil && clientDeleteOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientDeleteOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if clientDeleteOptions != nil && clientDeleteOptions.BlobDeleteType != nil {
+	if options != nil && options.BlobDeleteType != nil {
 		reqQP.Set("deletetype", "Permanent")
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if clientDeleteOptions != nil && clientDeleteOptions.DeleteSnapshots != nil {
-		req.Raw().Header.Set("x-ms-delete-snapshots", string(*clientDeleteOptions.DeleteSnapshots))
+	if options != nil && options.DeleteSnapshots != nil {
+		req.Raw().Header.Set("x-ms-delete-snapshots", string(*options.DeleteSnapshots))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -750,8 +748,8 @@ func (client *client) deleteCreateRequest(ctx context.Context, clientDeleteOptio
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientDeleteOptions != nil && clientDeleteOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientDeleteOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -843,12 +841,12 @@ func (client *client) deleteImmutabilityPolicyHandleResponse(resp *http.Response
 // Download - The Download operation reads or downloads a blob from the system, including its metadata and properties. You
 // can also call Download to read a snapshot.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientDownloadOptions - clientDownloadOptions contains the optional parameters for the client.Download method.
+// options - clientDownloadOptions contains the optional parameters for the client.Download method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Download(ctx context.Context, clientDownloadOptions *clientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientDownloadResponse, error) {
-	req, err := client.downloadCreateRequest(ctx, clientDownloadOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
+func (client *client) Download(ctx context.Context, options *clientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientDownloadResponse, error) {
+	req, err := client.downloadCreateRequest(ctx, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return clientDownloadResponse{}, err
 	}
@@ -863,34 +861,34 @@ func (client *client) Download(ctx context.Context, clientDownloadOptions *clien
 }
 
 // downloadCreateRequest creates the Download request.
-func (client *client) downloadCreateRequest(ctx context.Context, clientDownloadOptions *clientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) downloadCreateRequest(ctx context.Context, options *clientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientDownloadOptions != nil && clientDownloadOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientDownloadOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientDownloadOptions != nil && clientDownloadOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientDownloadOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
-	if clientDownloadOptions != nil && clientDownloadOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientDownloadOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	runtime.SkipBodyDownload(req)
-	if clientDownloadOptions != nil && clientDownloadOptions.Range != nil {
-		req.Raw().Header.Set("x-ms-range", *clientDownloadOptions.Range)
+	if options != nil && options.Range != nil {
+		req.Raw().Header.Set("x-ms-range", *options.Range)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if clientDownloadOptions != nil && clientDownloadOptions.RangeGetContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-range-get-content-md5", strconv.FormatBool(*clientDownloadOptions.RangeGetContentMD5))
+	if options != nil && options.RangeGetContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-range-get-content-md5", strconv.FormatBool(*options.RangeGetContentMD5))
 	}
-	if clientDownloadOptions != nil && clientDownloadOptions.RangeGetContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-range-get-content-crc64", strconv.FormatBool(*clientDownloadOptions.RangeGetContentCRC64))
+	if options != nil && options.RangeGetContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-range-get-content-crc64", strconv.FormatBool(*options.RangeGetContentCRC64))
 	}
 	if cpkInfo != nil && cpkInfo.EncryptionKey != nil {
 		req.Raw().Header.Set("x-ms-encryption-key", *cpkInfo.EncryptionKey)
@@ -917,8 +915,8 @@ func (client *client) downloadCreateRequest(ctx context.Context, clientDownloadO
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientDownloadOptions != nil && clientDownloadOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientDownloadOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -1136,12 +1134,11 @@ func (client *client) downloadHandleResponse(resp *http.Response) (clientDownloa
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a blob.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientGetAccessControlOptions - clientGetAccessControlOptions contains the optional parameters for the client.GetAccessControl
-// method.
+// options - clientGetAccessControlOptions contains the optional parameters for the client.GetAccessControl method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) GetAccessControl(ctx context.Context, action Enum22, clientGetAccessControlOptions *clientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientGetAccessControlResponse, error) {
-	req, err := client.getAccessControlCreateRequest(ctx, action, clientGetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *client) GetAccessControl(ctx context.Context, action Enum22, options *clientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientGetAccessControlResponse, error) {
+	req, err := client.getAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return clientGetAccessControlResponse{}, err
 	}
@@ -1156,18 +1153,18 @@ func (client *client) GetAccessControl(ctx context.Context, action Enum22, clien
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
-func (client *client) getAccessControlCreateRequest(ctx context.Context, action Enum22, clientGetAccessControlOptions *clientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *clientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("action", string(action))
-	if clientGetAccessControlOptions != nil && clientGetAccessControlOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientGetAccessControlOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if clientGetAccessControlOptions != nil && clientGetAccessControlOptions.Upn != nil {
-		reqQP.Set("upn", strconv.FormatBool(*clientGetAccessControlOptions.Upn))
+	if options != nil && options.Upn != nil {
+		reqQP.Set("upn", strconv.FormatBool(*options.Upn))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -1185,8 +1182,8 @@ func (client *client) getAccessControlCreateRequest(ctx context.Context, action 
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
-	if clientGetAccessControlOptions != nil && clientGetAccessControlOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientGetAccessControlOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
 	req.Raw().Header.Set("Accept", "application/xml")
@@ -1298,12 +1295,12 @@ func (client *client) getAccountInfoHandleResponse(resp *http.Response) (clientG
 // GetProperties - The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties
 // for the blob. It does not return the content of the blob.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientGetPropertiesOptions - clientGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
+// options - clientGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) GetProperties(ctx context.Context, clientGetPropertiesOptions *clientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientGetPropertiesResponse, error) {
-	req, err := client.getPropertiesCreateRequest(ctx, clientGetPropertiesOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
+func (client *client) GetProperties(ctx context.Context, options *clientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientGetPropertiesResponse, error) {
+	req, err := client.getPropertiesCreateRequest(ctx, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return clientGetPropertiesResponse{}, err
 	}
@@ -1318,20 +1315,20 @@ func (client *client) GetProperties(ctx context.Context, clientGetPropertiesOpti
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *client) getPropertiesCreateRequest(ctx context.Context, clientGetPropertiesOptions *clientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) getPropertiesCreateRequest(ctx context.Context, options *clientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientGetPropertiesOptions != nil && clientGetPropertiesOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientGetPropertiesOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientGetPropertiesOptions != nil && clientGetPropertiesOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientGetPropertiesOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
-	if clientGetPropertiesOptions != nil && clientGetPropertiesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientGetPropertiesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -1362,8 +1359,8 @@ func (client *client) getPropertiesCreateRequest(ctx context.Context, clientGetP
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientGetPropertiesOptions != nil && clientGetPropertiesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientGetPropertiesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -1611,11 +1608,11 @@ func (client *client) getPropertiesHandleResponse(resp *http.Response) (clientGe
 
 // GetTags - The Get Tags operation enables users to get the tags associated with a blob.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientGetTagsOptions - clientGetTagsOptions contains the optional parameters for the client.GetTags method.
+// options - clientGetTagsOptions contains the optional parameters for the client.GetTags method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) GetTags(ctx context.Context, comp Enum42, clientGetTagsOptions *clientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientGetTagsResponse, error) {
-	req, err := client.getTagsCreateRequest(ctx, comp, clientGetTagsOptions, modifiedAccessConditions, leaseAccessConditions)
+func (client *client) GetTags(ctx context.Context, comp Enum42, options *clientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientGetTagsResponse, error) {
+	req, err := client.getTagsCreateRequest(ctx, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return clientGetTagsResponse{}, err
 	}
@@ -1630,26 +1627,26 @@ func (client *client) GetTags(ctx context.Context, comp Enum42, clientGetTagsOpt
 }
 
 // getTagsCreateRequest creates the GetTags request.
-func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, clientGetTagsOptions *clientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, options *clientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientGetTagsOptions != nil && clientGetTagsOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientGetTagsOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if clientGetTagsOptions != nil && clientGetTagsOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientGetTagsOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientGetTagsOptions != nil && clientGetTagsOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientGetTagsOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientGetTagsOptions != nil && clientGetTagsOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientGetTagsOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfTags != nil {
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
@@ -1688,12 +1685,12 @@ func (client *client) getTagsHandleResponse(resp *http.Response) (clientGetTagsR
 
 // Query - The Query operation enables users to select/project on blob data by providing simple query expressions.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientQueryOptions - clientQueryOptions contains the optional parameters for the client.Query method.
+// options - clientQueryOptions contains the optional parameters for the client.Query method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Query(ctx context.Context, comp Enum40, clientQueryOptions *clientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientQueryResponse, error) {
-	req, err := client.queryCreateRequest(ctx, comp, clientQueryOptions, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
+func (client *client) Query(ctx context.Context, comp Enum40, options *clientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientQueryResponse, error) {
+	req, err := client.queryCreateRequest(ctx, comp, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return clientQueryResponse{}, err
 	}
@@ -1708,18 +1705,18 @@ func (client *client) Query(ctx context.Context, comp Enum40, clientQueryOptions
 }
 
 // queryCreateRequest creates the Query request.
-func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, clientQueryOptions *clientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, options *clientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientQueryOptions != nil && clientQueryOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientQueryOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientQueryOptions != nil && clientQueryOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientQueryOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	runtime.SkipBodyDownload(req)
@@ -1751,12 +1748,12 @@ func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, clien
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientQueryOptions != nil && clientQueryOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientQueryOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
-	if clientQueryOptions != nil && clientQueryOptions.QueryRequest != nil {
-		return req, runtime.MarshalAsXML(req, *clientQueryOptions.QueryRequest)
+	if options != nil && options.QueryRequest != nil {
+		return req, runtime.MarshalAsXML(req, *options.QueryRequest)
 	}
 	return req, nil
 }
@@ -1915,10 +1912,10 @@ func (client *client) queryHandleResponse(resp *http.Response) (clientQueryRespo
 // ReleaseLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 // leaseID - Specifies the current lease ID on the resource.
-// clientReleaseLeaseOptions - clientReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
+// options - clientReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, clientReleaseLeaseOptions *clientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientReleaseLeaseResponse, error) {
-	req, err := client.releaseLeaseCreateRequest(ctx, comp, leaseID, clientReleaseLeaseOptions, modifiedAccessConditions)
+func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, options *clientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientReleaseLeaseResponse, error) {
+	req, err := client.releaseLeaseCreateRequest(ctx, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return clientReleaseLeaseResponse{}, err
 	}
@@ -1933,15 +1930,15 @@ func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID str
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, clientReleaseLeaseOptions *clientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *clientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientReleaseLeaseOptions != nil && clientReleaseLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientReleaseLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "release")
@@ -1962,8 +1959,8 @@ func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientReleaseLeaseOptions != nil && clientReleaseLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientReleaseLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2010,14 +2007,14 @@ func (client *client) releaseLeaseHandleResponse(resp *http.Response) (clientRel
 // renameSource - The file or directory to be renamed. The value must have the following format: "/{filesysystem}/{path}".
 // If "x-ms-properties" is specified, the properties will overwrite the existing properties;
 // otherwise, the existing properties will be preserved.
-// clientRenameOptions - clientRenameOptions contains the optional parameters for the client.Rename method.
+// options - clientRenameOptions contains the optional parameters for the client.Rename method.
 // DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *client) Rename(ctx context.Context, renameSource string, clientRenameOptions *clientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (clientRenameResponse, error) {
-	req, err := client.renameCreateRequest(ctx, renameSource, clientRenameOptions, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
+func (client *client) Rename(ctx context.Context, renameSource string, options *clientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (clientRenameResponse, error) {
+	req, err := client.renameCreateRequest(ctx, renameSource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return clientRenameResponse{}, err
 	}
@@ -2032,28 +2029,28 @@ func (client *client) Rename(ctx context.Context, renameSource string, clientRen
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *client) renameCreateRequest(ctx context.Context, renameSource string, clientRenameOptions *clientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) renameCreateRequest(ctx context.Context, renameSource string, options *clientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientRenameOptions != nil && clientRenameOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientRenameOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	if client.pathRenameMode != nil {
 		reqQP.Set("mode", string(*client.pathRenameMode))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-rename-source", renameSource)
-	if clientRenameOptions != nil && clientRenameOptions.DirectoryProperties != nil {
-		req.Raw().Header.Set("x-ms-properties", *clientRenameOptions.DirectoryProperties)
+	if options != nil && options.DirectoryProperties != nil {
+		req.Raw().Header.Set("x-ms-properties", *options.DirectoryProperties)
 	}
-	if clientRenameOptions != nil && clientRenameOptions.PosixPermissions != nil {
-		req.Raw().Header.Set("x-ms-permissions", *clientRenameOptions.PosixPermissions)
+	if options != nil && options.PosixPermissions != nil {
+		req.Raw().Header.Set("x-ms-permissions", *options.PosixPermissions)
 	}
-	if clientRenameOptions != nil && clientRenameOptions.PosixUmask != nil {
-		req.Raw().Header.Set("x-ms-umask", *clientRenameOptions.PosixUmask)
+	if options != nil && options.PosixUmask != nil {
+		req.Raw().Header.Set("x-ms-umask", *options.PosixUmask)
 	}
 	if directoryHTTPHeaders != nil && directoryHTTPHeaders.CacheControl != nil {
 		req.Raw().Header.Set("x-ms-cache-control", *directoryHTTPHeaders.CacheControl)
@@ -2073,8 +2070,8 @@ func (client *client) renameCreateRequest(ctx context.Context, renameSource stri
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if clientRenameOptions != nil && clientRenameOptions.SourceLeaseID != nil {
-		req.Raw().Header.Set("x-ms-source-lease-id", *clientRenameOptions.SourceLeaseID)
+	if options != nil && options.SourceLeaseID != nil {
+		req.Raw().Header.Set("x-ms-source-lease-id", *options.SourceLeaseID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -2101,8 +2098,8 @@ func (client *client) renameCreateRequest(ctx context.Context, renameSource stri
 		req.Raw().Header.Set("x-ms-source-if-none-match", *sourceModifiedAccessConditions.SourceIfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientRenameOptions != nil && clientRenameOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientRenameOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2150,10 +2147,10 @@ func (client *client) renameHandleResponse(resp *http.Response) (clientRenameRes
 // RenewLease - [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
 // If the operation fails it returns an *azcore.ResponseError type.
 // leaseID - Specifies the current lease ID on the resource.
-// clientRenewLeaseOptions - clientRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
+// options - clientRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID string, clientRenewLeaseOptions *clientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientRenewLeaseResponse, error) {
-	req, err := client.renewLeaseCreateRequest(ctx, comp, leaseID, clientRenewLeaseOptions, modifiedAccessConditions)
+func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID string, options *clientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientRenewLeaseResponse, error) {
+	req, err := client.renewLeaseCreateRequest(ctx, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return clientRenewLeaseResponse{}, err
 	}
@@ -2168,15 +2165,15 @@ func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID strin
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, clientRenewLeaseOptions *clientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *clientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientRenewLeaseOptions != nil && clientRenewLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientRenewLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "renew")
@@ -2197,8 +2194,8 @@ func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, 
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientRenewLeaseOptions != nil && clientRenewLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientRenewLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2241,12 +2238,11 @@ func (client *client) renewLeaseHandleResponse(resp *http.Response) (clientRenew
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a blob.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientSetAccessControlOptions - clientSetAccessControlOptions contains the optional parameters for the client.SetAccessControl
-// method.
+// options - clientSetAccessControlOptions contains the optional parameters for the client.SetAccessControl method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetAccessControl(ctx context.Context, action Enum21, clientSetAccessControlOptions *clientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetAccessControlResponse, error) {
-	req, err := client.setAccessControlCreateRequest(ctx, action, clientSetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *client) SetAccessControl(ctx context.Context, action Enum21, options *clientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetAccessControlResponse, error) {
+	req, err := client.setAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return clientSetAccessControlResponse{}, err
 	}
@@ -2261,31 +2257,31 @@ func (client *client) SetAccessControl(ctx context.Context, action Enum21, clien
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
-func (client *client) setAccessControlCreateRequest(ctx context.Context, action Enum21, clientSetAccessControlOptions *clientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *clientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("action", string(action))
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetAccessControlOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.Owner != nil {
-		req.Raw().Header.Set("x-ms-owner", *clientSetAccessControlOptions.Owner)
+	if options != nil && options.Owner != nil {
+		req.Raw().Header.Set("x-ms-owner", *options.Owner)
 	}
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.Group != nil {
-		req.Raw().Header.Set("x-ms-group", *clientSetAccessControlOptions.Group)
+	if options != nil && options.Group != nil {
+		req.Raw().Header.Set("x-ms-group", *options.Group)
 	}
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.PosixPermissions != nil {
-		req.Raw().Header.Set("x-ms-permissions", *clientSetAccessControlOptions.PosixPermissions)
+	if options != nil && options.PosixPermissions != nil {
+		req.Raw().Header.Set("x-ms-permissions", *options.PosixPermissions)
 	}
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.PosixACL != nil {
-		req.Raw().Header.Set("x-ms-acl", *clientSetAccessControlOptions.PosixACL)
+	if options != nil && options.PosixACL != nil {
+		req.Raw().Header.Set("x-ms-acl", *options.PosixACL)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfMatch != nil {
 		req.Raw().Header.Set("If-Match", *modifiedAccessConditions.IfMatch)
@@ -2299,8 +2295,8 @@ func (client *client) setAccessControlCreateRequest(ctx context.Context, action 
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
-	if clientSetAccessControlOptions != nil && clientSetAccessControlOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetAccessControlOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
 	req.Raw().Header.Set("Accept", "application/xml")
@@ -2413,13 +2409,12 @@ func (client *client) setExpiryHandleResponse(resp *http.Response) (clientSetExp
 
 // SetHTTPHeaders - The Set HTTP Headers operation sets system properties on the blob
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientSetHTTPHeadersOptions - clientSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders
-// method.
+// options - clientSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, clientSetHTTPHeadersOptions *clientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetHTTPHeadersResponse, error) {
-	req, err := client.setHTTPHeadersCreateRequest(ctx, comp, clientSetHTTPHeadersOptions, blobHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
+func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, options *clientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetHTTPHeadersResponse, error) {
+	req, err := client.setHTTPHeadersCreateRequest(ctx, comp, options, blobHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return clientSetHTTPHeadersResponse{}, err
 	}
@@ -2434,15 +2429,15 @@ func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, clientSetH
 }
 
 // setHTTPHeadersCreateRequest creates the SetHTTPHeaders request.
-func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, clientSetHTTPHeadersOptions *clientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, options *clientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientSetHTTPHeadersOptions != nil && clientSetHTTPHeadersOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetHTTPHeadersOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
@@ -2482,8 +2477,8 @@ func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum
 		req.Raw().Header.Set("x-ms-blob-content-disposition", *blobHTTPHeaders.BlobContentDisposition)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientSetHTTPHeadersOptions != nil && clientSetHTTPHeadersOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetHTTPHeadersOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2530,11 +2525,10 @@ func (client *client) setHTTPHeadersHandleResponse(resp *http.Response) (clientS
 
 // SetImmutabilityPolicy - The Set Immutability Policy operation sets the immutability policy on the blob
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientSetImmutabilityPolicyOptions - clientSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy
-// method.
+// options - clientSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, clientSetImmutabilityPolicyOptions *clientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetImmutabilityPolicyResponse, error) {
-	req, err := client.setImmutabilityPolicyCreateRequest(ctx, comp, clientSetImmutabilityPolicyOptions, modifiedAccessConditions)
+func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, options *clientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetImmutabilityPolicyResponse, error) {
+	req, err := client.setImmutabilityPolicyCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return clientSetImmutabilityPolicyResponse{}, err
 	}
@@ -2549,29 +2543,29 @@ func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, cl
 }
 
 // setImmutabilityPolicyCreateRequest creates the SetImmutabilityPolicy request.
-func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, clientSetImmutabilityPolicyOptions *clientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *clientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientSetImmutabilityPolicyOptions != nil && clientSetImmutabilityPolicyOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetImmutabilityPolicyOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientSetImmutabilityPolicyOptions != nil && clientSetImmutabilityPolicyOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetImmutabilityPolicyOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
-	if clientSetImmutabilityPolicyOptions != nil && clientSetImmutabilityPolicyOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", clientSetImmutabilityPolicyOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if clientSetImmutabilityPolicyOptions != nil && clientSetImmutabilityPolicyOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*clientSetImmutabilityPolicyOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2681,13 +2675,13 @@ func (client *client) setLegalHoldHandleResponse(resp *http.Response) (clientSet
 // SetMetadata - The Set Blob Metadata operation sets user-defined metadata for the specified blob as one or more name-value
 // pairs
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientSetMetadataOptions - clientSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
+// options - clientSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetMetadata(ctx context.Context, comp Enum12, clientSetMetadataOptions *clientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientSetMetadataResponse, error) {
-	req, err := client.setMetadataCreateRequest(ctx, comp, clientSetMetadataOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *client) SetMetadata(ctx context.Context, comp Enum12, options *clientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (clientSetMetadataResponse, error) {
+	req, err := client.setMetadataCreateRequest(ctx, comp, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return clientSetMetadataResponse{}, err
 	}
@@ -2702,19 +2696,19 @@ func (client *client) SetMetadata(ctx context.Context, comp Enum12, clientSetMet
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12, clientSetMetadataOptions *clientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12, options *clientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientSetMetadataOptions != nil && clientSetMetadataOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetMetadataOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if clientSetMetadataOptions != nil && clientSetMetadataOptions.Metadata != nil {
-		for k, v := range clientSetMetadataOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -2749,8 +2743,8 @@ func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12,
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientSetMetadataOptions != nil && clientSetMetadataOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetMetadataOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -2806,11 +2800,11 @@ func (client *client) setMetadataHandleResponse(resp *http.Response) (clientSetM
 
 // SetTags - The Set Tags operation enables users to set tags on a blob.
 // If the operation fails it returns an *azcore.ResponseError type.
-// clientSetTagsOptions - clientSetTagsOptions contains the optional parameters for the client.SetTags method.
+// options - clientSetTagsOptions contains the optional parameters for the client.SetTags method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) SetTags(ctx context.Context, comp Enum42, clientSetTagsOptions *clientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientSetTagsResponse, error) {
-	req, err := client.setTagsCreateRequest(ctx, comp, clientSetTagsOptions, modifiedAccessConditions, leaseAccessConditions)
+func (client *client) SetTags(ctx context.Context, comp Enum42, options *clientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientSetTagsResponse, error) {
+	req, err := client.setTagsCreateRequest(ctx, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return clientSetTagsResponse{}, err
 	}
@@ -2825,29 +2819,29 @@ func (client *client) SetTags(ctx context.Context, comp Enum42, clientSetTagsOpt
 }
 
 // setTagsCreateRequest creates the SetTags request.
-func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, clientSetTagsOptions *clientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, options *clientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientSetTagsOptions != nil && clientSetTagsOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetTagsOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if clientSetTagsOptions != nil && clientSetTagsOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientSetTagsOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientSetTagsOptions != nil && clientSetTagsOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(clientSetTagsOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
-	if clientSetTagsOptions != nil && clientSetTagsOptions.TransactionalContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(clientSetTagsOptions.TransactionalContentCRC64))
+	if options != nil && options.TransactionalContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(options.TransactionalContentCRC64))
 	}
-	if clientSetTagsOptions != nil && clientSetTagsOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetTagsOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfTags != nil {
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
@@ -2856,8 +2850,8 @@ func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, cli
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
-	if clientSetTagsOptions != nil && clientSetTagsOptions.Tags != nil {
-		return req, runtime.MarshalAsXML(req, *clientSetTagsOptions.Tags)
+	if options != nil && options.Tags != nil {
+		return req, runtime.MarshalAsXML(req, *options.Tags)
 	}
 	return req, nil
 }
@@ -2890,11 +2884,11 @@ func (client *client) setTagsHandleResponse(resp *http.Response) (clientSetTagsR
 // storage type. This operation does not update the blob's ETag.
 // If the operation fails it returns an *azcore.ResponseError type.
 // tier - Indicates the tier to be set on the blob.
-// clientSetTierOptions - clientSetTierOptions contains the optional parameters for the client.SetTier method.
+// options - clientSetTierOptions contains the optional parameters for the client.SetTier method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier, clientSetTierOptions *clientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetTierResponse, error) {
-	req, err := client.setTierCreateRequest(ctx, comp, tier, clientSetTierOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier, options *clientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (clientSetTierResponse, error) {
+	req, err := client.setTierCreateRequest(ctx, comp, tier, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return clientSetTierResponse{}, err
 	}
@@ -2909,30 +2903,30 @@ func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier,
 }
 
 // setTierCreateRequest creates the SetTier request.
-func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, clientSetTierOptions *clientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, options *clientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if clientSetTierOptions != nil && clientSetTierOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *clientSetTierOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if clientSetTierOptions != nil && clientSetTierOptions.VersionID != nil {
-		reqQP.Set("versionid", *clientSetTierOptions.VersionID)
+	if options != nil && options.VersionID != nil {
+		reqQP.Set("versionid", *options.VersionID)
 	}
-	if clientSetTierOptions != nil && clientSetTierOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientSetTierOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-access-tier", string(tier))
-	if clientSetTierOptions != nil && clientSetTierOptions.RehydratePriority != nil {
-		req.Raw().Header.Set("x-ms-rehydrate-priority", string(*clientSetTierOptions.RehydratePriority))
+	if options != nil && options.RehydratePriority != nil {
+		req.Raw().Header.Set("x-ms-rehydrate-priority", string(*options.RehydratePriority))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientSetTierOptions != nil && clientSetTierOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientSetTierOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -2964,14 +2958,13 @@ func (client *client) setTierHandleResponse(resp *http.Response) (clientSetTierR
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// clientStartCopyFromURLOptions - clientStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL
-// method.
+// options - clientStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) StartCopyFromURL(ctx context.Context, copySource string, clientStartCopyFromURLOptions *clientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientStartCopyFromURLResponse, error) {
-	req, err := client.startCopyFromURLCreateRequest(ctx, copySource, clientStartCopyFromURLOptions, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
+func (client *client) StartCopyFromURL(ctx context.Context, copySource string, options *clientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (clientStartCopyFromURLResponse, error) {
+	req, err := client.startCopyFromURLCreateRequest(ctx, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return clientStartCopyFromURLResponse{}, err
 	}
@@ -2986,26 +2979,26 @@ func (client *client) StartCopyFromURL(ctx context.Context, copySource string, c
 }
 
 // startCopyFromURLCreateRequest creates the StartCopyFromURL request.
-func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySource string, clientStartCopyFromURLOptions *clientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySource string, options *clientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*clientStartCopyFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.Metadata != nil {
-		for k, v := range clientStartCopyFromURLOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*clientStartCopyFromURLOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.RehydratePriority != nil {
-		req.Raw().Header.Set("x-ms-rehydrate-priority", string(*clientStartCopyFromURLOptions.RehydratePriority))
+	if options != nil && options.RehydratePriority != nil {
+		req.Raw().Header.Set("x-ms-rehydrate-priority", string(*options.RehydratePriority))
 	}
 	if sourceModifiedAccessConditions != nil && sourceModifiedAccessConditions.SourceIfModifiedSince != nil {
 		req.Raw().Header.Set("x-ms-source-if-modified-since", sourceModifiedAccessConditions.SourceIfModifiedSince.Format(time.RFC1123))
@@ -3042,23 +3035,23 @@ func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySou
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *clientStartCopyFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *clientStartCopyFromURLOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.SealBlob != nil {
-		req.Raw().Header.Set("x-ms-seal-blob", strconv.FormatBool(*clientStartCopyFromURLOptions.SealBlob))
+	if options != nil && options.SealBlob != nil {
+		req.Raw().Header.Set("x-ms-seal-blob", strconv.FormatBool(*options.SealBlob))
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", clientStartCopyFromURLOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*clientStartCopyFromURLOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if clientStartCopyFromURLOptions != nil && clientStartCopyFromURLOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*clientStartCopyFromURLOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil

--- a/test/storage/2020-06-12/azblob/zz_generated_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_container_client.go
@@ -43,11 +43,10 @@ func newContainerClient(endpoint string, version Enum2, pl runtime.Pipeline) *co
 // AcquireLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15
 // to 60 seconds, or can be infinite
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientAcquireLeaseOptions - containerClientAcquireLeaseOptions contains the optional parameters for the containerClient.AcquireLease
-// method.
+// options - containerClientAcquireLeaseOptions contains the optional parameters for the containerClient.AcquireLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) AcquireLease(ctx context.Context, comp Enum16, restype Enum11, containerClientAcquireLeaseOptions *containerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientAcquireLeaseResponse, error) {
-	req, err := client.acquireLeaseCreateRequest(ctx, comp, restype, containerClientAcquireLeaseOptions, modifiedAccessConditions)
+func (client *containerClient) AcquireLease(ctx context.Context, comp Enum16, restype Enum11, options *containerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientAcquireLeaseResponse, error) {
+	req, err := client.acquireLeaseCreateRequest(ctx, comp, restype, options, modifiedAccessConditions)
 	if err != nil {
 		return containerClientAcquireLeaseResponse{}, err
 	}
@@ -62,7 +61,7 @@ func (client *containerClient) AcquireLease(ctx context.Context, comp Enum16, re
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, containerClientAcquireLeaseOptions *containerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *containerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -70,16 +69,16 @@ func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, co
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("restype", string(restype))
-	if containerClientAcquireLeaseOptions != nil && containerClientAcquireLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientAcquireLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "acquire")
-	if containerClientAcquireLeaseOptions != nil && containerClientAcquireLeaseOptions.Duration != nil {
-		req.Raw().Header.Set("x-ms-lease-duration", strconv.FormatInt(int64(*containerClientAcquireLeaseOptions.Duration), 10))
+	if options != nil && options.Duration != nil {
+		req.Raw().Header.Set("x-ms-lease-duration", strconv.FormatInt(int64(*options.Duration), 10))
 	}
-	if containerClientAcquireLeaseOptions != nil && containerClientAcquireLeaseOptions.ProposedLeaseID != nil {
-		req.Raw().Header.Set("x-ms-proposed-lease-id", *containerClientAcquireLeaseOptions.ProposedLeaseID)
+	if options != nil && options.ProposedLeaseID != nil {
+		req.Raw().Header.Set("x-ms-proposed-lease-id", *options.ProposedLeaseID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -88,8 +87,8 @@ func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, co
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientAcquireLeaseOptions != nil && containerClientAcquireLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientAcquireLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -133,11 +132,10 @@ func (client *containerClient) acquireLeaseHandleResponse(resp *http.Response) (
 // BreakLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15
 // to 60 seconds, or can be infinite
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientBreakLeaseOptions - containerClientBreakLeaseOptions contains the optional parameters for the containerClient.BreakLease
-// method.
+// options - containerClientBreakLeaseOptions contains the optional parameters for the containerClient.BreakLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) BreakLease(ctx context.Context, comp Enum16, restype Enum11, containerClientBreakLeaseOptions *containerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientBreakLeaseResponse, error) {
-	req, err := client.breakLeaseCreateRequest(ctx, comp, restype, containerClientBreakLeaseOptions, modifiedAccessConditions)
+func (client *containerClient) BreakLease(ctx context.Context, comp Enum16, restype Enum11, options *containerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientBreakLeaseResponse, error) {
+	req, err := client.breakLeaseCreateRequest(ctx, comp, restype, options, modifiedAccessConditions)
 	if err != nil {
 		return containerClientBreakLeaseResponse{}, err
 	}
@@ -152,7 +150,7 @@ func (client *containerClient) BreakLease(ctx context.Context, comp Enum16, rest
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, containerClientBreakLeaseOptions *containerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *containerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -160,13 +158,13 @@ func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("restype", string(restype))
-	if containerClientBreakLeaseOptions != nil && containerClientBreakLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientBreakLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "break")
-	if containerClientBreakLeaseOptions != nil && containerClientBreakLeaseOptions.BreakPeriod != nil {
-		req.Raw().Header.Set("x-ms-lease-break-period", strconv.FormatInt(int64(*containerClientBreakLeaseOptions.BreakPeriod), 10))
+	if options != nil && options.BreakPeriod != nil {
+		req.Raw().Header.Set("x-ms-lease-break-period", strconv.FormatInt(int64(*options.BreakPeriod), 10))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -175,8 +173,8 @@ func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientBreakLeaseOptions != nil && containerClientBreakLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientBreakLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -229,11 +227,10 @@ func (client *containerClient) breakLeaseHandleResponse(resp *http.Response) (co
 // proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 // lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 // string formats.
-// containerClientChangeLeaseOptions - containerClientChangeLeaseOptions contains the optional parameters for the containerClient.ChangeLease
-// method.
+// options - containerClientChangeLeaseOptions contains the optional parameters for the containerClient.ChangeLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) ChangeLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, containerClientChangeLeaseOptions *containerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientChangeLeaseResponse, error) {
-	req, err := client.changeLeaseCreateRequest(ctx, comp, restype, leaseID, proposedLeaseID, containerClientChangeLeaseOptions, modifiedAccessConditions)
+func (client *containerClient) ChangeLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *containerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientChangeLeaseResponse, error) {
+	req, err := client.changeLeaseCreateRequest(ctx, comp, restype, leaseID, proposedLeaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return containerClientChangeLeaseResponse{}, err
 	}
@@ -248,7 +245,7 @@ func (client *containerClient) ChangeLease(ctx context.Context, comp Enum16, res
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, containerClientChangeLeaseOptions *containerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *containerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -256,8 +253,8 @@ func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, com
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("restype", string(restype))
-	if containerClientChangeLeaseOptions != nil && containerClientChangeLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientChangeLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "change")
@@ -270,8 +267,8 @@ func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, com
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientChangeLeaseOptions != nil && containerClientChangeLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientChangeLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -315,11 +312,10 @@ func (client *containerClient) changeLeaseHandleResponse(resp *http.Response) (c
 // Create - creates a new container under the specified account. If the container with the same name already exists, the operation
 // fails
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientCreateOptions - containerClientCreateOptions contains the optional parameters for the containerClient.Create
-// method.
+// options - containerClientCreateOptions contains the optional parameters for the containerClient.Create method.
 // ContainerCpkScopeInfo - ContainerCpkScopeInfo contains a group of parameters for the containerClient.Create method.
-func (client *containerClient) Create(ctx context.Context, restype Enum11, containerClientCreateOptions *containerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (containerClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, restype, containerClientCreateOptions, containerCpkScopeInfo)
+func (client *containerClient) Create(ctx context.Context, restype Enum11, options *containerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (containerClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, restype, options, containerCpkScopeInfo)
 	if err != nil {
 		return containerClientCreateResponse{}, err
 	}
@@ -334,28 +330,28 @@ func (client *containerClient) Create(ctx context.Context, restype Enum11, conta
 }
 
 // createCreateRequest creates the Create request.
-func (client *containerClient) createCreateRequest(ctx context.Context, restype Enum11, containerClientCreateOptions *containerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*policy.Request, error) {
+func (client *containerClient) createCreateRequest(ctx context.Context, restype Enum11, options *containerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
-	if containerClientCreateOptions != nil && containerClientCreateOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientCreateOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if containerClientCreateOptions != nil && containerClientCreateOptions.Metadata != nil {
-		for k, v := range containerClientCreateOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
-	if containerClientCreateOptions != nil && containerClientCreateOptions.Access != nil {
-		req.Raw().Header.Set("x-ms-blob-public-access", string(*containerClientCreateOptions.Access))
+	if options != nil && options.Access != nil {
+		req.Raw().Header.Set("x-ms-blob-public-access", string(*options.Access))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientCreateOptions != nil && containerClientCreateOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientCreateOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	if containerCpkScopeInfo != nil && containerCpkScopeInfo.DefaultEncryptionScope != nil {
 		req.Raw().Header.Set("x-ms-default-encryption-scope", *containerCpkScopeInfo.DefaultEncryptionScope)
@@ -402,12 +398,11 @@ func (client *containerClient) createHandleResponse(resp *http.Response) (contai
 // Delete - operation marks the specified container for deletion. The container and any blobs contained within it are later
 // deleted during garbage collection
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientDeleteOptions - containerClientDeleteOptions contains the optional parameters for the containerClient.Delete
-// method.
+// options - containerClientDeleteOptions contains the optional parameters for the containerClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) Delete(ctx context.Context, restype Enum11, containerClientDeleteOptions *containerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientDeleteResponse, error) {
-	req, err := client.deleteCreateRequest(ctx, restype, containerClientDeleteOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *containerClient) Delete(ctx context.Context, restype Enum11, options *containerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientDeleteResponse, error) {
+	req, err := client.deleteCreateRequest(ctx, restype, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return containerClientDeleteResponse{}, err
 	}
@@ -422,15 +417,15 @@ func (client *containerClient) Delete(ctx context.Context, restype Enum11, conta
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *containerClient) deleteCreateRequest(ctx context.Context, restype Enum11, containerClientDeleteOptions *containerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) deleteCreateRequest(ctx context.Context, restype Enum11, options *containerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
-	if containerClientDeleteOptions != nil && containerClientDeleteOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientDeleteOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -443,8 +438,8 @@ func (client *containerClient) deleteCreateRequest(ctx context.Context, restype 
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientDeleteOptions != nil && containerClientDeleteOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientDeleteOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -475,11 +470,11 @@ func (client *containerClient) deleteHandleResponse(resp *http.Response) (contai
 // GetAccessPolicy - gets the permissions for the specified container. The permissions indicate whether container data may
 // be accessed publicly.
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientGetAccessPolicyOptions - containerClientGetAccessPolicyOptions contains the optional parameters for the
-// containerClient.GetAccessPolicy method.
+// options - containerClientGetAccessPolicyOptions contains the optional parameters for the containerClient.GetAccessPolicy
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *containerClient) GetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, containerClientGetAccessPolicyOptions *containerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (containerClientGetAccessPolicyResponse, error) {
-	req, err := client.getAccessPolicyCreateRequest(ctx, restype, comp, containerClientGetAccessPolicyOptions, leaseAccessConditions)
+func (client *containerClient) GetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *containerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (containerClientGetAccessPolicyResponse, error) {
+	req, err := client.getAccessPolicyCreateRequest(ctx, restype, comp, options, leaseAccessConditions)
 	if err != nil {
 		return containerClientGetAccessPolicyResponse{}, err
 	}
@@ -494,7 +489,7 @@ func (client *containerClient) GetAccessPolicy(ctx context.Context, restype Enum
 }
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
-func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, containerClientGetAccessPolicyOptions *containerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *containerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -502,16 +497,16 @@ func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context,
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
 	reqQP.Set("comp", string(comp))
-	if containerClientGetAccessPolicyOptions != nil && containerClientGetAccessPolicyOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientGetAccessPolicyOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientGetAccessPolicyOptions != nil && containerClientGetAccessPolicyOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientGetAccessPolicyOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -620,11 +615,10 @@ func (client *containerClient) getAccountInfoHandleResponse(resp *http.Response)
 // GetProperties - returns all user-defined metadata and system properties for the specified container. The data returned
 // does not include the container's list of blobs
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientGetPropertiesOptions - containerClientGetPropertiesOptions contains the optional parameters for the containerClient.GetProperties
-// method.
+// options - containerClientGetPropertiesOptions contains the optional parameters for the containerClient.GetProperties method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *containerClient) GetProperties(ctx context.Context, restype Enum11, containerClientGetPropertiesOptions *containerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (containerClientGetPropertiesResponse, error) {
-	req, err := client.getPropertiesCreateRequest(ctx, restype, containerClientGetPropertiesOptions, leaseAccessConditions)
+func (client *containerClient) GetProperties(ctx context.Context, restype Enum11, options *containerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (containerClientGetPropertiesResponse, error) {
+	req, err := client.getPropertiesCreateRequest(ctx, restype, options, leaseAccessConditions)
 	if err != nil {
 		return containerClientGetPropertiesResponse{}, err
 	}
@@ -639,23 +633,23 @@ func (client *containerClient) GetProperties(ctx context.Context, restype Enum11
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, restype Enum11, containerClientGetPropertiesOptions *containerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, restype Enum11, options *containerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
-	if containerClientGetPropertiesOptions != nil && containerClientGetPropertiesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientGetPropertiesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientGetPropertiesOptions != nil && containerClientGetPropertiesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientGetPropertiesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -906,11 +900,10 @@ func (client *containerClient) listBlobHierarchySegmentHandleResponse(resp *http
 // to 60 seconds, or can be infinite
 // If the operation fails it returns an *azcore.ResponseError type.
 // leaseID - Specifies the current lease ID on the resource.
-// containerClientReleaseLeaseOptions - containerClientReleaseLeaseOptions contains the optional parameters for the containerClient.ReleaseLease
-// method.
+// options - containerClientReleaseLeaseOptions contains the optional parameters for the containerClient.ReleaseLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) ReleaseLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, containerClientReleaseLeaseOptions *containerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientReleaseLeaseResponse, error) {
-	req, err := client.releaseLeaseCreateRequest(ctx, comp, restype, leaseID, containerClientReleaseLeaseOptions, modifiedAccessConditions)
+func (client *containerClient) ReleaseLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *containerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientReleaseLeaseResponse, error) {
+	req, err := client.releaseLeaseCreateRequest(ctx, comp, restype, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return containerClientReleaseLeaseResponse{}, err
 	}
@@ -925,7 +918,7 @@ func (client *containerClient) ReleaseLease(ctx context.Context, comp Enum16, re
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, containerClientReleaseLeaseOptions *containerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *containerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -933,8 +926,8 @@ func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, co
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("restype", string(restype))
-	if containerClientReleaseLeaseOptions != nil && containerClientReleaseLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientReleaseLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "release")
@@ -946,8 +939,8 @@ func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, co
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientReleaseLeaseOptions != nil && containerClientReleaseLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientReleaseLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -1055,11 +1048,10 @@ func (client *containerClient) renameHandleResponse(resp *http.Response) (contai
 // to 60 seconds, or can be infinite
 // If the operation fails it returns an *azcore.ResponseError type.
 // leaseID - Specifies the current lease ID on the resource.
-// containerClientRenewLeaseOptions - containerClientRenewLeaseOptions contains the optional parameters for the containerClient.RenewLease
-// method.
+// options - containerClientRenewLeaseOptions contains the optional parameters for the containerClient.RenewLease method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) RenewLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, containerClientRenewLeaseOptions *containerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientRenewLeaseResponse, error) {
-	req, err := client.renewLeaseCreateRequest(ctx, comp, restype, leaseID, containerClientRenewLeaseOptions, modifiedAccessConditions)
+func (client *containerClient) RenewLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *containerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientRenewLeaseResponse, error) {
+	req, err := client.renewLeaseCreateRequest(ctx, comp, restype, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return containerClientRenewLeaseResponse{}, err
 	}
@@ -1074,7 +1066,7 @@ func (client *containerClient) RenewLease(ctx context.Context, comp Enum16, rest
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, containerClientRenewLeaseOptions *containerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *containerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1082,8 +1074,8 @@ func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
 	reqQP.Set("restype", string(restype))
-	if containerClientRenewLeaseOptions != nil && containerClientRenewLeaseOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientRenewLeaseOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-lease-action", "renew")
@@ -1095,8 +1087,8 @@ func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientRenewLeaseOptions != nil && containerClientRenewLeaseOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientRenewLeaseOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -1207,12 +1199,12 @@ func (client *containerClient) restoreHandleResponse(resp *http.Response) (conta
 // SetAccessPolicy - sets the permissions for the specified container. The permissions indicate whether blobs in a container
 // may be accessed publicly.
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientSetAccessPolicyOptions - containerClientSetAccessPolicyOptions contains the optional parameters for the
-// containerClient.SetAccessPolicy method.
+// options - containerClientSetAccessPolicyOptions contains the optional parameters for the containerClient.SetAccessPolicy
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) SetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, containerClientSetAccessPolicyOptions *containerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientSetAccessPolicyResponse, error) {
-	req, err := client.setAccessPolicyCreateRequest(ctx, restype, comp, containerClientSetAccessPolicyOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *containerClient) SetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *containerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientSetAccessPolicyResponse, error) {
+	req, err := client.setAccessPolicyCreateRequest(ctx, restype, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return containerClientSetAccessPolicyResponse{}, err
 	}
@@ -1227,7 +1219,7 @@ func (client *containerClient) SetAccessPolicy(ctx context.Context, restype Enum
 }
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
-func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, containerClientSetAccessPolicyOptions *containerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *containerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1235,15 +1227,15 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
 	reqQP.Set("comp", string(comp))
-	if containerClientSetAccessPolicyOptions != nil && containerClientSetAccessPolicyOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientSetAccessPolicyOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if containerClientSetAccessPolicyOptions != nil && containerClientSetAccessPolicyOptions.Access != nil {
-		req.Raw().Header.Set("x-ms-blob-public-access", string(*containerClientSetAccessPolicyOptions.Access))
+	if options != nil && options.Access != nil {
+		req.Raw().Header.Set("x-ms-blob-public-access", string(*options.Access))
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -1252,16 +1244,16 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientSetAccessPolicyOptions != nil && containerClientSetAccessPolicyOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientSetAccessPolicyOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	type wrapper struct {
 		XMLName      xml.Name             `xml:"SignedIdentifiers"`
 		ContainerACL *[]*SignedIdentifier `xml:"SignedIdentifier"`
 	}
-	if containerClientSetAccessPolicyOptions != nil && containerClientSetAccessPolicyOptions.ContainerACL != nil {
-		return req, runtime.MarshalAsXML(req, wrapper{ContainerACL: &containerClientSetAccessPolicyOptions.ContainerACL})
+	if options != nil && options.ContainerACL != nil {
+		return req, runtime.MarshalAsXML(req, wrapper{ContainerACL: &options.ContainerACL})
 	}
 	return req, nil
 }
@@ -1300,12 +1292,11 @@ func (client *containerClient) setAccessPolicyHandleResponse(resp *http.Response
 
 // SetMetadata - operation sets one or more user-defined name-value pairs for the specified container.
 // If the operation fails it returns an *azcore.ResponseError type.
-// containerClientSetMetadataOptions - containerClientSetMetadataOptions contains the optional parameters for the containerClient.SetMetadata
-// method.
+// options - containerClientSetMetadataOptions contains the optional parameters for the containerClient.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) SetMetadata(ctx context.Context, restype Enum11, comp Enum12, containerClientSetMetadataOptions *containerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientSetMetadataResponse, error) {
-	req, err := client.setMetadataCreateRequest(ctx, restype, comp, containerClientSetMetadataOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *containerClient) SetMetadata(ctx context.Context, restype Enum11, comp Enum12, options *containerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (containerClientSetMetadataResponse, error) {
+	req, err := client.setMetadataCreateRequest(ctx, restype, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return containerClientSetMetadataResponse{}, err
 	}
@@ -1320,7 +1311,7 @@ func (client *containerClient) SetMetadata(ctx context.Context, restype Enum11, 
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *containerClient) setMetadataCreateRequest(ctx context.Context, restype Enum11, comp Enum12, containerClientSetMetadataOptions *containerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *containerClient) setMetadataCreateRequest(ctx context.Context, restype Enum11, comp Enum12, options *containerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1328,15 +1319,15 @@ func (client *containerClient) setMetadataCreateRequest(ctx context.Context, res
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("restype", string(restype))
 	reqQP.Set("comp", string(comp))
-	if containerClientSetMetadataOptions != nil && containerClientSetMetadataOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*containerClientSetMetadataOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if containerClientSetMetadataOptions != nil && containerClientSetMetadataOptions.Metadata != nil {
-		for k, v := range containerClientSetMetadataOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -1344,8 +1335,8 @@ func (client *containerClient) setMetadataCreateRequest(ctx context.Context, res
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if containerClientSetMetadataOptions != nil && containerClientSetMetadataOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *containerClientSetMetadataOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil

--- a/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_directory_client.go
@@ -45,13 +45,12 @@ func newDirectoryClient(endpoint string, version Enum2, pathRenameMode *PathRena
 // To
 // fail if the destination already exists, use a conditional request with If-None-Match: "*".
 // If the operation fails it returns an *azcore.ResponseError type.
-// directoryClientCreateOptions - directoryClientCreateOptions contains the optional parameters for the directoryClient.Create
-// method.
+// options - directoryClientCreateOptions contains the optional parameters for the directoryClient.Create method.
 // DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) Create(ctx context.Context, resource Enum20, directoryClientCreateOptions *directoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, resource, directoryClientCreateOptions, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
+func (client *directoryClient) Create(ctx context.Context, resource Enum20, options *directoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, resource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return directoryClientCreateResponse{}, err
 	}
@@ -66,25 +65,25 @@ func (client *directoryClient) Create(ctx context.Context, resource Enum20, dire
 }
 
 // createCreateRequest creates the Create request.
-func (client *directoryClient) createCreateRequest(ctx context.Context, resource Enum20, directoryClientCreateOptions *directoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *directoryClient) createCreateRequest(ctx context.Context, resource Enum20, options *directoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("resource", string(resource))
-	if directoryClientCreateOptions != nil && directoryClientCreateOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*directoryClientCreateOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if directoryClientCreateOptions != nil && directoryClientCreateOptions.DirectoryProperties != nil {
-		req.Raw().Header.Set("x-ms-properties", *directoryClientCreateOptions.DirectoryProperties)
+	if options != nil && options.DirectoryProperties != nil {
+		req.Raw().Header.Set("x-ms-properties", *options.DirectoryProperties)
 	}
-	if directoryClientCreateOptions != nil && directoryClientCreateOptions.PosixPermissions != nil {
-		req.Raw().Header.Set("x-ms-permissions", *directoryClientCreateOptions.PosixPermissions)
+	if options != nil && options.PosixPermissions != nil {
+		req.Raw().Header.Set("x-ms-permissions", *options.PosixPermissions)
 	}
-	if directoryClientCreateOptions != nil && directoryClientCreateOptions.PosixUmask != nil {
-		req.Raw().Header.Set("x-ms-umask", *directoryClientCreateOptions.PosixUmask)
+	if options != nil && options.PosixUmask != nil {
+		req.Raw().Header.Set("x-ms-umask", *options.PosixUmask)
 	}
 	if directoryHTTPHeaders != nil && directoryHTTPHeaders.CacheControl != nil {
 		req.Raw().Header.Set("x-ms-cache-control", *directoryHTTPHeaders.CacheControl)
@@ -117,8 +116,8 @@ func (client *directoryClient) createCreateRequest(ctx context.Context, resource
 		req.Raw().Header.Set("If-None-Match", *modifiedAccessConditions.IfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if directoryClientCreateOptions != nil && directoryClientCreateOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *directoryClientCreateOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -167,12 +166,11 @@ func (client *directoryClient) createHandleResponse(resp *http.Response) (direct
 // If the operation fails it returns an *azcore.ResponseError type.
 // recursiveDirectoryDelete - If "true", all paths beneath the directory will be deleted. If "false" and the directory is
 // non-empty, an error occurs.
-// directoryClientDeleteOptions - directoryClientDeleteOptions contains the optional parameters for the directoryClient.Delete
-// method.
+// options - directoryClientDeleteOptions contains the optional parameters for the directoryClient.Delete method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDelete bool, directoryClientDeleteOptions *directoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientDeleteResponse, error) {
-	req, err := client.deleteCreateRequest(ctx, recursiveDirectoryDelete, directoryClientDeleteOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDelete bool, options *directoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientDeleteResponse, error) {
+	req, err := client.deleteCreateRequest(ctx, recursiveDirectoryDelete, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return directoryClientDeleteResponse{}, err
 	}
@@ -187,18 +185,18 @@ func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDel
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiveDirectoryDelete bool, directoryClientDeleteOptions *directoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiveDirectoryDelete bool, options *directoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if directoryClientDeleteOptions != nil && directoryClientDeleteOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*directoryClientDeleteOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	reqQP.Set("recursive", strconv.FormatBool(recursiveDirectoryDelete))
-	if directoryClientDeleteOptions != nil && directoryClientDeleteOptions.Marker != nil {
-		reqQP.Set("continuation", *directoryClientDeleteOptions.Marker)
+	if options != nil && options.Marker != nil {
+		reqQP.Set("continuation", *options.Marker)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -217,8 +215,8 @@ func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiv
 		req.Raw().Header.Set("If-None-Match", *modifiedAccessConditions.IfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if directoryClientDeleteOptions != nil && directoryClientDeleteOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *directoryClientDeleteOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -251,12 +249,12 @@ func (client *directoryClient) deleteHandleResponse(resp *http.Response) (direct
 
 // GetAccessControl - Get the owner, group, permissions, or access control list for a directory.
 // If the operation fails it returns an *azcore.ResponseError type.
-// directoryClientGetAccessControlOptions - directoryClientGetAccessControlOptions contains the optional parameters for the
-// directoryClient.GetAccessControl method.
+// options - directoryClientGetAccessControlOptions contains the optional parameters for the directoryClient.GetAccessControl
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) GetAccessControl(ctx context.Context, action Enum22, directoryClientGetAccessControlOptions *directoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientGetAccessControlResponse, error) {
-	req, err := client.getAccessControlCreateRequest(ctx, action, directoryClientGetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *directoryClient) GetAccessControl(ctx context.Context, action Enum22, options *directoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientGetAccessControlResponse, error) {
+	req, err := client.getAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return directoryClientGetAccessControlResponse{}, err
 	}
@@ -271,18 +269,18 @@ func (client *directoryClient) GetAccessControl(ctx context.Context, action Enum
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
-func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context, action Enum22, directoryClientGetAccessControlOptions *directoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *directoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("action", string(action))
-	if directoryClientGetAccessControlOptions != nil && directoryClientGetAccessControlOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*directoryClientGetAccessControlOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if directoryClientGetAccessControlOptions != nil && directoryClientGetAccessControlOptions.Upn != nil {
-		reqQP.Set("upn", strconv.FormatBool(*directoryClientGetAccessControlOptions.Upn))
+	if options != nil && options.Upn != nil {
+		reqQP.Set("upn", strconv.FormatBool(*options.Upn))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -300,8 +298,8 @@ func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
-	if directoryClientGetAccessControlOptions != nil && directoryClientGetAccessControlOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *directoryClientGetAccessControlOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
 	req.Raw().Header.Set("Accept", "application/xml")
@@ -358,15 +356,14 @@ func (client *directoryClient) getAccessControlHandleResponse(resp *http.Respons
 // renameSource - The file or directory to be renamed. The value must have the following format: "/{filesysystem}/{path}".
 // If "x-ms-properties" is specified, the properties will overwrite the existing properties;
 // otherwise, the existing properties will be preserved.
-// directoryClientRenameOptions - directoryClientRenameOptions contains the optional parameters for the directoryClient.Rename
-// method.
+// options - directoryClientRenameOptions contains the optional parameters for the directoryClient.Rename method.
 // DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *directoryClient) Rename(ctx context.Context, renameSource string, directoryClientRenameOptions *directoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (directoryClientRenameResponse, error) {
-	req, err := client.renameCreateRequest(ctx, renameSource, directoryClientRenameOptions, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
+func (client *directoryClient) Rename(ctx context.Context, renameSource string, options *directoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (directoryClientRenameResponse, error) {
+	req, err := client.renameCreateRequest(ctx, renameSource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return directoryClientRenameResponse{}, err
 	}
@@ -381,31 +378,31 @@ func (client *directoryClient) Rename(ctx context.Context, renameSource string, 
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSource string, directoryClientRenameOptions *directoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSource string, options *directoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*directoryClientRenameOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.Marker != nil {
-		reqQP.Set("continuation", *directoryClientRenameOptions.Marker)
+	if options != nil && options.Marker != nil {
+		reqQP.Set("continuation", *options.Marker)
 	}
 	if client.pathRenameMode != nil {
 		reqQP.Set("mode", string(*client.pathRenameMode))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-rename-source", renameSource)
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.DirectoryProperties != nil {
-		req.Raw().Header.Set("x-ms-properties", *directoryClientRenameOptions.DirectoryProperties)
+	if options != nil && options.DirectoryProperties != nil {
+		req.Raw().Header.Set("x-ms-properties", *options.DirectoryProperties)
 	}
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.PosixPermissions != nil {
-		req.Raw().Header.Set("x-ms-permissions", *directoryClientRenameOptions.PosixPermissions)
+	if options != nil && options.PosixPermissions != nil {
+		req.Raw().Header.Set("x-ms-permissions", *options.PosixPermissions)
 	}
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.PosixUmask != nil {
-		req.Raw().Header.Set("x-ms-umask", *directoryClientRenameOptions.PosixUmask)
+	if options != nil && options.PosixUmask != nil {
+		req.Raw().Header.Set("x-ms-umask", *options.PosixUmask)
 	}
 	if directoryHTTPHeaders != nil && directoryHTTPHeaders.CacheControl != nil {
 		req.Raw().Header.Set("x-ms-cache-control", *directoryHTTPHeaders.CacheControl)
@@ -425,8 +422,8 @@ func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSo
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.SourceLeaseID != nil {
-		req.Raw().Header.Set("x-ms-source-lease-id", *directoryClientRenameOptions.SourceLeaseID)
+	if options != nil && options.SourceLeaseID != nil {
+		req.Raw().Header.Set("x-ms-source-lease-id", *options.SourceLeaseID)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
 		req.Raw().Header.Set("If-Modified-Since", modifiedAccessConditions.IfModifiedSince.Format(time.RFC1123))
@@ -453,8 +450,8 @@ func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSo
 		req.Raw().Header.Set("x-ms-source-if-none-match", *sourceModifiedAccessConditions.SourceIfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if directoryClientRenameOptions != nil && directoryClientRenameOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *directoryClientRenameOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -504,12 +501,12 @@ func (client *directoryClient) renameHandleResponse(resp *http.Response) (direct
 
 // SetAccessControl - Set the owner, group, permissions, or access control list for a directory.
 // If the operation fails it returns an *azcore.ResponseError type.
-// directoryClientSetAccessControlOptions - directoryClientSetAccessControlOptions contains the optional parameters for the
-// directoryClient.SetAccessControl method.
+// options - directoryClientSetAccessControlOptions contains the optional parameters for the directoryClient.SetAccessControl
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) SetAccessControl(ctx context.Context, action Enum21, directoryClientSetAccessControlOptions *directoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientSetAccessControlResponse, error) {
-	req, err := client.setAccessControlCreateRequest(ctx, action, directoryClientSetAccessControlOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *directoryClient) SetAccessControl(ctx context.Context, action Enum21, options *directoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (directoryClientSetAccessControlResponse, error) {
+	req, err := client.setAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return directoryClientSetAccessControlResponse{}, err
 	}
@@ -524,31 +521,31 @@ func (client *directoryClient) SetAccessControl(ctx context.Context, action Enum
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
-func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context, action Enum21, directoryClientSetAccessControlOptions *directoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *directoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("action", string(action))
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*directoryClientSetAccessControlOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
 	}
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.Owner != nil {
-		req.Raw().Header.Set("x-ms-owner", *directoryClientSetAccessControlOptions.Owner)
+	if options != nil && options.Owner != nil {
+		req.Raw().Header.Set("x-ms-owner", *options.Owner)
 	}
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.Group != nil {
-		req.Raw().Header.Set("x-ms-group", *directoryClientSetAccessControlOptions.Group)
+	if options != nil && options.Group != nil {
+		req.Raw().Header.Set("x-ms-group", *options.Group)
 	}
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.PosixPermissions != nil {
-		req.Raw().Header.Set("x-ms-permissions", *directoryClientSetAccessControlOptions.PosixPermissions)
+	if options != nil && options.PosixPermissions != nil {
+		req.Raw().Header.Set("x-ms-permissions", *options.PosixPermissions)
 	}
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.PosixACL != nil {
-		req.Raw().Header.Set("x-ms-acl", *directoryClientSetAccessControlOptions.PosixACL)
+	if options != nil && options.PosixACL != nil {
+		req.Raw().Header.Set("x-ms-acl", *options.PosixACL)
 	}
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfMatch != nil {
 		req.Raw().Header.Set("If-Match", *modifiedAccessConditions.IfMatch)
@@ -562,8 +559,8 @@ func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfUnmodifiedSince != nil {
 		req.Raw().Header.Set("If-Unmodified-Since", modifiedAccessConditions.IfUnmodifiedSince.Format(time.RFC1123))
 	}
-	if directoryClientSetAccessControlOptions != nil && directoryClientSetAccessControlOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *directoryClientSetAccessControlOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
 	req.Raw().Header.Set("Accept", "application/xml")

--- a/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_pageblob_client.go
@@ -41,16 +41,15 @@ func newPageBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *pag
 // ClearPages - The Clear Pages operation clears a set of pages from a page blob
 // If the operation fails it returns an *azcore.ResponseError type.
 // contentLength - The length of the request.
-// pageBlobClientClearPagesOptions - pageBlobClientClearPagesOptions contains the optional parameters for the pageBlobClient.ClearPages
-// method.
+// options - pageBlobClientClearPagesOptions contains the optional parameters for the pageBlobClient.ClearPages method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) ClearPages(ctx context.Context, comp Enum35, contentLength int64, pageBlobClientClearPagesOptions *pageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientClearPagesResponse, error) {
-	req, err := client.clearPagesCreateRequest(ctx, comp, contentLength, pageBlobClientClearPagesOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
+func (client *pageBlobClient) ClearPages(ctx context.Context, comp Enum35, contentLength int64, options *pageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientClearPagesResponse, error) {
+	req, err := client.clearPagesCreateRequest(ctx, comp, contentLength, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientClearPagesResponse{}, err
 	}
@@ -65,21 +64,21 @@ func (client *pageBlobClient) ClearPages(ctx context.Context, comp Enum35, conte
 }
 
 // clearPagesCreateRequest creates the ClearPages request.
-func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, pageBlobClientClearPagesOptions *pageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, options *pageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientClearPagesOptions != nil && pageBlobClientClearPagesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientClearPagesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-page-write", "clear")
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if pageBlobClientClearPagesOptions != nil && pageBlobClientClearPagesOptions.Range != nil {
-		req.Raw().Header.Set("x-ms-range", *pageBlobClientClearPagesOptions.Range)
+	if options != nil && options.Range != nil {
+		req.Raw().Header.Set("x-ms-range", *options.Range)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -121,8 +120,8 @@ func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp 
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientClearPagesOptions != nil && pageBlobClientClearPagesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientClearPagesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -190,11 +189,11 @@ func (client *pageBlobClient) clearPagesHandleResponse(resp *http.Response) (pag
 // copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 // a page blob snapshot. The value should be URL-encoded as it would appear in a request
 // URI. The source blob must either be public or must be authenticated via a shared access signature.
-// pageBlobClientCopyIncrementalOptions - pageBlobClientCopyIncrementalOptions contains the optional parameters for the pageBlobClient.CopyIncremental
+// options - pageBlobClientCopyIncrementalOptions contains the optional parameters for the pageBlobClient.CopyIncremental
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, copySource string, pageBlobClientCopyIncrementalOptions *pageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientCopyIncrementalResponse, error) {
-	req, err := client.copyIncrementalCreateRequest(ctx, comp, copySource, pageBlobClientCopyIncrementalOptions, modifiedAccessConditions)
+func (client *pageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, copySource string, options *pageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientCopyIncrementalResponse, error) {
+	req, err := client.copyIncrementalCreateRequest(ctx, comp, copySource, options, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientCopyIncrementalResponse{}, err
 	}
@@ -209,15 +208,15 @@ func (client *pageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, 
 }
 
 // copyIncrementalCreateRequest creates the CopyIncremental request.
-func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, comp Enum37, copySource string, pageBlobClientCopyIncrementalOptions *pageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, comp Enum37, copySource string, options *pageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientCopyIncrementalOptions != nil && pageBlobClientCopyIncrementalOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientCopyIncrementalOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if modifiedAccessConditions != nil && modifiedAccessConditions.IfModifiedSince != nil {
@@ -237,8 +236,8 @@ func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, 
 	}
 	req.Raw().Header.Set("x-ms-copy-source", copySource)
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientCopyIncrementalOptions != nil && pageBlobClientCopyIncrementalOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientCopyIncrementalOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -287,15 +286,14 @@ func (client *pageBlobClient) copyIncrementalHandleResponse(resp *http.Response)
 // contentLength - The length of the request.
 // blobContentLength - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned
 // to a 512-byte boundary.
-// pageBlobClientCreateOptions - pageBlobClientCreateOptions contains the optional parameters for the pageBlobClient.Create
-// method.
+// options - pageBlobClientCreateOptions contains the optional parameters for the pageBlobClient.Create method.
 // BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, blobContentLength int64, pageBlobClientCreateOptions *pageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientCreateResponse, error) {
-	req, err := client.createCreateRequest(ctx, contentLength, blobContentLength, pageBlobClientCreateOptions, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, blobContentLength int64, options *pageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientCreateResponse, error) {
+	req, err := client.createCreateRequest(ctx, contentLength, blobContentLength, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientCreateResponse{}, err
 	}
@@ -310,20 +308,20 @@ func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, b
 }
 
 // createCreateRequest creates the Create request.
-func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLength int64, blobContentLength int64, pageBlobClientCreateOptions *pageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLength int64, blobContentLength int64, options *pageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientCreateOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-blob-type", "PageBlob")
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.Tier != nil {
-		req.Raw().Header.Set("x-ms-access-tier", string(*pageBlobClientCreateOptions.Tier))
+	if options != nil && options.Tier != nil {
+		req.Raw().Header.Set("x-ms-access-tier", string(*options.Tier))
 	}
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobContentType != nil {
 		req.Raw().Header.Set("x-ms-blob-content-type", *blobHTTPHeaders.BlobContentType)
@@ -340,8 +338,8 @@ func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLe
 	if blobHTTPHeaders != nil && blobHTTPHeaders.BlobCacheControl != nil {
 		req.Raw().Header.Set("x-ms-blob-cache-control", *blobHTTPHeaders.BlobCacheControl)
 	}
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.Metadata != nil {
-		for k, v := range pageBlobClientCreateOptions.Metadata {
+	if options != nil && options.Metadata != nil {
+		for k, v := range options.Metadata {
 			req.Raw().Header.Set("x-ms-meta-"+k, v)
 		}
 	}
@@ -379,24 +377,24 @@ func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLe
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-blob-content-length", strconv.FormatInt(blobContentLength, 10))
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.BlobSequenceNumber != nil {
-		req.Raw().Header.Set("x-ms-blob-sequence-number", strconv.FormatInt(*pageBlobClientCreateOptions.BlobSequenceNumber, 10))
+	if options != nil && options.BlobSequenceNumber != nil {
+		req.Raw().Header.Set("x-ms-blob-sequence-number", strconv.FormatInt(*options.BlobSequenceNumber, 10))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientCreateOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.BlobTagsString != nil {
-		req.Raw().Header.Set("x-ms-tags", *pageBlobClientCreateOptions.BlobTagsString)
+	if options != nil && options.BlobTagsString != nil {
+		req.Raw().Header.Set("x-ms-tags", *options.BlobTagsString)
 	}
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.ImmutabilityPolicyExpiry != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-until-date", pageBlobClientCreateOptions.ImmutabilityPolicyExpiry.Format(time.RFC1123))
+	if options != nil && options.ImmutabilityPolicyExpiry != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-until-date", options.ImmutabilityPolicyExpiry.Format(time.RFC1123))
 	}
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.ImmutabilityPolicyMode != nil {
-		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*pageBlobClientCreateOptions.ImmutabilityPolicyMode))
+	if options != nil && options.ImmutabilityPolicyMode != nil {
+		req.Raw().Header.Set("x-ms-immutability-policy-mode", string(*options.ImmutabilityPolicyMode))
 	}
-	if pageBlobClientCreateOptions != nil && pageBlobClientCreateOptions.LegalHold != nil {
-		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*pageBlobClientCreateOptions.LegalHold))
+	if options != nil && options.LegalHold != nil {
+		req.Raw().Header.Set("x-ms-legal-hold", strconv.FormatBool(*options.LegalHold))
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -460,12 +458,11 @@ func (client *pageBlobClient) createHandleResponse(resp *http.Response) (pageBlo
 // GetPageRanges - The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page
 // blob
 // If the operation fails it returns an *azcore.ResponseError type.
-// pageBlobClientGetPageRangesOptions - pageBlobClientGetPageRangesOptions contains the optional parameters for the pageBlobClient.GetPageRanges
-// method.
+// options - pageBlobClientGetPageRangesOptions contains the optional parameters for the pageBlobClient.GetPageRanges method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, pageBlobClientGetPageRangesOptions *pageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientGetPageRangesResponse, error) {
-	req, err := client.getPageRangesCreateRequest(ctx, comp, pageBlobClientGetPageRangesOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *pageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, options *pageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientGetPageRangesResponse, error) {
+	req, err := client.getPageRangesCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientGetPageRangesResponse{}, err
 	}
@@ -480,22 +477,22 @@ func (client *pageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, pa
 }
 
 // getPageRangesCreateRequest creates the GetPageRanges request.
-func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, comp Enum36, pageBlobClientGetPageRangesOptions *pageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, comp Enum36, options *pageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientGetPageRangesOptions != nil && pageBlobClientGetPageRangesOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *pageBlobClientGetPageRangesOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if pageBlobClientGetPageRangesOptions != nil && pageBlobClientGetPageRangesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientGetPageRangesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if pageBlobClientGetPageRangesOptions != nil && pageBlobClientGetPageRangesOptions.Range != nil {
-		req.Raw().Header.Set("x-ms-range", *pageBlobClientGetPageRangesOptions.Range)
+	if options != nil && options.Range != nil {
+		req.Raw().Header.Set("x-ms-range", *options.Range)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -516,8 +513,8 @@ func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, co
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientGetPageRangesOptions != nil && pageBlobClientGetPageRangesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientGetPageRangesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -568,12 +565,12 @@ func (client *pageBlobClient) getPageRangesHandleResponse(resp *http.Response) (
 // GetPageRangesDiff - The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob that were
 // changed between target blob and previous snapshot.
 // If the operation fails it returns an *azcore.ResponseError type.
-// pageBlobClientGetPageRangesDiffOptions - pageBlobClientGetPageRangesDiffOptions contains the optional parameters for the
-// pageBlobClient.GetPageRangesDiff method.
+// options - pageBlobClientGetPageRangesDiffOptions contains the optional parameters for the pageBlobClient.GetPageRangesDiff
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36, pageBlobClientGetPageRangesDiffOptions *pageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientGetPageRangesDiffResponse, error) {
-	req, err := client.getPageRangesDiffCreateRequest(ctx, comp, pageBlobClientGetPageRangesDiffOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36, options *pageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientGetPageRangesDiffResponse, error) {
+	req, err := client.getPageRangesDiffCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientGetPageRangesDiffResponse{}, err
 	}
@@ -588,28 +585,28 @@ func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36
 }
 
 // getPageRangesDiffCreateRequest creates the GetPageRangesDiff request.
-func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context, comp Enum36, pageBlobClientGetPageRangesDiffOptions *pageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context, comp Enum36, options *pageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.Snapshot != nil {
-		reqQP.Set("snapshot", *pageBlobClientGetPageRangesDiffOptions.Snapshot)
+	if options != nil && options.Snapshot != nil {
+		reqQP.Set("snapshot", *options.Snapshot)
 	}
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientGetPageRangesDiffOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.Prevsnapshot != nil {
-		reqQP.Set("prevsnapshot", *pageBlobClientGetPageRangesDiffOptions.Prevsnapshot)
+	if options != nil && options.Prevsnapshot != nil {
+		reqQP.Set("prevsnapshot", *options.Prevsnapshot)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.PrevSnapshotURL != nil {
-		req.Raw().Header.Set("x-ms-previous-snapshot-url", *pageBlobClientGetPageRangesDiffOptions.PrevSnapshotURL)
+	if options != nil && options.PrevSnapshotURL != nil {
+		req.Raw().Header.Set("x-ms-previous-snapshot-url", *options.PrevSnapshotURL)
 	}
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.Range != nil {
-		req.Raw().Header.Set("x-ms-range", *pageBlobClientGetPageRangesDiffOptions.Range)
+	if options != nil && options.Range != nil {
+		req.Raw().Header.Set("x-ms-range", *options.Range)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -630,8 +627,8 @@ func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientGetPageRangesDiffOptions != nil && pageBlobClientGetPageRangesDiffOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientGetPageRangesDiffOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -683,14 +680,13 @@ func (client *pageBlobClient) getPageRangesDiffHandleResponse(resp *http.Respons
 // If the operation fails it returns an *azcore.ResponseError type.
 // blobContentLength - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned
 // to a 512-byte boundary.
-// pageBlobClientResizeOptions - pageBlobClientResizeOptions contains the optional parameters for the pageBlobClient.Resize
-// method.
+// options - pageBlobClientResizeOptions contains the optional parameters for the pageBlobClient.Resize method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) Resize(ctx context.Context, comp Enum1, blobContentLength int64, pageBlobClientResizeOptions *pageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientResizeResponse, error) {
-	req, err := client.resizeCreateRequest(ctx, comp, blobContentLength, pageBlobClientResizeOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
+func (client *pageBlobClient) Resize(ctx context.Context, comp Enum1, blobContentLength int64, options *pageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientResizeResponse, error) {
+	req, err := client.resizeCreateRequest(ctx, comp, blobContentLength, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientResizeResponse{}, err
 	}
@@ -705,15 +701,15 @@ func (client *pageBlobClient) Resize(ctx context.Context, comp Enum1, blobConten
 }
 
 // resizeCreateRequest creates the Resize request.
-func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum1, blobContentLength int64, pageBlobClientResizeOptions *pageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum1, blobContentLength int64, options *pageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientResizeOptions != nil && pageBlobClientResizeOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientResizeOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -748,8 +744,8 @@ func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum
 	}
 	req.Raw().Header.Set("x-ms-blob-content-length", strconv.FormatInt(blobContentLength, 10))
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientResizeOptions != nil && pageBlobClientResizeOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientResizeOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -798,12 +794,12 @@ func (client *pageBlobClient) resizeHandleResponse(resp *http.Response) (pageBlo
 // If the operation fails it returns an *azcore.ResponseError type.
 // sequenceNumberAction - Required if the x-ms-blob-sequence-number header is set for the request. This property applies to
 // page blobs only. This property indicates how the service should modify the blob's sequence number
-// pageBlobClientUpdateSequenceNumberOptions - pageBlobClientUpdateSequenceNumberOptions contains the optional parameters
-// for the pageBlobClient.UpdateSequenceNumber method.
+// options - pageBlobClientUpdateSequenceNumberOptions contains the optional parameters for the pageBlobClient.UpdateSequenceNumber
+// method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, pageBlobClientUpdateSequenceNumberOptions *pageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientUpdateSequenceNumberResponse, error) {
-	req, err := client.updateSequenceNumberCreateRequest(ctx, comp, sequenceNumberAction, pageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions, modifiedAccessConditions)
+func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *pageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientUpdateSequenceNumberResponse, error) {
+	req, err := client.updateSequenceNumberCreateRequest(ctx, comp, sequenceNumberAction, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientUpdateSequenceNumberResponse{}, err
 	}
@@ -818,15 +814,15 @@ func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enu
 }
 
 // updateSequenceNumberCreateRequest creates the UpdateSequenceNumber request.
-func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, pageBlobClientUpdateSequenceNumberOptions *pageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *pageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientUpdateSequenceNumberOptions != nil && pageBlobClientUpdateSequenceNumberOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientUpdateSequenceNumberOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
@@ -848,12 +844,12 @@ func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Cont
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-sequence-number-action", string(sequenceNumberAction))
-	if pageBlobClientUpdateSequenceNumberOptions != nil && pageBlobClientUpdateSequenceNumberOptions.BlobSequenceNumber != nil {
-		req.Raw().Header.Set("x-ms-blob-sequence-number", strconv.FormatInt(*pageBlobClientUpdateSequenceNumberOptions.BlobSequenceNumber, 10))
+	if options != nil && options.BlobSequenceNumber != nil {
+		req.Raw().Header.Set("x-ms-blob-sequence-number", strconv.FormatInt(*options.BlobSequenceNumber, 10))
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientUpdateSequenceNumberOptions != nil && pageBlobClientUpdateSequenceNumberOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientUpdateSequenceNumberOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil
@@ -902,16 +898,15 @@ func (client *pageBlobClient) updateSequenceNumberHandleResponse(resp *http.Resp
 // If the operation fails it returns an *azcore.ResponseError type.
 // contentLength - The length of the request.
 // body - Initial data
-// pageBlobClientUploadPagesOptions - pageBlobClientUploadPagesOptions contains the optional parameters for the pageBlobClient.UploadPages
-// method.
+// options - pageBlobClientUploadPagesOptions contains the optional parameters for the pageBlobClient.UploadPages method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages
 // method.
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) UploadPages(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, pageBlobClientUploadPagesOptions *pageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientUploadPagesResponse, error) {
-	req, err := client.uploadPagesCreateRequest(ctx, comp, contentLength, body, pageBlobClientUploadPagesOptions, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
+func (client *pageBlobClient) UploadPages(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *pageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (pageBlobClientUploadPagesResponse, error) {
+	req, err := client.uploadPagesCreateRequest(ctx, comp, contentLength, body, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientUploadPagesResponse{}, err
 	}
@@ -926,27 +921,27 @@ func (client *pageBlobClient) UploadPages(ctx context.Context, comp Enum35, cont
 }
 
 // uploadPagesCreateRequest creates the UploadPages request.
-func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, pageBlobClientUploadPagesOptions *pageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *pageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientUploadPagesOptions != nil && pageBlobClientUploadPagesOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientUploadPagesOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-page-write", "update")
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
-	if pageBlobClientUploadPagesOptions != nil && pageBlobClientUploadPagesOptions.TransactionalContentMD5 != nil {
-		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(pageBlobClientUploadPagesOptions.TransactionalContentMD5))
+	if options != nil && options.TransactionalContentMD5 != nil {
+		req.Raw().Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(options.TransactionalContentMD5))
 	}
-	if pageBlobClientUploadPagesOptions != nil && pageBlobClientUploadPagesOptions.TransactionalContentCRC64 != nil {
-		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(pageBlobClientUploadPagesOptions.TransactionalContentCRC64))
+	if options != nil && options.TransactionalContentCRC64 != nil {
+		req.Raw().Header.Set("x-ms-content-crc64", base64.StdEncoding.EncodeToString(options.TransactionalContentCRC64))
 	}
-	if pageBlobClientUploadPagesOptions != nil && pageBlobClientUploadPagesOptions.Range != nil {
-		req.Raw().Header.Set("x-ms-range", *pageBlobClientUploadPagesOptions.Range)
+	if options != nil && options.Range != nil {
+		req.Raw().Header.Set("x-ms-range", *options.Range)
 	}
 	if leaseAccessConditions != nil && leaseAccessConditions.LeaseID != nil {
 		req.Raw().Header.Set("x-ms-lease-id", *leaseAccessConditions.LeaseID)
@@ -988,8 +983,8 @@ func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp
 		req.Raw().Header.Set("x-ms-if-tags", *modifiedAccessConditions.IfTags)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientUploadPagesOptions != nil && pageBlobClientUploadPagesOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientUploadPagesOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, req.SetBody(body, "application/octet-stream")
@@ -1070,8 +1065,8 @@ func (client *pageBlobClient) uploadPagesHandleResponse(resp *http.Response) (pa
 // contentLength - The length of the request.
 // rangeParam - The range of bytes to which the source range would be written. The range should be 512 aligned and range-end
 // is required.
-// pageBlobClientUploadPagesFromURLOptions - pageBlobClientUploadPagesFromURLOptions contains the optional parameters for
-// the pageBlobClient.UploadPagesFromURL method.
+// options - pageBlobClientUploadPagesFromURLOptions contains the optional parameters for the pageBlobClient.UploadPagesFromURL
+// method.
 // CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
 // CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
 // LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
@@ -1080,8 +1075,8 @@ func (client *pageBlobClient) uploadPagesHandleResponse(resp *http.Response) (pa
 // ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
 // SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
 // method.
-func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, pageBlobClientUploadPagesFromURLOptions *pageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (pageBlobClientUploadPagesFromURLResponse, error) {
-	req, err := client.uploadPagesFromURLCreateRequest(ctx, comp, sourceURL, sourceRange, contentLength, rangeParam, pageBlobClientUploadPagesFromURLOptions, cpkInfo, cpkScopeInfo, leaseAccessConditions, sequenceNumberAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
+func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *pageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (pageBlobClientUploadPagesFromURLResponse, error) {
+	req, err := client.uploadPagesFromURLCreateRequest(ctx, comp, sourceURL, sourceRange, contentLength, rangeParam, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, sequenceNumberAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return pageBlobClientUploadPagesFromURLResponse{}, err
 	}
@@ -1096,25 +1091,25 @@ func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum3
 }
 
 // uploadPagesFromURLCreateRequest creates the UploadPagesFromURL request.
-func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, pageBlobClientUploadPagesFromURLOptions *pageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *pageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("comp", string(comp))
-	if pageBlobClientUploadPagesFromURLOptions != nil && pageBlobClientUploadPagesFromURLOptions.Timeout != nil {
-		reqQP.Set("timeout", strconv.FormatInt(int64(*pageBlobClientUploadPagesFromURLOptions.Timeout), 10))
+	if options != nil && options.Timeout != nil {
+		reqQP.Set("timeout", strconv.FormatInt(int64(*options.Timeout), 10))
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header.Set("x-ms-page-write", "update")
 	req.Raw().Header.Set("x-ms-copy-source", sourceURL)
 	req.Raw().Header.Set("x-ms-source-range", sourceRange)
-	if pageBlobClientUploadPagesFromURLOptions != nil && pageBlobClientUploadPagesFromURLOptions.SourceContentMD5 != nil {
-		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(pageBlobClientUploadPagesFromURLOptions.SourceContentMD5))
+	if options != nil && options.SourceContentMD5 != nil {
+		req.Raw().Header.Set("x-ms-source-content-md5", base64.StdEncoding.EncodeToString(options.SourceContentMD5))
 	}
-	if pageBlobClientUploadPagesFromURLOptions != nil && pageBlobClientUploadPagesFromURLOptions.SourceContentcrc64 != nil {
-		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(pageBlobClientUploadPagesFromURLOptions.SourceContentcrc64))
+	if options != nil && options.SourceContentcrc64 != nil {
+		req.Raw().Header.Set("x-ms-source-content-crc64", base64.StdEncoding.EncodeToString(options.SourceContentcrc64))
 	}
 	req.Raw().Header.Set("Content-Length", strconv.FormatInt(contentLength, 10))
 	req.Raw().Header.Set("x-ms-range", rangeParam)
@@ -1170,8 +1165,8 @@ func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Contex
 		req.Raw().Header.Set("x-ms-source-if-none-match", *sourceModifiedAccessConditions.SourceIfNoneMatch)
 	}
 	req.Raw().Header.Set("x-ms-version", string(client.version))
-	if pageBlobClientUploadPagesFromURLOptions != nil && pageBlobClientUploadPagesFromURLOptions.RequestID != nil {
-		req.Raw().Header.Set("x-ms-client-request-id", *pageBlobClientUploadPagesFromURLOptions.RequestID)
+	if options != nil && options.RequestID != nil {
+		req.Raw().Header.Set("x-ms-client-request-id", *options.RequestID)
 	}
 	req.Raw().Header.Set("Accept", "application/xml")
 	return req, nil


### PR DESCRIPTION
Don't treat any user-defined, optional, parameter groups as the default
options type (it wasn't working anyways).  This ensures that future,
optional, parameters that aren't part of any user-defined group don't
introduce a breaking change.