### PR TITLE
Fix for head as boolean

### DIFF
--- a/test/autorest/azurespecialsgroup/zz_generated_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_header_client.go
@@ -86,6 +86,9 @@ func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooCli
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDHeadResponse{}, err
 	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNotFound) {
+		return HeaderClientCustomNamedRequestIDHeadResponse{}, runtime.NewResponseError(resp)
+	}
 	return client.customNamedRequestIDHeadHandleResponse(resp)
 }
 
@@ -107,9 +110,7 @@ func (client *HeaderClient) customNamedRequestIDHeadHandleResponse(resp *http.Re
 	if val := resp.Header.Get("foo-request-id"); val != "" {
 		result.FooRequestID = &val
 	}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
-	}
+	result.Success = resp.StatusCode >= 200 && resp.StatusCode < 300
 	return result, nil
 }
 

--- a/test/autorest/headgroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/headgroup/zz_generated_httpsuccess_client.go
@@ -42,11 +42,10 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	result := HTTPSuccessClientHead200Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNotFound) {
+		return HTTPSuccessClientHead200Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead200Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head200CreateRequest creates the Head200 request.
@@ -71,11 +70,10 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	result := HTTPSuccessClientHead204Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusNoContent, http.StatusNotFound) {
+		return HTTPSuccessClientHead204Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead204Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head204CreateRequest creates the Head204 request.
@@ -100,11 +98,10 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	result := HTTPSuccessClientHead404Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusNoContent, http.StatusNotFound) {
+		return HTTPSuccessClientHead404Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead404Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head404CreateRequest creates the Head404 request.

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -88,37 +88,29 @@ func TestHTTPClientFailureGet416(t *testing.T) {
 func TestHTTPClientFailureHead400(t *testing.T) {
 	client := newHTTPClientFailureClient()
 	result, err := client.Head400(context.Background(), nil)
-	require.NoError(t, err)
-	if result.Success {
-		t.Fatal("Expected a false result")
-	}
+	require.Error(t, err)
+	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead401(t *testing.T) {
 	client := newHTTPClientFailureClient()
 	result, err := client.Head401(context.Background(), nil)
-	require.NoError(t, err)
-	if result.Success {
-		t.Fatal("Expected a false result")
-	}
+	require.Error(t, err)
+	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead410(t *testing.T) {
 	client := newHTTPClientFailureClient()
 	result, err := client.Head410(context.Background(), nil)
-	require.NoError(t, err)
-	if result.Success {
-		t.Fatal("Expected a false result")
-	}
+	require.Error(t, err)
+	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead429(t *testing.T) {
 	client := newHTTPClientFailureClient()
 	result, err := client.Head429(context.Background(), nil)
-	require.NoError(t, err)
-	if result.Success {
-		t.Fatal("Expected a false result")
-	}
+	require.Error(t, err)
+	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureOptions400(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -34,10 +34,8 @@ func TestHTTPServerFailureGet501(t *testing.T) {
 func TestHTTPServerFailureHead501(t *testing.T) {
 	client := newHTTPServerFailureClient()
 	result, err := client.Head501(context.Background(), nil)
-	require.NoError(t, err)
-	if result.Success {
-		t.Fatal("unexpected success")
-	}
+	require.Error(t, err)
+	require.False(t, result.Success)
 }
 
 func TestHTTPServerFailurePost505(t *testing.T) {

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpclientfailure_client.go
@@ -322,11 +322,10 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead400Response{}, err
 	}
-	result := HTTPClientFailureClientHead400Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return HTTPClientFailureClientHead400Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPClientFailureClientHead400Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head400CreateRequest creates the Head400 request.
@@ -353,11 +352,10 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead401Response{}, err
 	}
-	result := HTTPClientFailureClientHead401Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return HTTPClientFailureClientHead401Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPClientFailureClientHead401Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head401CreateRequest creates the Head401 request.
@@ -384,11 +382,10 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead410Response{}, err
 	}
-	result := HTTPClientFailureClientHead410Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return HTTPClientFailureClientHead410Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPClientFailureClientHead410Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head410CreateRequest creates the Head410 request.
@@ -415,11 +412,10 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead429Response{}, err
 	}
-	result := HTTPClientFailureClientHead429Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return HTTPClientFailureClientHead429Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPClientFailureClientHead429Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head429CreateRequest creates the Head429 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpredirects_client.go
@@ -204,6 +204,9 @@ func (client *HTTPRedirectsClient) Head300(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead300Response{}, err
 	}
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusMultipleChoices) {
+		return HTTPRedirectsClientHead300Response{}, runtime.NewResponseError(resp)
+	}
 	return client.head300HandleResponse(resp)
 }
 
@@ -224,9 +227,7 @@ func (client *HTTPRedirectsClient) head300HandleResponse(resp *http.Response) (H
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
 	}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
-	}
+	result.Success = resp.StatusCode >= 200 && resp.StatusCode < 300
 	return result, nil
 }
 
@@ -242,11 +243,10 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead301Response{}, err
 	}
-	result := HTTPRedirectsClientHead301Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return HTTPRedirectsClientHead301Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPRedirectsClientHead301Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head301CreateRequest creates the Head301 request.
@@ -272,11 +272,10 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead302Response{}, err
 	}
-	result := HTTPRedirectsClientHead302Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return HTTPRedirectsClientHead302Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPRedirectsClientHead302Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head302CreateRequest creates the Head302 request.
@@ -302,11 +301,10 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead307Response{}, err
 	}
-	result := HTTPRedirectsClientHead307Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return HTTPRedirectsClientHead307Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPRedirectsClientHead307Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head307CreateRequest creates the Head307 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpretry_client.go
@@ -102,11 +102,10 @@ func (client *HTTPRetryClient) Head408(ctx context.Context, options *HTTPRetryCl
 	if err != nil {
 		return HTTPRetryClientHead408Response{}, err
 	}
-	result := HTTPRetryClientHead408Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return HTTPRetryClientHead408Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPRetryClientHead408Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head408CreateRequest creates the Head408 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpserverfailure_client.go
@@ -105,11 +105,10 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPServerFailureClientHead501Response{}, err
 	}
-	result := HTTPServerFailureClientHead501Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusCreated, http.StatusAccepted, http.StatusNoContent) {
+		return HTTPServerFailureClientHead501Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPServerFailureClientHead501Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head501CreateRequest creates the Head501 request.

--- a/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_httpsuccess_client.go
@@ -171,11 +171,10 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	result := HTTPSuccessClientHead200Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusOK) {
+		return HTTPSuccessClientHead200Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead200Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head200CreateRequest creates the Head200 request.
@@ -201,11 +200,10 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	result := HTTPSuccessClientHead204Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusNoContent) {
+		return HTTPSuccessClientHead204Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead204Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head204CreateRequest creates the Head204 request.
@@ -231,11 +229,10 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	result := HTTPSuccessClientHead404Response{}
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		result.Success = true
+	if !runtime.HasStatusCode(resp, http.StatusNoContent, http.StatusNotFound) {
+		return HTTPSuccessClientHead404Response{}, runtime.NewResponseError(resp)
 	}
-	return result, nil
+	return HTTPSuccessClientHead404Response{Success: resp.StatusCode >= 200 && resp.StatusCode < 300}, nil
 }
 
 // head404CreateRequest creates the Head404 request.


### PR DESCRIPTION
Use the list of specified HTTP status codes from the swagger instead of
a hard-coded 4xx list for false.  This was masking some endpoints that
don't support HEAD and were returning a 405.