### PR TITLE
make step variable generation inline and support generation of all variable types

### DIFF
--- a/packages/autorest.gotest/src/template/sampleContent.go.njk
+++ b/packages/autorest.gotest/src/template/sampleContent.go.njk
@@ -17,13 +17,6 @@
         {%- set _ = allVariables.push(clientVariable) %}
         {%- endif %}
     {%- endif %}
-    {%- for name, variable in step.variablesOutput %}
-        {%- if variable.type === "prefix-string" %}
-    {{name}} {%- if allVariables.indexOf(name)<0 %}:{%- set _ = allVariables.push(name) %}{%- endif %}= generateAlphaNumericID({{variable.value}}, 6)
-        {%- else %}
-    {{name}} {%- if allVariables.indexOf(name)<0 %}:{%- set _ = allVariables.push(name) %}{%- endif %}= {{variable.value}}
-        {%- endif %}
-    {%- endfor %}
     {%- if step.type == "restCall" %}        
         {%- if example.checkResponse %}
             {%- set resVariable = jsFunc.genVariableName(example.returnInfo[0]) %}

--- a/packages/autorest.gotest/src/template/scenarioContent.go.njk
+++ b/packages/autorest.gotest/src/template/scenarioContent.go.njk
@@ -16,21 +16,6 @@ var err error
         {%- set _ = allVariables.push(clientVariable) %}
         {%- endif %}
     {%- endif %}
-    {%- for name, variable in step.variablesOutput %}
-    {%- if globalVariables.indexOf(name)>=0 %}
-        {%- if variable.type === "prefix-string" %}
-    testsuite.{{name}} = testutil.GenerateAlphaNumericID(testsuite.T(), {{variable.value}}, 6)
-        {%- else %}
-    testsuite.{{name}} = {{variable.value}}
-        {%- endif %}
-    {%- else %}
-        {%- if variable.type === "prefix-string" %}
-    {{name}} {%- if allVariables.indexOf(name)<0 %}:{%- set _ = allVariables.push(name) %}{%- endif %}= testutil.GenerateAlphaNumericID(testsuite.T(), {{variable.value}}, 6)
-        {%- else %}
-    {{name}} {%- if allVariables.indexOf(name)<0 %}:{%- set _ = allVariables.push(name) %}{%- endif %}= {{variable.value}}
-        {%- endif %}
-    {%- endif %}
-    {%- endfor %}
     {%- if step.type == "restCall" %}        
         {%- if example.checkResponse %}
             {%- set resVariable = jsFunc.genVariableName(example.returnInfo[0]) %}

--- a/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/__debug/go-tester.yaml
+++ b/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/__debug/go-tester.yaml
@@ -31395,8 +31395,13 @@ testModel:
           requiredVariablesDefault: {}
           secretVariables: []
           step: delete_cname_record
-          variables: {}
-          variablesOutput: {}
+          variables:
+            resourceGroupName:
+              type: string
+              value: $(dnsResourceGroup)
+            subscriptionId:
+              type: string
+              value: $(dnsSubscriptionId)
       prepareSteps:
         - type: armTemplateDeployment
           armTemplate: templates/generate_service_name.json
@@ -31443,7 +31448,6 @@ testModel:
           secretVariables: []
           step: Generate_Unique_ServiceName
           variables: {}
-          variablesOutput: {}
         - type: armTemplateDeployment
           armTemplate: templates/create_application_insights_instance.json
           armTemplateOutput: |-
@@ -31513,7 +31517,6 @@ testModel:
           secretVariables: []
           step: Create_Application_Insight_Instance
           variables: {}
-          variablesOutput: {}
         - type: armTemplateDeployment
           armTemplate: ''
           armTemplateOutput: >-
@@ -31685,8 +31688,13 @@ testModel:
           requiredVariablesDefault: {}
           secretVariables: []
           step: Add_Dns_Cname_Record
-          variables: {}
-          variablesOutput: {}
+          variables:
+            resourceGroupName:
+              type: string
+              value: $(dnsResourceGroup)
+            subscriptionId:
+              type: string
+              value: $(dnsSubscriptionId)
       requiredVariables:
         - customDomainName
         - mysqlKey
@@ -31836,7 +31844,6 @@ testModel:
               secretVariables: []
               step: Services_CheckNameAvailability
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -32489,7 +32496,6 @@ testModel:
               secretVariables: []
               step: Services_CreateOrUpdate
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -32876,7 +32882,6 @@ testModel:
               secretVariables: []
               step: Services_Get
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -33423,7 +33428,6 @@ testModel:
               secretVariables: []
               step: Services_Update
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -33571,7 +33575,6 @@ testModel:
               secretVariables: []
               step: Services_DisableTestEndpoint
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body: *ref_1252
@@ -33674,7 +33677,6 @@ testModel:
               secretVariables: []
               step: Services_EnableTestEndpoint
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -33799,7 +33801,6 @@ testModel:
               secretVariables: []
               step: Services_RegenerateTestKey
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -33907,7 +33908,6 @@ testModel:
               secretVariables: []
               step: Services_ListTestKeys
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -33982,7 +33982,7 @@ testModel:
                   - paramName: serviceName
                     paramOutput: serviceName
                   - paramName: certificateName
-                    paramOutput: certificateName
+                    paramOutput: '"asc-certificate"'
                   - paramName: certificateResource
                     paramOutput: |-
                       armappplatform.CertificateResource{
@@ -34000,9 +34000,9 @@ testModel:
                 pollerType: CertificatesClientCreateOrUpdateResponse
                 responseOutput: |-
                   armappplatform.CertificateResource{
-                  Name: to.Ptr(certificateName),
+                  Name: to.Ptr("asc-certificate"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/certificates"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/certificates/" + certificateName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/certificates/" + "asc-certificate"),
                   Properties: &armappplatform.CertificateProperties{
                   ActivateDate: to.Ptr("2019-02-22T07:40:42Z"),
                   DNSNames: []*string{
@@ -34269,10 +34269,6 @@ testModel:
                 certificateName:
                   type: string
                   value: asc-certificate
-              variablesOutput:
-                certificateName:
-                  type: string
-                  value: '"asc-certificate"'
               responses:
                 '200':
                   body:
@@ -34375,7 +34371,7 @@ testModel:
                   - paramName: serviceName
                     paramOutput: serviceName
                   - paramName: certificateName
-                    paramOutput: certificateName
+                    paramOutput: '"asc-certificate"'
                   - paramName: options
                     paramOutput: nil
                 opName: Get
@@ -34384,9 +34380,9 @@ testModel:
                 originalFile: ''
                 responseOutput: |-
                   armappplatform.CertificateResource{
-                  Name: to.Ptr(certificateName),
+                  Name: to.Ptr("asc-certificate"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/certificates"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/certificates/" + certificateName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/certificates/" + "asc-certificate"),
                   Properties: &armappplatform.CertificateProperties{
                   ActivateDate: to.Ptr("2019-02-22T07:40:42Z"),
                   CertVersion: to.Ptr("08a219d06d874795a96db47e06fbb01e"),
@@ -34504,10 +34500,6 @@ testModel:
                 certificateName:
                   type: string
                   value: asc-certificate
-              variablesOutput:
-                certificateName:
-                  type: string
-                  value: '"asc-certificate"'
               responses:
                 '200':
                   body:
@@ -34706,7 +34698,6 @@ testModel:
               secretVariables: []
               step: Certificates_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -34861,7 +34852,6 @@ testModel:
               secretVariables: []
               step: ConfigServers_Validate
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -35131,7 +35121,6 @@ testModel:
               secretVariables: []
               step: ConfigServers_UpdatePut
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -35387,7 +35376,6 @@ testModel:
               secretVariables: []
               step: ConfigServers_UpdatePatch
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -35553,7 +35541,6 @@ testModel:
               secretVariables: []
               step: ConfigServers_Get
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -35802,7 +35789,6 @@ testModel:
               secretVariables: []
               step: MonitoringSettings_UpdatePut
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -35966,7 +35952,6 @@ testModel:
               secretVariables: []
               step: MonitoringSettings_Get
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -36219,7 +36204,6 @@ testModel:
               secretVariables: []
               step: MonitoringSettings_UpdatePatch
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -36647,7 +36631,6 @@ testModel:
               secretVariables: []
               step: Apps_Create
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -36920,7 +36903,6 @@ testModel:
               secretVariables: []
               step: Apps_Get
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -37082,7 +37064,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"default"'
                   - paramName: deploymentResource
                     paramOutput: |-
                       armappplatform.DeploymentResource{
@@ -37118,9 +37100,9 @@ testModel:
                 pollerType: DeploymentsClientCreateOrUpdateResponse
                 responseOutput: |-
                   armappplatform.DeploymentResource{
-                  Name: to.Ptr(deploymentName),
+                  Name: to.Ptr("default"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/deployments"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + deploymentName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + "default"),
                   Properties: &armappplatform.DeploymentResourceProperties{
                   Active: to.Ptr(false),
                   AppName: to.Ptr(appName),
@@ -37611,10 +37593,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: default
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"default"'
               responses:
                 '200':
                   body:
@@ -37763,7 +37741,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"default"'
                   - paramName: options
                     paramOutput: nil
                 opName: Get
@@ -37772,9 +37750,9 @@ testModel:
                 originalFile: ''
                 responseOutput: |-
                   armappplatform.DeploymentResource{
-                  Name: to.Ptr(deploymentName),
+                  Name: to.Ptr("default"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/deployments"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + deploymentName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + "default"),
                   Properties: &armappplatform.DeploymentResourceProperties{
                   Active: to.Ptr(false),
                   AppName: to.Ptr(appName),
@@ -37970,10 +37948,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: default
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"default"'
               responses:
                 '200':
                   body:
@@ -38458,7 +38432,6 @@ testModel:
               secretVariables: []
               step: Apps_Update_ActiveDeployment
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -38963,7 +38936,6 @@ testModel:
               secretVariables: []
               step: Apps_Update_Disk
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -39232,7 +39204,6 @@ testModel:
               secretVariables: []
               step: Apps_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -39355,7 +39326,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: bindingName
-                    paramOutput: bindingName
+                    paramOutput: '"mysql-binding"'
                   - paramName: bindingResource
                     paramOutput: |-
                       armappplatform.BindingResource{
@@ -39377,9 +39348,9 @@ testModel:
                 pollerType: BindingsClientCreateOrUpdateResponse
                 responseOutput: |-
                   armappplatform.BindingResource{
-                  Name: to.Ptr(bindingName),
+                  Name: to.Ptr("mysql-binding"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/bindings"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + bindingName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + "mysql-binding"),
                   Properties: &armappplatform.BindingResourceProperties{
                   BindingParameters: map[string]interface{}{
                   "databaseName": "mysqldb",
@@ -39649,10 +39620,6 @@ testModel:
                 bindingName:
                   type: string
                   value: mysql-binding
-              variablesOutput:
-                bindingName:
-                  type: string
-                  value: '"mysql-binding"'
               responses:
                 '200':
                   body:
@@ -39801,7 +39768,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: bindingName
-                    paramOutput: bindingName
+                    paramOutput: '"mysql-binding"'
                   - paramName: bindingResource
                     paramOutput: |-
                       armappplatform.BindingResource{
@@ -39824,9 +39791,9 @@ testModel:
                 pollerType: BindingsClientUpdateResponse
                 responseOutput: |-
                   armappplatform.BindingResource{
-                  Name: to.Ptr(bindingName),
+                  Name: to.Ptr("mysql-binding"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/bindings"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + bindingName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + "mysql-binding"),
                   Properties: &armappplatform.BindingResourceProperties{
                   BindingParameters: map[string]interface{}{
                   "anotherLayer": map[string]interface{}{
@@ -40025,10 +39992,6 @@ testModel:
                 bindingName:
                   type: string
                   value: mysql-binding
-              variablesOutput:
-                bindingName:
-                  type: string
-                  value: '"mysql-binding"'
               responses:
                 '200':
                   body:
@@ -40121,7 +40084,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: bindingName
-                    paramOutput: bindingName
+                    paramOutput: '"mysql-binding"'
                   - paramName: options
                     paramOutput: nil
                 opName: Get
@@ -40130,9 +40093,9 @@ testModel:
                 originalFile: ''
                 responseOutput: |-
                   armappplatform.BindingResource{
-                  Name: to.Ptr(bindingName),
+                  Name: to.Ptr("mysql-binding"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/bindings"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + bindingName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/bindings/" + "mysql-binding"),
                   Properties: &armappplatform.BindingResourceProperties{
                   BindingParameters: map[string]interface{}{
                   "apiType": "SQL",
@@ -40239,10 +40202,6 @@ testModel:
                 bindingName:
                   type: string
                   value: mysql-binding
-              variablesOutput:
-                bindingName:
-                  type: string
-                  value: '"mysql-binding"'
               responses:
                 '200':
                   body:
@@ -40432,7 +40391,6 @@ testModel:
               secretVariables: []
               step: Bindings_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -40507,7 +40465,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: bindingName
-                    paramOutput: bindingName
+                    paramOutput: '"mysql-binding"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginDelete
@@ -40542,10 +40500,6 @@ testModel:
                 bindingName:
                   type: string
                   value: mysql-binding
-              variablesOutput:
-                bindingName:
-                  type: string
-                  value: '"mysql-binding"'
               responses:
                 '200':
                   body: *ref_1263
@@ -40660,7 +40614,6 @@ testModel:
               secretVariables: []
               step: Apps_ValidateDomain
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -40735,7 +40688,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: domainName
-                    paramOutput: domainName
+                    paramOutput: dnsCname + "." + customDomainName
                   - paramName: domainResource
                     paramOutput: |-
                       armappplatform.CustomDomainResource{
@@ -40752,9 +40705,9 @@ testModel:
                 pollerType: CustomDomainsClientCreateOrUpdateResponse
                 responseOutput: |-
                   armappplatform.CustomDomainResource{
-                  Name: to.Ptr(domainName),
+                  Name: to.Ptr(dnsCname + "." + customDomainName),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/domains"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + domainName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + dnsCname + "." + customDomainName),
                   Properties: &armappplatform.CustomDomainProperties{
                   AppName: to.Ptr(appName),
                   CertName: to.Ptr("asc-certificate"),
@@ -40909,10 +40862,6 @@ testModel:
                 domainName:
                   type: string
                   value: $(dnsCname).$(customDomainName)
-              variablesOutput:
-                domainName:
-                  type: string
-                  value: dnsCname + "." + customDomainName
               responses:
                 '200':
                   body:
@@ -41007,7 +40956,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: domainName
-                    paramOutput: domainName
+                    paramOutput: dnsCname + "." + customDomainName
                   - paramName: domainResource
                     paramOutput: |-
                       armappplatform.CustomDomainResource{
@@ -41024,9 +40973,9 @@ testModel:
                 pollerType: CustomDomainsClientUpdateResponse
                 responseOutput: |-
                   armappplatform.CustomDomainResource{
-                  Name: to.Ptr(domainName),
+                  Name: to.Ptr(dnsCname + "." + customDomainName),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/domains"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + domainName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + dnsCname + "." + customDomainName),
                   Properties: &armappplatform.CustomDomainProperties{
                   AppName: to.Ptr(appName),
                   CertName: to.Ptr("asc-certificate"),
@@ -41145,10 +41094,6 @@ testModel:
                 domainName:
                   type: string
                   value: $(dnsCname).$(customDomainName)
-              variablesOutput:
-                domainName:
-                  type: string
-                  value: dnsCname + "." + customDomainName
               responses:
                 '200':
                   body:
@@ -41221,7 +41166,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: domainName
-                    paramOutput: domainName
+                    paramOutput: dnsCname + "." + customDomainName
                   - paramName: options
                     paramOutput: nil
                 opName: Get
@@ -41230,9 +41175,9 @@ testModel:
                 originalFile: ''
                 responseOutput: |-
                   armappplatform.CustomDomainResource{
-                  Name: to.Ptr(domainName),
+                  Name: to.Ptr(dnsCname + "." + customDomainName),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/domains"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + domainName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/domains/" + dnsCname + "." + customDomainName),
                   Properties: &armappplatform.CustomDomainProperties{
                   AppName: to.Ptr(appName),
                   CertName: to.Ptr("mycert"),
@@ -41307,10 +41252,6 @@ testModel:
                 domainName:
                   type: string
                   value: $(dnsCname).$(customDomainName)
-              variablesOutput:
-                domainName:
-                  type: string
-                  value: dnsCname + "." + customDomainName
               responses:
                 '200':
                   body:
@@ -41463,7 +41404,6 @@ testModel:
               secretVariables: []
               step: CustomDomains_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -41588,7 +41528,6 @@ testModel:
               secretVariables: []
               step: Apps_GetResourceUploadUrl
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -41636,7 +41575,6 @@ testModel:
               secretVariables: []
               step: Upload_File
               variables: {}
-              variablesOutput: {}
             - type: restCall
               operationId: Deployments_CreateOrUpdate
               description: Deployments_CreateOrUpdate
@@ -41772,7 +41710,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: deploymentResource
                     paramOutput: |-
                       armappplatform.DeploymentResource{
@@ -41808,9 +41746,9 @@ testModel:
                 pollerType: DeploymentsClientCreateOrUpdateResponse
                 responseOutput: |-
                   armappplatform.DeploymentResource{
-                  Name: to.Ptr(deploymentName),
+                  Name: to.Ptr("blue"),
                   Type: to.Ptr("Microsoft.AppPlatform/Spring/apps/deployments"),
-                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + deploymentName),
+                  ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroupName + "/providers/Microsoft.AppPlatform/Spring/" + serviceName + "/apps/" + appName + "/deployments/" + "blue"),
                   Properties: &armappplatform.DeploymentResourceProperties{
                   Active: to.Ptr(false),
                   AppName: to.Ptr(appName),
@@ -42301,10 +42239,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body:
@@ -42851,7 +42785,6 @@ testModel:
               secretVariables: []
               step: Apps_Update
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -42958,7 +42891,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginRestart
@@ -42994,10 +42927,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body: *ref_1267
@@ -43057,7 +42986,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginStop
@@ -43093,10 +43022,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body: *ref_1270
@@ -43156,7 +43081,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginStart
@@ -43192,10 +43117,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body: *ref_1273
@@ -43255,7 +43176,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: options
                     paramOutput: nil
                 opName: GetLogFileURL
@@ -43304,10 +43225,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body:
@@ -43575,7 +43492,6 @@ testModel:
               secretVariables: []
               step: Deployments_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -43863,7 +43779,6 @@ testModel:
               secretVariables: []
               step: Deployments_ListForCluster
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -44169,7 +44084,6 @@ testModel:
               secretVariables: []
               step: Services_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -44474,7 +44388,6 @@ testModel:
               secretVariables: []
               step: Services_ListBySubscription
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -44569,7 +44482,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: deploymentName
-                    paramOutput: deploymentName
+                    paramOutput: '"blue"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginDelete
@@ -44604,10 +44517,6 @@ testModel:
                 deploymentName:
                   type: string
                   value: blue
-              variablesOutput:
-                deploymentName:
-                  type: string
-                  value: '"blue"'
               responses:
                 '200':
                   body: *ref_1276
@@ -44667,7 +44576,7 @@ testModel:
                   - paramName: appName
                     paramOutput: appName
                   - paramName: domainName
-                    paramOutput: domainName
+                    paramOutput: dnsCname + "." + customDomainName
                   - paramName: options
                     paramOutput: nil
                 opName: BeginDelete
@@ -44702,10 +44611,6 @@ testModel:
                 domainName:
                   type: string
                   value: $(dnsCname).$(customDomainName)
-              variablesOutput:
-                domainName:
-                  type: string
-                  value: dnsCname + "." + customDomainName
               responses:
                 '200':
                   body: *ref_1278
@@ -44758,7 +44663,7 @@ testModel:
                   - paramName: serviceName
                     paramOutput: serviceName
                   - paramName: appName
-                    paramOutput: appName
+                    paramOutput: '"app01"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginDelete
@@ -44792,10 +44697,6 @@ testModel:
                 appName:
                   type: string
                   value: app01
-              variablesOutput:
-                appName:
-                  type: string
-                  value: '"app01"'
               responses:
                 '200':
                   body: *ref_1280
@@ -44848,7 +44749,7 @@ testModel:
                   - paramName: serviceName
                     paramOutput: serviceName
                   - paramName: certificateName
-                    paramOutput: certificateName
+                    paramOutput: '"asc-certificate"'
                   - paramName: options
                     paramOutput: nil
                 opName: BeginDelete
@@ -44882,10 +44783,6 @@ testModel:
                 certificateName:
                   type: string
                   value: asc-certificate
-              variablesOutput:
-                certificateName:
-                  type: string
-                  value: '"asc-certificate"'
               responses:
                 '200':
                   body: *ref_1282
@@ -44962,7 +44859,6 @@ testModel:
               secretVariables: []
               step: Services_Delete
               variables: {}
-              variablesOutput: {}
               responses:
                 '202':
                   body: *ref_1284
@@ -45118,7 +45014,6 @@ testModel:
               secretVariables: []
               step: Skus_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -45254,7 +45149,6 @@ testModel:
               secretVariables: []
               step: Operations_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:

--- a/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/spring/main.go
+++ b/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/spring/main.go
@@ -291,8 +291,7 @@ func springSample() {
 	if err != nil {
 		panic(err)
 	}
-	certificateName := "asc-certificate"
-	certificatesClientCreateOrUpdateResponsePoller, err := certificatesClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, certificateName, armappplatform.CertificateResource{
+	certificatesClientCreateOrUpdateResponsePoller, err := certificatesClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, "asc-certificate", armappplatform.CertificateResource{
 		Properties: &armappplatform.CertificateProperties{
 			KeyVaultCertName: to.Ptr("pfx-cert"),
 			VaultURI:         to.Ptr("https://integration-test-prod.vault.azure.net/"),
@@ -307,8 +306,7 @@ func springSample() {
 	}
 
 	// From step Certificates_Get
-	certificateName = "asc-certificate"
-	_, err = certificatesClient.Get(ctx, resourceGroupName, serviceName, certificateName, nil)
+	_, err = certificatesClient.Get(ctx, resourceGroupName, serviceName, "asc-certificate", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -465,8 +463,7 @@ func springSample() {
 	if err != nil {
 		panic(err)
 	}
-	deploymentName := "default"
-	deploymentsClientCreateOrUpdateResponsePoller, err := deploymentsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, deploymentName, armappplatform.DeploymentResource{
+	deploymentsClientCreateOrUpdateResponsePoller, err := deploymentsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, "default", armappplatform.DeploymentResource{
 		Properties: &armappplatform.DeploymentResourceProperties{
 			DeploymentSettings: &armappplatform.DeploymentSettings{
 				CPU: to.Ptr[int32](1),
@@ -499,8 +496,7 @@ func springSample() {
 	}
 
 	// From step Deployments_Get
-	deploymentName = "default"
-	_, err = deploymentsClient.Get(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	_, err = deploymentsClient.Get(ctx, resourceGroupName, serviceName, appName, "default", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -580,8 +576,7 @@ func springSample() {
 	if err != nil {
 		panic(err)
 	}
-	bindingName := "mysql-binding"
-	bindingsClientCreateOrUpdateResponsePoller, err := bindingsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, bindingName, armappplatform.BindingResource{
+	bindingsClientCreateOrUpdateResponsePoller, err := bindingsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, "mysql-binding", armappplatform.BindingResource{
 		Properties: &armappplatform.BindingResourceProperties{
 			BindingParameters: map[string]interface{}{
 				"databaseName": "mysqldb",
@@ -600,8 +595,7 @@ func springSample() {
 	}
 
 	// From step Bindings_Update
-	bindingName = "mysql-binding"
-	bindingsClientUpdateResponsePoller, err := bindingsClient.BeginUpdate(ctx, resourceGroupName, serviceName, appName, bindingName, armappplatform.BindingResource{
+	bindingsClientUpdateResponsePoller, err := bindingsClient.BeginUpdate(ctx, resourceGroupName, serviceName, appName, "mysql-binding", armappplatform.BindingResource{
 		Properties: &armappplatform.BindingResourceProperties{
 			BindingParameters: map[string]interface{}{
 				"anotherLayer": map[string]interface{}{
@@ -621,8 +615,7 @@ func springSample() {
 	}
 
 	// From step Bindings_Get
-	bindingName = "mysql-binding"
-	_, err = bindingsClient.Get(ctx, resourceGroupName, serviceName, appName, bindingName, nil)
+	_, err = bindingsClient.Get(ctx, resourceGroupName, serviceName, appName, "mysql-binding", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -638,8 +631,7 @@ func springSample() {
 	}
 
 	// From step Bindings_Delete
-	bindingName = "mysql-binding"
-	bindingsClientDeleteResponsePoller, err := bindingsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, bindingName, nil)
+	bindingsClientDeleteResponsePoller, err := bindingsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, "mysql-binding", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -661,8 +653,7 @@ func springSample() {
 	if err != nil {
 		panic(err)
 	}
-	domainName := dnsCname + "." + customDomainName
-	customDomainsClientCreateOrUpdateResponsePoller, err := customDomainsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, domainName, armappplatform.CustomDomainResource{
+	customDomainsClientCreateOrUpdateResponsePoller, err := customDomainsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, dnsCname+"."+customDomainName, armappplatform.CustomDomainResource{
 		Properties: &armappplatform.CustomDomainProperties{
 			CertName: to.Ptr("asc-certificate"),
 		},
@@ -676,8 +667,7 @@ func springSample() {
 	}
 
 	// From step CustomDomains_Update
-	domainName = dnsCname + "." + customDomainName
-	customDomainsClientUpdateResponsePoller, err := customDomainsClient.BeginUpdate(ctx, resourceGroupName, serviceName, appName, domainName, armappplatform.CustomDomainResource{
+	customDomainsClientUpdateResponsePoller, err := customDomainsClient.BeginUpdate(ctx, resourceGroupName, serviceName, appName, dnsCname+"."+customDomainName, armappplatform.CustomDomainResource{
 		Properties: &armappplatform.CustomDomainProperties{
 			CertName: to.Ptr("asc-certificate"),
 		},
@@ -691,8 +681,7 @@ func springSample() {
 	}
 
 	// From step CustomDomains_Get
-	domainName = dnsCname + "." + customDomainName
-	_, err = customDomainsClient.Get(ctx, resourceGroupName, serviceName, appName, domainName, nil)
+	_, err = customDomainsClient.Get(ctx, resourceGroupName, serviceName, appName, dnsCname+"."+customDomainName, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -772,8 +761,7 @@ func springSample() {
 	_ = createDeployment("Upload_File", &deployment)
 
 	// From step Deployments_CreateOrUpdate
-	deploymentName = "blue"
-	deploymentsClientCreateOrUpdateResponsePoller, err = deploymentsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, deploymentName, armappplatform.DeploymentResource{
+	deploymentsClientCreateOrUpdateResponsePoller, err = deploymentsClient.BeginCreateOrUpdate(ctx, resourceGroupName, serviceName, appName, "blue", armappplatform.DeploymentResource{
 		Properties: &armappplatform.DeploymentResourceProperties{
 			DeploymentSettings: &armappplatform.DeploymentSettings{
 				CPU: to.Ptr[int32](1),
@@ -836,8 +824,7 @@ func springSample() {
 	}
 
 	// From step Deployments_Restart
-	deploymentName = "blue"
-	deploymentsClientRestartResponsePoller, err := deploymentsClient.BeginRestart(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	deploymentsClientRestartResponsePoller, err := deploymentsClient.BeginRestart(ctx, resourceGroupName, serviceName, appName, "blue", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -847,8 +834,7 @@ func springSample() {
 	}
 
 	// From step Deployments_Stop
-	deploymentName = "blue"
-	deploymentsClientStopResponsePoller, err := deploymentsClient.BeginStop(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	deploymentsClientStopResponsePoller, err := deploymentsClient.BeginStop(ctx, resourceGroupName, serviceName, appName, "blue", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -858,8 +844,7 @@ func springSample() {
 	}
 
 	// From step Deployments_Start
-	deploymentName = "blue"
-	deploymentsClientStartResponsePoller, err := deploymentsClient.BeginStart(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	deploymentsClientStartResponsePoller, err := deploymentsClient.BeginStart(ctx, resourceGroupName, serviceName, appName, "blue", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -869,8 +854,7 @@ func springSample() {
 	}
 
 	// From step Deployments_GetLogFileUrl
-	deploymentName = "blue"
-	_, err = deploymentsClient.GetLogFileURL(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	_, err = deploymentsClient.GetLogFileURL(ctx, resourceGroupName, serviceName, appName, "blue", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -916,8 +900,7 @@ func springSample() {
 	}
 
 	// From step Deployments_Delete
-	deploymentName = "blue"
-	deploymentsClientDeleteResponsePoller, err := deploymentsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, deploymentName, nil)
+	deploymentsClientDeleteResponsePoller, err := deploymentsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, "blue", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -927,8 +910,7 @@ func springSample() {
 	}
 
 	// From step CustomDomains_Delete
-	domainName = dnsCname + "." + customDomainName
-	customDomainsClientDeleteResponsePoller, err := customDomainsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, domainName, nil)
+	customDomainsClientDeleteResponsePoller, err := customDomainsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, dnsCname+"."+customDomainName, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -938,8 +920,7 @@ func springSample() {
 	}
 
 	// From step Apps_Delete
-	appName := "app01"
-	appsClientDeleteResponsePoller, err := appsClient.BeginDelete(ctx, resourceGroupName, serviceName, appName, nil)
+	appsClientDeleteResponsePoller, err := appsClient.BeginDelete(ctx, resourceGroupName, serviceName, "app01", nil)
 	if err != nil {
 		panic(err)
 	}
@@ -949,8 +930,7 @@ func springSample() {
 	}
 
 	// From step Certificates_Delete
-	certificateName = "asc-certificate"
-	certificatesClientDeleteResponsePoller, err := certificatesClient.BeginDelete(ctx, resourceGroupName, serviceName, certificateName, nil)
+	certificatesClientDeleteResponsePoller, err := certificatesClient.BeginDelete(ctx, resourceGroupName, serviceName, "asc-certificate", nil)
 	if err != nil {
 		panic(err)
 	}

--- a/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/spring_live_test.go
+++ b/packages/autorest.gotest/test/integrationtest/output/appplatform/armappplatform/spring_live_test.go
@@ -294,8 +294,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	// From step Certificates_CreateOrUpdate
 	certificatesClient, err := armappplatform.NewCertificatesClient(testsuite.subscriptionId, testsuite.cred, testsuite.options)
 	testsuite.Require().NoError(err)
-	certificateName := "asc-certificate"
-	certificatesClientCreateOrUpdateResponsePoller, err := certificatesClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, certificateName, armappplatform.CertificateResource{
+	certificatesClientCreateOrUpdateResponsePoller, err := certificatesClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, "asc-certificate", armappplatform.CertificateResource{
 		Properties: &armappplatform.CertificateProperties{
 			KeyVaultCertName: to.Ptr("pfx-cert"),
 			VaultURI:         to.Ptr("https://integration-test-prod.vault.azure.net/"),
@@ -306,8 +305,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Certificates_Get
-	certificateName = "asc-certificate"
-	_, err = certificatesClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, certificateName, nil)
+	_, err = certificatesClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, "asc-certificate", nil)
 	testsuite.Require().NoError(err)
 
 	// From step Certificates_List
@@ -422,8 +420,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	// From step Deployments_CreateOrUpdate_Default
 	deploymentsClient, err := armappplatform.NewDeploymentsClient(testsuite.subscriptionId, testsuite.cred, testsuite.options)
 	testsuite.Require().NoError(err)
-	deploymentName := "default"
-	deploymentsClientCreateOrUpdateResponsePoller, err := deploymentsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, armappplatform.DeploymentResource{
+	deploymentsClientCreateOrUpdateResponsePoller, err := deploymentsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "default", armappplatform.DeploymentResource{
 		Properties: &armappplatform.DeploymentResourceProperties{
 			DeploymentSettings: &armappplatform.DeploymentSettings{
 				CPU: to.Ptr[int32](1),
@@ -452,8 +449,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_Get
-	deploymentName = "default"
-	_, err = deploymentsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	_, err = deploymentsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "default", nil)
 	testsuite.Require().NoError(err)
 
 	// From step Apps_Update_ActiveDeployment
@@ -519,8 +515,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	// From step Bindings_Create
 	bindingsClient, err := armappplatform.NewBindingsClient(testsuite.subscriptionId, testsuite.cred, testsuite.options)
 	testsuite.Require().NoError(err)
-	bindingName := "mysql-binding"
-	bindingsClientCreateOrUpdateResponsePoller, err := bindingsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, bindingName, armappplatform.BindingResource{
+	bindingsClientCreateOrUpdateResponsePoller, err := bindingsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "mysql-binding", armappplatform.BindingResource{
 		Properties: &armappplatform.BindingResourceProperties{
 			BindingParameters: map[string]interface{}{
 				"databaseName": "mysqldb",
@@ -535,8 +530,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Bindings_Update
-	bindingName = "mysql-binding"
-	bindingsClientUpdateResponsePoller, err := bindingsClient.BeginUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, bindingName, armappplatform.BindingResource{
+	bindingsClientUpdateResponsePoller, err := bindingsClient.BeginUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "mysql-binding", armappplatform.BindingResource{
 		Properties: &armappplatform.BindingResourceProperties{
 			BindingParameters: map[string]interface{}{
 				"anotherLayer": map[string]interface{}{
@@ -552,8 +546,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Bindings_Get
-	bindingName = "mysql-binding"
-	_, err = bindingsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, bindingName, nil)
+	_, err = bindingsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "mysql-binding", nil)
 	testsuite.Require().NoError(err)
 
 	// From step Bindings_List
@@ -565,8 +558,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	}
 
 	// From step Bindings_Delete
-	bindingName = "mysql-binding"
-	bindingsClientDeleteResponsePoller, err := bindingsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, bindingName, nil)
+	bindingsClientDeleteResponsePoller, err := bindingsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "mysql-binding", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, bindingsClientDeleteResponsePoller)
 	testsuite.Require().NoError(err)
@@ -580,8 +572,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	// From step CustomDomains_CreateOrUpdate
 	customDomainsClient, err := armappplatform.NewCustomDomainsClient(testsuite.subscriptionId, testsuite.cred, testsuite.options)
 	testsuite.Require().NoError(err)
-	domainName := testsuite.dnsCname + "." + testsuite.customDomainName
-	customDomainsClientCreateOrUpdateResponsePoller, err := customDomainsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, domainName, armappplatform.CustomDomainResource{
+	customDomainsClientCreateOrUpdateResponsePoller, err := customDomainsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, testsuite.dnsCname+"."+testsuite.customDomainName, armappplatform.CustomDomainResource{
 		Properties: &armappplatform.CustomDomainProperties{
 			CertName: to.Ptr("asc-certificate"),
 		},
@@ -591,8 +582,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step CustomDomains_Update
-	domainName = testsuite.dnsCname + "." + testsuite.customDomainName
-	customDomainsClientUpdateResponsePoller, err := customDomainsClient.BeginUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, domainName, armappplatform.CustomDomainResource{
+	customDomainsClientUpdateResponsePoller, err := customDomainsClient.BeginUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, testsuite.dnsCname+"."+testsuite.customDomainName, armappplatform.CustomDomainResource{
 		Properties: &armappplatform.CustomDomainProperties{
 			CertName: to.Ptr("asc-certificate"),
 		},
@@ -602,8 +592,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step CustomDomains_Get
-	domainName = testsuite.dnsCname + "." + testsuite.customDomainName
-	_, err = customDomainsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, domainName, nil)
+	_, err = customDomainsClient.Get(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, testsuite.dnsCname+"."+testsuite.customDomainName, nil)
 	testsuite.Require().NoError(err)
 
 	// From step CustomDomains_List
@@ -678,8 +667,7 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_CreateOrUpdate
-	deploymentName = "blue"
-	deploymentsClientCreateOrUpdateResponsePoller, err = deploymentsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, armappplatform.DeploymentResource{
+	deploymentsClientCreateOrUpdateResponsePoller, err = deploymentsClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", armappplatform.DeploymentResource{
 		Properties: &armappplatform.DeploymentResourceProperties{
 			DeploymentSettings: &armappplatform.DeploymentSettings{
 				CPU: to.Ptr[int32](1),
@@ -734,29 +722,25 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_Restart
-	deploymentName = "blue"
-	deploymentsClientRestartResponsePoller, err := deploymentsClient.BeginRestart(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	deploymentsClientRestartResponsePoller, err := deploymentsClient.BeginRestart(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, deploymentsClientRestartResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_Stop
-	deploymentName = "blue"
-	deploymentsClientStopResponsePoller, err := deploymentsClient.BeginStop(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	deploymentsClientStopResponsePoller, err := deploymentsClient.BeginStop(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, deploymentsClientStopResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_Start
-	deploymentName = "blue"
-	deploymentsClientStartResponsePoller, err := deploymentsClient.BeginStart(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	deploymentsClientStartResponsePoller, err := deploymentsClient.BeginStart(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, deploymentsClientStartResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_GetLogFileUrl
-	deploymentName = "blue"
-	_, err = deploymentsClient.GetLogFileURL(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	_, err = deploymentsClient.GetLogFileURL(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", nil)
 	testsuite.Require().NoError(err)
 
 	// From step Deployments_List
@@ -792,29 +776,25 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	}
 
 	// From step Deployments_Delete
-	deploymentName = "blue"
-	deploymentsClientDeleteResponsePoller, err := deploymentsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, deploymentName, nil)
+	deploymentsClientDeleteResponsePoller, err := deploymentsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, "blue", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, deploymentsClientDeleteResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step CustomDomains_Delete
-	domainName = testsuite.dnsCname + "." + testsuite.customDomainName
-	customDomainsClientDeleteResponsePoller, err := customDomainsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, domainName, nil)
+	customDomainsClientDeleteResponsePoller, err := customDomainsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, testsuite.dnsCname+"."+testsuite.customDomainName, nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, customDomainsClientDeleteResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step Apps_Delete
-	testsuite.appName = "app01"
-	appsClientDeleteResponsePoller, err := appsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, testsuite.appName, nil)
+	appsClientDeleteResponsePoller, err := appsClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, "app01", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, appsClientDeleteResponsePoller)
 	testsuite.Require().NoError(err)
 
 	// From step Certificates_Delete
-	certificateName = "asc-certificate"
-	certificatesClientDeleteResponsePoller, err := certificatesClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, certificateName, nil)
+	certificatesClientDeleteResponsePoller, err := certificatesClient.BeginDelete(testsuite.ctx, testsuite.resourceGroupName, testsuite.serviceName, "asc-certificate", nil)
 	testsuite.Require().NoError(err)
 	_, err = testutil.PollForTest(testsuite.ctx, certificatesClientDeleteResponsePoller)
 	testsuite.Require().NoError(err)

--- a/packages/autorest.gotest/test/integrationtest/output/compute/armcompute/sample/main.go
+++ b/packages/autorest.gotest/test/integrationtest/output/compute/armcompute/sample/main.go
@@ -127,11 +127,10 @@ func scenario0Sample() {
 	if err != nil {
 		panic(err)
 	}
-	fakeStepVar := "signalrswaggertest6"
 	virtualMachinesClientCreateOrUpdateResponsePoller, err := virtualMachinesClient.BeginCreateOrUpdate(ctx, resourceGroupName, "myVM", armcompute.VirtualMachine{
 		Location: to.Ptr(location),
 		Plan: &armcompute.Plan{
-			Name:      to.Ptr(fakeStepVar),
+			Name:      to.Ptr("signalrswaggertest6"),
 			Product:   to.Ptr("windows-data-science-vm"),
 			Publisher: to.Ptr("microsoft-ads"),
 		},

--- a/packages/autorest.gotest/test/integrationtest/output/compute/armcompute/sample_live_test.go
+++ b/packages/autorest.gotest/test/integrationtest/output/compute/armcompute/sample_live_test.go
@@ -131,11 +131,10 @@ func (testsuite *SampleTestSuite) TestScenario0() {
 	// From step Create_a_vm_with_Host_Encryption_using_encryptionAtHost_property
 	virtualMachinesClient, err := armcompute.NewVirtualMachinesClient(testsuite.subscriptionId, testsuite.cred, testsuite.options)
 	testsuite.Require().NoError(err)
-	testsuite.fakeStepVar = "signalrswaggertest6"
 	virtualMachinesClientCreateOrUpdateResponsePoller, err := virtualMachinesClient.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, "myVM", armcompute.VirtualMachine{
 		Location: to.Ptr(testsuite.location),
 		Plan: &armcompute.Plan{
-			Name:      to.Ptr(testsuite.fakeStepVar),
+			Name:      to.Ptr("signalrswaggertest6"),
 			Product:   to.Ptr("windows-data-science-vm"),
 			Publisher: to.Ptr("microsoft-ads"),
 		},

--- a/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/go-tester-pre.yaml
+++ b/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/go-tester-pre.yaml
@@ -14552,6 +14552,10 @@ testModel:
                               schema: *ref_113
                               rawValue: Enabled
                               language: *ref_425
+                            publicPort:
+                              schema: *ref_94
+                              rawValue: $(publicPort)
+                              language: *ref_426
                             tls:
                               schema: *ref_128
                               parentsValue: {}
@@ -14658,7 +14662,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_383
                             tags:
                               schema: *ref_86
@@ -14929,7 +14933,7 @@ testModel:
                               language: *ref_425
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_426
                             serverPort:
                               schema: *ref_95
@@ -15043,7 +15047,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_383
                             tags:
                               schema: *ref_86
@@ -15314,7 +15318,7 @@ testModel:
                               language: *ref_425
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_426
                             serverPort:
                               schema: *ref_95
@@ -15452,6 +15456,7 @@ testModel:
                         allow:
                           - ClientConnection
                     publicNetworkAccess: Enabled
+                    publicPort: $(publicPort)
                     tls:
                       clientCertEnabled: false
                     upstream:
@@ -15477,7 +15482,10 @@ testModel:
               requiredVariablesDefault: {}
               secretVariables: []
               step: SignalR_CreateOrUpdate
-              variables: {}
+              variables:
+                location:
+                  type: string
+                  value: $(globalLocation)-test2
               responses:
                 '200':
                   body:
@@ -15489,7 +15497,7 @@ testModel:
                       principalId: $(subscriptionId)
                       tenantId: $(subscriptionId)
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -15541,7 +15549,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -15573,7 +15581,7 @@ testModel:
                       principalId: 00000000-0000-0000-0000-000000000000
                       tenantId: 00000000-0000-0000-0000-000000000000
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -15626,7 +15634,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -18483,7 +18491,13 @@ testModel:
       scope: ResourceGroup
       secretVariables: []
       useArmTemplate: true
-      variables: {}
+      variables:
+        globalLocation:
+          type: string
+          value: Global
+        publicPort:
+          type: int
+          value: 6910
 language:
   default:
     name: SignalRManagementClient

--- a/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/go-tester.yaml
+++ b/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/go-tester.yaml
@@ -16367,7 +16367,6 @@ testModel:
               secretVariables: []
               step: Generate_Unique_Name
               variables: {}
-              variablesOutput: {}
             - type: restCall
               operationId: SignalR_CheckNameAvailability
               description: SignalR_CheckNameAvailability
@@ -16472,7 +16471,6 @@ testModel:
               secretVariables: []
               step: SignalR_CheckNameAvailability
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -16681,6 +16679,10 @@ testModel:
                               schema: *ref_113
                               rawValue: Enabled
                               language: *ref_426
+                            publicPort:
+                              schema: *ref_94
+                              rawValue: $(publicPort)
+                              language: *ref_427
                             tls:
                               schema: *ref_128
                               parentsValue: {}
@@ -16766,7 +16768,7 @@ testModel:
                   - paramName: parameters
                     paramOutput: |-
                       armsignalr.ResourceInfo{
-                      Location: to.Ptr(location),
+                      Location: to.Ptr(globalLocation + "-test2"),
                       Tags: map[string]*string{
                       "key1": to.Ptr("value1"),
                       },
@@ -16821,6 +16823,7 @@ testModel:
                       },
                       },
                       PublicNetworkAccess: to.Ptr("Enabled"),
+                      PublicPort: to.Ptr[int32](publicPort),
                       TLS: &armsignalr.TLSSettings{
                       ClientCertEnabled: to.Ptr(false),
                       },
@@ -16862,7 +16865,7 @@ testModel:
 
                   ID: to.Ptr("/subscriptions/" + subscriptionId + "/resourcegroups/" + resourceGroupName + "/providers/Microsoft.SignalRService/SignalR/" + resourceName),
 
-                  Location: to.Ptr("eastus"),
+                  Location: to.Ptr(globalLocation + "-test2" + "-test1"),
 
                   Tags: map[string]*string{
 
@@ -17031,7 +17034,7 @@ testModel:
 
                   PublicNetworkAccess: to.Ptr("Enabled"),
 
-                  PublicPort: to.Ptr[int32](443),
+                  PublicPort: to.Ptr[int32](publicPort),
 
                   ServerPort: to.Ptr[int32](443),
 
@@ -17119,7 +17122,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_384
                             tags:
                               schema: *ref_86
@@ -17390,7 +17393,7 @@ testModel:
                               language: *ref_426
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_427
                             serverPort:
                               schema: *ref_95
@@ -17504,7 +17507,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_384
                             tags:
                               schema: *ref_86
@@ -17775,7 +17778,7 @@ testModel:
                               language: *ref_426
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_427
                             serverPort:
                               schema: *ref_95
@@ -17915,6 +17918,7 @@ testModel:
                         allow:
                           - ClientConnection
                     publicNetworkAccess: Enabled
+                    publicPort: $(publicPort)
                     tls:
                       clientCertEnabled: false
                     upstream:
@@ -17940,8 +17944,10 @@ testModel:
               requiredVariablesDefault: {}
               secretVariables: []
               step: SignalR_CreateOrUpdate
-              variables: {}
-              variablesOutput: {}
+              variables:
+                location:
+                  type: string
+                  value: $(globalLocation)-test2
               responses:
                 '200':
                   body:
@@ -17953,7 +17959,7 @@ testModel:
                       principalId: $(subscriptionId)
                       tenantId: $(subscriptionId)
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -18005,7 +18011,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -18037,7 +18043,7 @@ testModel:
                       principalId: 00000000-0000-0000-0000-000000000000
                       tenantId: 00000000-0000-0000-0000-000000000000
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -18090,7 +18096,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -18798,7 +18804,6 @@ testModel:
               secretVariables: []
               step: SignalR_Get
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -19956,7 +19961,6 @@ testModel:
               secretVariables: []
               step: SignalR_Update
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -20118,7 +20122,6 @@ testModel:
               secretVariables: []
               step: SignalR_ListKeys
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body: {}
@@ -20212,7 +20215,6 @@ testModel:
               secretVariables: []
               step: SignalR_RegenerateKey
               variables: {}
-              variablesOutput: {}
               responses:
                 '202':
                   body: {}
@@ -20289,7 +20291,6 @@ testModel:
               secretVariables: []
               step: SignalR_Restart
               variables: {}
-              variablesOutput: {}
               responses:
                 '202':
                   body: *ref_586
@@ -20453,7 +20454,6 @@ testModel:
               secretVariables: []
               step: Usages_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -21160,7 +21160,6 @@ testModel:
               secretVariables: []
               step: SignalR_ListByResourceGroup
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -21927,7 +21926,6 @@ testModel:
               secretVariables: []
               step: SignalR_ListBySubscription
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -22121,7 +22119,6 @@ testModel:
               secretVariables: []
               step: Operations_List
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body:
@@ -22208,7 +22205,6 @@ testModel:
               secretVariables: []
               step: SignalR_Delete
               variables: {}
-              variablesOutput: {}
               responses:
                 '200':
                   body: *ref_589
@@ -22224,8 +22220,20 @@ testModel:
       scope: ResourceGroup
       secretVariables: []
       useArmTemplate: true
-      variables: {}
-      variablesOutput: {}
+      variables:
+        globalLocation:
+          type: string
+          value: Global
+        publicPort:
+          type: int
+          value: 6910
+      variablesOutput:
+        globalLocation:
+          type: string
+          value: '"Global"'
+        publicPort:
+          type: int
+          value: '6910'
 language:
   default:
     name: SignalRManagementClient

--- a/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/test-modeler.yaml
+++ b/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/__debug/test-modeler.yaml
@@ -14552,6 +14552,10 @@ testModel:
                               schema: *ref_113
                               rawValue: Enabled
                               language: *ref_472
+                            publicPort:
+                              schema: *ref_94
+                              rawValue: $(publicPort)
+                              language: *ref_431
                             tls:
                               schema: *ref_128
                               parentsValue: {}
@@ -14658,7 +14662,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_482
                             tags:
                               schema: *ref_86
@@ -14929,7 +14933,7 @@ testModel:
                               language: *ref_472
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_431
                             serverPort:
                               schema: *ref_95
@@ -15043,7 +15047,7 @@ testModel:
                           properties:
                             location:
                               schema: *ref_85
-                              rawValue: eastus
+                              rawValue: $(location)-test1
                               language: *ref_482
                             tags:
                               schema: *ref_86
@@ -15314,7 +15318,7 @@ testModel:
                               language: *ref_472
                             publicPort:
                               schema: *ref_94
-                              rawValue: 443
+                              rawValue: $(publicPort)
                               language: *ref_431
                             serverPort:
                               schema: *ref_95
@@ -15452,6 +15456,7 @@ testModel:
                         allow:
                           - ClientConnection
                     publicNetworkAccess: Enabled
+                    publicPort: $(publicPort)
                     tls:
                       clientCertEnabled: false
                     upstream:
@@ -15477,7 +15482,10 @@ testModel:
               requiredVariablesDefault: {}
               secretVariables: []
               step: SignalR_CreateOrUpdate
-              variables: {}
+              variables:
+                location:
+                  type: string
+                  value: $(globalLocation)-test2
               responses:
                 '200':
                   body:
@@ -15489,7 +15497,7 @@ testModel:
                       principalId: $(subscriptionId)
                       tenantId: $(subscriptionId)
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -15541,7 +15549,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -15573,7 +15581,7 @@ testModel:
                       principalId: 00000000-0000-0000-0000-000000000000
                       tenantId: 00000000-0000-0000-0000-000000000000
                     kind: SignalR
-                    location: eastus
+                    location: $(location)-test1
                     properties:
                       cors:
                         allowedOrigins:
@@ -15626,7 +15634,7 @@ testModel:
                             lastModifiedByType: User
                       provisioningState: Succeeded
                       publicNetworkAccess: Enabled
-                      publicPort: 443
+                      publicPort: $(publicPort)
                       serverPort: 443
                       tls:
                         clientCertEnabled: true
@@ -18483,7 +18491,13 @@ testModel:
       scope: ResourceGroup
       secretVariables: []
       useArmTemplate: true
-      variables: {}
+      variables:
+        globalLocation:
+          type: string
+          value: Global
+        publicPort:
+          type: int
+          value: 6910
 language:
   default:
     name: SignalRManagementClient

--- a/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/signalr/main.go
+++ b/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/signalr/main.go
@@ -28,6 +28,8 @@ var (
 	ctx               context.Context
 	cred              azcore.TokenCredential
 	letterRunes       = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	globalLocation    = "Global"
+	publicPort        = 6910
 	location          = getEnv("LOCATION", "westus")
 	resourceGroupName = getEnv("RESOURCE_GROUP_NAME", "scenarioTestTempGroup")
 	subscriptionId    = getEnv("AZURE_SUBSCRIPTION_ID", "")
@@ -92,7 +94,7 @@ func signalRSample() {
 
 	// From step SignalR_CreateOrUpdate
 	clientCreateOrUpdateResponsePoller, err := client.BeginCreateOrUpdate(ctx, resourceGroupName, resourceName, armsignalr.ResourceInfo{
-		Location: to.Ptr(location),
+		Location: to.Ptr(globalLocation + "-test2"),
 		Tags: map[string]*string{
 			"key1": to.Ptr("value1"),
 		},
@@ -143,6 +145,7 @@ func signalRSample() {
 				},
 			},
 			PublicNetworkAccess: to.Ptr("Enabled"),
+			PublicPort:          to.Ptr[int32](publicPort),
 			TLS: &armsignalr.TLSSettings{
 				ClientCertEnabled: to.Ptr(false),
 			},

--- a/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/signalr_live_test.go
+++ b/packages/autorest.gotest/test/integrationtest/output/signalr/armsignalr/signalr_live_test.go
@@ -27,6 +27,8 @@ type SignalRTestSuite struct {
 	ctx               context.Context
 	cred              azcore.TokenCredential
 	options           *arm.ClientOptions
+	globalLocation    string
+	publicPort        int
 	location          string
 	resourceGroupName string
 	subscriptionId    string
@@ -37,6 +39,8 @@ func (testsuite *SignalRTestSuite) SetupSuite() {
 
 	testsuite.ctx = context.Background()
 	testsuite.cred, testsuite.options = testutil.GetCredAndClientOptions(testsuite.T())
+	testsuite.globalLocation = "Global"
+	testsuite.publicPort = 6910
 	testsuite.location = testutil.GetEnv("LOCATION", "westus")
 	testsuite.resourceGroupName = testutil.GetEnv("RESOURCE_GROUP_NAME", "scenarioTestTempGroup")
 	testsuite.subscriptionId = testutil.GetEnv("AZURE_SUBSCRIPTION_ID", "00000000-00000000-00000000-00000000")
@@ -101,7 +105,7 @@ func (testsuite *SignalRTestSuite) TestSignalR() {
 
 	// From step SignalR_CreateOrUpdate
 	clientCreateOrUpdateResponsePoller, err := client.BeginCreateOrUpdate(testsuite.ctx, testsuite.resourceGroupName, resourceName, armsignalr.ResourceInfo{
-		Location: to.Ptr(testsuite.location),
+		Location: to.Ptr(testsuite.globalLocation + "-test2"),
 		Tags: map[string]*string{
 			"key1": to.Ptr("value1"),
 		},
@@ -152,6 +156,7 @@ func (testsuite *SignalRTestSuite) TestSignalR() {
 				},
 			},
 			PublicNetworkAccess: to.Ptr("Enabled"),
+			PublicPort:          to.Ptr[int32](testsuite.publicPort),
 			TLS: &armsignalr.TLSSettings{
 				ClientCertEnabled: to.Ptr(false),
 			},

--- a/swagger/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2021-06-01-preview/scenarios/signalR.yaml
+++ b/swagger/specification/signalr/resource-manager/Microsoft.SignalRService/preview/2021-06-01-preview/scenarios/signalR.yaml
@@ -4,6 +4,12 @@ scope: ResourceGroup
 # variables:
 #   resourceName: signalrswaggertest4
 
+variables:
+  globalLocation: Global
+  publicPort:
+    type: int
+    value: 6910
+
 scenarios:
   - scenario: SignalR
     description: Microsoft.SignalRService/Basic_CRUD
@@ -22,6 +28,13 @@ scenarios:
       #     Also, some validations like for keys kike IP or pec ID needs to be suppressed
       - step: SignalR_CreateOrUpdate
         exampleFile: ../examples/SignalR_CreateOrUpdate.json
+        requestUpdate:
+          - replace: /parameters/properties/publicPort
+            value: $(publicPort)
+          - replace: /parameters/location
+            value: $(location)-test1
+        variables:
+          location: $(globalLocation)-test2
         outputVariables:
           signalRId:
             fromResponse: /id


### PR DESCRIPTION
Resolve #890.
For API scenario, step variable is meaningless. So we just generate them inline with the real value. Also, all variable types support ref, so change related logic to support variable replacement.