### PR TITLE
Move track2 branch references to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cumbersome.
 
 ### Autorest plugin configuration
 - Please don't edit this section unless you're re-configuring how the Go extension plugs in to AutoRest.  
-AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/master/docs/developer/architecture/AutoRest-extension.md
+AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/main/docs/developer/writing-an-extension.md
 
 > see https://aka.ms/autorest
 

--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -1,12 +1,12 @@
 trigger:
   branches:
     include:
-    - track2
+    - main
 
 pr:
   branches:
     include:
-    - track2
+    - main
 
 variables:
   NodeVersion: '16.x'

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -4,7 +4,7 @@ The Go plugin is used to generate Go source code.
 
 ### Autorest plugin configuration
 - Please don't edit this section unless you're re-configuring how the Go extension plugs in to AutoRest
-AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/master/docs/developer/architecture/AutoRest-extension.md
+AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/main/docs/developer/writing-an-extension.md
 
 # Pipeline Configuration
 ``` yaml

--- a/src/package.json
+++ b/src/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/Azure/autorest.go/issues"
   },
   "homepage": "https://github.com/Azure/autorest.go#readme",
-  "readme": "https://github.com/Azure/autorest.go/blob/track2/readme.md",
+  "readme": "https://github.com/Azure/autorest.go/blob/main/readme.md",
   "devDependencies": {
     "@types/js-yaml": "3.12.1",
     "@types/node": "17.0.23",

--- a/src/readme.md
+++ b/src/readme.md
@@ -21,7 +21,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ### Autorest plugin configuration
 - Please don't edit this section unless you're re-configuring how the Go extension plugs in to AutoRest
-AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/master/docs/developer/architecture/AutoRest-extension.md
+AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/main/docs/developer/writing-an-extension.md
 
 > AutoRest configuration is stored in the 'autorest-configuation.md' file.
 


### PR DESCRIPTION
Resolves #694

@RickWinter @jhendrixMSFT there is a dead link in the README.md to https://github.com/Azure/autorest/blob/master/docs/developer/architecture/AutoRest-extension.md that I can't find the proper location for as the file is gone. It seems this doc is also still linked in the main autorest repository as well but was never updated.