### PR TITLE
Select Go version before generating in release pipelines

### DIFF
--- a/eng/pipelines/publish-dev-release.yml
+++ b/eng/pipelines/publish-dev-release.yml
@@ -26,6 +26,11 @@ steps:
       rush rebuild -v
     displayName: 'Build Generator Sources'
 
+  - task: GoTool@0
+    inputs:
+      version: '1.18'
+    displayName: "Select Go Version"
+
   - script: |
       rush regenerate
       rush modtidy 2>&1
@@ -33,11 +38,6 @@ steps:
       git diff --staged -w 1>&2
     displayName: 'Regenerate Autorest Tests'
     failOnStderr: true
-
-  - task: GoTool@0
-    inputs:
-      version: '1.18'
-    displayName: "Select Go Version"
 
   - script: |
       set -e

--- a/eng/pipelines/publish-release.yml
+++ b/eng/pipelines/publish-release.yml
@@ -26,6 +26,11 @@ steps:
       rush rebuild -v
     displayName: 'Build Generator Sources'
 
+  - task: GoTool@0
+    inputs:
+      version: '1.18'
+    displayName: "Select Go Version"
+
   - script: |
       rush regenerate
       rush modtidy 2>&1
@@ -33,11 +38,6 @@ steps:
       git diff --staged -w 1>&2
     displayName: 'Regenerate Autorest Tests'
     failOnStderr: true
-
-  - task: GoTool@0
-    inputs:
-      version: '1.18'
-    displayName: "Select Go Version"
 
   - script: |
       set -e


### PR DESCRIPTION
Release pipelines are fmting and mod tidying with the default Go version, which is not 1.18, causing the regeneration step to fail because generated code requires 1.18. Simple fix is to place the Go version selection step ahead of the regeneration step, as we've done for the PR validation pipeline.