### PR TITLE
`publish autorest test server coverage report` only triggered in main branch ci

### DIFF
--- a/eng/pipelines/ci.yml
+++ b/eng/pipelines/ci.yml
@@ -36,3 +36,5 @@ jobs:
           GoVersion: "$(go.version)"
 
       - template: ../steps/build-test.yaml
+        parameters:
+          PublishAutorestCoverage: true

--- a/eng/steps/build-test.yaml
+++ b/eng/steps/build-test.yaml
@@ -101,4 +101,3 @@ steps:
           cd src/node_modules/@microsoft.azure/autorest.testserver;
           npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(azuresdk-github-pat) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --version=$currentVersion;
         displayName: "Publish AutoRest Test Server Coverage Report"
-        condition: succeededOrFailed()

--- a/eng/steps/build-test.yaml
+++ b/eng/steps/build-test.yaml
@@ -1,5 +1,6 @@
 parameters:
   GoTestPath: "$(system.defaultWorkingDirectory)/test"
+  PublishAutorestCoverage: false
 
 steps:
   - script: |
@@ -94,7 +95,7 @@ steps:
       testResultsFiles: ${{ parameters.GoTestPath }}/**/report.xml
       failTaskOnFailedTests: true
 
-  - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(parameters.PublishAutorestCoverage, true))}}:
       - pwsh: |
           $currentVersion = node -p -e "require('./src/package.json').version";
           $currentVersion="$currentVersion-$(Build.BuildNumber)";

--- a/eng/steps/build-test.yaml
+++ b/eng/steps/build-test.yaml
@@ -99,5 +99,5 @@ steps:
           $currentVersion = node -p -e "require('./src/package.json').version";
           $currentVersion="$currentVersion-$(Build.BuildNumber)";
           cd src/node_modules/@microsoft.azure/autorest.testserver;
-          npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(azuresdk-github-pat) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --version=$currentVersion;
+          npm run coverage -- publish --repo=$(Build.Repository.Name) --ref=$(Build.SourceBranch) --githubToken=$(github-token) --azStorageAccount=$(storage-coverage-user) --azStorageAccessKey=$(storage-coverage-pass) --version=$currentVersion;
         displayName: "Publish AutoRest Test Server Coverage Report"


### PR DESCRIPTION
This PR fixes the failure of autorest/go publish. The root reason is that when I try to extract and reuse build and test step in this [PR](https://github.com/Azure/autorest.go/pull/845), I forgot to exclude the coverage report step from the publish pipeline. Revert #869, #870 and close #871.