### PR TITLE
Move discriminator substitution to transform phase

### DIFF
--- a/packages/autorest.gotest/src/generator/mockTestGenerator.ts
+++ b/packages/autorest.gotest/src/generator/mockTestGenerator.ts
@@ -22,7 +22,6 @@ import { ExampleParameter, ExampleValue } from '@autorest/testmodeler/dist/src/c
 import { GoExampleModel, GoMockTestDefinitionModel, ParameterOutput } from '../common/model';
 import { GoHelper } from '../util/goHelper';
 import { Helper } from '@autorest/testmodeler/dist/src/util/helper';
-import { elementByValueForParam } from '@autorest/go/dist/generator/helpers';
 import { generateReturnsInfo, getAPIParametersSig, getClientParametersSig, getSchemaResponse } from '../util/codegenBridge';
 import { isLROOperation, isMultiRespOperation, isPageableOperation } from '@autorest/go/dist/common/helpers';
 import _ = require('lodash');
@@ -514,4 +513,14 @@ export class MockTestCodeGenerator extends BaseCodeGenerator {
       },
     });
   }
+}
+
+// returns true if the element type for a parameter should be passed by value
+export function elementByValueForParam(param: Parameter): boolean {
+  // passing nil for array elements in headers, paths, and query params
+  // isn't very useful as we'd just skip nil entries.  so disable it.
+  if (param.schema.type === SchemaType.Array) {
+    return param.protocol.http!.in === 'header' || param.protocol.http!.in === 'path' || param.protocol.http!.in === 'query';
+  }
+  return false;
 }

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -9,7 +9,7 @@ import { ApiVersions, ArraySchema, ByteArraySchema, ChoiceSchema, CodeModel, Con
 import { values } from '@azure-tools/linq';
 import { aggregateParameters, formatConstantValue, getSchemaResponse, isArraySchema, isBinaryResponseOperation, isMultiRespOperation, isPageableOperation, isSchemaResponse, isTypePassedByValue, isLROOperation, commentLength } from '../common/helpers';
 import { OperationNaming } from '../transform/namer';
-import { contentPreamble, elementByValueForParam, formatCommentAsBulletItem, formatParameterTypeName, formatStatusCodes, formatValue, getClientDefaultValue, getResponseEnvelope, getResponseEnvelopeName, getResultFieldName, getStatusCodes, hasDescription, hasResultProperty, hasSchemaResponse, skipURLEncoding, sortAscending, getCreateRequestParameters, getCreateRequestParametersSig, getMethodParameters, getParamName, formatParamValue, dateFormat, datetimeRFC1123Format, datetimeRFC3339Format, sortParametersByRequired, substituteDiscriminator } from './helpers';
+import { contentPreamble, formatCommentAsBulletItem, formatParameterTypeName, formatStatusCodes, formatValue, getClientDefaultValue, getResponseEnvelope, getResponseEnvelopeName, getResultFieldName, getStatusCodes, hasDescription, hasResultProperty, hasSchemaResponse, skipURLEncoding, sortAscending, getCreateRequestParameters, getCreateRequestParametersSig, getMethodParameters, getParamName, formatParamValue, dateFormat, datetimeRFC1123Format, datetimeRFC3339Format, sortParametersByRequired } from './helpers';
 import { ImportManager } from './imports';
 
 // represents the generated content for an operation group
@@ -90,7 +90,7 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
       for (const clientParam of values(clientParams)) {
         clientText += `\t${clientParam.language.go!.name} `;
         if (clientParam.required) {
-          clientText += `${substituteDiscriminator(clientParam.schema, elementByValueForParam(clientParam))}\n`;
+          clientText += `${clientParam.schema.language.go!.name}\n`;
         } else {
           clientText += `${formatParameterTypeName(clientParam)}\n`;
         }

--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -7,7 +7,7 @@ import { capitalize, comment } from '@azure-tools/codegen';
 import { ConstantSchema, ImplementationLocation, Language, SchemaType, Parameter, Property } from '@autorest/codemodel';
 import { values } from '@azure-tools/linq';
 import { commentLength, isArraySchema } from '../common/helpers';
-import { elementByValueForParam, hasDescription, sortAscending, substituteDiscriminator } from './helpers';
+import { hasDescription, sortAscending } from './helpers';
 import { ImportManager } from './imports';
 
 // represents a struct method
@@ -84,8 +84,7 @@ export class StructDef {
         }
         text += `\t${comment(prop.language.go!.description, '// ', undefined, commentLength)}\n`;
       }
-      let elemByVal = false;
-      let typeName = substituteDiscriminator(prop.schema, elemByVal);
+      let typeName = prop.schema.language.go!.name;
       if (prop.schema.type === SchemaType.Constant) {
         // for constants we use the underlying type name
         typeName = (<ConstantSchema>prop.schema).valueType.language.go!.name;
@@ -128,7 +127,7 @@ export class StructDef {
       if (param.required || param.language.go!.byValue === true) {
         pointer = '';
       }
-      const typeName = substituteDiscriminator(param.schema, elementByValueForParam(param));
+      const typeName = param.schema.language.go!.name;
       text += `\t${capitalize(param.language.go!.name)} ${pointer}${typeName}\n`;
     }
     text += '}\n\n';
@@ -169,7 +168,7 @@ export function generateStruct(imports: ImportManager, lang: Language, props?: P
   for (const prop of values(props)) {
     imports.addImportForSchemaType(prop.schema);
     if (prop.language.go!.embeddedType) {
-      st.ComposedOf.push(substituteDiscriminator(prop.schema, true));
+      st.ComposedOf.push(prop.schema.language.go!.name);
     }
   }
   return st;


### PR DESCRIPTION
Don't transform the model during the codegen phase.  The transformations aren't persisted and have to be sprinkled throughout various parts of the codegen logic.