### PR TITLE
Remove moduleName and moduleVersion constants for data-plane

### DIFF
--- a/.scripts/buildvet.js
+++ b/.scripts/buildvet.js
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+
+recursiveFindGoMod('test');
+
+function recursiveFindGoMod(cur) {
+    const dir = fs.opendirSync(cur);
+    while (true) {
+        const dirEnt = dir.readSync()
+        if (dirEnt === null) {
+            break;
+        }
+        if (dirEnt.isFile() && dirEnt.name === 'go.mod') {
+            console.log('go build && go vet ' + cur);
+            try {
+                execSync('go build ./...', { cwd: cur });
+                execSync('go vet ./...', { cwd: cur });
+            } catch (err) {
+                console.error(err);
+            }
+        } else if (dirEnt.isDirectory()) {
+            recursiveFindGoMod(cur + '/' + dirEnt.name);
+        }
+    }
+    dir.close();
+}

--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -60,6 +60,12 @@
       "name": "modtidy",
       "summary": "run node .scripts/modtidy.js to perform tidy up all go.mod files",
       "shellCommand": "node .scripts/modtidy.js"
+    },
+    {
+      "commandKind": "global",
+      "name": "buildvet",
+      "summary": "run node .scripts/buildvet.js to build and vet all modules",
+      "shellCommand": "node .scripts/buildvet.js"
     }
   ],
   "parameters": [

--- a/src/generator/constants.ts
+++ b/src/generator/constants.ts
@@ -20,10 +20,13 @@ export async function generateConstants(session: Session<CodeModel>, version: st
   if (session.model.language.go!.host) {
     text += `const host = "${session.model.language.go!.host}"\n\n`;
   }
-  text += `const (\n`;
-  text += `\tmoduleName = "${session.model.language.go!.packageName}"\n`;
-  text += `\tmoduleVersion = "v${version}"\n`;
-  text += ')\n\n';
+  // data-plane clients must manage their own constants for these values
+  if (<boolean>session.model.language.go!.azureARM) {
+    text += `const (\n`;
+    text += `\tmoduleName = "${session.model.language.go!.packageName}"\n`;
+    text += `\tmoduleVersion = "v${version}"\n`;
+    text += ')\n\n';
+  }
   for (const enm of values(getEnums(session.model.schemas))) {
     if (enm.desc) {
       text += `${comment(`${enm.name} - ${enm.desc}`, '// ', undefined, commentLength)}\n`;

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -6,6 +6,7 @@ package additionalpropsgroup
 import (
 	"context"
 	"encoding/base64"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -16,7 +17,7 @@ import (
 )
 
 func newPetsClient() *PetsClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPetsClient(pl)
 }
 

--- a/test/autorest/additionalpropsgroup/zz_generated_constants.go
+++ b/test/autorest/additionalpropsgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package additionalpropsgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "additionalpropsgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -5,6 +5,7 @@ package arraygroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func newArrayClient() *ArrayClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewArrayClient(pl)
 }
 

--- a/test/autorest/arraygroup/zz_generated_constants.go
+++ b/test/autorest/arraygroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package arraygroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "arraygroup"
-	moduleVersion = "v0.1.0"
-)
-
 type Enum0 string
 
 const (

--- a/test/autorest/azurereportgroup/zz_generated_constants.go
+++ b/test/autorest/azurereportgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package azurereportgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "azurereportgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newAPIVersionDefaultClient() *APIVersionDefaultClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewAPIVersionDefaultClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newAPIVersionLocalClient() *APIVersionLocalClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewAPIVersionLocalClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newHeaderClient() *HeaderClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHeaderClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/odata_test.go
+++ b/test/autorest/azurespecialsgroup/odata_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newODataClient() *ODataClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewODataClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newSkipURLEncodingClient() *SkipURLEncodingClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewSkipURLEncodingClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newSubscriptionInCredentialsClient() *SubscriptionInCredentialsClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewSubscriptionInCredentialsClient("1234-5678-9012-3456", pl)
 }
 

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newSubscriptionInMethodClient() *SubscriptionInMethodClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewSubscriptionInMethodClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -5,6 +5,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newXMSClientRequestIDClient() *XMSClientRequestIDClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewXMSClientRequestIDClient(pl)
 }
 

--- a/test/autorest/azurespecialsgroup/zz_generated_constants.go
+++ b/test/autorest/azurespecialsgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package azurespecialsgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "azurespecialsgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/binarygroup/binarygroup_test.go
+++ b/test/autorest/binarygroup/binarygroup_test.go
@@ -6,6 +6,7 @@ package binarygroup
 import (
 	"bytes"
 	"context"
+	"generatortests"
 	"strings"
 	"testing"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func newBinaryGroupClient() *UploadClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewUploadClient(pl)
 }
 

--- a/test/autorest/binarygroup/zz_generated_constants.go
+++ b/test/autorest/binarygroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package binarygroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "binarygroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -5,6 +5,7 @@ package booleangroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newBoolClient() *BoolClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewBoolClient(pl)
 }
 

--- a/test/autorest/booleangroup/zz_generated_constants.go
+++ b/test/autorest/booleangroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package booleangroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "booleangroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/bytegroup/bytegroup_test.go
+++ b/test/autorest/bytegroup/bytegroup_test.go
@@ -5,6 +5,7 @@ package bytegroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newByteClient() *ByteClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewByteClient(pl)
 }
 

--- a/test/autorest/bytegroup/zz_generated_constants.go
+++ b/test/autorest/bytegroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package bytegroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "bytegroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newArrayClient() *ArrayClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewArrayClient(pl)
 }
 

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newBasicClient() *BasicClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewBasicClient(pl)
 }
 

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newDictionaryClient() *DictionaryClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDictionaryClient(pl)
 }
 

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newInheritanceClient() *InheritanceClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewInheritanceClient(pl)
 }
 

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func newPolymorphicrecursiveClient() *PolymorphicrecursiveClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPolymorphicrecursiveClient(pl)
 }
 

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func newPolymorphismClient() *PolymorphismClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPolymorphismClient(pl)
 }
 

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -6,6 +6,7 @@ package complexgroup
 import (
 	"context"
 	"encoding/json"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ import (
 )
 
 func newPrimitiveClient() *PrimitiveClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPrimitiveClient(pl)
 }
 

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -5,6 +5,7 @@ package complexgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newReadonlypropertyClient() *ReadonlypropertyClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewReadonlypropertyClient(pl)
 }
 

--- a/test/autorest/complexgroup/zz_generated_constants.go
+++ b/test/autorest/complexgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package complexgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "complexgroup"
-	moduleVersion = "v0.1.0"
-)
-
 type CMYKColors string
 
 const (

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -5,6 +5,7 @@ package complexmodelgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newComplexModelClient() *ComplexModelClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewComplexModelClient(pl)
 }
 

--- a/test/autorest/complexmodelgroup/zz_generated_constants.go
+++ b/test/autorest/complexmodelgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package complexmodelgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "complexmodelgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/constants.go
+++ b/test/autorest/constants.go
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package generatortests
+
+const (
+	ModuleName    = "generatortests"
+	ModuleVersion = "v1.0.0"
+)

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -5,6 +5,7 @@ package custombaseurlgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newPathsClient() *PathsClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPathsClient(to.Ptr(":3000"), pl)
 }
 

--- a/test/autorest/custombaseurlgroup/zz_generated_constants.go
+++ b/test/autorest/custombaseurlgroup/zz_generated_constants.go
@@ -7,8 +7,3 @@
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 package custombaseurlgroup
-
-const (
-	moduleName    = "custombaseurlgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/dategroup/date_test.go
+++ b/test/autorest/dategroup/date_test.go
@@ -5,6 +5,7 @@ package dategroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func newDateClient() *DateClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDateClient(pl)
 }
 

--- a/test/autorest/dategroup/zz_generated_constants.go
+++ b/test/autorest/dategroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package dategroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "dategroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -5,6 +5,7 @@ package datetimegroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func newDatetimeClient() *DatetimeClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDatetimeClient(pl)
 }
 

--- a/test/autorest/datetimegroup/zz_generated_constants.go
+++ b/test/autorest/datetimegroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package datetimegroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "datetimegroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -5,6 +5,7 @@ package datetimerfc1123group
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 )
 
 func newDatetimerfc1123Client() *Datetimerfc1123Client {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDatetimerfc1123Client(pl)
 }
 

--- a/test/autorest/datetimerfc1123group/zz_generated_constants.go
+++ b/test/autorest/datetimerfc1123group/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package datetimerfc1123group
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "datetimerfc1123group"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -5,6 +5,7 @@ package dictionarygroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 )
 
 func newDictionaryClient() *DictionaryClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDictionaryClient(pl)
 }
 

--- a/test/autorest/dictionarygroup/zz_generated_constants.go
+++ b/test/autorest/dictionarygroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package dictionarygroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "dictionarygroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/durationgroup/durationgroup_test.go
+++ b/test/autorest/durationgroup/durationgroup_test.go
@@ -5,6 +5,7 @@ package durationgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newDurationClient() *DurationClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewDurationClient(pl)
 }
 

--- a/test/autorest/durationgroup/zz_generated_constants.go
+++ b/test/autorest/durationgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package durationgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "durationgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/errorsgroup/errorsgroup_test.go
+++ b/test/autorest/errorsgroup/errorsgroup_test.go
@@ -6,6 +6,7 @@ package errorsgroup
 import (
 	"context"
 	"errors"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ import (
 func newPetClient() *PetClient {
 	options := azcore.ClientOptions{}
 	options.Retry.MaxRetryDelay = 20 * time.Millisecond
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewPetClient(pl)
 }
 

--- a/test/autorest/errorsgroup/zz_generated_constants.go
+++ b/test/autorest/errorsgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package errorsgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "errorsgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/extenumsgroup/extenumsgroup_test.go
+++ b/test/autorest/extenumsgroup/extenumsgroup_test.go
@@ -5,6 +5,7 @@ package extenumsgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newPetClient() *PetClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPetClient(pl)
 }
 

--- a/test/autorest/extenumsgroup/zz_generated_constants.go
+++ b/test/autorest/extenumsgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package extenumsgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "extenumsgroup"
-	moduleVersion = "v0.1.0"
-)
-
 // DaysOfWeekExtensibleEnum - Type of Pet
 type DaysOfWeekExtensibleEnum string
 

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -5,6 +5,7 @@ package filegroup
 
 import (
 	"context"
+	"generatortests"
 	"io/ioutil"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newFilesClient() *FilesClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewFilesClient(pl)
 }
 

--- a/test/autorest/filegroup/zz_generated_constants.go
+++ b/test/autorest/filegroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package filegroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "filegroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/formdatagroup/formgroup_test.go
+++ b/test/autorest/formdatagroup/formgroup_test.go
@@ -5,6 +5,7 @@ package formdatagroup
 
 import (
 	"context"
+	"generatortests"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -17,7 +18,7 @@ import (
 )
 
 func newFormdataClient() *FormdataClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewFormdataClient(pl)
 }
 

--- a/test/autorest/formdatagroup/zz_generated_constants.go
+++ b/test/autorest/formdatagroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package formdatagroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "formdatagroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -5,6 +5,7 @@ package headergroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"testing"
 	"time"
@@ -17,7 +18,7 @@ import (
 )
 
 func newHeaderClient() *HeaderClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHeaderClient(pl)
 }
 

--- a/test/autorest/headergroup/zz_generated_constants.go
+++ b/test/autorest/headergroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package headergroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "headergroup"
-	moduleVersion = "v0.1.0"
-)
-
 type GreyscaleColors string
 
 const (

--- a/test/autorest/headgroup/headgroup_test.go
+++ b/test/autorest/headgroup/headgroup_test.go
@@ -5,6 +5,7 @@ package headgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newHTTPSuccessOperationsClient() *HTTPSuccessClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHTTPSuccessClient(pl)
 }
 

--- a/test/autorest/headgroup/zz_generated_constants.go
+++ b/test/autorest/headgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package headgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "headgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newHTTPClientFailureClient() *HTTPClientFailureClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &policy.ClientOptions{
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &policy.ClientOptions{
 		Retry: policy.RetryOptions{
 			MaxRetryDelay: 2 * time.Second,
 		},

--- a/test/autorest/httpinfrastructuregroup/httpfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpfailure_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newHTTPFailureClient() *HTTPFailureClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHTTPFailureClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -6,6 +6,7 @@ package httpinfrastructuregroup
 import (
 	"context"
 	"errors"
+	"generatortests"
 	"reflect"
 	"testing"
 
@@ -18,7 +19,7 @@ import (
 )
 
 func newMultipleResponsesClient() *MultipleResponsesClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewMultipleResponsesClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newHTTPRedirectsClient() *HTTPRedirectsClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHTTPRedirectsClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"net/http/cookiejar"
 	"testing"
@@ -20,7 +21,7 @@ func newHTTPRetryClient() *HTTPRetryClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewHTTPRetryClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newHTTPServerFailureClient() *HTTPServerFailureClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHTTPServerFailureClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -5,6 +5,7 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newHTTPSuccessClient() *HTTPSuccessClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewHTTPSuccessClient(pl)
 }
 

--- a/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
+++ b/test/autorest/httpinfrastructuregroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package httpinfrastructuregroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "httpinfrastructuregroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -5,6 +5,7 @@ package integergroup
 
 import (
 	"context"
+	"generatortests"
 	"math"
 	"testing"
 	"time"
@@ -16,7 +17,7 @@ import (
 )
 
 func newIntClient() *IntClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewIntClient(pl)
 }
 

--- a/test/autorest/integergroup/zz_generated_constants.go
+++ b/test/autorest/integergroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package integergroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "integergroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -5,6 +5,7 @@ package lrogroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ func newLRORetrysClient() *LRORetrysClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewLRORetrysClient(pl)
 }
 

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -6,6 +6,7 @@ package lrogroup
 import (
 	"context"
 	"errors"
+	"generatortests"
 	"net/http"
 	"net/http/cookiejar"
 	"reflect"
@@ -23,7 +24,7 @@ func newLROSClient() *LROsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewLROsClient(pl)
 }
 

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -5,6 +5,7 @@ package lrogroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func newLrosaDsClient() *LROSADsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewLROSADsClient(pl)
 }
 

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -5,6 +5,7 @@ package lrogroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func newLrOSCustomHeaderClient() *LROsCustomHeaderClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewLROsCustomHeaderClient(pl)
 }
 

--- a/test/autorest/lrogroup/zz_generated_constants.go
+++ b/test/autorest/lrogroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package lrogroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "lrogroup"
-	moduleVersion = "v0.1.0"
-)
-
 // OperationResultStatus - The status of the request
 type OperationResultStatus string
 

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -6,6 +6,7 @@ package mediatypesgroup
 import (
 	"bytes"
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -16,7 +17,7 @@ import (
 )
 
 func newMediaTypesClient() *MediaTypesClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewMediaTypesClient(pl)
 }
 

--- a/test/autorest/mediatypesgroup/zz_generated_constants.go
+++ b/test/autorest/mediatypesgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package mediatypesgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "mediatypesgroup"
-	moduleVersion = "v0.1.0"
-)
-
 // ContentType - Content type for upload
 type ContentType string
 

--- a/test/autorest/migroup/migroup_test.go
+++ b/test/autorest/migroup/migroup_test.go
@@ -5,6 +5,7 @@ package migroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newMultipleInheritanceServiceClient() *MultipleInheritanceServiceClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewMultipleInheritanceServiceClient(pl)
 }
 

--- a/test/autorest/migroup/zz_generated_constants.go
+++ b/test/autorest/migroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package migroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "migroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -5,6 +5,7 @@ package morecustombaseurigroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 
 func newPathsClient() *PathsClient {
 	// dnsSuffix string, subscriptionID string
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPathsClient(to.Ptr(":3000"), "test12", pl)
 }
 

--- a/test/autorest/morecustombaseurigroup/zz_generated_constants.go
+++ b/test/autorest/morecustombaseurigroup/zz_generated_constants.go
@@ -7,8 +7,3 @@
 // Changes may cause incorrect behavior and will be lost if the code is regenerated.
 
 package morecustombaseurigroup
-
-const (
-	moduleName    = "morecustombaseurigroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -5,6 +5,7 @@ package nonstringenumgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newFloatClient() *FloatClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewFloatClient(pl)
 }
 

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -5,6 +5,7 @@ package nonstringenumgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newIntClient() *IntClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewIntClient(pl)
 }
 

--- a/test/autorest/nonstringenumgroup/zz_generated_constants.go
+++ b/test/autorest/nonstringenumgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package nonstringenumgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "nonstringenumgroup"
-	moduleVersion = "v0.1.0"
-)
-
 // FloatEnum - List of float enums
 type FloatEnum float32
 

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -5,6 +5,7 @@ package numbergroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newNumberClient() *NumberClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewNumberClient(pl)
 }
 

--- a/test/autorest/numbergroup/zz_generated_constants.go
+++ b/test/autorest/numbergroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package numbergroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "numbergroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/objectgroup/objectgroup_test.go
+++ b/test/autorest/objectgroup/objectgroup_test.go
@@ -5,6 +5,7 @@ package objectgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newObjectTypeClient() *ObjectTypeClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewObjectTypeClient(pl)
 }
 

--- a/test/autorest/objectgroup/zz_generated_constants.go
+++ b/test/autorest/objectgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package objectgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "objectgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -5,6 +5,7 @@ package optionalgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newExplicitClient() *ExplicitClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewExplicitClient(pl)
 }
 

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -5,6 +5,7 @@ package optionalgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newImplicitClient() *ImplicitClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewImplicitClient("", "", nil, pl)
 }
 

--- a/test/autorest/optionalgroup/zz_generated_constants.go
+++ b/test/autorest/optionalgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package optionalgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "optionalgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/paginggroup/paginggroup_test.go
+++ b/test/autorest/paginggroup/paginggroup_test.go
@@ -5,6 +5,7 @@ package paginggroup
 
 import (
 	"context"
+	"generatortests"
 	"net/http"
 	"net/http/cookiejar"
 	"reflect"
@@ -22,7 +23,7 @@ func newPagingClient() *PagingClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &options)
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
 	return NewPagingClient(pl)
 }
 

--- a/test/autorest/paginggroup/zz_generated_constants.go
+++ b/test/autorest/paginggroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package paginggroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "paginggroup"
-	moduleVersion = "v0.1.0"
-)
-
 // OperationResultStatus - The status of the request
 type OperationResultStatus string
 

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -5,6 +5,7 @@ package paramgroupinggroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,7 +14,7 @@ import (
 )
 
 func newParameterGroupingClient() *ParameterGroupingClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewParameterGroupingClient(pl)
 }
 

--- a/test/autorest/paramgroupinggroup/zz_generated_constants.go
+++ b/test/autorest/paramgroupinggroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package paramgroupinggroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "paramgroupinggroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/reportgroup/zz_generated_constants.go
+++ b/test/autorest/reportgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package reportgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "reportgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -5,6 +5,7 @@ package stringgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newEnumClient() *EnumClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewEnumClient(pl)
 }
 

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -5,6 +5,7 @@ package stringgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newStringClient() *StringClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewStringClient(pl)
 }
 

--- a/test/autorest/stringgroup/zz_generated_constants.go
+++ b/test/autorest/stringgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package stringgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "stringgroup"
-	moduleVersion = "v0.1.0"
-)
-
 // Colors - Referenced Color Enum Description.
 type Colors string
 

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -5,6 +5,7 @@ package urlgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestGetAllWithValues(t *testing.T) {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
 	result, err := grp.GetAllWithValues(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetAllWithValuesOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
@@ -25,7 +26,7 @@ func TestGetAllWithValues(t *testing.T) {
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	grp := NewPathItemsClient("globalStringPath", nil, pl)
 	result, err := grp.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalAndLocalQueryNullOptions{
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
@@ -35,7 +36,7 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	grp := NewPathItemsClient("globalStringPath", nil, pl)
 	result, err := grp.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalQueryNullOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
@@ -46,7 +47,7 @@ func TestGetGlobalQueryNull(t *testing.T) {
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
 	result, err := grp.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "localStringPath", nil)
 	require.NoError(t, err)

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -5,6 +5,7 @@ package urlgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newPathsClient() *PathsClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewPathsClient(pl)
 }
 

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -5,6 +5,7 @@ package urlgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -14,7 +15,7 @@ import (
 )
 
 func newQueriesClient() *QueriesClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewQueriesClient(pl)
 }
 

--- a/test/autorest/urlgroup/zz_generated_constants.go
+++ b/test/autorest/urlgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package urlgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "urlgroup"
-	moduleVersion = "v0.1.0"
-)
-
 type URIColor string
 
 const (

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -5,6 +5,7 @@ package urlmultigroup
 
 import (
 	"context"
+	"generatortests"
 	"net/url"
 	"testing"
 
@@ -14,7 +15,7 @@ import (
 )
 
 func newQueriesClient() *QueriesClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewQueriesClient(pl)
 }
 

--- a/test/autorest/urlmultigroup/zz_generated_constants.go
+++ b/test/autorest/urlmultigroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package urlmultigroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "urlmultigroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -5,6 +5,7 @@ package validationgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,7 @@ import (
 )
 
 func newAutoRestValidationTestClient() *AutoRestValidationTestClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
 	return NewAutoRestValidationTestClient("", pl)
 }
 

--- a/test/autorest/validationgroup/zz_generated_constants.go
+++ b/test/autorest/validationgroup/zz_generated_constants.go
@@ -9,8 +9,3 @@
 package validationgroup
 
 const host = "http://localhost:3000"
-
-const (
-	moduleName    = "validationgroup"
-	moduleVersion = "v0.1.0"
-)

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -5,6 +5,7 @@ package xmlgroup
 
 import (
 	"context"
+	"generatortests"
 	"testing"
 	"time"
 
@@ -25,7 +26,7 @@ func toTimePtr(layout string, value string) *time.Time {
 }
 
 func newXMLClient() *XMLClient {
-	pl := runtime.NewPipeline(moduleName, moduleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{
+	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{
 		Logging: policy.LogOptions{
 			IncludeBody: true,
 		},

--- a/test/autorest/xmlgroup/zz_generated_constants.go
+++ b/test/autorest/xmlgroup/zz_generated_constants.go
@@ -10,11 +10,6 @@ package xmlgroup
 
 const host = "http://localhost:3000"
 
-const (
-	moduleName    = "xmlgroup"
-	moduleVersion = "v0.1.0"
-)
-
 type AccessTier string
 
 const (

--- a/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package azkeyvault
 
-const (
-	moduleName    = "azkeyvault"
-	moduleVersion = "v0.1.0"
-)
-
 // ActionType - The type of the action.
 type ActionType string
 

--- a/test/maps/azalias/zz_generated_constants.go
+++ b/test/maps/azalias/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package azalias
 
-const (
-	moduleName    = "azalias"
-	moduleVersion = "v0.1.0"
-)
-
 // GeoJSONObjectType - Specifies the GeoJSON type. Must be one of the nine valid GeoJSON object types - Point, MultiPoint,
 // LineString, MultiLineString, Polygon, MultiPolygon, GeometryCollection, Feature and
 // FeatureCollection.

--- a/test/storage/2020-06-12/azblob/zz_generated_constants.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package azblob
 
-const (
-	moduleName    = "azblob"
-	moduleVersion = "v0.1.0"
-)
-
 type AccessTier string
 
 const (

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package azartifacts
 
-const (
-	moduleName    = "azartifacts"
-	moduleVersion = "v0.1.0"
-)
-
 type AvroCompressionCodec string
 
 const (

--- a/test/synapse/2019-06-01/azspark/zz_generated_constants.go
+++ b/test/synapse/2019-06-01/azspark/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package azspark
 
-const (
-	moduleName    = "azspark"
-	moduleVersion = "v0.1.0"
-)
-
 type PluginCurrentState string
 
 const (

--- a/test/tables/2019-02-02/aztables/zz_generated_constants.go
+++ b/test/tables/2019-02-02/aztables/zz_generated_constants.go
@@ -8,11 +8,6 @@
 
 package aztables
 
-const (
-	moduleName    = "aztables"
-	moduleVersion = "v0.1.0"
-)
-
 type Enum0 string
 
 const (


### PR DESCRIPTION
They are no longer used by the generated code.  SDK authors must
maintain their own constants of these values which is better than
editing generated code anyways.
Added 'rush buildvet' command to 'go build' and 'go vet' the things.