### PR TITLE
Fix collision between receiver var and params

### DIFF
--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -385,7 +385,7 @@ function generateXMLMarshaller(structDef: StructDef, imports: ImportManager) {
   // only needed for types with time.Time or where the XML name doesn't match the type name
   const receiver = structDef.receiverName();
   const desc = `MarshalXML implements the xml.Marshaller interface for type ${structDef.Language.name}.`;
-  let text = `func (${receiver} ${structDef.Language.name}) MarshalXML(e *xml.Encoder, start xml.StartElement) error {\n`;
+  let text = `func (${receiver} ${structDef.Language.name}) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {\n`;
   if (structDef.Language.xmlWrapperName) {
     text += `\tstart.Name.Local = "${structDef.Language.xmlWrapperName}"\n`;
   }
@@ -407,7 +407,7 @@ function generateXMLMarshaller(structDef: StructDef, imports: ImportManager) {
       text += '\t}\n';
     }
   }
-  text += '\treturn e.EncodeElement(aux, start)\n';
+  text += '\treturn enc.EncodeElement(aux, start)\n';
   text += '}\n\n';
   structDef.SerDeMethods.push({ name: 'MarshalXML', desc: desc, text: text });
 }
@@ -416,9 +416,9 @@ function generateXMLUnmarshaller(structDef: StructDef, imports: ImportManager) {
   // non-polymorphic case, must be something with time.Time
   const receiver = structDef.receiverName();
   const desc = `UnmarshalXML implements the xml.Unmarshaller interface for type ${structDef.Language.name}.`;
-  let text = `func (${receiver} *${structDef.Language.name}) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {\n`;
+  let text = `func (${receiver} *${structDef.Language.name}) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {\n`;
   text += generateAliasType(structDef, receiver, false);
-  text += '\tif err := d.DecodeElement(aux, &start); err != nil {\n';
+  text += '\tif err := dec.DecodeElement(aux, &start); err != nil {\n';
   text += '\t\treturn err\n';
   text += '\t}\n';
   for (const prop of values(structDef.Properties)) {

--- a/test/autorest/xmlgroup/zz_models_serde.go
+++ b/test/autorest/xmlgroup/zz_models_serde.go
@@ -20,7 +20,7 @@ import (
 )
 
 // MarshalXML implements the xml.Marshaller interface for type AccessPolicy.
-func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a AccessPolicy) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -31,11 +31,11 @@ func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Expiry: (*timeRFC3339)(a.Expiry),
 		Start:  (*timeRFC3339)(a.Start),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type AccessPolicy.
-func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (a *AccessPolicy) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -44,7 +44,7 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	}{
 		alias: (*alias)(a),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	a.Expiry = (*time.Time)(aux.Expiry)
@@ -53,7 +53,7 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 }
 
 // MarshalXML implements the xml.Marshaller interface for type AppleBarrel.
-func (a AppleBarrel) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a AppleBarrel) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias AppleBarrel
 	aux := &struct {
 		*alias
@@ -68,11 +68,11 @@ func (a AppleBarrel) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if a.GoodApples != nil {
 		aux.GoodApples = &a.GoodApples
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Banana.
-func (b Banana) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (b Banana) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "banana"
 	type alias Banana
 	aux := &struct {
@@ -82,11 +82,11 @@ func (b Banana) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		alias:      (*alias)(&b),
 		Expiration: (*timeRFC3339)(b.Expiration),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type Banana.
-func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (b *Banana) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias Banana
 	aux := &struct {
 		*alias
@@ -94,7 +94,7 @@ func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}{
 		alias: (*alias)(b),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	b.Expiration = (*time.Time)(aux.Expiration)
@@ -102,7 +102,7 @@ func (b *Banana) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type Blob.
-func (b *Blob) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (b *Blob) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias Blob
 	aux := &struct {
 		*alias
@@ -110,7 +110,7 @@ func (b *Blob) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}{
 		alias: (*alias)(b),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	b.Metadata = (map[string]*string)(aux.Metadata)
@@ -118,7 +118,7 @@ func (b *Blob) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlobProperties.
-func (b BlobProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (b BlobProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias BlobProperties
 	aux := &struct {
 		*alias
@@ -131,11 +131,11 @@ func (b BlobProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 		DeletedTime:        (*timeRFC1123)(b.DeletedTime),
 		LastModified:       (*timeRFC1123)(b.LastModified),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type BlobProperties.
-func (b *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (b *BlobProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias BlobProperties
 	aux := &struct {
 		*alias
@@ -145,7 +145,7 @@ func (b *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	}{
 		alias: (*alias)(b),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	b.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
@@ -155,7 +155,7 @@ func (b *BlobProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Blobs.
-func (b Blobs) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (b Blobs) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias Blobs
 	aux := &struct {
 		*alias
@@ -170,11 +170,11 @@ func (b Blobs) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if b.BlobPrefix != nil {
 		aux.BlobPrefix = &b.BlobPrefix
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type Container.
-func (c *Container) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (c *Container) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias Container
 	aux := &struct {
 		*alias
@@ -182,7 +182,7 @@ func (c *Container) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	}{
 		alias: (*alias)(c),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	c.Metadata = (map[string]*string)(aux.Metadata)
@@ -190,7 +190,7 @@ func (c *Container) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ContainerProperties.
-func (c ContainerProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (c ContainerProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ContainerProperties
 	aux := &struct {
 		*alias
@@ -199,11 +199,11 @@ func (c ContainerProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 		alias:        (*alias)(&c),
 		LastModified: (*timeRFC1123)(c.LastModified),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type ContainerProperties.
-func (c *ContainerProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (c *ContainerProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ContainerProperties
 	aux := &struct {
 		*alias
@@ -211,7 +211,7 @@ func (c *ContainerProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 	}{
 		alias: (*alias)(c),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	c.LastModified = (*time.Time)(aux.LastModified)
@@ -273,7 +273,7 @@ func (j *JSONOutput) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ListContainersResponse.
-func (l ListContainersResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (l ListContainersResponse) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ListContainersResponse
 	aux := &struct {
 		*alias
@@ -284,11 +284,11 @@ func (l ListContainersResponse) MarshalXML(e *xml.Encoder, start xml.StartElemen
 	if l.Containers != nil {
 		aux.Containers = &l.Containers
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ModelWithByteProperty.
-func (m ModelWithByteProperty) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (m ModelWithByteProperty) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ModelWithByteProperty
 	aux := &struct {
 		*alias
@@ -300,11 +300,11 @@ func (m ModelWithByteProperty) MarshalXML(e *xml.Encoder, start xml.StartElement
 		encodedBytes := runtime.EncodeByteArray(m.Bytes, runtime.Base64StdFormat)
 		aux.Bytes = &encodedBytes
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type ModelWithByteProperty.
-func (m *ModelWithByteProperty) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (m *ModelWithByteProperty) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ModelWithByteProperty
 	aux := &struct {
 		*alias
@@ -312,7 +312,7 @@ func (m *ModelWithByteProperty) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 	}{
 		alias: (*alias)(m),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	if aux.Bytes != nil {
@@ -324,7 +324,7 @@ func (m *ModelWithByteProperty) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Slide.
-func (s Slide) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (s Slide) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias Slide
 	aux := &struct {
 		*alias
@@ -335,11 +335,11 @@ func (s Slide) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if s.Items != nil {
 		aux.Items = &s.Items
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Slideshow.
-func (s Slideshow) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (s Slideshow) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "slideshow"
 	type alias Slideshow
 	aux := &struct {
@@ -351,11 +351,11 @@ func (s Slideshow) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if s.Slides != nil {
 		aux.Slides = &s.Slides
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type StorageServiceProperties.
-func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (s StorageServiceProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias StorageServiceProperties
 	aux := &struct {
 		*alias
@@ -366,7 +366,7 @@ func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElem
 	if s.Cors != nil {
 		aux.Cors = &s.Cors
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 func populate(m map[string]any, k string, v any) {

--- a/test/storage/2020-06-12/azblob/zz_models_serde.go
+++ b/test/storage/2020-06-12/azblob/zz_models_serde.go
@@ -20,7 +20,7 @@ import (
 )
 
 // MarshalXML implements the xml.Marshaller interface for type AccessPolicy.
-func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a AccessPolicy) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -31,11 +31,11 @@ func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Expiry: (*timeRFC3339)(a.Expiry),
 		Start:  (*timeRFC3339)(a.Start),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type AccessPolicy.
-func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (a *AccessPolicy) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -44,7 +44,7 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	}{
 		alias: (*alias)(a),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	a.Expiry = (*time.Time)(aux.Expiry)
@@ -53,7 +53,7 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ArrowConfiguration.
-func (a ArrowConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a ArrowConfiguration) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ArrowConfiguration
 	aux := &struct {
 		*alias
@@ -64,11 +64,11 @@ func (a ArrowConfiguration) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 	if a.Schema != nil {
 		aux.Schema = &a.Schema
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlockList.
-func (b BlockList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (b BlockList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias BlockList
 	aux := &struct {
 		*alias
@@ -83,11 +83,11 @@ func (b BlockList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if b.UncommittedBlocks != nil {
 		aux.UncommittedBlocks = &b.UncommittedBlocks
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type BlockLookupList.
-func (b BlockLookupList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (b BlockLookupList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "BlockList"
 	type alias BlockLookupList
 	aux := &struct {
@@ -107,11 +107,11 @@ func (b BlockLookupList) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	if b.Uncommitted != nil {
 		aux.Uncommitted = &b.Uncommitted
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type ContainerItem.
-func (c *ContainerItem) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (c *ContainerItem) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ContainerItem
 	aux := &struct {
 		*alias
@@ -119,7 +119,7 @@ func (c *ContainerItem) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 	}{
 		alias: (*alias)(c),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	c.Metadata = (map[string]*string)(aux.Metadata)
@@ -127,7 +127,7 @@ func (c *ContainerItem) UnmarshalXML(d *xml.Decoder, start xml.StartElement) err
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ContainerProperties.
-func (c ContainerProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (c ContainerProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ContainerProperties
 	aux := &struct {
 		*alias
@@ -138,11 +138,11 @@ func (c ContainerProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) 
 		DeletedTime:  (*timeRFC1123)(c.DeletedTime),
 		LastModified: (*timeRFC1123)(c.LastModified),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type ContainerProperties.
-func (c *ContainerProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (c *ContainerProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ContainerProperties
 	aux := &struct {
 		*alias
@@ -151,7 +151,7 @@ func (c *ContainerProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElemen
 	}{
 		alias: (*alias)(c),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	c.DeletedTime = (*time.Time)(aux.DeletedTime)
@@ -218,7 +218,7 @@ func (d *DataLakeStorageErrorError) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type FilterBlobSegment.
-func (f FilterBlobSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (f FilterBlobSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias FilterBlobSegment
 	aux := &struct {
 		*alias
@@ -229,11 +229,11 @@ func (f FilterBlobSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	if f.Blobs != nil {
 		aux.Blobs = &f.Blobs
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type FlatListSegment.
-func (f FlatListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (f FlatListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias FlatListSegment
 	aux := &struct {
 		*alias
@@ -244,11 +244,11 @@ func (f FlatListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) erro
 	if f.BlobItems != nil {
 		aux.BlobItems = &f.BlobItems
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type GeoReplication.
-func (g GeoReplication) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (g GeoReplication) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias GeoReplication
 	aux := &struct {
 		*alias
@@ -257,11 +257,11 @@ func (g GeoReplication) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 		alias:        (*alias)(&g),
 		LastSyncTime: (*timeRFC1123)(g.LastSyncTime),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type GeoReplication.
-func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (g *GeoReplication) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias GeoReplication
 	aux := &struct {
 		*alias
@@ -269,7 +269,7 @@ func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	}{
 		alias: (*alias)(g),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
@@ -277,7 +277,7 @@ func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 }
 
 // MarshalXML implements the xml.Marshaller interface for type HierarchyListSegment.
-func (h HierarchyListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (h HierarchyListSegment) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias HierarchyListSegment
 	aux := &struct {
 		*alias
@@ -292,11 +292,11 @@ func (h HierarchyListSegment) MarshalXML(e *xml.Encoder, start xml.StartElement)
 	if h.BlobPrefixes != nil {
 		aux.BlobPrefixes = &h.BlobPrefixes
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type ItemInternal.
-func (i *ItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (i *ItemInternal) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias ItemInternal
 	aux := &struct {
 		*alias
@@ -304,7 +304,7 @@ func (i *ItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	}{
 		alias: (*alias)(i),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	i.ObjectReplicationMetadata = (map[string]*string)(aux.ObjectReplicationMetadata)
@@ -312,7 +312,7 @@ func (i *ItemInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ListContainersSegmentResponse.
-func (l ListContainersSegmentResponse) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (l ListContainersSegmentResponse) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias ListContainersSegmentResponse
 	aux := &struct {
 		*alias
@@ -323,11 +323,11 @@ func (l ListContainersSegmentResponse) MarshalXML(e *xml.Encoder, start xml.Star
 	if l.ContainerItems != nil {
 		aux.ContainerItems = &l.ContainerItems
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type PageList.
-func (p PageList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (p PageList) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias PageList
 	aux := &struct {
 		*alias
@@ -342,11 +342,11 @@ func (p PageList) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if p.PageRange != nil {
 		aux.PageRange = &p.PageRange
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type PropertiesInternal.
-func (p PropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (p PropertiesInternal) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias PropertiesInternal
 	aux := &struct {
 		*alias
@@ -374,11 +374,11 @@ func (p PropertiesInternal) MarshalXML(e *xml.Encoder, start xml.StartElement) e
 		encodedContentMD5 := runtime.EncodeByteArray(p.ContentMD5, runtime.Base64StdFormat)
 		aux.ContentMD5 = &encodedContentMD5
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type PropertiesInternal.
-func (p *PropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (p *PropertiesInternal) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias PropertiesInternal
 	aux := &struct {
 		*alias
@@ -394,7 +394,7 @@ func (p *PropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 	}{
 		alias: (*alias)(p),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	p.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
@@ -414,7 +414,7 @@ func (p *PropertiesInternal) UnmarshalXML(d *xml.Decoder, start xml.StartElement
 }
 
 // MarshalXML implements the xml.Marshaller interface for type QueryRequest.
-func (q QueryRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (q QueryRequest) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "QueryRequest"
 	type alias QueryRequest
 	aux := &struct {
@@ -422,7 +422,7 @@ func (q QueryRequest) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	}{
 		alias: (*alias)(&q),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalJSON implements the json.Marshaller interface for type StorageError.
@@ -453,7 +453,7 @@ func (s *StorageError) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type StorageServiceProperties.
-func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (s StorageServiceProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias StorageServiceProperties
 	aux := &struct {
 		*alias
@@ -464,11 +464,11 @@ func (s StorageServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElem
 	if s.Cors != nil {
 		aux.Cors = &s.Cors
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type Tags.
-func (t Tags) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (t Tags) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "Tags"
 	type alias Tags
 	aux := &struct {
@@ -480,11 +480,11 @@ func (t Tags) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	if t.BlobTagSet != nil {
 		aux.BlobTagSet = &t.BlobTagSet
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // MarshalXML implements the xml.Marshaller interface for type UserDelegationKey.
-func (u UserDelegationKey) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (u UserDelegationKey) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias UserDelegationKey
 	aux := &struct {
 		*alias
@@ -495,11 +495,11 @@ func (u UserDelegationKey) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 		SignedExpiry: (*timeRFC3339)(u.SignedExpiry),
 		SignedStart:  (*timeRFC3339)(u.SignedStart),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type UserDelegationKey.
-func (u *UserDelegationKey) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (u *UserDelegationKey) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias UserDelegationKey
 	aux := &struct {
 		*alias
@@ -508,7 +508,7 @@ func (u *UserDelegationKey) UnmarshalXML(d *xml.Decoder, start xml.StartElement)
 	}{
 		alias: (*alias)(u),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	u.SignedExpiry = (*time.Time)(aux.SignedExpiry)

--- a/test/tables/2019-02-02/aztables/zz_models_serde.go
+++ b/test/tables/2019-02-02/aztables/zz_models_serde.go
@@ -19,7 +19,7 @@ import (
 )
 
 // MarshalXML implements the xml.Marshaller interface for type AccessPolicy.
-func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (a AccessPolicy) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -30,11 +30,11 @@ func (a AccessPolicy) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 		Expiry: (*timeRFC3339)(a.Expiry),
 		Start:  (*timeRFC3339)(a.Start),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type AccessPolicy.
-func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (a *AccessPolicy) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias AccessPolicy
 	aux := &struct {
 		*alias
@@ -43,7 +43,7 @@ func (a *AccessPolicy) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	}{
 		alias: (*alias)(a),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	a.Expiry = (*time.Time)(aux.Expiry)
@@ -83,7 +83,7 @@ func (e *EntityQueryResponse) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type GeoReplication.
-func (g GeoReplication) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (g GeoReplication) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	type alias GeoReplication
 	aux := &struct {
 		*alias
@@ -92,11 +92,11 @@ func (g GeoReplication) MarshalXML(e *xml.Encoder, start xml.StartElement) error
 		alias:        (*alias)(&g),
 		LastSyncTime: (*timeRFC1123)(g.LastSyncTime),
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 // UnmarshalXML implements the xml.Unmarshaller interface for type GeoReplication.
-func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+func (g *GeoReplication) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	type alias GeoReplication
 	aux := &struct {
 		*alias
@@ -104,7 +104,7 @@ func (g *GeoReplication) UnmarshalXML(d *xml.Decoder, start xml.StartElement) er
 	}{
 		alias: (*alias)(g),
 	}
-	if err := d.DecodeElement(aux, &start); err != nil {
+	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
 	g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
@@ -279,7 +279,7 @@ func (s *ServiceError) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalXML implements the xml.Marshaller interface for type ServiceProperties.
-func (s ServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+func (s ServiceProperties) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	start.Name.Local = "StorageServiceProperties"
 	type alias ServiceProperties
 	aux := &struct {
@@ -291,7 +291,7 @@ func (s ServiceProperties) MarshalXML(e *xml.Encoder, start xml.StartElement) er
 	if s.Cors != nil {
 		aux.Cors = &s.Cors
 	}
-	return e.EncodeElement(aux, start)
+	return enc.EncodeElement(aux, start)
 }
 
 func populate(m map[string]any, k string, v any) {


### PR DESCRIPTION
Recevier var names are single-letter and in some cases can collide with var names for XML SerDe methods.
Use longer param var names to avoid collision.