### PR TITLE
Don't fail the build if we fail to publish autorest code coverage

### DIFF
--- a/eng/steps/build-test.yaml
+++ b/eng/steps/build-test.yaml
@@ -101,3 +101,4 @@ steps:
           cd src/node_modules/@microsoft.azure/autorest.testserver;
           npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(azuresdk-github-pat) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --version=$currentVersion;
         displayName: "Publish AutoRest Test Server Coverage Report"
+        condition: succeededOrFailed()


### PR DESCRIPTION
It isn't germane to the correcness of the product.