### PR TITLE
Remove incorrect doc comment for Pager APIs

### DIFF
--- a/test/autorest/paginggroup/zz_generated_paging_client.go
+++ b/test/autorest/paginggroup/zz_generated_paging_client.go
@@ -37,7 +37,6 @@ func NewPagingClient(pl runtime.Pipeline) *PagingClient {
 
 // NewDuplicateParamsPager - Define filter as a query param for all calls. However, the returned next link will also include
 // the filter as part of it. Make sure you don't end up duplicating the filter param in the url sent.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientDuplicateParamsOptions contains the optional parameters for the PagingClient.DuplicateParams method.
 func (client *PagingClient) NewDuplicateParamsPager(options *PagingClientDuplicateParamsOptions) *runtime.Pager[PagingClientDuplicateParamsResponse] {
@@ -95,7 +94,6 @@ func (client *PagingClient) duplicateParamsHandleResponse(resp *http.Response) (
 
 // NewFirstResponseEmptyPager - A paging operation whose first response's items list is empty, but still returns a next link.
 // Second (and final) call, will give you an items list of 1.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientFirstResponseEmptyOptions contains the optional parameters for the PagingClient.FirstResponseEmpty
 // method.
@@ -148,7 +146,6 @@ func (client *PagingClient) firstResponseEmptyHandleResponse(resp *http.Response
 }
 
 // NewGetMultiplePagesPager - A paging operation that includes a nextLink that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesOptions contains the optional parameters for the PagingClient.GetMultiplePages method.
 func (client *PagingClient) NewGetMultiplePagesPager(options *PagingClientGetMultiplePagesOptions) *runtime.Pager[PagingClientGetMultiplePagesResponse] {
@@ -209,7 +206,6 @@ func (client *PagingClient) getMultiplePagesHandleResponse(resp *http.Response) 
 }
 
 // NewGetMultiplePagesFailurePager - A paging operation that receives a 400 on the second call
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesFailureOptions contains the optional parameters for the PagingClient.GetMultiplePagesFailure
 // method.
@@ -262,7 +258,6 @@ func (client *PagingClient) getMultiplePagesFailureHandleResponse(resp *http.Res
 }
 
 // NewGetMultiplePagesFailureURIPager - A paging operation that receives an invalid nextLink
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesFailureURIOptions contains the optional parameters for the PagingClient.GetMultiplePagesFailureURI
 // method.
@@ -315,7 +310,6 @@ func (client *PagingClient) getMultiplePagesFailureURIHandleResponse(resp *http.
 }
 
 // NewGetMultiplePagesFragmentNextLinkPager - A paging operation that doesn't return a full URL, just a fragment
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // apiVersion - Sets the api version to use.
 // tenant - Sets the tenant to use.
@@ -378,7 +372,6 @@ func (client *PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp 
 
 // NewGetMultiplePagesFragmentWithGroupingNextLinkPager - A paging operation that doesn't return a full URL, just a fragment
 // with parameters grouped
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // CustomParameterGroup - CustomParameterGroup contains a group of parameters for the PagingClient.GetMultiplePagesFragmentWithGroupingNextLink
 // method.
@@ -440,7 +433,6 @@ func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkHandleRe
 }
 
 // BeginGetMultiplePagesLRO - A long-running paging operation that includes a nextLink that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientBeginGetMultiplePagesLROOptions contains the optional parameters for the PagingClient.BeginGetMultiplePagesLRO
 // method.
@@ -480,7 +472,6 @@ func (client *PagingClient) BeginGetMultiplePagesLRO(ctx context.Context, option
 }
 
 // GetMultiplePagesLRO - A long-running paging operation that includes a nextLink that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 func (client *PagingClient) getMultiplePagesLRO(ctx context.Context, options *PagingClientBeginGetMultiplePagesLROOptions) (*http.Response, error) {
 	req, err := client.getMultiplePagesLROCreateRequest(ctx, options)
@@ -528,7 +519,6 @@ func (client *PagingClient) getMultiplePagesLROHandleResponse(resp *http.Respons
 
 // NewGetMultiplePagesRetryFirstPager - A paging operation that fails on the first call with 500 and then retries and then
 // get a response including a nextLink that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesRetryFirstOptions contains the optional parameters for the PagingClient.GetMultiplePagesRetryFirst
 // method.
@@ -582,7 +572,6 @@ func (client *PagingClient) getMultiplePagesRetryFirstHandleResponse(resp *http.
 
 // NewGetMultiplePagesRetrySecondPager - A paging operation that includes a nextLink that has 10 pages, of which the 2nd call
 // fails first with 500. The client should retry and finish all 10 pages eventually.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesRetrySecondOptions contains the optional parameters for the PagingClient.GetMultiplePagesRetrySecond
 // method.
@@ -635,7 +624,6 @@ func (client *PagingClient) getMultiplePagesRetrySecondHandleResponse(resp *http
 }
 
 // NewGetMultiplePagesWithOffsetPager - A paging operation that includes a nextLink that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetMultiplePagesWithOffsetOptions contains the optional parameters for the PagingClient.GetMultiplePagesWithOffset
 // method.
@@ -698,7 +686,6 @@ func (client *PagingClient) getMultiplePagesWithOffsetHandleResponse(resp *http.
 }
 
 // NewGetNoItemNamePagesPager - A paging operation that must return result of the default 'value' node.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetNoItemNamePagesOptions contains the optional parameters for the PagingClient.GetNoItemNamePages
 // method.
@@ -751,7 +738,6 @@ func (client *PagingClient) getNoItemNamePagesHandleResponse(resp *http.Response
 }
 
 // NewGetNullNextLinkNamePagesPager - A paging operation that must ignore any kind of nextLink, and stop after page 1.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetNullNextLinkNamePagesOptions contains the optional parameters for the PagingClient.GetNullNextLinkNamePages
 // method.
@@ -798,7 +784,6 @@ func (client *PagingClient) getNullNextLinkNamePagesHandleResponse(resp *http.Re
 }
 
 // NewGetODataMultiplePagesPager - A paging operation that includes a nextLink in odata format that has 10 pages
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetODataMultiplePagesOptions contains the optional parameters for the PagingClient.GetODataMultiplePages
 // method.
@@ -861,7 +846,6 @@ func (client *PagingClient) getODataMultiplePagesHandleResponse(resp *http.Respo
 
 // NewGetPagingModelWithItemNameWithXMSClientNamePager - A paging operation that returns a paging model whose item name is
 // is overriden by x-ms-client-name 'indexes'.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetPagingModelWithItemNameWithXMSClientNameOptions contains the optional parameters for the PagingClient.GetPagingModelWithItemNameWithXMSClientName
 // method.
@@ -914,7 +898,6 @@ func (client *PagingClient) getPagingModelWithItemNameWithXMSClientNameHandleRes
 }
 
 // NewGetSinglePagesPager - A paging operation that finishes on the first call without a nextlink
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetSinglePagesOptions contains the optional parameters for the PagingClient.GetSinglePages method.
 func (client *PagingClient) NewGetSinglePagesPager(options *PagingClientGetSinglePagesOptions) *runtime.Pager[PagingClientGetSinglePagesResponse] {
@@ -966,7 +949,6 @@ func (client *PagingClient) getSinglePagesHandleResponse(resp *http.Response) (P
 }
 
 // NewGetSinglePagesFailurePager - A paging operation that receives a 400 on the first call
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // options - PagingClientGetSinglePagesFailureOptions contains the optional parameters for the PagingClient.GetSinglePagesFailure
 // method.
@@ -1020,7 +1002,6 @@ func (client *PagingClient) getSinglePagesFailureHandleResponse(resp *http.Respo
 
 // NewGetWithQueryParamsPager - A paging operation that includes a next operation. It has a different query parameter from
 // it's next operation nextOperationWithQueryParams. Returns a ProductResult
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 1.0.0
 // requiredQueryParameter - A required integer query parameter. Put in value '100' to pass test.
 // options - PagingClientGetWithQueryParamsOptions contains the optional parameters for the PagingClient.GetWithQueryParams

--- a/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_availabilitysets_client.go
@@ -217,7 +217,6 @@ func (client *AvailabilitySetsClient) getHandleResponse(resp *http.Response) (Av
 }
 
 // NewListPager - Lists all availability sets in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - AvailabilitySetsClientListOptions contains the optional parameters for the AvailabilitySetsClient.List method.
@@ -282,7 +281,6 @@ func (client *AvailabilitySetsClient) listHandleResponse(resp *http.Response) (A
 
 // NewListAvailableSizesPager - Lists all available virtual machine sizes that can be used to create a new virtual machine
 // in an existing availability set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // availabilitySetName - The name of the availability set.
@@ -346,7 +344,6 @@ func (client *AvailabilitySetsClient) listAvailableSizesHandleResponse(resp *htt
 }
 
 // NewListBySubscriptionPager - Lists all availability sets in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - AvailabilitySetsClientListBySubscriptionOptions contains the optional parameters for the AvailabilitySetsClient.ListBySubscription
 // method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_containerservices_client.go
@@ -251,7 +251,6 @@ func (client *ContainerServicesClient) getHandleResponse(resp *http.Response) (C
 // NewListPager - Gets a list of container services in the specified subscription. The operation returns properties of each
 // container service including state, orchestrator, number of masters and agents, and FQDNs of
 // masters and agents.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2017-01-31
 // options - ContainerServicesClientListOptions contains the optional parameters for the ContainerServicesClient.List method.
 func (client *ContainerServicesClient) NewListPager(options *ContainerServicesClientListOptions) *runtime.Pager[ContainerServicesClientListResponse] {
@@ -312,7 +311,6 @@ func (client *ContainerServicesClient) listHandleResponse(resp *http.Response) (
 // NewListByResourceGroupPager - Gets a list of container services in the specified subscription and resource group. The operation
 // returns properties of each container service including state, orchestrator, number of masters and
 // agents, and FQDNs of masters and agents.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2017-01-31
 // resourceGroupName - The name of the resource group.
 // options - ContainerServicesClientListByResourceGroupOptions contains the optional parameters for the ContainerServicesClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhostgroups_client.go
@@ -220,7 +220,6 @@ func (client *DedicatedHostGroupsClient) getHandleResponse(resp *http.Response) 
 
 // NewListByResourceGroupPager - Lists all of the dedicated host groups in the specified resource group. Use the nextLink
 // property in the response to get the next page of dedicated host groups.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - DedicatedHostGroupsClientListByResourceGroupOptions contains the optional parameters for the DedicatedHostGroupsClient.ListByResourceGroup
@@ -286,7 +285,6 @@ func (client *DedicatedHostGroupsClient) listByResourceGroupHandleResponse(resp 
 
 // NewListBySubscriptionPager - Lists all of the dedicated host groups in the subscription. Use the nextLink property in the
 // response to get the next page of dedicated host groups.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - DedicatedHostGroupsClientListBySubscriptionOptions contains the optional parameters for the DedicatedHostGroupsClient.ListBySubscription
 // method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_dedicatedhosts_client.go
@@ -258,7 +258,6 @@ func (client *DedicatedHostsClient) getHandleResponse(resp *http.Response) (Dedi
 
 // NewListByHostGroupPager - Lists all of the dedicated hosts in the specified dedicated host group. Use the nextLink property
 // in the response to get the next page of dedicated hosts.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // hostGroupName - The name of the dedicated host group.

--- a/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_diskencryptionsets_client.go
@@ -246,7 +246,6 @@ func (client *DiskEncryptionSetsClient) getHandleResponse(resp *http.Response) (
 }
 
 // NewListPager - Lists all the disk encryption sets under a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // options - DiskEncryptionSetsClientListOptions contains the optional parameters for the DiskEncryptionSetsClient.List method.
 func (client *DiskEncryptionSetsClient) NewListPager(options *DiskEncryptionSetsClientListOptions) *runtime.Pager[DiskEncryptionSetsClientListResponse] {
@@ -305,7 +304,6 @@ func (client *DiskEncryptionSetsClient) listHandleResponse(resp *http.Response) 
 }
 
 // NewListByResourceGroupPager - Lists all the disk encryption sets under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // resourceGroupName - The name of the resource group.
 // options - DiskEncryptionSetsClientListByResourceGroupOptions contains the optional parameters for the DiskEncryptionSetsClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_disks_client.go
@@ -311,7 +311,6 @@ func (client *DisksClient) grantAccessCreateRequest(ctx context.Context, resourc
 }
 
 // NewListPager - Lists all the disks under a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // options - DisksClientListOptions contains the optional parameters for the DisksClient.List method.
 func (client *DisksClient) NewListPager(options *DisksClientListOptions) *runtime.Pager[DisksClientListResponse] {
@@ -370,7 +369,6 @@ func (client *DisksClient) listHandleResponse(resp *http.Response) (DisksClientL
 }
 
 // NewListByResourceGroupPager - Lists all the disks under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // resourceGroupName - The name of the resource group.
 // options - DisksClientListByResourceGroupOptions contains the optional parameters for the DisksClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleries_client.go
@@ -240,7 +240,6 @@ func (client *GalleriesClient) getHandleResponse(resp *http.Response) (Galleries
 }
 
 // NewListPager - List galleries under a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - GalleriesClientListOptions contains the optional parameters for the GalleriesClient.List method.
 func (client *GalleriesClient) NewListPager(options *GalleriesClientListOptions) *runtime.Pager[GalleriesClientListResponse] {
@@ -299,7 +298,6 @@ func (client *GalleriesClient) listHandleResponse(resp *http.Response) (Gallerie
 }
 
 // NewListByResourceGroupPager - List galleries under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - GalleriesClientListByResourceGroupOptions contains the optional parameters for the GalleriesClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplications_client.go
@@ -257,7 +257,6 @@ func (client *GalleryApplicationsClient) getHandleResponse(resp *http.Response) 
 }
 
 // NewListByGalleryPager - List gallery Application Definitions in a gallery.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // galleryName - The name of the Shared Application Gallery from which Application Definitions are to be listed.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryapplicationversions_client.go
@@ -276,7 +276,6 @@ func (client *GalleryApplicationVersionsClient) getHandleResponse(resp *http.Res
 }
 
 // NewListByGalleryApplicationPager - List gallery Application Versions in a gallery Application Definition.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // galleryName - The name of the Shared Application Gallery in which the Application Definition resides.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimages_client.go
@@ -257,7 +257,6 @@ func (client *GalleryImagesClient) getHandleResponse(resp *http.Response) (Galle
 }
 
 // NewListByGalleryPager - List gallery Image Definitions in a gallery.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // galleryName - The name of the Shared Image Gallery from which Image Definitions are to be listed.

--- a/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_galleryimageversions_client.go
@@ -276,7 +276,6 @@ func (client *GalleryImageVersionsClient) getHandleResponse(resp *http.Response)
 }
 
 // NewListByGalleryImagePager - List gallery Image Versions in a gallery Image Definition.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // galleryName - The name of the Shared Image Gallery in which the Image Definition resides.

--- a/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_images_client.go
@@ -242,7 +242,6 @@ func (client *ImagesClient) getHandleResponse(resp *http.Response) (ImagesClient
 
 // NewListPager - Gets the list of Images in the subscription. Use nextLink property in the response to get the next page
 // of Images. Do this till nextLink is null to fetch all the Images.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - ImagesClientListOptions contains the optional parameters for the ImagesClient.List method.
 func (client *ImagesClient) NewListPager(options *ImagesClientListOptions) *runtime.Pager[ImagesClientListResponse] {
@@ -301,7 +300,6 @@ func (client *ImagesClient) listHandleResponse(resp *http.Response) (ImagesClien
 }
 
 // NewListByResourceGroupPager - Gets the list of images under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - ImagesClientListByResourceGroupOptions contains the optional parameters for the ImagesClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_operations_client.go
@@ -50,7 +50,6 @@ func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientO
 }
 
 // NewListPager - Gets a list of compute operations.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - OperationsClientListOptions contains the optional parameters for the OperationsClient.List method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {

--- a/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_proximityplacementgroups_client.go
@@ -222,7 +222,6 @@ func (client *ProximityPlacementGroupsClient) getHandleResponse(resp *http.Respo
 }
 
 // NewListByResourceGroupPager - Lists all proximity placement groups in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - ProximityPlacementGroupsClientListByResourceGroupOptions contains the optional parameters for the ProximityPlacementGroupsClient.ListByResourceGroup
@@ -287,7 +286,6 @@ func (client *ProximityPlacementGroupsClient) listByResourceGroupHandleResponse(
 }
 
 // NewListBySubscriptionPager - Lists all proximity placement groups in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - ProximityPlacementGroupsClientListBySubscriptionOptions contains the optional parameters for the ProximityPlacementGroupsClient.ListBySubscription
 // method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_resourceskus_client.go
@@ -57,7 +57,6 @@ func NewResourceSKUsClient(subscriptionID string, credential azcore.TokenCredent
 }
 
 // NewListPager - Gets the list of Microsoft.Compute SKUs available for your Subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-04-01
 // options - ResourceSKUsClientListOptions contains the optional parameters for the ResourceSKUsClient.List method.
 func (client *ResourceSKUsClient) NewListPager(options *ResourceSKUsClientListOptions) *runtime.Pager[ResourceSKUsClientListResponse] {

--- a/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_snapshots_client.go
@@ -312,7 +312,6 @@ func (client *SnapshotsClient) grantAccessCreateRequest(ctx context.Context, res
 }
 
 // NewListPager - Lists snapshots under a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // options - SnapshotsClientListOptions contains the optional parameters for the SnapshotsClient.List method.
 func (client *SnapshotsClient) NewListPager(options *SnapshotsClientListOptions) *runtime.Pager[SnapshotsClientListResponse] {
@@ -371,7 +370,6 @@ func (client *SnapshotsClient) listHandleResponse(resp *http.Response) (Snapshot
 }
 
 // NewListByResourceGroupPager - Lists snapshots under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-11-01
 // resourceGroupName - The name of the resource group.
 // options - SnapshotsClientListByResourceGroupOptions contains the optional parameters for the SnapshotsClient.ListByResourceGroup

--- a/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_sshpublickeys_client.go
@@ -276,7 +276,6 @@ func (client *SSHPublicKeysClient) getHandleResponse(resp *http.Response) (SSHPu
 
 // NewListByResourceGroupPager - Lists all of the SSH public keys in the specified resource group. Use the nextLink property
 // in the response to get the next page of SSH public keys.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - SSHPublicKeysClientListByResourceGroupOptions contains the optional parameters for the SSHPublicKeysClient.ListByResourceGroup
@@ -342,7 +341,6 @@ func (client *SSHPublicKeysClient) listByResourceGroupHandleResponse(resp *http.
 
 // NewListBySubscriptionPager - Lists all of the SSH public keys in the subscription. Use the nextLink property in the response
 // to get the next page of SSH public keys.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - SSHPublicKeysClientListBySubscriptionOptions contains the optional parameters for the SSHPublicKeysClient.ListBySubscription
 // method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_usage_client.go
@@ -58,7 +58,6 @@ func NewUsageClient(subscriptionID string, credential azcore.TokenCredential, op
 
 // NewListPager - Gets, for the specified location, the current compute resource usage information as well as the limits for
 // compute resources under the subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // location - The location for which resource usage is queried.
 // options - UsageClientListOptions contains the optional parameters for the UsageClient.List method.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachineruncommands_client.go
@@ -114,7 +114,6 @@ func (client *VirtualMachineRunCommandsClient) getHandleResponse(resp *http.Resp
 }
 
 // NewListPager - Lists all available run commands for a subscription in a location.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // location - The location upon which run commands is queried.
 // options - VirtualMachineRunCommandsClientListOptions contains the optional parameters for the VirtualMachineRunCommandsClient.List

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachines_client.go
@@ -556,7 +556,6 @@ func (client *VirtualMachinesClient) instanceViewHandleResponse(resp *http.Respo
 
 // NewListPager - Lists all of the virtual machines in the specified resource group. Use the nextLink property in the response
 // to get the next page of virtual machines.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualMachinesClientListOptions contains the optional parameters for the VirtualMachinesClient.List method.
@@ -621,7 +620,6 @@ func (client *VirtualMachinesClient) listHandleResponse(resp *http.Response) (Vi
 
 // NewListAllPager - Lists all of the virtual machines in the specified subscription. Use the nextLink property in the response
 // to get the next page of virtual machines.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - VirtualMachinesClientListAllOptions contains the optional parameters for the VirtualMachinesClient.ListAll method.
 func (client *VirtualMachinesClient) NewListAllPager(options *VirtualMachinesClientListAllOptions) *runtime.Pager[VirtualMachinesClientListAllResponse] {
@@ -683,7 +681,6 @@ func (client *VirtualMachinesClient) listAllHandleResponse(resp *http.Response) 
 }
 
 // NewListAvailableSizesPager - Lists all available virtual machine sizes to which the specified virtual machine can be resized.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // vmName - The name of the virtual machine.
@@ -747,7 +744,6 @@ func (client *VirtualMachinesClient) listAvailableSizesHandleResponse(resp *http
 }
 
 // NewListByLocationPager - Gets all the virtual machines under the specified subscription for the specified location.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // location - The location for which virtual machines under the subscription are queried.
 // options - VirtualMachinesClientListByLocationOptions contains the optional parameters for the VirtualMachinesClient.ListByLocation

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetextensions_client.go
@@ -258,7 +258,6 @@ func (client *VirtualMachineScaleSetExtensionsClient) getHandleResponse(resp *ht
 }
 
 // NewListPager - Gets a list of all extensions in a VM scale set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // vmScaleSetName - The name of the VM scale set containing the extension.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesets_client.go
@@ -538,7 +538,6 @@ func (client *VirtualMachineScaleSetsClient) getInstanceViewHandleResponse(resp 
 }
 
 // NewGetOSUpgradeHistoryPager - Gets list of OS upgrades on a VM scale set instance.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // vmScaleSetName - The name of the VM scale set.
@@ -608,7 +607,6 @@ func (client *VirtualMachineScaleSetsClient) getOSUpgradeHistoryHandleResponse(r
 }
 
 // NewListPager - Gets a list of all VM scale sets under a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualMachineScaleSetsClientListOptions contains the optional parameters for the VirtualMachineScaleSetsClient.List
@@ -675,7 +673,6 @@ func (client *VirtualMachineScaleSetsClient) listHandleResponse(resp *http.Respo
 // NewListAllPager - Gets a list of all VM Scale Sets in the subscription, regardless of the associated resource group. Use
 // nextLink property in the response to get the next page of VM Scale Sets. Do this till nextLink is
 // null to fetch all the VM Scale Sets.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // options - VirtualMachineScaleSetsClientListAllOptions contains the optional parameters for the VirtualMachineScaleSetsClient.ListAll
 // method.
@@ -736,7 +733,6 @@ func (client *VirtualMachineScaleSetsClient) listAllHandleResponse(resp *http.Re
 
 // NewListSKUsPager - Gets a list of SKUs available for your VM scale set, including the minimum and maximum VM instances
 // allowed for each SKU.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // vmScaleSetName - The name of the VM scale set.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinescalesetvms_client.go
@@ -323,7 +323,6 @@ func (client *VirtualMachineScaleSetVMsClient) getInstanceViewHandleResponse(res
 }
 
 // NewListPager - Gets a list of all virtual machines in a VM scale sets.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the VM scale set.

--- a/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_generated_virtualmachinesizes_client.go
@@ -57,7 +57,6 @@ func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.Token
 }
 
 // NewListPager - This API is deprecated. Use Resources Skus [https://docs.microsoft.com/en-us/rest/api/compute/resourceskus/list]
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-12-01
 // location - The location upon which virtual-machine-sizes is queried.
 // options - VirtualMachineSizesClientListOptions contains the optional parameters for the VirtualMachineSizesClient.List

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_budgets_client.go
@@ -218,7 +218,6 @@ func (client *BudgetsClient) getHandleResponse(resp *http.Response) (BudgetsClie
 }
 
 // NewListPager - Lists all budgets for the defined scope.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with budget operations. This includes '/subscriptions/{subscriptionId}/' for subscription
 // scope, '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}' for

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_events_client.go
@@ -51,7 +51,6 @@ func NewEventsClient(credential azcore.TokenCredential, options *arm.ClientOptio
 }
 
 // NewListPager - Lists the events by billingAccountId and billingProfileId for given start and end date.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // startDate - Start date
 // endDate - End date

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_forecasts_client.go
@@ -58,7 +58,6 @@ func NewForecastsClient(subscriptionID string, credential azcore.TokenCredential
 // NewListPager - Lists the forecast charges for scope defined. Please note that this API is no longer actively under development.
 // We recommend using our new Forecast API moving forward:
 // https://docs.microsoft.com/en-us/rest/api/cost-management/forecast/usage.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // options - ForecastsClientListOptions contains the optional parameters for the ForecastsClient.List method.
 func (client *ForecastsClient) NewListPager(options *ForecastsClientListOptions) *runtime.Pager[ForecastsClientListResponse] {

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_lots_client.go
@@ -51,7 +51,6 @@ func NewLotsClient(credential azcore.TokenCredential, options *arm.ClientOptions
 }
 
 // NewListPager - Lists the lots by billingAccountId and billingProfileId.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with Lots operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}/billingProfile/{billingProfileId}'
 // for Billing Profile scope, and

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_marketplaces_client.go
@@ -53,7 +53,6 @@ func NewMarketplacesClient(credential azcore.TokenCredential, options *arm.Clien
 
 // NewListPager - Lists the marketplaces for a scope at the defined scope. Marketplaces are available via this API only for
 // May 1, 2014 or later.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with marketplace operations. This includes '/subscriptions/{subscriptionId}/' for subscription
 // scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for Billing

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_operations_client.go
@@ -50,7 +50,6 @@ func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientO
 }
 
 // NewListPager - Lists all of the available consumption REST API operations.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // options - OperationsClientListOptions contains the optional parameters for the OperationsClient.List method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationrecommendations_client.go
@@ -51,7 +51,6 @@ func NewReservationRecommendationsClient(credential azcore.TokenCredential, opti
 }
 
 // NewListPager - List of recommendations for purchasing reserved instances.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with reservation recommendations operations. This includes '/subscriptions/{subscriptionId}/'
 // for subscription scope,

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationsdetails_client.go
@@ -53,7 +53,6 @@ func NewReservationsDetailsClient(credential azcore.TokenCredential, options *ar
 }
 
 // NewListPager - Lists the reservations details for the defined scope and provided date range.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with reservations details operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}'
 // for BillingAccount scope (legacy), and
@@ -129,7 +128,6 @@ func (client *ReservationsDetailsClient) listHandleResponse(resp *http.Response)
 }
 
 // NewListByReservationOrderPager - Lists the reservations details for provided date range.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // reservationOrderID - Order Id of the reservation
 // filter - Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports
@@ -193,7 +191,6 @@ func (client *ReservationsDetailsClient) listByReservationOrderHandleResponse(re
 }
 
 // NewListByReservationOrderAndReservationPager - Lists the reservations details for provided date range.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // reservationOrderID - Order Id of the reservation
 // reservationID - Id of the reservation

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationssummaries_client.go
@@ -53,7 +53,6 @@ func NewReservationsSummariesClient(credential azcore.TokenCredential, options *
 }
 
 // NewListPager - Lists the reservations summaries for the defined scope daily or monthly grain.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with reservations summaries operations. This includes '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}'
 // for BillingAccount scope (legacy), and
@@ -131,7 +130,6 @@ func (client *ReservationsSummariesClient) listHandleResponse(resp *http.Respons
 }
 
 // NewListByReservationOrderPager - Lists the reservations summaries for daily or monthly grain.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // reservationOrderID - Order Id of the reservation
 // grain - Can be daily or monthly
@@ -197,7 +195,6 @@ func (client *ReservationsSummariesClient) listByReservationOrderHandleResponse(
 }
 
 // NewListByReservationOrderAndReservationPager - Lists the reservations summaries for daily or monthly grain.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // reservationOrderID - Order Id of the reservation
 // reservationID - Id of the reservation

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_reservationtransactions_client.go
@@ -53,7 +53,6 @@ func NewReservationTransactionsClient(credential azcore.TokenCredential, options
 }
 
 // NewListPager - List of transactions for reserved instances on billing account scope
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // billingAccountID - BillingAccount ID
 // options - ReservationTransactionsClientListOptions contains the optional parameters for the ReservationTransactionsClient.List
@@ -117,7 +116,6 @@ func (client *ReservationTransactionsClient) listHandleResponse(resp *http.Respo
 }
 
 // NewListByBillingProfilePager - List of transactions for reserved instances on billing account scope
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // billingAccountID - BillingAccount ID
 // billingProfileID - Azure Billing Profile ID.

--- a/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_generated_usagedetails_client.go
@@ -54,7 +54,6 @@ func NewUsageDetailsClient(credential azcore.TokenCredential, options *arm.Clien
 // NewListPager - Lists the usage details for the defined scope. Usage details are available via this API only for May 1,
 // 2014 or later. For more information on using this API, including how to specify a date range,
 // please see: https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/manage-automation
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-10-01
 // scope - The scope associated with usage details operations. This includes '/subscriptions/{subscriptionId}/' for subscription
 // scope, '/providers/Microsoft.Billing/billingAccounts/{billingAccountId}' for

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_addons_client.go
@@ -259,7 +259,6 @@ func (client *AddonsClient) getHandleResponse(resp *http.Response) (AddonsClient
 }
 
 // NewListByRolePager - Lists all the addons configured in the role.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // roleName - The role name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_alerts_client.go
@@ -114,7 +114,6 @@ func (client *AlertsClient) getHandleResponse(resp *http.Response) (AlertsClient
 }
 
 // NewListByDataBoxEdgeDevicePager - Gets all the alerts for a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_availableskus_client.go
@@ -56,7 +56,6 @@ func NewAvailableSKUsClient(subscriptionID string, credential azcore.TokenCreden
 }
 
 // NewListPager - List all the available Skus and information related to them.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // options - AvailableSKUsClientListOptions contains the optional parameters for the AvailableSKUsClient.List method.
 func (client *AvailableSKUsClient) NewListPager(options *AvailableSKUsClientListOptions) *runtime.Pager[AvailableSKUsClientListResponse] {

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_bandwidthschedules_client.go
@@ -245,7 +245,6 @@ func (client *BandwidthSchedulesClient) getHandleResponse(resp *http.Response) (
 }
 
 // NewListByDataBoxEdgeDevicePager - Gets all the bandwidth schedules for a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_containers_client.go
@@ -259,7 +259,6 @@ func (client *ContainersClient) getHandleResponse(resp *http.Response) (Containe
 }
 
 // NewListByStorageAccountPager - Lists all the containers of a storage Account in a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // storageAccountName - The storage Account name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_devices_client.go
@@ -620,7 +620,6 @@ func (client *DevicesClient) installUpdatesCreateRequest(ctx context.Context, de
 }
 
 // NewListByResourceGroupPager - Gets all the Data Box Edge/Data Box Gateway devices in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // resourceGroupName - The resource group name.
 // options - DevicesClientListByResourceGroupOptions contains the optional parameters for the DevicesClient.ListByResourceGroup
@@ -688,7 +687,6 @@ func (client *DevicesClient) listByResourceGroupHandleResponse(resp *http.Respon
 }
 
 // NewListBySubscriptionPager - Gets all the Data Box Edge/Data Box Gateway devices in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // options - DevicesClientListBySubscriptionOptions contains the optional parameters for the DevicesClient.ListBySubscription
 // method.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_monitoringconfig_client.go
@@ -245,7 +245,6 @@ func (client *MonitoringConfigClient) getHandleResponse(resp *http.Response) (Mo
 }
 
 // NewListPager - Lists metric configurations in a role.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // roleName - The role name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_nodes_client.go
@@ -56,7 +56,6 @@ func NewNodesClient(subscriptionID string, credential azcore.TokenCredential, op
 }
 
 // NewListByDataBoxEdgeDevicePager - Gets all the nodes currently configured under this Data Box Edge device
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_operations_client.go
@@ -50,7 +50,6 @@ func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientO
 }
 
 // NewListPager - List all the supported operations.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // options - OperationsClientListOptions contains the optional parameters for the OperationsClient.List method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_orders_client.go
@@ -229,7 +229,6 @@ func (client *OrdersClient) getHandleResponse(resp *http.Response) (OrdersClient
 }
 
 // NewListByDataBoxEdgeDevicePager - Lists all the orders related to a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_roles_client.go
@@ -244,7 +244,6 @@ func (client *RolesClient) getHandleResponse(resp *http.Response) (RolesClientGe
 }
 
 // NewListByDataBoxEdgeDevicePager - Lists all the roles configured in a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_shares_client.go
@@ -244,7 +244,6 @@ func (client *SharesClient) getHandleResponse(resp *http.Response) (SharesClient
 }
 
 // NewListByDataBoxEdgeDevicePager - Lists all the shares in a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccountcredentials_client.go
@@ -246,7 +246,6 @@ func (client *StorageAccountCredentialsClient) getHandleResponse(resp *http.Resp
 }
 
 // NewListByDataBoxEdgeDevicePager - Gets all the storage account credentials in a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_storageaccounts_client.go
@@ -245,7 +245,6 @@ func (client *StorageAccountsClient) getHandleResponse(resp *http.Response) (Sto
 }
 
 // NewListByDataBoxEdgeDevicePager - Lists all the StorageAccounts in a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_triggers_client.go
@@ -244,7 +244,6 @@ func (client *TriggersClient) getHandleResponse(resp *http.Response) (TriggersCl
 }
 
 // NewListByDataBoxEdgeDevicePager - Lists all the triggers configured in the device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_generated_users_client.go
@@ -245,7 +245,6 @@ func (client *UsersClient) getHandleResponse(resp *http.Response) (UsersClientGe
 }
 
 // NewListByDataBoxEdgeDevicePager - Gets all the users registered on a Data Box Edge/Data Box Gateway device.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2021-02-01
 // deviceName - The device name.
 // resourceGroupName - The resource group name.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_client.go
@@ -1204,7 +1204,6 @@ func (client *Client) getCertificateIssuerHandleResponse(resp *http.Response) (C
 
 // NewGetCertificateIssuersPager - The GetCertificateIssuers operation returns the set of certificate issuer resources in
 // the specified key vault. This operation requires the certificates/manageissuers/getissuers permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetCertificateIssuersOptions contains the optional parameters for the Client.GetCertificateIssuers method.
@@ -1369,7 +1368,6 @@ func (client *Client) getCertificatePolicyHandleResponse(resp *http.Response) (C
 
 // NewGetCertificateVersionsPager - The GetCertificateVersions operation returns the versions of a certificate in the specified
 // key vault. This operation requires the certificates/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // certificateName - The name of the certificate.
@@ -1436,7 +1434,6 @@ func (client *Client) getCertificateVersionsHandleResponse(resp *http.Response) 
 
 // NewGetCertificatesPager - The GetCertificates operation returns the set of certificates resources in the specified key
 // vault. This operation requires the certificates/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetCertificatesOptions contains the optional parameters for the Client.GetCertificates method.
@@ -1555,7 +1552,6 @@ func (client *Client) getDeletedCertificateHandleResponse(resp *http.Response) (
 // are in a deleted state and ready for recovery or purging. This operation includes deletion-specific
 // information. This operation requires the certificates/get/list permission. This operation can only be enabled on soft-delete
 // enabled vaults.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetDeletedCertificatesOptions contains the optional parameters for the Client.GetDeletedCertificates method.
@@ -1675,7 +1671,6 @@ func (client *Client) getDeletedKeyHandleResponse(resp *http.Response) (ClientGe
 // operation is applicable for vaults enabled for soft-delete. While the operation can be invoked on any vault, it will return
 // an error if invoked on a non soft-delete enabled vault. This operation
 // requires the keys/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetDeletedKeysOptions contains the optional parameters for the Client.GetDeletedKeys method.
@@ -1794,7 +1789,6 @@ func (client *Client) getDeletedSasDefinitionHandleResponse(resp *http.Response)
 
 // NewGetDeletedSasDefinitionsPager - The Get Deleted Sas Definitions operation returns the SAS definitions that have been
 // deleted for a vault enabled for soft-delete. This operation requires the storage/listsas permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
@@ -1913,7 +1907,6 @@ func (client *Client) getDeletedSecretHandleResponse(resp *http.Response) (Clien
 
 // NewGetDeletedSecretsPager - The Get Deleted Secrets operation returns the secrets that have been deleted for a vault enabled
 // for soft-delete. This operation requires the secrets/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetDeletedSecretsOptions contains the optional parameters for the Client.GetDeletedSecrets method.
@@ -2027,7 +2020,6 @@ func (client *Client) getDeletedStorageAccountHandleResponse(resp *http.Response
 
 // NewGetDeletedStorageAccountsPager - The Get Deleted Storage Accounts operation returns the storage accounts that have been
 // deleted for a vault enabled for soft-delete. This operation requires the storage/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetDeletedStorageAccountsOptions contains the optional parameters for the Client.GetDeletedStorageAccounts
@@ -2147,7 +2139,6 @@ func (client *Client) getKeyHandleResponse(resp *http.Response) (ClientGetKeyRes
 
 // NewGetKeyVersionsPager - The full key identifier, attributes, and tags are provided in the response. This operation requires
 // the keys/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // keyName - The name of the key.
@@ -2216,7 +2207,6 @@ func (client *Client) getKeyVersionsHandleResponse(resp *http.Response) (ClientG
 // of a stored key. The LIST operation is applicable to all key types, however only the base key
 // identifier, attributes, and tags are provided in the response. Individual versions of a key are not listed in the response.
 // This operation requires the keys/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetKeysOptions contains the optional parameters for the Client.GetKeys method.
@@ -2334,7 +2324,6 @@ func (client *Client) getSasDefinitionHandleResponse(resp *http.Response) (Clien
 
 // NewGetSasDefinitionsPager - List storage SAS definitions for the given storage account. This operation requires the storage/listsas
 // permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // storageAccountName - The name of the storage account.
@@ -2458,7 +2447,6 @@ func (client *Client) getSecretHandleResponse(resp *http.Response) (ClientGetSec
 
 // NewGetSecretVersionsPager - The full secret identifier and attributes are provided in the response. No values are returned
 // for the secrets. This operations requires the secrets/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // secretName - The name of the secret.
@@ -2526,7 +2514,6 @@ func (client *Client) getSecretVersionsHandleResponse(resp *http.Response) (Clie
 // NewGetSecretsPager - The Get Secrets operation is applicable to the entire vault. However, only the base secret identifier
 // and its attributes are provided in the response. Individual secret versions are not listed in the
 // response. This operation requires the secrets/list permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetSecretsOptions contains the optional parameters for the Client.GetSecrets method.
@@ -2638,7 +2625,6 @@ func (client *Client) getStorageAccountHandleResponse(resp *http.Response) (Clie
 
 // NewGetStorageAccountsPager - List storage accounts managed by the specified key vault. This operation requires the storage/list
 // permission.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // options - ClientGetStorageAccountsOptions contains the optional parameters for the Client.GetStorageAccounts method.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roleassignments_client.go
@@ -192,7 +192,6 @@ func (client *RoleAssignmentsClient) getHandleResponse(resp *http.Response) (Rol
 }
 
 // NewListForScopePager - Gets role assignments for a scope.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role assignments.

--- a/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_generated_roledefinitions_client.go
@@ -193,7 +193,6 @@ func (client *RoleDefinitionsClient) getHandleResponse(resp *http.Response) (Rol
 }
 
 // NewListPager - Get all role definitions that are applicable at scope and above.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 7.2
 // vaultBaseURL - The vault name, for example https://myvault.vault.azure.net.
 // scope - The scope of the role definition.

--- a/test/maps/azalias/zz_generated_client.go
+++ b/test/maps/azalias/zz_generated_client.go
@@ -187,7 +187,6 @@ func (client *client) getScriptHandleResponse(resp *http.Response) (ClientGetScr
 // "2020-02-13T21:19:22.123Z" }, { "createdTimestamp": "2020-02-18T19:53:33.123Z", "aliasId": "1856dbfc-7a66-ee5a-bf8d-51dbfe1906f6",
 // "creatorDataItemId": null, "lastUpdatedTimestamp":
 // "2020-02-18T19:53:33.123Z" } ] }
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2.0
 // options - clientListOptions contains the optional parameters for the client.List method.
 func (client *client) NewListPager(options *clientListOptions) *runtime.Pager[ClientListResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationgateways_client.go
@@ -435,7 +435,6 @@ func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyHandleResponse(re
 }
 
 // NewListPager - Lists all application gateways in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ApplicationGatewaysClientListOptions contains the optional parameters for the ApplicationGatewaysClient.List
@@ -500,7 +499,6 @@ func (client *ApplicationGatewaysClient) listHandleResponse(resp *http.Response)
 }
 
 // NewListAllPager - Gets all the application gateways in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ApplicationGatewaysClientListAllOptions contains the optional parameters for the ApplicationGatewaysClient.ListAll
 // method.
@@ -701,7 +699,6 @@ func (client *ApplicationGatewaysClient) listAvailableSSLOptionsHandleResponse(r
 }
 
 // NewListAvailableSSLPredefinedPoliciesPager - Lists all SSL predefined policies for configuring Ssl policy.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesOptions contains the optional parameters for the ApplicationGatewaysClient.ListAvailableSSLPredefinedPolicies
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_applicationsecuritygroups_client.go
@@ -245,7 +245,6 @@ func (client *ApplicationSecurityGroupsClient) getHandleResponse(resp *http.Resp
 }
 
 // NewListPager - Gets all the application security groups in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ApplicationSecurityGroupsClientListOptions contains the optional parameters for the ApplicationSecurityGroupsClient.List
@@ -310,7 +309,6 @@ func (client *ApplicationSecurityGroupsClient) listHandleResponse(resp *http.Res
 }
 
 // NewListAllPager - Gets all application security groups in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ApplicationSecurityGroupsClientListAllOptions contains the optional parameters for the ApplicationSecurityGroupsClient.ListAll
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availabledelegations_client.go
@@ -57,7 +57,6 @@ func NewAvailableDelegationsClient(subscriptionID string, credential azcore.Toke
 }
 
 // NewListPager - Gets all of the available subnet delegations for this subscription in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the subnet.
 // options - AvailableDelegationsClientListOptions contains the optional parameters for the AvailableDelegationsClient.List

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableendpointservices_client.go
@@ -57,7 +57,6 @@ func NewAvailableEndpointServicesClient(subscriptionID string, credential azcore
 }
 
 // NewListPager - List what values of endpoint services are available for use.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location to check available endpoint services.
 // options - AvailableEndpointServicesClientListOptions contains the optional parameters for the AvailableEndpointServicesClient.List

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableprivateendpointtypes_client.go
@@ -58,7 +58,6 @@ func NewAvailablePrivateEndpointTypesClient(subscriptionID string, credential az
 
 // NewListPager - Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this
 // region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the domain name.
 // options - AvailablePrivateEndpointTypesClientListOptions contains the optional parameters for the AvailablePrivateEndpointTypesClient.List
@@ -124,7 +123,6 @@ func (client *AvailablePrivateEndpointTypesClient) listHandleResponse(resp *http
 
 // NewListByResourceGroupPager - Returns all of the resource types that can be linked to a Private Endpoint in this subscription
 // in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the domain name.
 // resourceGroupName - The name of the resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableresourcegroupdelegations_client.go
@@ -57,7 +57,6 @@ func NewAvailableResourceGroupDelegationsClient(subscriptionID string, credentia
 }
 
 // NewListPager - Gets all of the available subnet delegations for this resource group in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the domain name.
 // resourceGroupName - The name of the resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_availableservicealiases_client.go
@@ -57,7 +57,6 @@ func NewAvailableServiceAliasesClient(subscriptionID string, credential azcore.T
 }
 
 // NewListPager - Gets all available service aliases for this subscription in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location.
 // options - AvailableServiceAliasesClientListOptions contains the optional parameters for the AvailableServiceAliasesClient.List
@@ -122,7 +121,6 @@ func (client *AvailableServiceAliasesClient) listHandleResponse(resp *http.Respo
 }
 
 // NewListByResourceGroupPager - Gets all available service aliases for this resource group in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // location - The location.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewallfqdntags_client.go
@@ -57,7 +57,6 @@ func NewAzureFirewallFqdnTagsClient(subscriptionID string, credential azcore.Tok
 }
 
 // NewListAllPager - Gets all the Azure Firewall FQDN Tags in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - AzureFirewallFqdnTagsClientListAllOptions contains the optional parameters for the AzureFirewallFqdnTagsClient.ListAll
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_azurefirewalls_client.go
@@ -244,7 +244,6 @@ func (client *AzureFirewallsClient) getHandleResponse(resp *http.Response) (Azur
 }
 
 // NewListPager - Lists all Azure Firewalls in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - AzureFirewallsClientListOptions contains the optional parameters for the AzureFirewallsClient.List method.
@@ -308,7 +307,6 @@ func (client *AzureFirewallsClient) listHandleResponse(resp *http.Response) (Azu
 }
 
 // NewListAllPager - Gets all the Azure Firewalls in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - AzureFirewallsClientListAllOptions contains the optional parameters for the AzureFirewallsClient.ListAll method.
 func (client *AzureFirewallsClient) NewListAllPager(options *AzureFirewallsClientListAllOptions) *runtime.Pager[AzureFirewallsClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bastionhosts_client.go
@@ -244,7 +244,6 @@ func (client *BastionHostsClient) getHandleResponse(resp *http.Response) (Bastio
 }
 
 // NewListPager - Lists all Bastion Hosts in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - BastionHostsClientListOptions contains the optional parameters for the BastionHostsClient.List method.
 func (client *BastionHostsClient) NewListPager(options *BastionHostsClientListOptions) *runtime.Pager[BastionHostsClientListResponse] {
@@ -303,7 +302,6 @@ func (client *BastionHostsClient) listHandleResponse(resp *http.Response) (Basti
 }
 
 // NewListByResourceGroupPager - Lists all Bastion Hosts in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - BastionHostsClientListByResourceGroupOptions contains the optional parameters for the BastionHostsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_bgpservicecommunities_client.go
@@ -57,7 +57,6 @@ func NewBgpServiceCommunitiesClient(subscriptionID string, credential azcore.Tok
 }
 
 // NewListPager - Gets all the available bgp service communities.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - BgpServiceCommunitiesClientListOptions contains the optional parameters for the BgpServiceCommunitiesClient.List
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_connectionmonitors_client.go
@@ -259,7 +259,6 @@ func (client *ConnectionMonitorsClient) getHandleResponse(resp *http.Response) (
 }
 
 // NewListPager - Lists all connection monitors for the specified Network Watcher.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group containing Network Watcher.
 // networkWatcherName - The name of the Network Watcher resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ddosprotectionplans_client.go
@@ -244,7 +244,6 @@ func (client *DdosProtectionPlansClient) getHandleResponse(resp *http.Response) 
 }
 
 // NewListPager - Gets all DDoS protection plans in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - DdosProtectionPlansClientListOptions contains the optional parameters for the DdosProtectionPlansClient.List
 // method.
@@ -304,7 +303,6 @@ func (client *DdosProtectionPlansClient) listHandleResponse(resp *http.Response)
 }
 
 // NewListByResourceGroupPager - Gets all the DDoS protection plans in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - DdosProtectionPlansClientListByResourceGroupOptions contains the optional parameters for the DdosProtectionPlansClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_defaultsecurityrules_client.go
@@ -119,7 +119,6 @@ func (client *DefaultSecurityRulesClient) getHandleResponse(resp *http.Response)
 }
 
 // NewListPager - Gets all default security rules in a network security group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitauthorizations_client.go
@@ -260,7 +260,6 @@ func (client *ExpressRouteCircuitAuthorizationsClient) getHandleResponse(resp *h
 }
 
 // NewListPager - Gets all authorizations in an express route circuit.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // circuitName - The name of the circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitconnections_client.go
@@ -276,7 +276,6 @@ func (client *ExpressRouteCircuitConnectionsClient) getHandleResponse(resp *http
 }
 
 // NewListPager - Gets all global reach connections associated with a private peering in an express route circuit.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // circuitName - The name of the circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuitpeerings_client.go
@@ -260,7 +260,6 @@ func (client *ExpressRouteCircuitPeeringsClient) getHandleResponse(resp *http.Re
 }
 
 // NewListPager - Gets all peerings in a specified express route circuit.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // circuitName - The name of the express route circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecircuits_client.go
@@ -364,7 +364,6 @@ func (client *ExpressRouteCircuitsClient) getStatsHandleResponse(resp *http.Resp
 }
 
 // NewListPager - Gets all the express route circuits in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ExpressRouteCircuitsClientListOptions contains the optional parameters for the ExpressRouteCircuitsClient.List
@@ -429,7 +428,6 @@ func (client *ExpressRouteCircuitsClient) listHandleResponse(resp *http.Response
 }
 
 // NewListAllPager - Gets all the express route circuits in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ExpressRouteCircuitsClientListAllOptions contains the optional parameters for the ExpressRouteCircuitsClient.ListAll
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnectionpeerings_client.go
@@ -260,7 +260,6 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) getHandleResponse(resp 
 }
 
 // NewListPager - Gets all peerings in a specified ExpressRouteCrossConnection.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // crossConnectionName - The name of the ExpressRouteCrossConnection.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutecrossconnections_client.go
@@ -180,7 +180,6 @@ func (client *ExpressRouteCrossConnectionsClient) getHandleResponse(resp *http.R
 }
 
 // NewListPager - Retrieves all the ExpressRouteCrossConnections in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ExpressRouteCrossConnectionsClientListOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.List
 // method.
@@ -317,7 +316,6 @@ func (client *ExpressRouteCrossConnectionsClient) listArpTableCreateRequest(ctx 
 }
 
 // NewListByResourceGroupPager - Retrieves all the ExpressRouteCrossConnections in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ExpressRouteCrossConnectionsClientListByResourceGroupOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressroutelinks_client.go
@@ -118,7 +118,6 @@ func (client *ExpressRouteLinksClient) getHandleResponse(resp *http.Response) (E
 }
 
 // NewListPager - Retrieve the ExpressRouteLink sub-resources of the specified ExpressRoutePort resource.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // expressRoutePortName - The name of the ExpressRoutePort resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteports_client.go
@@ -244,7 +244,6 @@ func (client *ExpressRoutePortsClient) getHandleResponse(resp *http.Response) (E
 }
 
 // NewListPager - List all the ExpressRoutePort resources in the specified subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ExpressRoutePortsClientListOptions contains the optional parameters for the ExpressRoutePortsClient.List method.
 func (client *ExpressRoutePortsClient) NewListPager(options *ExpressRoutePortsClientListOptions) *runtime.Pager[ExpressRoutePortsClientListResponse] {
@@ -303,7 +302,6 @@ func (client *ExpressRoutePortsClient) listHandleResponse(resp *http.Response) (
 }
 
 // NewListByResourceGroupPager - List all the ExpressRoutePort resources in the specified resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ExpressRoutePortsClientListByResourceGroupOptions contains the optional parameters for the ExpressRoutePortsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteportslocations_client.go
@@ -111,7 +111,6 @@ func (client *ExpressRoutePortsLocationsClient) getHandleResponse(resp *http.Res
 
 // NewListPager - Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location.
 // Available bandwidths can only be obtained when retrieving a specific peering location.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ExpressRoutePortsLocationsClientListOptions contains the optional parameters for the ExpressRoutePortsLocationsClient.List
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_expressrouteserviceproviders_client.go
@@ -57,7 +57,6 @@ func NewExpressRouteServiceProvidersClient(subscriptionID string, credential azc
 }
 
 // NewListPager - Gets all the available express route service providers.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ExpressRouteServiceProvidersClientListOptions contains the optional parameters for the ExpressRouteServiceProvidersClient.List
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicies_client.go
@@ -247,7 +247,6 @@ func (client *FirewallPoliciesClient) getHandleResponse(resp *http.Response) (Fi
 }
 
 // NewListPager - Lists all Firewall Policies in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - FirewallPoliciesClientListOptions contains the optional parameters for the FirewallPoliciesClient.List method.
@@ -311,7 +310,6 @@ func (client *FirewallPoliciesClient) listHandleResponse(resp *http.Response) (F
 }
 
 // NewListAllPager - Gets all the Firewall Policies in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - FirewallPoliciesClientListAllOptions contains the optional parameters for the FirewallPoliciesClient.ListAll
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_firewallpolicyrulegroups_client.go
@@ -260,7 +260,6 @@ func (client *FirewallPolicyRuleGroupsClient) getHandleResponse(resp *http.Respo
 }
 
 // NewListPager - Lists all FirewallPolicyRuleGroups in a FirewallPolicy resource.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // firewallPolicyName - The name of the Firewall Policy.

--- a/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_flowlogs_client.go
@@ -258,7 +258,6 @@ func (client *FlowLogsClient) getHandleResponse(resp *http.Response) (FlowLogsCl
 }
 
 // NewListPager - Lists all flow log resources for the specified Network Watcher.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group containing Network Watcher.
 // networkWatcherName - The name of the Network Watcher resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_hubvirtualnetworkconnections_client.go
@@ -119,7 +119,6 @@ func (client *HubVirtualNetworkConnectionsClient) getHandleResponse(resp *http.R
 }
 
 // NewListPager - Retrieves the details of all HubVirtualNetworkConnections.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VirtualHub.
 // virtualHubName - The name of the VirtualHub.

--- a/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_inboundnatrules_client.go
@@ -262,7 +262,6 @@ func (client *InboundNatRulesClient) getHandleResponse(resp *http.Response) (Inb
 }
 
 // NewListPager - Gets all the inbound nat rules in a load balancer.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceipconfigurations_client.go
@@ -119,7 +119,6 @@ func (client *InterfaceIPConfigurationsClient) getHandleResponse(resp *http.Resp
 }
 
 // NewListPager - Get all ip configurations in a network interface.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaceloadbalancers_client.go
@@ -57,7 +57,6 @@ func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.To
 }
 
 // NewListPager - List all load balancers in a network interface.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfaces_client.go
@@ -457,7 +457,6 @@ func (client *InterfacesClient) getVirtualMachineScaleSetNetworkInterfaceHandleR
 }
 
 // NewListPager - Gets all network interfaces in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - InterfacesClientListOptions contains the optional parameters for the InterfacesClient.List method.
@@ -521,7 +520,6 @@ func (client *InterfacesClient) listHandleResponse(resp *http.Response) (Interfa
 }
 
 // NewListAllPager - Gets all network interfaces in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - InterfacesClientListAllOptions contains the optional parameters for the InterfacesClient.ListAll method.
 func (client *InterfacesClient) NewListAllPager(options *InterfacesClientListAllOptions) *runtime.Pager[InterfacesClientListAllResponse] {
@@ -646,7 +644,6 @@ func (client *InterfacesClient) listEffectiveNetworkSecurityGroupsCreateRequest(
 
 // NewListVirtualMachineScaleSetIPConfigurationsPager - Get the specified network interface ip configuration in a virtual
 // machine scale set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2018-10-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
@@ -729,7 +726,6 @@ func (client *InterfacesClient) listVirtualMachineScaleSetIPConfigurationsHandle
 }
 
 // NewListVirtualMachineScaleSetNetworkInterfacesPager - Gets all network interfaces in a virtual machine scale set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2018-10-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
@@ -800,7 +796,6 @@ func (client *InterfacesClient) listVirtualMachineScaleSetNetworkInterfacesHandl
 
 // NewListVirtualMachineScaleSetVMNetworkInterfacesPager - Gets information about all network interfaces in a virtual machine
 // in a virtual machine scale set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2018-10-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.

--- a/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_interfacetapconfigurations_client.go
@@ -260,7 +260,6 @@ func (client *InterfaceTapConfigurationsClient) getHandleResponse(resp *http.Res
 }
 
 // NewListPager - Get all Tap configurations in a network interface.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkInterfaceName - The name of the network interface.

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipallocations_client.go
@@ -247,7 +247,6 @@ func (client *IPAllocationsClient) getHandleResponse(resp *http.Response) (IPAll
 }
 
 // NewListPager - Gets all IpAllocations in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - IPAllocationsClientListOptions contains the optional parameters for the IPAllocationsClient.List method.
 func (client *IPAllocationsClient) NewListPager(options *IPAllocationsClientListOptions) *runtime.Pager[IPAllocationsClientListResponse] {
@@ -306,7 +305,6 @@ func (client *IPAllocationsClient) listHandleResponse(resp *http.Response) (IPAl
 }
 
 // NewListByResourceGroupPager - Gets all IpAllocations in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - IPAllocationsClientListByResourceGroupOptions contains the optional parameters for the IPAllocationsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_ipgroups_client.go
@@ -246,7 +246,6 @@ func (client *IPGroupsClient) getHandleResponse(resp *http.Response) (IPGroupsCl
 }
 
 // NewListPager - Gets all IpGroups in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - IPGroupsClientListOptions contains the optional parameters for the IPGroupsClient.List method.
 func (client *IPGroupsClient) NewListPager(options *IPGroupsClientListOptions) *runtime.Pager[IPGroupsClientListResponse] {
@@ -305,7 +304,6 @@ func (client *IPGroupsClient) listHandleResponse(resp *http.Response) (IPGroupsC
 }
 
 // NewListByResourceGroupPager - Gets all IpGroups in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - IPGroupsClientListByResourceGroupOptions contains the optional parameters for the IPGroupsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerbackendaddresspools_client.go
@@ -119,7 +119,6 @@ func (client *LoadBalancerBackendAddressPoolsClient) getHandleResponse(resp *htt
 }
 
 // NewListPager - Gets all the load balancer backed address pools.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerfrontendipconfigurations_client.go
@@ -119,7 +119,6 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) getHandleResponse(resp
 }
 
 // NewListPager - Gets all the load balancer frontend IP configurations.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerloadbalancingrules_client.go
@@ -119,7 +119,6 @@ func (client *LoadBalancerLoadBalancingRulesClient) getHandleResponse(resp *http
 }
 
 // NewListPager - Gets all the load balancing rules in a load balancer.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancernetworkinterfaces_client.go
@@ -57,7 +57,6 @@ func NewLoadBalancerNetworkInterfacesClient(subscriptionID string, credential az
 }
 
 // NewListPager - Gets associated load balancer network interfaces.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalanceroutboundrules_client.go
@@ -119,7 +119,6 @@ func (client *LoadBalancerOutboundRulesClient) getHandleResponse(resp *http.Resp
 }
 
 // NewListPager - Gets all the outbound rules in a load balancer.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancerprobes_client.go
@@ -118,7 +118,6 @@ func (client *LoadBalancerProbesClient) getHandleResponse(resp *http.Response) (
 }
 
 // NewListPager - Gets all the load balancer probes.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // loadBalancerName - The name of the load balancer.

--- a/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_loadbalancers_client.go
@@ -247,7 +247,6 @@ func (client *LoadBalancersClient) getHandleResponse(resp *http.Response) (LoadB
 }
 
 // NewListPager - Gets all the load balancers in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - LoadBalancersClientListOptions contains the optional parameters for the LoadBalancersClient.List method.
@@ -311,7 +310,6 @@ func (client *LoadBalancersClient) listHandleResponse(resp *http.Response) (Load
 }
 
 // NewListAllPager - Gets all the load balancers in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - LoadBalancersClientListAllOptions contains the optional parameters for the LoadBalancersClient.ListAll method.
 func (client *LoadBalancersClient) NewListAllPager(options *LoadBalancersClientListAllOptions) *runtime.Pager[LoadBalancersClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_localnetworkgateways_client.go
@@ -245,7 +245,6 @@ func (client *LocalNetworkGatewaysClient) getHandleResponse(resp *http.Response)
 }
 
 // NewListPager - Gets all the local network gateways in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - LocalNetworkGatewaysClientListOptions contains the optional parameters for the LocalNetworkGatewaysClient.List

--- a/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_management_client.go
@@ -177,7 +177,6 @@ func (client *ManagementClient) deleteBastionShareableLinkCreateRequest(ctx cont
 }
 
 // NewDisconnectActiveSessionsPager - Returns the list of currently active sessions on the Bastion.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
@@ -316,7 +315,6 @@ func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofi
 }
 
 // BeginGetActiveSessions - Returns the list of currently active sessions on the Bastion.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
@@ -359,7 +357,6 @@ func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, reso
 }
 
 // GetActiveSessions - Returns the list of currently active sessions on the Bastion.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 func (client *ManagementClient) getActiveSessions(ctx context.Context, resourceGroupName string, bastionHostName string, options *ManagementClientBeginGetActiveSessionsOptions) (*http.Response, error) {
 	req, err := client.getActiveSessionsCreateRequest(ctx, resourceGroupName, bastionHostName, options)
@@ -412,7 +409,6 @@ func (client *ManagementClient) getActiveSessionsHandleResponse(resp *http.Respo
 }
 
 // NewGetBastionShareableLinkPager - Return the Bastion Shareable Links for all the VMs specified in the request.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
@@ -483,7 +479,6 @@ func (client *ManagementClient) getBastionShareableLinkHandleResponse(resp *http
 }
 
 // BeginPutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // bastionHostName - The name of the Bastion Host.
@@ -527,7 +522,6 @@ func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context
 }
 
 // PutBastionShareableLink - Creates a Bastion Shareable Links for all the VMs specified in the request.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 func (client *ManagementClient) putBastionShareableLink(ctx context.Context, resourceGroupName string, bastionHostName string, bslRequest BastionShareableLinkListRequest, options *ManagementClientBeginPutBastionShareableLinkOptions) (*http.Response, error) {
 	req, err := client.putBastionShareableLinkCreateRequest(ctx, resourceGroupName, bastionHostName, bslRequest, options)

--- a/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_natgateways_client.go
@@ -246,7 +246,6 @@ func (client *NatGatewaysClient) getHandleResponse(resp *http.Response) (NatGate
 }
 
 // NewListPager - Gets all nat gateways in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - NatGatewaysClientListOptions contains the optional parameters for the NatGatewaysClient.List method.
@@ -310,7 +309,6 @@ func (client *NatGatewaysClient) listHandleResponse(resp *http.Response) (NatGat
 }
 
 // NewListAllPager - Gets all the Nat Gateways in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - NatGatewaysClientListAllOptions contains the optional parameters for the NatGatewaysClient.ListAll method.
 func (client *NatGatewaysClient) NewListAllPager(options *NatGatewaysClientListAllOptions) *runtime.Pager[NatGatewaysClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_operations_client.go
@@ -50,7 +50,6 @@ func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientO
 }
 
 // NewListPager - Lists all of the available Network Rest API operations.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - OperationsClientListOptions contains the optional parameters for the OperationsClient.List method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_p2svpngateways_client.go
@@ -513,7 +513,6 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthDetailedCreateReque
 }
 
 // NewListPager - Lists all the P2SVpnGateways in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - P2SVPNGatewaysClientListOptions contains the optional parameters for the P2SVPNGatewaysClient.List method.
 func (client *P2SVPNGatewaysClient) NewListPager(options *P2SVPNGatewaysClientListOptions) *runtime.Pager[P2SVPNGatewaysClientListResponse] {
@@ -572,7 +571,6 @@ func (client *P2SVPNGatewaysClient) listHandleResponse(resp *http.Response) (P2S
 }
 
 // NewListByResourceGroupPager - Lists all the P2SVpnGateways in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the P2SVpnGateway.
 // options - P2SVPNGatewaysClientListByResourceGroupOptions contains the optional parameters for the P2SVPNGatewaysClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_packetcaptures_client.go
@@ -329,7 +329,6 @@ func (client *PacketCapturesClient) getStatusCreateRequest(ctx context.Context, 
 }
 
 // NewListPager - Lists all packet capture sessions within the specified resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkWatcherName - The name of the Network Watcher resource.

--- a/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_peerexpressroutecircuitconnections_client.go
@@ -124,7 +124,6 @@ func (client *PeerExpressRouteCircuitConnectionsClient) getHandleResponse(resp *
 }
 
 // NewListPager - Gets all global reach peer connections associated with a private peering in an express route circuit.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // circuitName - The name of the circuit.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatednszonegroups_client.go
@@ -260,7 +260,6 @@ func (client *PrivateDNSZoneGroupsClient) getHandleResponse(resp *http.Response)
 }
 
 // NewListPager - Gets all private dns zone groups in a private endpoint.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // privateEndpointName - The name of the private endpoint.
 // resourceGroupName - The name of the resource group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privateendpoints_client.go
@@ -247,7 +247,6 @@ func (client *PrivateEndpointsClient) getHandleResponse(resp *http.Response) (Pr
 }
 
 // NewListPager - Gets all private endpoints in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - PrivateEndpointsClientListOptions contains the optional parameters for the PrivateEndpointsClient.List method.
@@ -311,7 +310,6 @@ func (client *PrivateEndpointsClient) listHandleResponse(resp *http.Response) (P
 }
 
 // NewListBySubscriptionPager - Gets all private endpoints in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - PrivateEndpointsClientListBySubscriptionOptions contains the optional parameters for the PrivateEndpointsClient.ListBySubscription
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_privatelinkservices_client.go
@@ -512,7 +512,6 @@ func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionHandleRespo
 }
 
 // NewListPager - Gets all private link services in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - PrivateLinkServicesClientListOptions contains the optional parameters for the PrivateLinkServicesClient.List
@@ -578,7 +577,6 @@ func (client *PrivateLinkServicesClient) listHandleResponse(resp *http.Response)
 
 // NewListAutoApprovedPrivateLinkServicesPager - Returns all of the private link service ids that can be linked to a Private
 // Endpoint with auto approved in this subscription in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the domain name.
 // options - PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesOptions contains the optional parameters for the
@@ -644,7 +642,6 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesHand
 
 // NewListAutoApprovedPrivateLinkServicesByResourceGroupPager - Returns all of the private link service ids that can be linked
 // to a Private Endpoint with auto approved in this subscription in this region.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location of the domain name.
 // resourceGroupName - The name of the resource group.
@@ -714,7 +711,6 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByRe
 }
 
 // NewListBySubscriptionPager - Gets all private link service in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - PrivateLinkServicesClientListBySubscriptionOptions contains the optional parameters for the PrivateLinkServicesClient.ListBySubscription
 // method.
@@ -774,7 +770,6 @@ func (client *PrivateLinkServicesClient) listBySubscriptionHandleResponse(resp *
 }
 
 // NewListPrivateEndpointConnectionsPager - Gets all private end point connections for a specific private link service.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // serviceName - The name of the private link service.

--- a/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_profiles_client.go
@@ -237,7 +237,6 @@ func (client *ProfilesClient) getHandleResponse(resp *http.Response) (ProfilesCl
 }
 
 // NewListPager - Gets all network profiles in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ProfilesClientListOptions contains the optional parameters for the ProfilesClient.List method.
@@ -301,7 +300,6 @@ func (client *ProfilesClient) listHandleResponse(resp *http.Response) (ProfilesC
 }
 
 // NewListAllPager - Gets all the network profiles in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ProfilesClientListAllOptions contains the optional parameters for the ProfilesClient.ListAll method.
 func (client *ProfilesClient) NewListAllPager(options *ProfilesClientListAllOptions) *runtime.Pager[ProfilesClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipaddresses_client.go
@@ -327,7 +327,6 @@ func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressH
 }
 
 // NewListPager - Gets all public IP addresses in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - PublicIPAddressesClientListOptions contains the optional parameters for the PublicIPAddressesClient.List method.
@@ -391,7 +390,6 @@ func (client *PublicIPAddressesClient) listHandleResponse(resp *http.Response) (
 }
 
 // NewListAllPager - Gets all the public IP addresses in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - PublicIPAddressesClientListAllOptions contains the optional parameters for the PublicIPAddressesClient.ListAll
 // method.
@@ -452,7 +450,6 @@ func (client *PublicIPAddressesClient) listAllHandleResponse(resp *http.Response
 
 // NewListVirtualMachineScaleSetPublicIPAddressesPager - Gets information about all public IP addresses on a virtual machine
 // scale set level.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2018-10-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.
@@ -523,7 +520,6 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddress
 
 // NewListVirtualMachineScaleSetVMPublicIPAddressesPager - Gets information about all public IP addresses in a virtual machine
 // IP configuration in a virtual machine scale set.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2018-10-01
 // resourceGroupName - The name of the resource group.
 // virtualMachineScaleSetName - The name of the virtual machine scale set.

--- a/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_publicipprefixes_client.go
@@ -247,7 +247,6 @@ func (client *PublicIPPrefixesClient) getHandleResponse(resp *http.Response) (Pu
 }
 
 // NewListPager - Gets all public IP prefixes in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - PublicIPPrefixesClientListOptions contains the optional parameters for the PublicIPPrefixesClient.List method.
@@ -311,7 +310,6 @@ func (client *PublicIPPrefixesClient) listHandleResponse(resp *http.Response) (P
 }
 
 // NewListAllPager - Gets all the public IP prefixes in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - PublicIPPrefixesClientListAllOptions contains the optional parameters for the PublicIPPrefixesClient.ListAll
 // method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilterrules_client.go
@@ -259,7 +259,6 @@ func (client *RouteFilterRulesClient) getHandleResponse(resp *http.Response) (Ro
 }
 
 // NewListByRouteFilterPager - Gets all RouteFilterRules in a route filter.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // routeFilterName - The name of the route filter.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routefilters_client.go
@@ -247,7 +247,6 @@ func (client *RouteFiltersClient) getHandleResponse(resp *http.Response) (RouteF
 }
 
 // NewListPager - Gets all route filters in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - RouteFiltersClientListOptions contains the optional parameters for the RouteFiltersClient.List method.
 func (client *RouteFiltersClient) NewListPager(options *RouteFiltersClientListOptions) *runtime.Pager[RouteFiltersClientListResponse] {
@@ -306,7 +305,6 @@ func (client *RouteFiltersClient) listHandleResponse(resp *http.Response) (Route
 }
 
 // NewListByResourceGroupPager - Gets all route filters in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - RouteFiltersClientListByResourceGroupOptions contains the optional parameters for the RouteFiltersClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routes_client.go
@@ -258,7 +258,6 @@ func (client *RoutesClient) getHandleResponse(resp *http.Response) (RoutesClient
 }
 
 // NewListPager - Gets all routes in a route table.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // routeTableName - The name of the route table.

--- a/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_routetables_client.go
@@ -246,7 +246,6 @@ func (client *RouteTablesClient) getHandleResponse(resp *http.Response) (RouteTa
 }
 
 // NewListPager - Gets all route tables in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - RouteTablesClientListOptions contains the optional parameters for the RouteTablesClient.List method.
@@ -310,7 +309,6 @@ func (client *RouteTablesClient) listHandleResponse(resp *http.Response) (RouteT
 }
 
 // NewListAllPager - Gets all route tables in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - RouteTablesClientListAllOptions contains the optional parameters for the RouteTablesClient.ListAll method.
 func (client *RouteTablesClient) NewListAllPager(options *RouteTablesClientListAllOptions) *runtime.Pager[RouteTablesClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitygroups_client.go
@@ -247,7 +247,6 @@ func (client *SecurityGroupsClient) getHandleResponse(resp *http.Response) (Secu
 }
 
 // NewListPager - Gets all network security groups in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - SecurityGroupsClientListOptions contains the optional parameters for the SecurityGroupsClient.List method.
@@ -311,7 +310,6 @@ func (client *SecurityGroupsClient) listHandleResponse(resp *http.Response) (Sec
 }
 
 // NewListAllPager - Gets all network security groups in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - SecurityGroupsClientListAllOptions contains the optional parameters for the SecurityGroupsClient.ListAll method.
 func (client *SecurityGroupsClient) NewListAllPager(options *SecurityGroupsClientListAllOptions) *runtime.Pager[SecurityGroupsClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securitypartnerproviders_client.go
@@ -245,7 +245,6 @@ func (client *SecurityPartnerProvidersClient) getHandleResponse(resp *http.Respo
 }
 
 // NewListPager - Gets all the Security Partner Providers in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - SecurityPartnerProvidersClientListOptions contains the optional parameters for the SecurityPartnerProvidersClient.List
 // method.
@@ -305,7 +304,6 @@ func (client *SecurityPartnerProvidersClient) listHandleResponse(resp *http.Resp
 }
 
 // NewListByResourceGroupPager - Lists all Security Partner Providers in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - SecurityPartnerProvidersClientListByResourceGroupOptions contains the optional parameters for the SecurityPartnerProvidersClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_securityrules_client.go
@@ -259,7 +259,6 @@ func (client *SecurityRulesClient) getHandleResponse(resp *http.Response) (Secur
 }
 
 // NewListPager - Gets all security rules in a network security group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // networkSecurityGroupName - The name of the network security group.

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicies_client.go
@@ -248,7 +248,6 @@ func (client *ServiceEndpointPoliciesClient) getHandleResponse(resp *http.Respon
 }
 
 // NewListPager - Gets all the service endpoint policies in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - ServiceEndpointPoliciesClientListOptions contains the optional parameters for the ServiceEndpointPoliciesClient.List
 // method.
@@ -308,7 +307,6 @@ func (client *ServiceEndpointPoliciesClient) listHandleResponse(resp *http.Respo
 }
 
 // NewListByResourceGroupPager - Gets all service endpoint Policies in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - ServiceEndpointPoliciesClientListByResourceGroupOptions contains the optional parameters for the ServiceEndpointPoliciesClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_serviceendpointpolicydefinitions_client.go
@@ -260,7 +260,6 @@ func (client *ServiceEndpointPolicyDefinitionsClient) getHandleResponse(resp *ht
 }
 
 // NewListByResourceGroupPager - Gets all service endpoint policy definitions in a service end point policy.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // serviceEndpointPolicyName - The name of the service endpoint policy name.

--- a/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_subnets_client.go
@@ -261,7 +261,6 @@ func (client *SubnetsClient) getHandleResponse(resp *http.Response) (SubnetsClie
 }
 
 // NewListPager - Gets all subnets in a virtual network.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // virtualNetworkName - The name of the virtual network.

--- a/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_usages_client.go
@@ -57,7 +57,6 @@ func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, o
 }
 
 // NewListPager - List network usages for a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // location - The location where resource usage is queried.
 // options - UsagesClientListOptions contains the optional parameters for the UsagesClient.List method.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualappliances_client.go
@@ -247,7 +247,6 @@ func (client *VirtualAppliancesClient) getHandleResponse(resp *http.Response) (V
 }
 
 // NewListPager - Gets all Network Virtual Appliances in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualAppliancesClientListOptions contains the optional parameters for the VirtualAppliancesClient.List method.
 func (client *VirtualAppliancesClient) NewListPager(options *VirtualAppliancesClientListOptions) *runtime.Pager[VirtualAppliancesClientListResponse] {
@@ -306,7 +305,6 @@ func (client *VirtualAppliancesClient) listHandleResponse(resp *http.Response) (
 }
 
 // NewListByResourceGroupPager - Lists all Network Virtual Appliances in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualAppliancesClientListByResourceGroupOptions contains the optional parameters for the VirtualAppliancesClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubroutetablev2s_client.go
@@ -260,7 +260,6 @@ func (client *VirtualHubRouteTableV2SClient) getHandleResponse(resp *http.Respon
 }
 
 // NewListPager - Retrieves the details of all VirtualHubRouteTableV2s.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VirtualHub.
 // virtualHubName - The name of the VirtualHub.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualhubs_client.go
@@ -243,7 +243,6 @@ func (client *VirtualHubsClient) getHandleResponse(resp *http.Response) (Virtual
 }
 
 // NewListPager - Lists all the VirtualHubs in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualHubsClientListOptions contains the optional parameters for the VirtualHubsClient.List method.
 func (client *VirtualHubsClient) NewListPager(options *VirtualHubsClientListOptions) *runtime.Pager[VirtualHubsClientListResponse] {
@@ -302,7 +301,6 @@ func (client *VirtualHubsClient) listHandleResponse(resp *http.Response) (Virtua
 }
 
 // NewListByResourceGroupPager - Lists all the VirtualHubs in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VirtualHub.
 // options - VirtualHubsClientListByResourceGroupOptions contains the optional parameters for the VirtualHubsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgatewayconnections_client.go
@@ -304,7 +304,6 @@ func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyHandleResponse
 
 // NewListPager - The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections
 // created.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualNetworkGatewayConnectionsClientListOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.List

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkgateways_client.go
@@ -856,7 +856,6 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientIPSecParametersCreateReq
 }
 
 // NewListPager - Gets all virtual network gateways by resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualNetworkGatewaysClientListOptions contains the optional parameters for the VirtualNetworkGatewaysClient.List
@@ -921,7 +920,6 @@ func (client *VirtualNetworkGatewaysClient) listHandleResponse(resp *http.Respon
 }
 
 // NewListConnectionsPager - Gets all the connections in a virtual network gateway.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // virtualNetworkGatewayName - The name of the virtual network gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworkpeerings_client.go
@@ -260,7 +260,6 @@ func (client *VirtualNetworkPeeringsClient) getHandleResponse(resp *http.Respons
 }
 
 // NewListPager - Gets all virtual network peerings in a virtual network.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // virtualNetworkName - The name of the virtual network.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworks_client.go
@@ -306,7 +306,6 @@ func (client *VirtualNetworksClient) getHandleResponse(resp *http.Response) (Vir
 }
 
 // NewListPager - Gets all virtual networks in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualNetworksClientListOptions contains the optional parameters for the VirtualNetworksClient.List method.
@@ -370,7 +369,6 @@ func (client *VirtualNetworksClient) listHandleResponse(resp *http.Response) (Vi
 }
 
 // NewListAllPager - Gets all virtual networks in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualNetworksClientListAllOptions contains the optional parameters for the VirtualNetworksClient.ListAll method.
 func (client *VirtualNetworksClient) NewListAllPager(options *VirtualNetworksClientListAllOptions) *runtime.Pager[VirtualNetworksClientListAllResponse] {
@@ -429,7 +427,6 @@ func (client *VirtualNetworksClient) listAllHandleResponse(resp *http.Response) 
 }
 
 // NewListUsagePager - Lists usage stats.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // virtualNetworkName - The name of the virtual network.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualnetworktaps_client.go
@@ -244,7 +244,6 @@ func (client *VirtualNetworkTapsClient) getHandleResponse(resp *http.Response) (
 }
 
 // NewListAllPager - Gets all the VirtualNetworkTaps in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualNetworkTapsClientListAllOptions contains the optional parameters for the VirtualNetworkTapsClient.ListAll
 // method.
@@ -304,7 +303,6 @@ func (client *VirtualNetworkTapsClient) listAllHandleResponse(resp *http.Respons
 }
 
 // NewListByResourceGroupPager - Gets all the VirtualNetworkTaps in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualNetworkTapsClientListByResourceGroupOptions contains the optional parameters for the VirtualNetworkTapsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouterpeerings_client.go
@@ -260,7 +260,6 @@ func (client *VirtualRouterPeeringsClient) getHandleResponse(resp *http.Response
 }
 
 // NewListPager - Lists all Virtual Router Peerings in a Virtual Router resource.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // virtualRouterName - The name of the Virtual Router.

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualrouters_client.go
@@ -247,7 +247,6 @@ func (client *VirtualRoutersClient) getHandleResponse(resp *http.Response) (Virt
 }
 
 // NewListPager - Gets all the Virtual Routers in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualRoutersClientListOptions contains the optional parameters for the VirtualRoutersClient.List method.
 func (client *VirtualRoutersClient) NewListPager(options *VirtualRoutersClientListOptions) *runtime.Pager[VirtualRoutersClientListResponse] {
@@ -306,7 +305,6 @@ func (client *VirtualRoutersClient) listHandleResponse(resp *http.Response) (Vir
 }
 
 // NewListByResourceGroupPager - Lists all Virtual Routers in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - VirtualRoutersClientListByResourceGroupOptions contains the optional parameters for the VirtualRoutersClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_virtualwans_client.go
@@ -243,7 +243,6 @@ func (client *VirtualWansClient) getHandleResponse(resp *http.Response) (Virtual
 }
 
 // NewListPager - Lists all the VirtualWANs in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VirtualWansClientListOptions contains the optional parameters for the VirtualWansClient.List method.
 func (client *VirtualWansClient) NewListPager(options *VirtualWansClientListOptions) *runtime.Pager[VirtualWansClientListResponse] {
@@ -302,7 +301,6 @@ func (client *VirtualWansClient) listHandleResponse(resp *http.Response) (Virtua
 }
 
 // NewListByResourceGroupPager - Lists all the VirtualWANs in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VirtualWan.
 // options - VirtualWansClientListByResourceGroupOptions contains the optional parameters for the VirtualWansClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnconnections_client.go
@@ -260,7 +260,6 @@ func (client *VPNConnectionsClient) getHandleResponse(resp *http.Response) (VPNC
 }
 
 // NewListByVPNGatewayPager - Retrieves all vpn connections for a particular virtual wan vpn gateway.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnGateway.
 // gatewayName - The name of the gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpngateways_client.go
@@ -243,7 +243,6 @@ func (client *VPNGatewaysClient) getHandleResponse(resp *http.Response) (VPNGate
 }
 
 // NewListPager - Lists all the VpnGateways in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VPNGatewaysClientListOptions contains the optional parameters for the VPNGatewaysClient.List method.
 func (client *VPNGatewaysClient) NewListPager(options *VPNGatewaysClientListOptions) *runtime.Pager[VPNGatewaysClientListResponse] {
@@ -302,7 +301,6 @@ func (client *VPNGatewaysClient) listHandleResponse(resp *http.Response) (VPNGat
 }
 
 // NewListByResourceGroupPager - Lists all the VpnGateways in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnGateway.
 // options - VPNGatewaysClientListByResourceGroupOptions contains the optional parameters for the VPNGatewaysClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnlinkconnections_client.go
@@ -57,7 +57,6 @@ func NewVPNLinkConnectionsClient(subscriptionID string, credential azcore.TokenC
 }
 
 // NewListByVPNConnectionPager - Retrieves all vpn site link connections for a particular virtual wan vpn gateway vpn connection.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnGateway.
 // gatewayName - The name of the gateway.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnserverconfigurations_client.go
@@ -245,7 +245,6 @@ func (client *VPNServerConfigurationsClient) getHandleResponse(resp *http.Respon
 }
 
 // NewListPager - Lists all the VpnServerConfigurations in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VPNServerConfigurationsClientListOptions contains the optional parameters for the VPNServerConfigurationsClient.List
 // method.
@@ -305,7 +304,6 @@ func (client *VPNServerConfigurationsClient) listHandleResponse(resp *http.Respo
 }
 
 // NewListByResourceGroupPager - Lists all the vpnServerConfigurations in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnServerConfiguration.
 // options - VPNServerConfigurationsClientListByResourceGroupOptions contains the optional parameters for the VPNServerConfigurationsClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsitelinks_client.go
@@ -118,7 +118,6 @@ func (client *VPNSiteLinksClient) getHandleResponse(resp *http.Response) (VPNSit
 }
 
 // NewListByVPNSitePager - Lists all the vpnSiteLinks in a resource group for a vpn site.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnSite.
 // vpnSiteName - The name of the VpnSite.

--- a/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_vpnsites_client.go
@@ -243,7 +243,6 @@ func (client *VPNSitesClient) getHandleResponse(resp *http.Response) (VPNSitesCl
 }
 
 // NewListPager - Lists all the VpnSites in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - VPNSitesClientListOptions contains the optional parameters for the VPNSitesClient.List method.
 func (client *VPNSitesClient) NewListPager(options *VPNSitesClientListOptions) *runtime.Pager[VPNSitesClientListResponse] {
@@ -302,7 +301,6 @@ func (client *VPNSitesClient) listHandleResponse(resp *http.Response) (VPNSitesC
 }
 
 // NewListByResourceGroupPager - Lists all the vpnSites in a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The resource group name of the VpnSite.
 // options - VPNSitesClientListByResourceGroupOptions contains the optional parameters for the VPNSitesClient.ListByResourceGroup

--- a/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_watchers_client.go
@@ -831,7 +831,6 @@ func (client *WatchersClient) getVMSecurityRulesCreateRequest(ctx context.Contex
 }
 
 // NewListPager - Gets all network watchers by resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - WatchersClientListOptions contains the optional parameters for the WatchersClient.List method.
@@ -889,7 +888,6 @@ func (client *WatchersClient) listHandleResponse(resp *http.Response) (WatchersC
 }
 
 // NewListAllPager - Gets all network watchers by subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - WatchersClientListAllOptions contains the optional parameters for the WatchersClient.ListAll method.
 func (client *WatchersClient) NewListAllPager(options *WatchersClientListAllOptions) *runtime.Pager[WatchersClientListAllResponse] {

--- a/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_generated_webapplicationfirewallpolicies_client.go
@@ -237,7 +237,6 @@ func (client *WebApplicationFirewallPoliciesClient) getHandleResponse(resp *http
 }
 
 // NewListPager - Lists all of the protection policies within a resource group.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // resourceGroupName - The name of the resource group.
 // options - WebApplicationFirewallPoliciesClientListOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.List
@@ -302,7 +301,6 @@ func (client *WebApplicationFirewallPoliciesClient) listHandleResponse(resp *htt
 }
 
 // NewListAllPager - Gets all the WAF policies in a subscription.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-03-01
 // options - WebApplicationFirewallPoliciesClientListAllOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.ListAll
 // method.

--- a/test/storage/2020-06-12/azblob/zz_generated_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_container_client.go
@@ -748,7 +748,6 @@ func (client *containerClient) getPropertiesHandleResponse(resp *http.Response) 
 }
 
 // NewListBlobFlatSegmentPager - [Update] The List Blobs operation returns a list of the blobs under the specified container
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-06-12
 // options - containerClientListBlobFlatSegmentOptions contains the optional parameters for the containerClient.ListBlobFlatSegment
 // method.
@@ -842,7 +841,6 @@ func (client *containerClient) listBlobFlatSegmentHandleResponse(resp *http.Resp
 }
 
 // NewListBlobHierarchySegmentPager - [Update] The List Blobs operation returns a list of the blobs under the specified container
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-06-12
 // delimiter - When the request includes this parameter, the operation returns a BlobPrefix element in the response body that
 // acts as a placeholder for all blobs whose names begin with the same substring up to the

--- a/test/storage/2020-06-12/azblob/zz_generated_service_client.go
+++ b/test/storage/2020-06-12/azblob/zz_generated_service_client.go
@@ -378,7 +378,6 @@ func (client *serviceClient) getUserDelegationKeyHandleResponse(resp *http.Respo
 
 // NewListContainersSegmentPager - The List Containers Segment operation returns a list of the containers under the specified
 // account
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2020-06-12
 // options - serviceClientListContainersSegmentOptions contains the optional parameters for the serviceClient.ListContainersSegment
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflow_client.go
@@ -198,7 +198,6 @@ func (client *dataFlowClient) getDataFlowHandleResponse(resp *http.Response) (Da
 }
 
 // NewGetDataFlowsByWorkspacePager - Lists data flows.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - dataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the dataFlowClient.GetDataFlowsByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataflowdebugsession_client.go
@@ -212,7 +212,6 @@ func (client *dataFlowDebugSessionClient) executeCommandCreateRequest(ctx contex
 }
 
 // NewQueryDataFlowDebugSessionsByWorkspacePager - Query all active data flow debug sessions.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - dataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the
 // dataFlowDebugSessionClient.QueryDataFlowDebugSessionsByWorkspace method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_dataset_client.go
@@ -198,7 +198,6 @@ func (client *datasetClient) getDatasetHandleResponse(resp *http.Response) (Data
 }
 
 // NewGetDatasetsByWorkspacePager - Lists datasets.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - datasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the datasetClient.GetDatasetsByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_library_client.go
@@ -349,7 +349,6 @@ func (client *libraryClient) getOperationResultHandleResponse(resp *http.Respons
 }
 
 // NewListPager - Lists Library.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - libraryClientListOptions contains the optional parameters for the libraryClient.List method.
 func (client *libraryClient) NewListPager(options *libraryClientListOptions) *runtime.Pager[LibraryClientListResponse] {

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_linkedservice_client.go
@@ -199,7 +199,6 @@ func (client *linkedServiceClient) getLinkedServiceHandleResponse(resp *http.Res
 }
 
 // NewGetLinkedServicesByWorkspacePager - Lists linked services.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - linkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the linkedServiceClient.GetLinkedServicesByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_notebook_client.go
@@ -198,7 +198,6 @@ func (client *notebookClient) getNotebookHandleResponse(resp *http.Response) (No
 }
 
 // NewGetNotebookSummaryByWorkSpacePager - Lists a summary of Notebooks.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - notebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the notebookClient.GetNotebookSummaryByWorkSpace
 // method.
@@ -254,7 +253,6 @@ func (client *notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *
 }
 
 // NewGetNotebooksByWorkspacePager - Lists Notebooks.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - notebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the notebookClient.GetNotebooksByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_pipeline_client.go
@@ -259,7 +259,6 @@ func (client *pipelineClient) getPipelineHandleResponse(resp *http.Response) (Pi
 }
 
 // NewGetPipelinesByWorkspacePager - Lists pipelines.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - pipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the pipelineClient.GetPipelinesByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sparkjobdefinition_client.go
@@ -307,7 +307,6 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp
 }
 
 // NewGetSparkJobDefinitionsByWorkspacePager - Lists spark job definitions.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - sparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the sparkJobDefinitionClient.GetSparkJobDefinitionsByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_sqlscript_client.go
@@ -198,7 +198,6 @@ func (client *sqlScriptClient) getSQLScriptHandleResponse(resp *http.Response) (
 }
 
 // NewGetSQLScriptsByWorkspacePager - Lists sql scripts.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - sqlScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the sqlScriptClient.GetSQLScriptsByWorkspace
 // method.

--- a/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_generated_trigger_client.go
@@ -246,7 +246,6 @@ func (client *triggerClient) getTriggerHandleResponse(resp *http.Response) (Trig
 }
 
 // NewGetTriggersByWorkspacePager - Lists triggers.
-// If the operation fails it returns an *azcore.ResponseError type.
 // Generated from API version 2019-06-01-preview
 // options - triggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the triggerClient.GetTriggersByWorkspace
 // method.


### PR DESCRIPTION
They don't return an error, only the *Pager[T].