### PR TITLE
Unify vanilla and data-plane clients

### DIFF
--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -8,13 +8,16 @@ import (
 	"encoding/base64"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newPetsClient() *PetsClient {
-	return NewPetsClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPetsClient(pl)
 }
 
 // CreateAPInProperties - Create a Pet which contains more properties than what is defined.

--- a/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_pets_client.go
@@ -10,7 +10,6 @@ package additionalpropsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type PetsClient struct {
 }
 
 // NewPetsClient creates a new instance of PetsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPetsClient(options *azcore.ClientOptions) *PetsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPetsClient(pl runtime.Pipeline) *PetsClient {
 	client := &PetsClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -8,13 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newArrayClient() *ArrayClient {
-	return NewArrayClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewArrayClient(pl)
 }
 
 // GetArrayEmpty - Get an empty array []

--- a/test/autorest/arraygroup/zz_generated_array_client.go
+++ b/test/autorest/arraygroup/zz_generated_array_client.go
@@ -10,7 +10,6 @@ package arraygroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type ArrayClient struct {
 }
 
 // NewArrayClient creates a new instance of ArrayClient with the specified values.
-// options - pass nil to accept the default values.
-func NewArrayClient(options *azcore.ClientOptions) *ArrayClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewArrayClient(pl runtime.Pipeline) *ArrayClient {
 	client := &ArrayClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
+++ b/test/autorest/azurereportgroup/zz_generated_autorestreportserviceforazure_client.go
@@ -10,7 +10,6 @@ package azurereportgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type AutoRestReportServiceForAzureClient struct {
 }
 
 // NewAutoRestReportServiceForAzureClient creates a new instance of AutoRestReportServiceForAzureClient with the specified values.
-// options - pass nil to accept the default values.
-func NewAutoRestReportServiceForAzureClient(options *azcore.ClientOptions) *AutoRestReportServiceForAzureClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewAutoRestReportServiceForAzureClient(pl runtime.Pipeline) *AutoRestReportServiceForAzureClient {
 	client := &AutoRestReportServiceForAzureClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newAPIVersionDefaultClient() *APIVersionDefaultClient {
-	return NewAPIVersionDefaultClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewAPIVersionDefaultClient(pl)
 }
 
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newAPIVersionLocalClient() *APIVersionLocalClient {
-	return NewAPIVersionLocalClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewAPIVersionLocalClient(pl)
 }
 
 // GetMethodLocalNull - Get method with api-version modeled in the method.  pass in api-version = null to succeed

--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newHeaderClient() *HeaderClient {
-	return NewHeaderClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHeaderClient(pl)
 }
 
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request

--- a/test/autorest/azurespecialsgroup/odata_test.go
+++ b/test/autorest/azurespecialsgroup/odata_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func newODataClient() *ODataClient {
-	return NewODataClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewODataClient(pl)
 }
 
 // GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newSkipURLEncodingClient() *SkipURLEncodingClient {
-	return NewSkipURLEncodingClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewSkipURLEncodingClient(pl)
 }
 
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newSubscriptionInCredentialsClient() *SubscriptionInCredentialsClient {
-	return NewSubscriptionInCredentialsClient("1234-5678-9012-3456", nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewSubscriptionInCredentialsClient("1234-5678-9012-3456", pl)
 }
 
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newSubscriptionInMethodClient() *SubscriptionInMethodClient {
-	return NewSubscriptionInMethodClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewSubscriptionInMethodClient(pl)
 }
 
 // PostMethodLocalNull - POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -8,12 +8,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newXMSClientRequestIDClient() *XMSClientRequestIDClient {
-	return NewXMSClientRequestIDClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewXMSClientRequestIDClient(pl)
 }
 
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversiondefault_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type APIVersionDefaultClient struct {
 }
 
 // NewAPIVersionDefaultClient creates a new instance of APIVersionDefaultClient with the specified values.
-// options - pass nil to accept the default values.
-func NewAPIVersionDefaultClient(options *azcore.ClientOptions) *APIVersionDefaultClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewAPIVersionDefaultClient(pl runtime.Pipeline) *APIVersionDefaultClient {
 	client := &APIVersionDefaultClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_apiversionlocal_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type APIVersionLocalClient struct {
 }
 
 // NewAPIVersionLocalClient creates a new instance of APIVersionLocalClient with the specified values.
-// options - pass nil to accept the default values.
-func NewAPIVersionLocalClient(options *azcore.ClientOptions) *APIVersionLocalClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewAPIVersionLocalClient(pl runtime.Pipeline) *APIVersionLocalClient {
 	client := &APIVersionLocalClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HeaderClient struct {
 }
 
 // NewHeaderClient creates a new instance of HeaderClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHeaderClient(options *azcore.ClientOptions) *HeaderClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHeaderClient(pl runtime.Pipeline) *HeaderClient {
 	client := &HeaderClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_odata_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type ODataClient struct {
 }
 
 // NewODataClient creates a new instance of ODataClient with the specified values.
-// options - pass nil to accept the default values.
-func NewODataClient(options *azcore.ClientOptions) *ODataClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewODataClient(pl runtime.Pipeline) *ODataClient {
 	client := &ODataClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_skipurlencoding_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type SkipURLEncodingClient struct {
 }
 
 // NewSkipURLEncodingClient creates a new instance of SkipURLEncodingClient with the specified values.
-// options - pass nil to accept the default values.
-func NewSkipURLEncodingClient(options *azcore.ClientOptions) *SkipURLEncodingClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewSkipURLEncodingClient(pl runtime.Pipeline) *SkipURLEncodingClient {
 	client := &SkipURLEncodingClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptionincredentials_client.go
@@ -11,7 +11,6 @@ package azurespecialsgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -28,14 +27,11 @@ type SubscriptionInCredentialsClient struct {
 
 // NewSubscriptionInCredentialsClient creates a new instance of SubscriptionInCredentialsClient with the specified values.
 // subscriptionID - The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
-// options - pass nil to accept the default values.
-func NewSubscriptionInCredentialsClient(subscriptionID string, options *azcore.ClientOptions) *SubscriptionInCredentialsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewSubscriptionInCredentialsClient(subscriptionID string, pl runtime.Pipeline) *SubscriptionInCredentialsClient {
 	client := &SubscriptionInCredentialsClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl:             pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_subscriptioninmethod_client.go
@@ -11,7 +11,6 @@ package azurespecialsgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,13 +25,10 @@ type SubscriptionInMethodClient struct {
 }
 
 // NewSubscriptionInMethodClient creates a new instance of SubscriptionInMethodClient with the specified values.
-// options - pass nil to accept the default values.
-func NewSubscriptionInMethodClient(options *azcore.ClientOptions) *SubscriptionInMethodClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewSubscriptionInMethodClient(pl runtime.Pipeline) *SubscriptionInMethodClient {
 	client := &SubscriptionInMethodClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_xmsclientrequestid_client.go
@@ -10,7 +10,6 @@ package azurespecialsgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type XMSClientRequestIDClient struct {
 }
 
 // NewXMSClientRequestIDClient creates a new instance of XMSClientRequestIDClient with the specified values.
-// options - pass nil to accept the default values.
-func NewXMSClientRequestIDClient(options *azcore.ClientOptions) *XMSClientRequestIDClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewXMSClientRequestIDClient(pl runtime.Pipeline) *XMSClientRequestIDClient {
 	client := &XMSClientRequestIDClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/binarygroup/binarygroup_test.go
+++ b/test/autorest/binarygroup/binarygroup_test.go
@@ -9,12 +9,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/stretchr/testify/require"
 )
 
 func newBinaryGroupClient() *UploadClient {
-	return NewUploadClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewUploadClient(pl)
 }
 
 func TestBinary(t *testing.T) {

--- a/test/autorest/binarygroup/zz_generated_upload_client.go
+++ b/test/autorest/binarygroup/zz_generated_upload_client.go
@@ -10,7 +10,6 @@ package binarygroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -24,13 +23,10 @@ type UploadClient struct {
 }
 
 // NewUploadClient creates a new instance of UploadClient with the specified values.
-// options - pass nil to accept the default values.
-func NewUploadClient(options *azcore.ClientOptions) *UploadClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewUploadClient(pl runtime.Pipeline) *UploadClient {
 	client := &UploadClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newBoolClient() *BoolClient {
-	return NewBoolClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewBoolClient(pl)
 }
 
 func TestGetTrue(t *testing.T) {

--- a/test/autorest/booleangroup/zz_generated_bool_client.go
+++ b/test/autorest/booleangroup/zz_generated_bool_client.go
@@ -10,7 +10,6 @@ package booleangroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type BoolClient struct {
 }
 
 // NewBoolClient creates a new instance of BoolClient with the specified values.
-// options - pass nil to accept the default values.
-func NewBoolClient(options *azcore.ClientOptions) *BoolClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewBoolClient(pl runtime.Pipeline) *BoolClient {
 	client := &BoolClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newByteClient() *ByteClient {
-	return NewByteClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewByteClient(pl)
 }
 
 func TestGetEmpty(t *testing.T) {

--- a/test/autorest/bytegroup/zz_generated_byte_client.go
+++ b/test/autorest/bytegroup/zz_generated_byte_client.go
@@ -10,7 +10,6 @@ package bytegroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type ByteClient struct {
 }
 
 // NewByteClient creates a new instance of ByteClient with the specified values.
-// options - pass nil to accept the default values.
-func NewByteClient(options *azcore.ClientOptions) *ByteClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewByteClient(pl runtime.Pipeline) *ByteClient {
 	client := &ByteClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newArrayClient() *ArrayClient {
-	return NewArrayClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewArrayClient(pl)
 }
 
 func TestArrayGetEmpty(t *testing.T) {

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newBasicClient() *BasicClient {
-	return NewBasicClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewBasicClient(pl)
 }
 
 func TestBasicGetValid(t *testing.T) {

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDictionaryClient() *DictionaryClient {
-	return NewDictionaryClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDictionaryClient(pl)
 }
 
 func TestDictionaryGetEmpty(t *testing.T) {

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newInheritanceClient() *InheritanceClient {
-	return NewInheritanceClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewInheritanceClient(pl)
 }
 
 func TestInheritanceGetValid(t *testing.T) {

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -8,13 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newPolymorphicrecursiveClient() *PolymorphicrecursiveClient {
-	return NewPolymorphicrecursiveClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPolymorphicrecursiveClient(pl)
 }
 
 // GetValid - Get complex types that are polymorphic and have recursive references

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -8,13 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newPolymorphismClient() *PolymorphismClient {
-	return NewPolymorphismClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPolymorphismClient(pl)
 }
 
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -10,13 +10,15 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newPrimitiveClient() *PrimitiveClient {
-	return NewPrimitiveClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPrimitiveClient(pl)
 }
 
 func TestPrimitiveGetInt(t *testing.T) {

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newReadonlypropertyClient() *ReadonlypropertyClient {
-	return NewReadonlypropertyClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewReadonlypropertyClient(pl)
 }
 
 func TestReadonlypropertyGetValid(t *testing.T) {

--- a/test/autorest/complexgroup/zz_generated_array_client.go
+++ b/test/autorest/complexgroup/zz_generated_array_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type ArrayClient struct {
 }
 
 // NewArrayClient creates a new instance of ArrayClient with the specified values.
-// options - pass nil to accept the default values.
-func NewArrayClient(options *azcore.ClientOptions) *ArrayClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewArrayClient(pl runtime.Pipeline) *ArrayClient {
 	client := &ArrayClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_basic_client.go
+++ b/test/autorest/complexgroup/zz_generated_basic_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type BasicClient struct {
 }
 
 // NewBasicClient creates a new instance of BasicClient with the specified values.
-// options - pass nil to accept the default values.
-func NewBasicClient(options *azcore.ClientOptions) *BasicClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewBasicClient(pl runtime.Pipeline) *BasicClient {
 	client := &BasicClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_dictionary_client.go
+++ b/test/autorest/complexgroup/zz_generated_dictionary_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type DictionaryClient struct {
 }
 
 // NewDictionaryClient creates a new instance of DictionaryClient with the specified values.
-// options - pass nil to accept the default values.
-func NewDictionaryClient(options *azcore.ClientOptions) *DictionaryClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDictionaryClient(pl runtime.Pipeline) *DictionaryClient {
 	client := &DictionaryClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
+++ b/test/autorest/complexgroup/zz_generated_flattencomplex_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type FlattencomplexClient struct {
 }
 
 // NewFlattencomplexClient creates a new instance of FlattencomplexClient with the specified values.
-// options - pass nil to accept the default values.
-func NewFlattencomplexClient(options *azcore.ClientOptions) *FlattencomplexClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewFlattencomplexClient(pl runtime.Pipeline) *FlattencomplexClient {
 	client := &FlattencomplexClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_inheritance_client.go
+++ b/test/autorest/complexgroup/zz_generated_inheritance_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type InheritanceClient struct {
 }
 
 // NewInheritanceClient creates a new instance of InheritanceClient with the specified values.
-// options - pass nil to accept the default values.
-func NewInheritanceClient(options *azcore.ClientOptions) *InheritanceClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewInheritanceClient(pl runtime.Pipeline) *InheritanceClient {
 	client := &InheritanceClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphicrecursive_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type PolymorphicrecursiveClient struct {
 }
 
 // NewPolymorphicrecursiveClient creates a new instance of PolymorphicrecursiveClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPolymorphicrecursiveClient(options *azcore.ClientOptions) *PolymorphicrecursiveClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPolymorphicrecursiveClient(pl runtime.Pipeline) *PolymorphicrecursiveClient {
 	client := &PolymorphicrecursiveClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_polymorphism_client.go
+++ b/test/autorest/complexgroup/zz_generated_polymorphism_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type PolymorphismClient struct {
 }
 
 // NewPolymorphismClient creates a new instance of PolymorphismClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPolymorphismClient(options *azcore.ClientOptions) *PolymorphismClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPolymorphismClient(pl runtime.Pipeline) *PolymorphismClient {
 	client := &PolymorphismClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_primitive_client.go
+++ b/test/autorest/complexgroup/zz_generated_primitive_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type PrimitiveClient struct {
 }
 
 // NewPrimitiveClient creates a new instance of PrimitiveClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPrimitiveClient(options *azcore.ClientOptions) *PrimitiveClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPrimitiveClient(pl runtime.Pipeline) *PrimitiveClient {
 	client := &PrimitiveClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
+++ b/test/autorest/complexgroup/zz_generated_readonlyproperty_client.go
@@ -10,7 +10,6 @@ package complexgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type ReadonlypropertyClient struct {
 }
 
 // NewReadonlypropertyClient creates a new instance of ReadonlypropertyClient with the specified values.
-// options - pass nil to accept the default values.
-func NewReadonlypropertyClient(options *azcore.ClientOptions) *ReadonlypropertyClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewReadonlypropertyClient(pl runtime.Pipeline) *ReadonlypropertyClient {
 	client := &ReadonlypropertyClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newComplexModelClient() *ComplexModelClient {
-	return NewComplexModelClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewComplexModelClient(pl)
 }
 
 func TestCreate(t *testing.T) {

--- a/test/autorest/complexmodelgroup/zz_generated_complexmodel_client.go
+++ b/test/autorest/complexmodelgroup/zz_generated_complexmodel_client.go
@@ -11,7 +11,6 @@ package complexmodelgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,13 +25,10 @@ type ComplexModelClient struct {
 }
 
 // NewComplexModelClient creates a new instance of ComplexModelClient with the specified values.
-// options - pass nil to accept the default values.
-func NewComplexModelClient(options *azcore.ClientOptions) *ComplexModelClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewComplexModelClient(pl runtime.Pipeline) *ComplexModelClient {
 	client := &ComplexModelClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -9,16 +9,20 @@ import (
 	"generatortests/azurereportgroup"
 	"generatortests/reportgroup"
 	"sort"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 // generate autorest test server coverage report
 func main() {
-	vanillaClient := reportgroup.NewAutoRestReportServiceClient(nil)
+	pl := runtime.NewPipeline("covreport", "v0.1.0", runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	vanillaClient := reportgroup.NewAutoRestReportServiceClient(pl)
 	vanillaReport, err := vanillaClient.GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)
 	}
-	azureClient := azurereportgroup.NewAutoRestReportServiceForAzureClient(nil)
+	azureClient := azurereportgroup.NewAutoRestReportServiceForAzureClient(pl)
 	azureReport, err := azureClient.GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -7,14 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func newPathsClient() *PathsClient {
-	return NewPathsClient(&PathsClientOptions{
-		Host: to.Ptr(":3000"),
-	})
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPathsClient(to.Ptr(":3000"), pl)
 }
 
 func TestGetEmpty(t *testing.T) {

--- a/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_paths_client.go
@@ -10,7 +10,6 @@ package custombaseurlgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,24 +23,16 @@ type PathsClient struct {
 	pl   runtime.Pipeline
 }
 
-// PathsClientOptions contains the optional parameters for NewPathsClient.
-type PathsClientOptions struct {
-	azcore.ClientOptions
-	Host *string
-}
-
 // NewPathsClient creates a new instance of PathsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPathsClient(options *PathsClientOptions) *PathsClient {
-	if options == nil {
-		options = &PathsClientOptions{}
-	}
+// host - A string value that is used as a global part of the parameterized host
+// pl - the pipeline used for sending requests and handling responses.
+func NewPathsClient(host *string, pl runtime.Pipeline) *PathsClient {
 	client := &PathsClient{
 		host: "host",
-		pl:   runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options.ClientOptions),
+		pl:   pl,
 	}
-	if options.Host != nil {
-		client.host = *options.Host
+	if host != nil {
+		client.host = *host
 	}
 	return client
 }

--- a/test/autorest/dategroup/date_test.go
+++ b/test/autorest/dategroup/date_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDateClient() *DateClient {
-	return NewDateClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDateClient(pl)
 }
 
 func TestGetInvalidDate(t *testing.T) {

--- a/test/autorest/dategroup/zz_generated_date_client.go
+++ b/test/autorest/dategroup/zz_generated_date_client.go
@@ -10,7 +10,6 @@ package dategroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type DateClient struct {
 }
 
 // NewDateClient creates a new instance of DateClient with the specified values.
-// options - pass nil to accept the default values.
-func NewDateClient(options *azcore.ClientOptions) *DateClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDateClient(pl runtime.Pipeline) *DateClient {
 	client := &DateClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDatetimeClient() *DatetimeClient {
-	return NewDatetimeClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDatetimeClient(pl)
 }
 
 func TestGetInvalid(t *testing.T) {

--- a/test/autorest/datetimegroup/zz_generated_datetime_client.go
+++ b/test/autorest/datetimegroup/zz_generated_datetime_client.go
@@ -10,7 +10,6 @@ package datetimegroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type DatetimeClient struct {
 }
 
 // NewDatetimeClient creates a new instance of DatetimeClient with the specified values.
-// options - pass nil to accept the default values.
-func NewDatetimeClient(options *azcore.ClientOptions) *DatetimeClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDatetimeClient(pl runtime.Pipeline) *DatetimeClient {
 	client := &DatetimeClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -8,12 +8,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDatetimerfc1123Client() *Datetimerfc1123Client {
-	return NewDatetimerfc1123Client(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDatetimerfc1123Client(pl)
 }
 
 func TestGetInvalid(t *testing.T) {

--- a/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_datetimerfc1123_client.go
@@ -10,7 +10,6 @@ package datetimerfc1123group
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type Datetimerfc1123Client struct {
 }
 
 // NewDatetimerfc1123Client creates a new instance of Datetimerfc1123Client with the specified values.
-// options - pass nil to accept the default values.
-func NewDatetimerfc1123Client(options *azcore.ClientOptions) *Datetimerfc1123Client {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDatetimerfc1123Client(pl runtime.Pipeline) *Datetimerfc1123Client {
 	client := &Datetimerfc1123Client{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -8,13 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDictionaryClient() *DictionaryClient {
-	return NewDictionaryClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDictionaryClient(pl)
 }
 
 // GetArrayEmpty - Get an empty dictionary {}

--- a/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
+++ b/test/autorest/dictionarygroup/zz_generated_dictionary_client.go
@@ -10,7 +10,6 @@ package dictionarygroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type DictionaryClient struct {
 }
 
 // NewDictionaryClient creates a new instance of DictionaryClient with the specified values.
-// options - pass nil to accept the default values.
-func NewDictionaryClient(options *azcore.ClientOptions) *DictionaryClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDictionaryClient(pl runtime.Pipeline) *DictionaryClient {
 	client := &DictionaryClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/durationgroup/durationgroup_test.go
+++ b/test/autorest/durationgroup/durationgroup_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newDurationClient() *DurationClient {
-	return NewDurationClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewDurationClient(pl)
 }
 
 func TestGetInvalid(t *testing.T) {

--- a/test/autorest/durationgroup/zz_generated_duration_client.go
+++ b/test/autorest/durationgroup/zz_generated_duration_client.go
@@ -10,7 +10,6 @@ package durationgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type DurationClient struct {
 }
 
 // NewDurationClient creates a new instance of DurationClient with the specified values.
-// options - pass nil to accept the default values.
-func NewDurationClient(options *azcore.ClientOptions) *DurationClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewDurationClient(pl runtime.Pipeline) *DurationClient {
 	client := &DurationClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,8 @@ import (
 func newPetClient() *PetClient {
 	options := azcore.ClientOptions{}
 	options.Retry.MaxRetryDelay = 20 * time.Millisecond
-	return NewPetClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewPetClient(pl)
 }
 
 // DoSomething - Asks pet to do something

--- a/test/autorest/errorsgroup/zz_generated_pet_client.go
+++ b/test/autorest/errorsgroup/zz_generated_pet_client.go
@@ -11,7 +11,6 @@ package errorsgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,13 +25,10 @@ type PetClient struct {
 }
 
 // NewPetClient creates a new instance of PetClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPetClient(options *azcore.ClientOptions) *PetClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPetClient(pl runtime.Pipeline) *PetClient {
 	client := &PetClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/extenumsgroup/extenumsgroup_test.go
+++ b/test/autorest/extenumsgroup/extenumsgroup_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newPetClient() *PetClient {
-	return NewPetClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPetClient(pl)
 }
 
 func TestAddPet(t *testing.T) {

--- a/test/autorest/extenumsgroup/zz_generated_pet_client.go
+++ b/test/autorest/extenumsgroup/zz_generated_pet_client.go
@@ -11,7 +11,6 @@ package extenumsgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,13 +25,10 @@ type PetClient struct {
 }
 
 // NewPetClient creates a new instance of PetClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPetClient(options *azcore.ClientOptions) *PetClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPetClient(pl runtime.Pipeline) *PetClient {
 	client := &PetClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -8,11 +8,14 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newFilesClient() *FilesClient {
-	return NewFilesClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewFilesClient(pl)
 }
 
 func TestGetEmptyFile(t *testing.T) {

--- a/test/autorest/filegroup/zz_generated_files_client.go
+++ b/test/autorest/filegroup/zz_generated_files_client.go
@@ -10,7 +10,6 @@ package filegroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type FilesClient struct {
 }
 
 // NewFilesClient creates a new instance of FilesClient with the specified values.
-// options - pass nil to accept the default values.
-func NewFilesClient(options *azcore.ClientOptions) *FilesClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewFilesClient(pl runtime.Pipeline) *FilesClient {
 	client := &FilesClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/formdatagroup/formgroup_test.go
+++ b/test/autorest/formdatagroup/formgroup_test.go
@@ -10,12 +10,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/stretchr/testify/require"
 )
 
 func newFormdataClient() *FormdataClient {
-	return NewFormdataClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewFormdataClient(pl)
 }
 
 func TestUploadFile(t *testing.T) {

--- a/test/autorest/formdatagroup/zz_generated_formdata_client.go
+++ b/test/autorest/formdatagroup/zz_generated_formdata_client.go
@@ -10,7 +10,6 @@ package formdatagroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -24,13 +23,10 @@ type FormdataClient struct {
 }
 
 // NewFormdataClient creates a new instance of FormdataClient with the specified values.
-// options - pass nil to accept the default values.
-func NewFormdataClient(options *azcore.ClientOptions) *FormdataClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewFormdataClient(pl runtime.Pipeline) *FormdataClient {
 	client := &FormdataClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
@@ -16,7 +17,8 @@ import (
 )
 
 func newHeaderClient() *HeaderClient {
-	return NewHeaderClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHeaderClient(pl)
 }
 
 func TestHeaderCustomRequestID(t *testing.T) {

--- a/test/autorest/headergroup/zz_generated_header_client.go
+++ b/test/autorest/headergroup/zz_generated_header_client.go
@@ -11,7 +11,6 @@ package headergroup
 import (
 	"context"
 	"encoding/base64"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,13 +25,10 @@ type HeaderClient struct {
 }
 
 // NewHeaderClient creates a new instance of HeaderClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHeaderClient(options *azcore.ClientOptions) *HeaderClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHeaderClient(pl runtime.Pipeline) *HeaderClient {
 	client := &HeaderClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/headgroup/headgroup_test.go
+++ b/test/autorest/headgroup/headgroup_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPSuccessOperationsClient() *HTTPSuccessClient {
-	return NewHTTPSuccessClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHTTPSuccessClient(pl)
 }
 
 // Head200 - Return 200 status code if successful

--- a/test/autorest/headgroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/headgroup/zz_generated_httpsuccess_client.go
@@ -10,7 +10,6 @@ package headgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPSuccessClient struct {
 }
 
 // NewHTTPSuccessClient creates a new instance of HTTPSuccessClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPSuccessClient(options *azcore.ClientOptions) *HTTPSuccessClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPSuccessClient(pl runtime.Pipeline) *HTTPSuccessClient {
 	client := &HTTPSuccessClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -9,15 +9,17 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPClientFailureClient() *HTTPClientFailureClient {
-	return NewHTTPClientFailureClient(&policy.ClientOptions{
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &policy.ClientOptions{
 		Retry: policy.RetryOptions{
 			MaxRetryDelay: 2 * time.Second,
 		},
 	})
+	return NewHTTPClientFailureClient(pl)
 }
 
 func TestHTTPClientFailureDelete400(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/httpfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpfailure_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPFailureClient() *HTTPFailureClient {
-	return NewHTTPFailureClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHTTPFailureClient(pl)
 }
 
 func TestHTTPFailureGetEmptyError(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -17,7 +18,8 @@ import (
 )
 
 func newMultipleResponsesClient() *MultipleResponsesClient {
-	return NewMultipleResponsesClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewMultipleResponsesClient(pl)
 }
 
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPRedirectsClient() *HTTPRedirectsClient {
-	return NewHTTPRedirectsClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHTTPRedirectsClient(pl)
 }
 
 func TestHTTPRedirectsDelete307(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,7 +20,8 @@ func newHTTPRetryClient() *HTTPRetryClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.Transport = httpClientWithCookieJar()
-	return NewHTTPRetryClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewHTTPRetryClient(pl)
 }
 
 func httpClientWithCookieJar() policy.Transporter {

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPServerFailureClient() *HTTPServerFailureClient {
-	return NewHTTPServerFailureClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHTTPServerFailureClient(pl)
 }
 
 func TestHTTPServerFailureDelete505(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newHTTPSuccessClient() *HTTPSuccessClient {
-	return NewHTTPSuccessClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewHTTPSuccessClient(pl)
 }
 
 func TestHTTPSuccessDelete200(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPClientFailureClient struct {
 }
 
 // NewHTTPClientFailureClient creates a new instance of HTTPClientFailureClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPClientFailureClient(options *azcore.ClientOptions) *HTTPClientFailureClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPClientFailureClient(pl runtime.Pipeline) *HTTPClientFailureClient {
 	client := &HTTPClientFailureClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpfailure_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPFailureClient struct {
 }
 
 // NewHTTPFailureClient creates a new instance of HTTPFailureClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPFailureClient(options *azcore.ClientOptions) *HTTPFailureClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPFailureClient(pl runtime.Pipeline) *HTTPFailureClient {
 	client := &HTTPFailureClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPRedirectsClient struct {
 }
 
 // NewHTTPRedirectsClient creates a new instance of HTTPRedirectsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPRedirectsClient(options *azcore.ClientOptions) *HTTPRedirectsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPRedirectsClient(pl runtime.Pipeline) *HTTPRedirectsClient {
 	client := &HTTPRedirectsClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPRetryClient struct {
 }
 
 // NewHTTPRetryClient creates a new instance of HTTPRetryClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPRetryClient(options *azcore.ClientOptions) *HTTPRetryClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPRetryClient(pl runtime.Pipeline) *HTTPRetryClient {
 	client := &HTTPRetryClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPServerFailureClient struct {
 }
 
 // NewHTTPServerFailureClient creates a new instance of HTTPServerFailureClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPServerFailureClient(options *azcore.ClientOptions) *HTTPServerFailureClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPServerFailureClient(pl runtime.Pipeline) *HTTPServerFailureClient {
 	client := &HTTPServerFailureClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
@@ -10,7 +10,6 @@ package httpinfrastructuregroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type HTTPSuccessClient struct {
 }
 
 // NewHTTPSuccessClient creates a new instance of HTTPSuccessClient with the specified values.
-// options - pass nil to accept the default values.
-func NewHTTPSuccessClient(options *azcore.ClientOptions) *HTTPSuccessClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewHTTPSuccessClient(pl runtime.Pipeline) *HTTPSuccessClient {
 	client := &HTTPSuccessClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_multipleresponses_client.go
@@ -11,7 +11,6 @@ package httpinfrastructuregroup
 import (
 	"context"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type MultipleResponsesClient struct {
 }
 
 // NewMultipleResponsesClient creates a new instance of MultipleResponsesClient with the specified values.
-// options - pass nil to accept the default values.
-func NewMultipleResponsesClient(options *azcore.ClientOptions) *MultipleResponsesClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewMultipleResponsesClient(pl runtime.Pipeline) *MultipleResponsesClient {
 	client := &MultipleResponsesClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -9,12 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newIntClient() *IntClient {
-	return NewIntClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewIntClient(pl)
 }
 
 func TestIntGetInvalid(t *testing.T) {

--- a/test/autorest/integergroup/zz_generated_int_client.go
+++ b/test/autorest/integergroup/zz_generated_int_client.go
@@ -10,7 +10,6 @@ package integergroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type IntClient struct {
 }
 
 // NewIntClient creates a new instance of IntClient with the specified values.
-// options - pass nil to accept the default values.
-func NewIntClient(options *azcore.ClientOptions) *IntClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewIntClient(pl runtime.Pipeline) *IntClient {
 	client := &IntClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -18,7 +19,8 @@ func newLRORetrysClient() *LRORetrysClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	return NewLRORetrysClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewLRORetrysClient(pl)
 }
 
 func TestLRORetrysBeginDelete202Retry200(t *testing.T) {

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,8 @@ func newLROSClient() *LROsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	return NewLROsClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewLROsClient(pl)
 }
 
 func httpClientWithCookieJar() policy.Transporter {

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,7 +17,8 @@ func newLrosaDsClient() *LROSADsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	return NewLROSADsClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewLROSADsClient(pl)
 }
 
 func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -20,7 +20,8 @@ func newLrOSCustomHeaderClient() *LROsCustomHeaderClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	return NewLROsCustomHeaderClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewLROsCustomHeaderClient(pl)
 }
 
 func ctxWithHTTPHeader() context.Context {

--- a/test/autorest/lrogroup/zz_generated_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroretrys_client.go
@@ -10,7 +10,6 @@ package lrogroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,13 +23,10 @@ type LRORetrysClient struct {
 }
 
 // NewLRORetrysClient creates a new instance of LRORetrysClient with the specified values.
-// options - pass nil to accept the default values.
-func NewLRORetrysClient(options *azcore.ClientOptions) *LRORetrysClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewLRORetrysClient(pl runtime.Pipeline) *LRORetrysClient {
 	client := &LRORetrysClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/lrogroup/zz_generated_lros_client.go
+++ b/test/autorest/lrogroup/zz_generated_lros_client.go
@@ -10,7 +10,6 @@ package lrogroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,13 +23,10 @@ type LROsClient struct {
 }
 
 // NewLROsClient creates a new instance of LROsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewLROsClient(options *azcore.ClientOptions) *LROsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewLROsClient(pl runtime.Pipeline) *LROsClient {
 	client := &LROsClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/lrogroup/zz_generated_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_generated_lrosads_client.go
@@ -10,7 +10,6 @@ package lrogroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,13 +23,10 @@ type LROSADsClient struct {
 }
 
 // NewLROSADsClient creates a new instance of LROSADsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewLROSADsClient(options *azcore.ClientOptions) *LROSADsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewLROSADsClient(pl runtime.Pipeline) *LROSADsClient {
 	client := &LROSADsClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_generated_lroscustomheader_client.go
@@ -10,7 +10,6 @@ package lrogroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -24,13 +23,10 @@ type LROsCustomHeaderClient struct {
 }
 
 // NewLROsCustomHeaderClient creates a new instance of LROsCustomHeaderClient with the specified values.
-// options - pass nil to accept the default values.
-func NewLROsCustomHeaderClient(options *azcore.ClientOptions) *LROsCustomHeaderClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewLROsCustomHeaderClient(pl runtime.Pipeline) *LROsCustomHeaderClient {
 	client := &LROsCustomHeaderClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func newMediaTypesClient() *MediaTypesClient {
-	return NewMediaTypesClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewMediaTypesClient(pl)
 }
 
 func TestAnalyzeBody(t *testing.T) {

--- a/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
+++ b/test/autorest/mediatypesgroup/zz_generated_mediatypes_client.go
@@ -10,7 +10,6 @@ package mediatypesgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -26,13 +25,10 @@ type MediaTypesClient struct {
 }
 
 // NewMediaTypesClient creates a new instance of MediaTypesClient with the specified values.
-// options - pass nil to accept the default values.
-func NewMediaTypesClient(options *azcore.ClientOptions) *MediaTypesClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewMediaTypesClient(pl runtime.Pipeline) *MediaTypesClient {
 	client := &MediaTypesClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/migroup/migroup_test.go
+++ b/test/autorest/migroup/migroup_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newMultipleInheritanceServiceClient() *MultipleInheritanceServiceClient {
-	return NewMultipleInheritanceServiceClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewMultipleInheritanceServiceClient(pl)
 }
 
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true

--- a/test/autorest/migroup/zz_generated_multipleinheritanceservice_client.go
+++ b/test/autorest/migroup/zz_generated_multipleinheritanceservice_client.go
@@ -10,7 +10,6 @@ package migroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type MultipleInheritanceServiceClient struct {
 }
 
 // NewMultipleInheritanceServiceClient creates a new instance of MultipleInheritanceServiceClient with the specified values.
-// options - pass nil to accept the default values.
-func NewMultipleInheritanceServiceClient(options *azcore.ClientOptions) *MultipleInheritanceServiceClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewMultipleInheritanceServiceClient(pl runtime.Pipeline) *MultipleInheritanceServiceClient {
 	client := &MultipleInheritanceServiceClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -7,15 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func newPathsClient() *PathsClient {
 	// dnsSuffix string, subscriptionID string
-	return NewPathsClient("test12", &PathsClientOptions{
-		DnsSuffix: to.Ptr(":3000"),
-	})
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPathsClient(to.Ptr(":3000"), "test12", pl)
 }
 
 func TestGetEmpty(t *testing.T) {

--- a/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_paths_client.go
@@ -11,7 +11,6 @@ package morecustombaseurigroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -27,26 +26,18 @@ type PathsClient struct {
 	pl             runtime.Pipeline
 }
 
-// PathsClientOptions contains the optional parameters for NewPathsClient.
-type PathsClientOptions struct {
-	azcore.ClientOptions
-	DnsSuffix *string
-}
-
 // NewPathsClient creates a new instance of PathsClient with the specified values.
+// dnsSuffix - A string value that is used as a global part of the parameterized host. Default value 'host'.
 // subscriptionID - The subscription id with value 'test12'.
-// options - pass nil to accept the default values.
-func NewPathsClient(subscriptionID string, options *PathsClientOptions) *PathsClient {
-	if options == nil {
-		options = &PathsClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPathsClient(dnsSuffix *string, subscriptionID string, pl runtime.Pipeline) *PathsClient {
 	client := &PathsClient{
 		dnsSuffix:      "host",
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options.ClientOptions),
+		pl:             pl,
 	}
-	if options.DnsSuffix != nil {
-		client.dnsSuffix = *options.DnsSuffix
+	if dnsSuffix != nil {
+		client.dnsSuffix = *dnsSuffix
 	}
 	return client
 }

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newFloatClient() *FloatClient {
-	return NewFloatClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewFloatClient(pl)
 }
 
 // Get - Get a float enum

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newIntClient() *IntClient {
-	return NewIntClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewIntClient(pl)
 }
 
 // Get - Get an int enum

--- a/test/autorest/nonstringenumgroup/zz_generated_float_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_float_client.go
@@ -10,7 +10,6 @@ package nonstringenumgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type FloatClient struct {
 }
 
 // NewFloatClient creates a new instance of FloatClient with the specified values.
-// options - pass nil to accept the default values.
-func NewFloatClient(options *azcore.ClientOptions) *FloatClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewFloatClient(pl runtime.Pipeline) *FloatClient {
 	client := &FloatClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/nonstringenumgroup/zz_generated_int_client.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_int_client.go
@@ -10,7 +10,6 @@ package nonstringenumgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type IntClient struct {
 }
 
 // NewIntClient creates a new instance of IntClient with the specified values.
-// options - pass nil to accept the default values.
-func NewIntClient(options *azcore.ClientOptions) *IntClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewIntClient(pl runtime.Pipeline) *IntClient {
 	client := &IntClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newNumberClient() *NumberClient {
-	return NewNumberClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewNumberClient(pl)
 }
 
 func TestNumberGetBigDecimal(t *testing.T) {

--- a/test/autorest/numbergroup/zz_generated_number_client.go
+++ b/test/autorest/numbergroup/zz_generated_number_client.go
@@ -10,7 +10,6 @@ package numbergroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type NumberClient struct {
 }
 
 // NewNumberClient creates a new instance of NumberClient with the specified values.
-// options - pass nil to accept the default values.
-func NewNumberClient(options *azcore.ClientOptions) *NumberClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewNumberClient(pl runtime.Pipeline) *NumberClient {
 	client := &NumberClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/objectgroup/objectgroup_test.go
+++ b/test/autorest/objectgroup/objectgroup_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newObjectTypeClient() *ObjectTypeClient {
-	return NewObjectTypeClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewObjectTypeClient(pl)
 }
 
 func TestGet(t *testing.T) {

--- a/test/autorest/objectgroup/zz_generated_objecttype_client.go
+++ b/test/autorest/objectgroup/zz_generated_objecttype_client.go
@@ -10,7 +10,6 @@ package objectgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type ObjectTypeClient struct {
 }
 
 // NewObjectTypeClient creates a new instance of ObjectTypeClient with the specified values.
-// options - pass nil to accept the default values.
-func NewObjectTypeClient(options *azcore.ClientOptions) *ObjectTypeClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewObjectTypeClient(pl runtime.Pipeline) *ObjectTypeClient {
 	client := &ObjectTypeClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newExplicitClient() *ExplicitClient {
-	return NewExplicitClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewExplicitClient(pl)
 }
 
 func TestExplicitPostOptionalArrayHeader(t *testing.T) {

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newImplicitClient() *ImplicitClient {
-	return NewImplicitClient("", "", nil, nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewImplicitClient("", "", nil, pl)
 }
 
 func TestImplicitGetOptionalGlobalQuery(t *testing.T) {

--- a/test/autorest/optionalgroup/zz_generated_explicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_explicit_client.go
@@ -10,7 +10,6 @@ package optionalgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -27,13 +26,10 @@ type ExplicitClient struct {
 }
 
 // NewExplicitClient creates a new instance of ExplicitClient with the specified values.
-// options - pass nil to accept the default values.
-func NewExplicitClient(options *azcore.ClientOptions) *ExplicitClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewExplicitClient(pl runtime.Pipeline) *ExplicitClient {
 	client := &ExplicitClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/optionalgroup/zz_generated_implicit_client.go
+++ b/test/autorest/optionalgroup/zz_generated_implicit_client.go
@@ -11,7 +11,6 @@ package optionalgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -34,16 +33,13 @@ type ImplicitClient struct {
 // requiredGlobalPath - number of items to skip
 // requiredGlobalQuery - number of items to skip
 // optionalGlobalQuery - number of items to skip
-// options - pass nil to accept the default values.
-func NewImplicitClient(requiredGlobalPath string, requiredGlobalQuery string, optionalGlobalQuery *int32, options *azcore.ClientOptions) *ImplicitClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewImplicitClient(requiredGlobalPath string, requiredGlobalQuery string, optionalGlobalQuery *int32, pl runtime.Pipeline) *ImplicitClient {
 	client := &ImplicitClient{
 		requiredGlobalPath:  requiredGlobalPath,
 		requiredGlobalQuery: requiredGlobalQuery,
 		optionalGlobalQuery: optionalGlobalQuery,
-		pl:                  runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl:                  pl,
 	}
 	return client
 }

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +22,8 @@ func newPagingClient() *PagingClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	return NewPagingClient(&options)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	return NewPagingClient(pl)
 }
 
 func httpClientWithCookieJar() policy.Transporter {

--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -11,7 +11,6 @@ package paginggroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -28,13 +27,10 @@ type PagingClient struct {
 }
 
 // NewPagingClient creates a new instance of PagingClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPagingClient(options *azcore.ClientOptions) *PagingClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPagingClient(pl runtime.Pipeline) *PagingClient {
 	client := &PagingClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newParameterGroupingClient() *ParameterGroupingClient {
-	return NewParameterGroupingClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewParameterGroupingClient(pl)
 }
 
 // PostMultiParamGroups - Post parameters from multiple different parameter groups

--- a/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_parametergrouping_client.go
@@ -11,7 +11,6 @@ package paramgroupinggroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -27,13 +26,10 @@ type ParameterGroupingClient struct {
 }
 
 // NewParameterGroupingClient creates a new instance of ParameterGroupingClient with the specified values.
-// options - pass nil to accept the default values.
-func NewParameterGroupingClient(options *azcore.ClientOptions) *ParameterGroupingClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewParameterGroupingClient(pl runtime.Pipeline) *ParameterGroupingClient {
 	client := &ParameterGroupingClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
+++ b/test/autorest/reportgroup/zz_generated_autorestreportservice_client.go
@@ -10,7 +10,6 @@ package reportgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type AutoRestReportServiceClient struct {
 }
 
 // NewAutoRestReportServiceClient creates a new instance of AutoRestReportServiceClient with the specified values.
-// options - pass nil to accept the default values.
-func NewAutoRestReportServiceClient(options *azcore.ClientOptions) *AutoRestReportServiceClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewAutoRestReportServiceClient(pl runtime.Pipeline) *AutoRestReportServiceClient {
 	client := &AutoRestReportServiceClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newEnumClient() *EnumClient {
-	return NewEnumClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewEnumClient(pl)
 }
 
 func TestEnumGetNotExpandable(t *testing.T) {

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newStringClient() *StringClient {
-	return NewStringClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewStringClient(pl)
 }
 
 func TestStringGetMBCS(t *testing.T) {

--- a/test/autorest/stringgroup/zz_generated_enum_client.go
+++ b/test/autorest/stringgroup/zz_generated_enum_client.go
@@ -10,7 +10,6 @@ package stringgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type EnumClient struct {
 }
 
 // NewEnumClient creates a new instance of EnumClient with the specified values.
-// options - pass nil to accept the default values.
-func NewEnumClient(options *azcore.ClientOptions) *EnumClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewEnumClient(pl runtime.Pipeline) *EnumClient {
 	client := &EnumClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/stringgroup/zz_generated_string_client.go
+++ b/test/autorest/stringgroup/zz_generated_string_client.go
@@ -10,7 +10,6 @@ package stringgroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -25,13 +24,10 @@ type StringClient struct {
 }
 
 // NewStringClient creates a new instance of StringClient with the specified values.
-// options - pass nil to accept the default values.
-func NewStringClient(options *azcore.ClientOptions) *StringClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewStringClient(pl runtime.Pipeline) *StringClient {
 	client := &StringClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetAllWithValues(t *testing.T) {
-	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
 	result, err := grp.GetAllWithValues(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetAllWithValuesOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
@@ -22,7 +25,8 @@ func TestGetAllWithValues(t *testing.T) {
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
-	grp := NewPathItemsClient("globalStringPath", nil, nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	grp := NewPathItemsClient("globalStringPath", nil, pl)
 	result, err := grp.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalAndLocalQueryNullOptions{
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
 	})
@@ -31,7 +35,8 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
-	grp := NewPathItemsClient("globalStringPath", nil, nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	grp := NewPathItemsClient("globalStringPath", nil, pl)
 	result, err := grp.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalQueryNullOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
@@ -41,7 +46,8 @@ func TestGetGlobalQueryNull(t *testing.T) {
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
-	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
 	result, err := grp.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "localStringPath", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -8,11 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newPathsClient() *PathsClient {
-	return NewPathsClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewPathsClient(pl)
 }
 
 func TestArrayCSVInPath(t *testing.T) {

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -7,12 +7,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
 func newQueriesClient() *QueriesClient {
-	return NewQueriesClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewQueriesClient(pl)
 }
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format

--- a/test/autorest/urlgroup/zz_generated_pathitems_client.go
+++ b/test/autorest/urlgroup/zz_generated_pathitems_client.go
@@ -11,7 +11,6 @@ package urlgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -30,15 +29,12 @@ type PathItemsClient struct {
 // NewPathItemsClient creates a new instance of PathItemsClient with the specified values.
 // globalStringPath - A string value 'globalItemStringPath' that appears in the path
 // globalStringQuery - should contain value null
-// options - pass nil to accept the default values.
-func NewPathItemsClient(globalStringPath string, globalStringQuery *string, options *azcore.ClientOptions) *PathItemsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPathItemsClient(globalStringPath string, globalStringQuery *string, pl runtime.Pipeline) *PathItemsClient {
 	client := &PathItemsClient{
 		globalStringPath:  globalStringPath,
 		globalStringQuery: globalStringQuery,
-		pl:                runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl:                pl,
 	}
 	return client
 }

--- a/test/autorest/urlgroup/zz_generated_paths_client.go
+++ b/test/autorest/urlgroup/zz_generated_paths_client.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -28,13 +27,10 @@ type PathsClient struct {
 }
 
 // NewPathsClient creates a new instance of PathsClient with the specified values.
-// options - pass nil to accept the default values.
-func NewPathsClient(options *azcore.ClientOptions) *PathsClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewPathsClient(pl runtime.Pipeline) *PathsClient {
 	client := &PathsClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/urlgroup/zz_generated_queries_client.go
+++ b/test/autorest/urlgroup/zz_generated_queries_client.go
@@ -11,7 +11,6 @@ package urlgroup
 import (
 	"context"
 	"encoding/base64"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -27,13 +26,10 @@ type QueriesClient struct {
 }
 
 // NewQueriesClient creates a new instance of QueriesClient with the specified values.
-// options - pass nil to accept the default values.
-func NewQueriesClient(options *azcore.ClientOptions) *QueriesClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewQueriesClient(pl runtime.Pipeline) *QueriesClient {
 	client := &QueriesClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -8,11 +8,14 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
 func newQueriesClient() *QueriesClient {
-	return NewQueriesClient(nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewQueriesClient(pl)
 }
 
 func TestURLMultiArrayStringMultiEmpty(t *testing.T) {

--- a/test/autorest/urlmultigroup/zz_generated_queries_client.go
+++ b/test/autorest/urlmultigroup/zz_generated_queries_client.go
@@ -10,7 +10,6 @@ package urlmultigroup
 
 import (
 	"context"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,13 +22,10 @@ type QueriesClient struct {
 }
 
 // NewQueriesClient creates a new instance of QueriesClient with the specified values.
-// options - pass nil to accept the default values.
-func NewQueriesClient(options *azcore.ClientOptions) *QueriesClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewQueriesClient(pl runtime.Pipeline) *QueriesClient {
 	client := &QueriesClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -7,13 +7,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
 
 func newAutoRestValidationTestClient() *AutoRestValidationTestClient {
-	return NewAutoRestValidationTestClient("", nil)
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	return NewAutoRestValidationTestClient("", pl)
 }
 
 func TestValidationGetWithConstantInPath(t *testing.T) {

--- a/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
+++ b/test/autorest/validationgroup/zz_generated_autorestvalidationtest_client.go
@@ -11,7 +11,6 @@ package validationgroup
 import (
 	"context"
 	"errors"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -29,14 +28,11 @@ type AutoRestValidationTestClient struct {
 
 // NewAutoRestValidationTestClient creates a new instance of AutoRestValidationTestClient with the specified values.
 // subscriptionID - Subscription ID.
-// options - pass nil to accept the default values.
-func NewAutoRestValidationTestClient(subscriptionID string, options *azcore.ClientOptions) *AutoRestValidationTestClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewAutoRestValidationTestClient(subscriptionID string, pl runtime.Pipeline) *AutoRestValidationTestClient {
 	client := &AutoRestValidationTestClient{
 		subscriptionID: subscriptionID,
-		pl:             runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl:             pl,
 	}
 	return client
 }

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
@@ -24,11 +25,12 @@ func toTimePtr(layout string, value string) *time.Time {
 }
 
 func newXMLClient() *XMLClient {
-	return NewXMLClient(&azcore.ClientOptions{
+	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{
 		Logging: policy.LogOptions{
 			IncludeBody: true,
 		},
 	})
+	return NewXMLClient(pl)
 }
 
 func TestGetACLs(t *testing.T) {

--- a/test/autorest/xmlgroup/zz_generated_xml_client.go
+++ b/test/autorest/xmlgroup/zz_generated_xml_client.go
@@ -11,7 +11,6 @@ package xmlgroup
 import (
 	"context"
 	"encoding/xml"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,13 +23,10 @@ type XMLClient struct {
 }
 
 // NewXMLClient creates a new instance of XMLClient with the specified values.
-// options - pass nil to accept the default values.
-func NewXMLClient(options *azcore.ClientOptions) *XMLClient {
-	if options == nil {
-		options = &azcore.ClientOptions{}
-	}
+// pl - the pipeline used for sending requests and handling responses.
+func NewXMLClient(pl runtime.Pipeline) *XMLClient {
 	client := &XMLClient{
-		pl: runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, options),
+		pl: pl,
 	}
 	return client
 }

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -37,19 +37,17 @@ func newClient(geography *Geography, clientVersion *string, clientIndex *int32, 
 		geography = &defaultValue
 	}
 	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
-	if clientVersion == nil {
-		clientVersionDefault := "2.0"
-		clientVersion = &clientVersionDefault
-	}
-	if clientIndex == nil {
-		clientIndexDefault := int32(567)
-		clientIndex = &clientIndexDefault
-	}
 	client := &client{
+		clientVersion: "2.0",
+		clientIndex:   int32(567),
 		endpoint:      hostURL,
-		clientVersion: *clientVersion,
-		clientIndex:   *clientIndex,
 		pl:            pl,
+	}
+	if clientVersion != nil {
+		client.clientVersion = *clientVersion
+	}
+	if clientIndex != nil {
+		client.clientIndex = *clientIndex
 	}
 	return client
 }


### PR DESCRIPTION
The client constructors for vanilla and data-plane are now the same.
They both require discrete required/optional parameters and a pipeline.
Unified the population of client parameters with default values.
Start to remove predicating codegen choices on "vanilla ARM".