### PR TITLE
Make module-verison switch required for Azure ARM only

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -146,7 +146,7 @@ function generate(name, inputFile, outputDir, additionalArgs) {
         console.log('generating ' + inputFile);
         outputDir = fullPath(outputDir);
         cleanGeneratedFiles(outputDir);
-        exec('autorest --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --module-version=0.1.0 --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
+        exec('autorest --use=. --file-prefix="zz_generated_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
     });
 }
 

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -72,7 +72,7 @@ help-content:
         type: boolean
         description: Indicates if generated clients are to be exported.  Default to true for ARM, false for data-plane.
       - key: module-version
-        description: Semantic version to include in generated telemetryInfo constant without the leading 'v' (e.g. 1.2.3).
+        description: When --azure-arm is true, semantic version to include in generated telemetryInfo constant without the leading 'v' (e.g. 1.2.3).
         type: string
       - key: group-parameters
         description: Enables parameter grouping via x-ms-parameter-grouping, defaults to true.

--- a/src/generator/generator.ts
+++ b/src/generator/generator.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { serialize } from '@azure-tools/codegen';
-import { AutorestExtensionHost, startSession, Session } from '@autorest/extension-base';
+import { AutorestExtensionHost, startSession } from '@autorest/extension-base';
 import { codeModelSchema, CodeModel } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
 import { generateOperations } from './operations';
@@ -16,16 +16,6 @@ import { generatePolymorphicHelpers } from './polymorphics';
 import { generateGoModFile } from './gomod';
 import { generateXMLAdditionalPropsHelpers } from './xmlAdditionalProps';
 
-async function getModuleVersion(session: Session<CodeModel>): Promise<string> {
-  const version = await session.getValue('module-version', '');
-  if (version === '') {
-    throw new Error('--module-version is a required parameter');
-  } else if (!version.match(/^\d+\.\d+\.\d+$/) && !version.match(/^\d+\.\d+\.\d+-beta\.\d+$/)) {
-    throw new Error(`module version ${version} must in the format major.minor.patch[-beta.N]`);
-  }
-  return version;
-}
-
 // The generator emits Go source code files to disk.
 export async function protocolGen(host: AutorestExtensionHost) {
   const debug = await host.getValue('debug') || false;
@@ -33,7 +23,6 @@ export async function protocolGen(host: AutorestExtensionHost) {
   try {
     // get the code model from the core
     const session = await startSession<CodeModel>(host, codeModelSchema);
-    const version = await getModuleVersion(session);
 
     const operations = await generateOperations(session);
     let filePrefix = await session.getValue('file-prefix', '');
@@ -65,7 +54,7 @@ export async function protocolGen(host: AutorestExtensionHost) {
       });
     }
 
-    const constants = await generateConstants(session, version);
+    const constants = await generateConstants(session);
     host.writeFile({
       filename: `${filePrefix}constants.go`,
       content: constants,


### PR DESCRIPTION
As the moduleVersion constant is no longer generated for data-plane, the
switch should only be required for Azure ARM.