### PR TITLE
Add --rawjson-as-bytes option

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -17,7 +17,7 @@ const goMappings = {
     'binarygroup': ['body-binary.json', '--remove-unreferenced-types'],
     'booleangroup': ['body-boolean.json', '--remove-unreferenced-types'],
     'bytegroup': ['body-byte.json', '--remove-unreferenced-types'],
-    'complexgroup': ['body-complex.json', '--remove-unreferenced-types'],
+    'complexgroup': ['body-complex.json', '--remove-unreferenced-types', '--rawjson-as-bytes'],
     'complexmodelgroup': ['complex-model.json', '--remove-unreferenced-types'],
     'custombaseurlgroup': ['custom-baseUrl.json', '--remove-unreferenced-types'],
     'dategroup': ['body-date.json', '--remove-unreferenced-types'],
@@ -42,7 +42,7 @@ const goMappings = {
     'nonstringenumgroup': ['non-string-enum.json', '--remove-unreferenced-types'],
     'noopsgroup': ['no-operations.json'],
     'numbergroup': ['body-number.json', '--remove-unreferenced-types'],
-    'objectgroup': ['object-type.json', '--remove-unreferenced-types'],
+    'objectgroup': ['object-type.json', '--remove-unreferenced-types', '--rawjson-as-bytes'],
     'optionalgroup': ['required-optional.json', '--remove-unreferenced-types'],
     'paginggroup': ['paging.json', '--remove-unreferenced-types'],
     'paramgroupinggroup': ['azure-parameter-grouping.json', '--remove-unreferenced-types'],
@@ -100,7 +100,7 @@ const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/22
 generateFromReadme("armnetwork", network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--module=armnetwork --azure-arm=true --remove-unreferenced-types');
 
 const compute = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/compute/resource-manager/readme.md';
-generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types');
+generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types -rawjson-as-bytes');
 
 const synapseArtifacts = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/synapse/data-plane/readme.md';
 generateFromReadme("azartifacts", synapseArtifacts, 'package-artifacts-2019-06-01-preview', 'test/synapse/2019-06-01/azartifacts', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azartifacts" --openapi-type="data-plane"');
@@ -109,7 +109,7 @@ const synapseSpark = 'https://raw.githubusercontent.com/Azure/azure-rest-api-spe
 generateFromReadme("azspark", synapseSpark, 'package-spark-2019-11-01-preview', 'test/synapse/2019-06-01/azspark', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azspark" --openapi-type="data-plane"');
 
 const tables = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/cosmos-db/data-plane/readme.md';
-generateFromReadme("aztables", tables, 'package-2019-02', 'test/tables/2019-02-02/aztables', '--security=AADToken --security-scopes="https://tables.azure.com/.default" --module=aztables --openapi-type="data-plane" --export-clients --azure-validator=false --group-parameters=false --stutter=table');
+generateFromReadme("aztables", tables, 'package-2019-02', 'test/tables/2019-02-02/aztables', '--security=AADToken --security-scopes="https://tables.azure.com/.default" --module=aztables --openapi-type="data-plane" --export-clients --azure-validator=false --group-parameters=false --stutter=table --rawjson-as-bytes');
 
 const keyvault = fullPath('test/keyvault/7.2/azkeyvault/autorest.md');
 generateFromReadme("azkeyvault", keyvault, 'package-7.2', 'test/keyvault/7.2/azkeyvault');
@@ -121,9 +121,9 @@ const databoxedge = fullPath('test/databoxedge/2021-02-01/armdataboxedge/autores
 generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/databoxedge/2021-02-01/armdataboxedge', '--remove-unreferenced-types');
 
 const acr = 'https://github.com/Azure/azure-rest-api-specs/blob/195cd610db0accd0422c3e00a72df739ab4de677/specification/containerregistry/data-plane/Azure.ContainerRegistry/stable/2021-07-01/containerregistry.json';
-generate("azacr", acr, 'test/acr/2021-07-01/azacr', '--module="azacr" --openapi-type="data-plane"');
+generate("azacr", acr, 'test/acr/2021-07-01/azacr', '--module="azacr" --openapi-type="data-plane" --rawjson-as-bytes');
 
-generate("azalias", 'test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --openapi-type="data-plane"');
+generate("azalias", 'test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --openapi-type="data-plane" --rawjson-as-bytes');
 
 function should_generate(name) {
     if (filter !== undefined) {

--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -100,7 +100,7 @@ const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/22
 generateFromReadme("armnetwork", network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--module=armnetwork --azure-arm=true --remove-unreferenced-types');
 
 const compute = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/compute/resource-manager/readme.md';
-generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types -rawjson-as-bytes');
+generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types --rawjson-as-bytes');
 
 const synapseArtifacts = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/synapse/data-plane/readme.md';
 generateFromReadme("azartifacts", synapseArtifacts, 'package-artifacts-2019-06-01-preview', 'test/synapse/2019-06-01/azartifacts', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azartifacts" --openapi-type="data-plane"');

--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -89,4 +89,7 @@ help-content:
       - key: normalize-operation-name
         type: boolean
         description: When true, add suffix for operation with unstructured body type and keep original name for operation with structured body type. When false, keep original name if only one body type, and add suffix for operation with non-binary body type if more than one body type.
+      - key: rawjson-as-bytes
+        type: boolean
+        description: When true, properties that are untyped (i.e. raw JSON) are exposed as []byte instead of any or map[string]any. The default is false.
 ```

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -254,6 +254,8 @@ function generateJSONMarshallerBody(obj: ObjectSchema, structDef: StructDef, imp
       marshaller += `\tpopulate(objectMap, "${prop.serializedName}", aux)\n`;
     } else if (prop.schema.type === SchemaType.Constant) {
       marshaller += `\tobjectMap["${prop.serializedName}"] = ${formatConstantValue(<ConstantSchema>prop.schema)}\n`;
+    } else if (prop.schema.language.go!.rawJSONAsBytes && (prop.schema.type === SchemaType.Any || prop.schema.type === SchemaType.AnyObject)) {
+      marshaller += `\tpopulate(objectMap, "${prop.serializedName}", json.RawMessage(${receiver}.${prop.language.go!.name}))\n`;
     } else {
       if (prop.clientDefaultValue) {
         imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/to');
@@ -363,6 +365,8 @@ function generateJSONUnmarshallerBody(structDef: StructDef, imports: ImportManag
       }
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       unmarshalBody += `\t\t\terr = runtime.DecodeByteArray(string(val), &${receiver}.${prop.language.go!.name}, runtime.Base64${base64Format}Format)\n`;
+    } else if (prop.schema.language.go!.rawJSONAsBytes && (prop.schema.type === SchemaType.Any || prop.schema.type === SchemaType.AnyObject)) {
+      unmarshalBody += `\t\t\t${receiver}.${prop.language.go!.name} = val\n`;
     } else {
       unmarshalBody += `\t\t\t\terr = unpopulate(val, "${prop.language.go!.name}", &${receiver}.${prop.language.go!.name})\n`;
     }

--- a/src/generator/models.ts
+++ b/src/generator/models.ts
@@ -254,7 +254,7 @@ function generateJSONMarshallerBody(obj: ObjectSchema, structDef: StructDef, imp
       marshaller += `\tpopulate(objectMap, "${prop.serializedName}", aux)\n`;
     } else if (prop.schema.type === SchemaType.Constant) {
       marshaller += `\tobjectMap["${prop.serializedName}"] = ${formatConstantValue(<ConstantSchema>prop.schema)}\n`;
-    } else if (prop.schema.language.go!.rawJSONAsBytes && (prop.schema.type === SchemaType.Any || prop.schema.type === SchemaType.AnyObject)) {
+    } else if (prop.schema.language.go!.rawJSONAsBytes) {
       marshaller += `\tpopulate(objectMap, "${prop.serializedName}", json.RawMessage(${receiver}.${prop.language.go!.name}))\n`;
     } else {
       if (prop.clientDefaultValue) {
@@ -365,7 +365,7 @@ function generateJSONUnmarshallerBody(structDef: StructDef, imports: ImportManag
       }
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime');
       unmarshalBody += `\t\t\terr = runtime.DecodeByteArray(string(val), &${receiver}.${prop.language.go!.name}, runtime.Base64${base64Format}Format)\n`;
-    } else if (prop.schema.language.go!.rawJSONAsBytes && (prop.schema.type === SchemaType.Any || prop.schema.type === SchemaType.AnyObject)) {
+    } else if (prop.schema.language.go!.rawJSONAsBytes) {
       unmarshalBody += `\t\t\t${receiver}.${prop.language.go!.name} = val\n`;
     } else {
       unmarshalBody += `\t\t\t\terr = unpopulate(val, "${prop.language.go!.name}", &${receiver}.${prop.language.go!.name})\n`;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -897,7 +897,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
       body = 'aux';
     }
     let setBody = `runtime.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, `req, ${body}`)}`;
-    if (bodyParam!.schema.language.go!.rawJSONAsBytes && (bodyParam!.schema.type === SchemaType.Any || bodyParam!.schema.type === SchemaType.AnyObject)) {
+    if (bodyParam!.schema.language.go!.rawJSONAsBytes) {
       imports.add('bytes');
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
       setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${mediaType.toLowerCase()}")`;
@@ -1075,7 +1075,7 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
   }
   const mediaType = getMediaType(response.protocol);
   if (mediaType === 'JSON' || mediaType === 'XML') {
-    if (response.schema.language.go!.rawJSONAsBytes && (response.schema.type === SchemaType.Any || response.schema.type === SchemaType.AnyObject)) {
+    if (response.schema.language.go!.rawJSONAsBytes) {
       unmarshallerText += `\tbody, err := runtime.Payload(resp)\n`;
       unmarshallerText += '\tif err != nil {\n';
       unmarshallerText += `\t\treturn ${zeroValue}, err\n`;

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -896,11 +896,17 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
       text += '\t}\n';
       body = 'aux';
     }
+    let setBody = `runtime.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, `req, ${body}`)}`;
+    if (bodyParam!.schema.language.go!.rawJSONAsBytes && (bodyParam!.schema.type === SchemaType.Any || bodyParam!.schema.type === SchemaType.AnyObject)) {
+      imports.add('bytes');
+      imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
+      setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${mediaType.toLowerCase()}")`;
+    }
     if (bodyParam!.required || bodyParam!.schema.type === SchemaType.Constant) {
-      text += `\treturn req, runtime.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, `req, ${body}`)}\n`;
+      text += `\treturn req, ${setBody}\n`;
     } else {
       text += emitParamGroupCheck(<GroupProperty>bodyParam!.language.go!.paramGroup, bodyParam!);
-      text += `\t\treturn req, runtime.MarshalAs${getMediaFormat(bodyParam!.schema, mediaType, `req, ${body}`)}\n`;
+      text += `\t\treturn req, ${setBody}\n`;
       text += '\t}\n';
       text += '\treturn req, nil\n';
     }
@@ -1069,9 +1075,17 @@ function generateResponseUnmarshaller(op: Operation, response: SchemaResponse, u
   }
   const mediaType = getMediaType(response.protocol);
   if (mediaType === 'JSON' || mediaType === 'XML') {
-    unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaFormat(response.schema, mediaType, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
-    unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
-    unmarshallerText += '\t}\n';
+    if (response.schema.language.go!.rawJSONAsBytes && (response.schema.type === SchemaType.Any || response.schema.type === SchemaType.AnyObject)) {
+      unmarshallerText += `\tbody, err := runtime.Payload(resp)\n`;
+      unmarshallerText += '\tif err != nil {\n';
+      unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+      unmarshallerText += '\t}\n';
+      unmarshallerText += `\t${unmarshalTarget} = body\n`;
+    } else {
+      unmarshallerText += `\tif err := runtime.UnmarshalAs${getMediaFormat(response.schema, mediaType, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
+      unmarshallerText += `\t\treturn ${zeroValue}, err\n`;
+      unmarshallerText += '\t}\n';
+    }
   } else if (mediaType === 'text') {
     unmarshallerText += `\tbody, err := runtime.Payload(resp)\n`;
     unmarshallerText += '\tif err != nil {\n';

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -88,6 +88,8 @@ export async function namer(session: Session<CodeModel>) {
   const groupParameters = await session.getValue('group-parameters', true);
   model.language.go!.groupParameters = groupParameters;
   const honorBodyPlacement = await session.getValue('honor-body-placement', false);
+  const rawJSONAsBytes = await session.getValue('rawjson-as-bytes', false);
+  model.language.go!.rawJSONAsBytes = rawJSONAsBytes;
 
   // fix up type names
   const structNames = new Set<string>();

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -245,7 +245,8 @@ function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, type: 'Propert
       const arraySchema = <ArraySchema>schema;
       const arrayElem = <Schema>arraySchema.elementType;
       if (rawJSONAsBytes && (arrayElem.type === SchemaType.Any || arrayElem.type === SchemaType.AnyObject)) {
-        return 'any';
+        schema.language.go!.rawJSONAsBytes = rawJSONAsBytes;
+        return '[]byte';
       }
       arraySchema.language.go!.elementIsPtr = !isTypePassedByValue(arrayElem);
       arrayElem.language.go!.name = schemaTypeToGoType(codeModel, arrayElem, type);

--- a/src/transform/transform.ts
+++ b/src/transform/transform.ts
@@ -102,6 +102,9 @@ async function process(session: Session<CodeModel>) {
       }
       if (prop.language.go!.description) {
         descriptionMods.push(parseComments(prop.language.go!.description));
+      } else if (prop.schema.language.go!.rawJSONAsBytes) {
+        // add a basic description if one isn't available
+        descriptionMods.push('The contents of this field are raw JSON.');
       }
       prop.language.go!.description = descriptionMods.join('; ');
       const details = <Language>prop.schema.language.go;
@@ -219,16 +222,32 @@ function substitueDiscriminator(item: Property | Parameter | SchemaResponse): Sc
   return item.schema;
 }
 
+const dictionaryElementAnySchema = new AnySchema('any schema for maps');
+dictionaryElementAnySchema.language.go = dictionaryElementAnySchema.language.default;
+dictionaryElementAnySchema.language.go!.name = 'any';
+
 function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, type: 'Property' | 'InBody' | 'HeaderParam' | 'PathParam' | 'QueryParam'): string {
+  const rawJSONAsBytes = <boolean>codeModel.language.go!.rawJSONAsBytes;
   switch (schema.type) {
     case SchemaType.Any:
+      if (rawJSONAsBytes) {
+        schema.language.go!.rawJSONAsBytes = rawJSONAsBytes;
+        return '[]byte';
+      }
       return 'any';
     case SchemaType.AnyObject:
+      if (rawJSONAsBytes) {
+        schema.language.go!.rawJSONAsBytes = rawJSONAsBytes;
+        return '[]byte';
+      }
       return 'map[string]any';
     case SchemaType.Array:
       const arraySchema = <ArraySchema>schema;
-      arraySchema.language.go!.elementIsPtr = !isTypePassedByValue(arraySchema.elementType);
       const arrayElem = <Schema>arraySchema.elementType;
+      if (rawJSONAsBytes && (arrayElem.type === SchemaType.Any || arrayElem.type === SchemaType.AnyObject)) {
+        return 'any';
+      }
+      arraySchema.language.go!.elementIsPtr = !isTypePassedByValue(arrayElem);
       arrayElem.language.go!.name = schemaTypeToGoType(codeModel, arrayElem, type);
       // passing nil for array elements in headers, paths, and query params
       // isn't very useful as we'd just skip nil entries.  so disable it.
@@ -271,8 +290,12 @@ function schemaTypeToGoType(codeModel: CodeModel, schema: Schema, type: 'Propert
       return 'time.Time';
     case SchemaType.Dictionary:
       const dictSchema = <DictionarySchema>schema;
-      dictSchema.language.go!.elementIsPtr = !isTypePassedByValue(dictSchema.elementType);
       const dictElem = <Schema>dictSchema.elementType;
+      if (rawJSONAsBytes && (dictElem.type === SchemaType.Any || dictElem.type === SchemaType.AnyObject)) {
+        dictSchema.elementType = dictionaryElementAnySchema;
+        return `map[string]${dictionaryElementAnySchema.language.go!.name}`;
+      }
+      dictSchema.language.go!.elementIsPtr = !isTypePassedByValue(dictSchema.elementType);
       dictElem.language.go!.name = schemaTypeToGoType(codeModel, dictElem, type);
       if (<boolean>dictSchema.language.go!.elementIsPtr) {
         return `map[string]*${dictElem.language.go!.name}`;
@@ -754,6 +777,7 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
   const response = getSchemaResponse(op);
   // if the response defines a schema then add it to the response envelope
   if (response) {
+    const rawJSONAsBytes = <boolean>codeModel.language.go!.rawJSONAsBytes;
     // propagate marshalling format to the response envelope
     respEnv.language.go!.marshallingFormat = response.schema.language.go!.marshallingFormat;
     // for operations that return scalar types we use a fixed field name
@@ -764,6 +788,8 @@ function createResponseEnvelope(codeModel: CodeModel, group: OperationGroup, op:
     } else if (response.schema.type === SchemaType.Array) {
       // for array types use the element type's name
       propName = recursiveTypeName(response.schema);
+    } else if (rawJSONAsBytes && (response.schema.type === SchemaType.Any || response.schema.type === SchemaType.AnyObject)) {
+      propName = 'RawJSON';
     } else if (response.schema.type === SchemaType.Any) {
       propName = 'Interface';
     } else if (response.schema.type === SchemaType.AnyObject) {
@@ -883,10 +909,17 @@ function getMarshallingFormat(protocol: Protocols): 'json' | 'xml' | 'na' {
 }
 
 function recursiveTypeName(schema: Schema): string {
+  const rawJSON = 'RawJSON';
   switch (schema.type) {
     case SchemaType.Any:
+      if (schema.language.go!.rawJSONAsBytes) {
+        return rawJSON;
+      }
       return 'Interface';
     case SchemaType.AnyObject:
+      if (schema.language.go!.rawJSONAsBytes) {
+        return rawJSON;
+      }
       return 'Object';
     case SchemaType.Array:
       const arraySchema = <ArraySchema>schema;

--- a/test/acr/2021-07-01/azacr/zz_containerregistry_client.go
+++ b/test/acr/2021-07-01/azacr/zz_containerregistry_client.go
@@ -130,9 +130,11 @@ func (client *containerRegistryClient) createManifestHandleResponse(resp *http.R
 		}
 		result.ContentLength = &contentLength
 	}
-	if err := runtime.UnmarshalAsJSON(resp, &result.Interface); err != nil {
+	body, err := runtime.Payload(resp)
+	if err != nil {
 		return ContainerRegistryClientCreateManifestResponse{}, err
 	}
+	result.RawJSON = body
 	return result, nil
 }
 

--- a/test/acr/2021-07-01/azacr/zz_models.go
+++ b/test/acr/2021-07-01/azacr/zz_models.go
@@ -347,7 +347,7 @@ type ErrorInfo struct {
 	Code *string `json:"code,omitempty"`
 
 	// Error details
-	Detail any `json:"detail,omitempty"`
+	Detail []byte `json:"detail,omitempty"`
 
 	// Error message
 	Message *string `json:"message,omitempty"`

--- a/test/acr/2021-07-01/azacr/zz_models_serde.go
+++ b/test/acr/2021-07-01/azacr/zz_models_serde.go
@@ -364,7 +364,7 @@ func (d *Descriptor) UnmarshalJSON(data []byte) error {
 func (e ErrorInfo) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "code", e.Code)
-	populate(objectMap, "detail", &e.Detail)
+	populate(objectMap, "detail", json.RawMessage(e.Detail))
 	populate(objectMap, "message", e.Message)
 	return json.Marshal(objectMap)
 }
@@ -382,7 +382,7 @@ func (e *ErrorInfo) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Code", &e.Code)
 			delete(rawMsg, key)
 		case "detail":
-			err = unpopulate(val, "Detail", &e.Detail)
+			e.Detail = val
 			delete(rawMsg, key)
 		case "message":
 			err = unpopulate(val, "Message", &e.Message)

--- a/test/acr/2021-07-01/azacr/zz_response_types.go
+++ b/test/acr/2021-07-01/azacr/zz_response_types.go
@@ -152,11 +152,11 @@ type ContainerRegistryClientCreateManifestResponse struct {
 	// DockerContentDigest contains the information returned from the Docker-Content-Digest header response.
 	DockerContentDigest *string
 
-	// Anything
-	Interface any
-
 	// Location contains the information returned from the Location header response.
 	Location *string
+
+	// Anything
+	RawJSON []byte
 }
 
 // ContainerRegistryClientDeleteManifestResponse contains the response from method containerRegistryClient.DeleteManifest.

--- a/test/autorest/objectgroup/objectgroup_test.go
+++ b/test/autorest/objectgroup/objectgroup_test.go
@@ -23,18 +23,14 @@ func TestGet(t *testing.T) {
 	client := newObjectTypeClient()
 	resp, err := client.Get(context.Background(), nil)
 	require.NoError(t, err)
-	if r := cmp.Diff(resp.Interface, map[string]interface{}{
-		"message": "An object was successfully returned",
-	}); r != "" {
+	if r := cmp.Diff(string(resp.RawJSON), `{ "message": "An object was successfully returned" }`); r != "" {
 		t.Fatal(r)
 	}
 }
 
 func TestPut(t *testing.T) {
 	client := newObjectTypeClient()
-	result, err := client.Put(context.Background(), map[string]interface{}{
-		"foo": "bar",
-	}, nil)
+	result, err := client.Put(context.Background(), []byte(`{ "foo": "bar" }`), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }

--- a/test/autorest/objectgroup/zz_response_types.go
+++ b/test/autorest/objectgroup/zz_response_types.go
@@ -12,7 +12,7 @@ package objectgroup
 // ObjectTypeClientGetResponse contains the response from method ObjectTypeClient.Get.
 type ObjectTypeClientGetResponse struct {
 	// Anything
-	Interface any
+	RawJSON []byte
 }
 
 // ObjectTypeClientPutResponse contains the response from method ObjectTypeClient.Put.

--- a/test/compute/2019-12-01/armcompute/zz_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_models.go
@@ -3688,7 +3688,7 @@ type VirtualMachineCaptureResult struct {
 	Parameters []byte `json:"parameters,omitempty" azure:"ro"`
 
 	// READ-ONLY; a list of resource items of the captured virtual machine
-	Resources any `json:"resources,omitempty" azure:"ro"`
+	Resources []byte `json:"resources,omitempty" azure:"ro"`
 
 	// READ-ONLY; the schema of the captured virtual machine
 	Schema *string `json:"$schema,omitempty" azure:"ro"`

--- a/test/compute/2019-12-01/armcompute/zz_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_models.go
@@ -3685,10 +3685,10 @@ type VirtualMachineCaptureResult struct {
 	ContentVersion *string `json:"contentVersion,omitempty" azure:"ro"`
 
 	// READ-ONLY; parameters of the captured virtual machine
-	Parameters any `json:"parameters,omitempty" azure:"ro"`
+	Parameters []byte `json:"parameters,omitempty" azure:"ro"`
 
 	// READ-ONLY; a list of resource items of the captured virtual machine
-	Resources []any `json:"resources,omitempty" azure:"ro"`
+	Resources any `json:"resources,omitempty" azure:"ro"`
 
 	// READ-ONLY; the schema of the captured virtual machine
 	Schema *string `json:"$schema,omitempty" azure:"ro"`
@@ -3821,13 +3821,13 @@ type VirtualMachineExtensionProperties struct {
 	InstanceView *VirtualMachineExtensionInstanceView `json:"instanceView,omitempty"`
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings any `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
 
 	// The name of the extension handler publisher.
 	Publisher *string `json:"publisher,omitempty"`
 
 	// Json formatted public settings for the extension.
-	Settings any `json:"settings,omitempty"`
+	Settings []byte `json:"settings,omitempty"`
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string `json:"type,omitempty"`
@@ -3859,13 +3859,13 @@ type VirtualMachineExtensionUpdateProperties struct {
 	ForceUpdateTag *string `json:"forceUpdateTag,omitempty"`
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings any `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
 
 	// The name of the extension handler publisher.
 	Publisher *string `json:"publisher,omitempty"`
 
 	// Json formatted public settings for the extension.
-	Settings any `json:"settings,omitempty"`
+	Settings []byte `json:"settings,omitempty"`
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string `json:"type,omitempty"`
@@ -4302,7 +4302,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	ForceUpdateTag *string `json:"forceUpdateTag,omitempty"`
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings any `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
 
 	// Collection of extension names after which this extension needs to be provisioned.
 	ProvisionAfterExtensions []*string `json:"provisionAfterExtensions,omitempty"`
@@ -4311,7 +4311,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	Publisher *string `json:"publisher,omitempty"`
 
 	// Json formatted public settings for the extension.
-	Settings any `json:"settings,omitempty"`
+	Settings []byte `json:"settings,omitempty"`
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string `json:"type,omitempty"`

--- a/test/compute/2019-12-01/armcompute/zz_models_serde.go
+++ b/test/compute/2019-12-01/armcompute/zz_models_serde.go
@@ -7611,7 +7611,7 @@ func (v VirtualMachineCaptureResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "contentVersion", v.ContentVersion)
 	populate(objectMap, "id", v.ID)
-	populate(objectMap, "parameters", &v.Parameters)
+	populate(objectMap, "parameters", json.RawMessage(v.Parameters))
 	populate(objectMap, "resources", v.Resources)
 	populate(objectMap, "$schema", v.Schema)
 	return json.Marshal(objectMap)
@@ -7633,7 +7633,7 @@ func (v *VirtualMachineCaptureResult) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &v.ID)
 			delete(rawMsg, key)
 		case "parameters":
-			err = unpopulate(val, "Parameters", &v.Parameters)
+			v.Parameters = val
 			delete(rawMsg, key)
 		case "resources":
 			err = unpopulate(val, "Resources", &v.Resources)
@@ -7870,10 +7870,10 @@ func (v VirtualMachineExtensionProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
 	populate(objectMap, "instanceView", v.InstanceView)
-	populate(objectMap, "protectedSettings", &v.ProtectedSettings)
+	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
 	populate(objectMap, "provisioningState", v.ProvisioningState)
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", &v.Settings)
+	populate(objectMap, "settings", json.RawMessage(v.Settings))
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -7898,7 +7898,7 @@ func (v *VirtualMachineExtensionProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "InstanceView", &v.InstanceView)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
+			v.ProtectedSettings = val
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &v.ProvisioningState)
@@ -7907,7 +7907,7 @@ func (v *VirtualMachineExtensionProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			err = unpopulate(val, "Settings", &v.Settings)
+			v.Settings = val
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)
@@ -7959,9 +7959,9 @@ func (v VirtualMachineExtensionUpdateProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
-	populate(objectMap, "protectedSettings", &v.ProtectedSettings)
+	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", &v.Settings)
+	populate(objectMap, "settings", json.RawMessage(v.Settings))
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -7983,13 +7983,13 @@ func (v *VirtualMachineExtensionUpdateProperties) UnmarshalJSON(data []byte) err
 			err = unpopulate(val, "ForceUpdateTag", &v.ForceUpdateTag)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
+			v.ProtectedSettings = val
 			delete(rawMsg, key)
 		case "publisher":
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			err = unpopulate(val, "Settings", &v.Settings)
+			v.Settings = val
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)
@@ -8671,11 +8671,11 @@ func (v VirtualMachineScaleSetExtensionProperties) MarshalJSON() ([]byte, error)
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
-	populate(objectMap, "protectedSettings", &v.ProtectedSettings)
+	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
 	populate(objectMap, "provisionAfterExtensions", v.ProvisionAfterExtensions)
 	populate(objectMap, "provisioningState", v.ProvisioningState)
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", &v.Settings)
+	populate(objectMap, "settings", json.RawMessage(v.Settings))
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -8697,7 +8697,7 @@ func (v *VirtualMachineScaleSetExtensionProperties) UnmarshalJSON(data []byte) e
 			err = unpopulate(val, "ForceUpdateTag", &v.ForceUpdateTag)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
+			v.ProtectedSettings = val
 			delete(rawMsg, key)
 		case "provisionAfterExtensions":
 			err = unpopulate(val, "ProvisionAfterExtensions", &v.ProvisionAfterExtensions)
@@ -8709,7 +8709,7 @@ func (v *VirtualMachineScaleSetExtensionProperties) UnmarshalJSON(data []byte) e
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			err = unpopulate(val, "Settings", &v.Settings)
+			v.Settings = val
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)

--- a/test/compute/2019-12-01/armcompute/zz_models_serde.go
+++ b/test/compute/2019-12-01/armcompute/zz_models_serde.go
@@ -7612,7 +7612,7 @@ func (v VirtualMachineCaptureResult) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "contentVersion", v.ContentVersion)
 	populate(objectMap, "id", v.ID)
 	populate(objectMap, "parameters", json.RawMessage(v.Parameters))
-	populate(objectMap, "resources", v.Resources)
+	populate(objectMap, "resources", json.RawMessage(v.Resources))
 	populate(objectMap, "$schema", v.Schema)
 	return json.Marshal(objectMap)
 }
@@ -7636,7 +7636,7 @@ func (v *VirtualMachineCaptureResult) UnmarshalJSON(data []byte) error {
 			v.Parameters = val
 			delete(rawMsg, key)
 		case "resources":
-			err = unpopulate(val, "Resources", &v.Resources)
+			v.Resources = val
 			delete(rawMsg, key)
 		case "$schema":
 			err = unpopulate(val, "Schema", &v.Schema)

--- a/test/maps/azalias/models_test.go
+++ b/test/maps/azalias/models_test.go
@@ -14,16 +14,16 @@ func TestPolicyAssignmentProperties(t *testing.T) {
 	if err := json.Unmarshal([]byte(payload), &paprops); err != nil {
 		t.Fatal(err)
 	}
-	s, ok := paprops.Parameters["effect"].Value.(string)
-	if !ok {
-		t.Fatalf("unexpected type %T", paprops.Parameters["effect"].Value)
+	var s string
+	if err := json.Unmarshal(paprops.Parameters["effect"].Value, &s); err != nil {
+		t.Fatal(err)
 	}
 	if s != "Audit" {
 		t.Fatalf("got %s, want Audit", s)
 	}
-	sl, ok := paprops.Parameters["listOfResourceTypesNotAllowed"].Value.([]interface{})
-	if !ok {
-		t.Fatalf("unexpected type %T", paprops.Parameters["listOfResourceTypesNotAllowed"].Value)
+	sl := []string{}
+	if err := json.Unmarshal(paprops.Parameters["listOfResourceTypesNotAllowed"].Value, &sl); err != nil {
+		t.Fatal(err)
 	}
 	if len(sl) != 1 {
 		t.Fatal("unexpected slice len")
@@ -35,9 +35,9 @@ func TestPolicyAssignmentProperties(t *testing.T) {
 	if !ok {
 		t.Fatal("missing one")
 	}
-	mm, ok := m.Value.(map[string]interface{})
-	if !ok {
-		t.Fatalf("unexpected type %T", m.Value)
+	mm := map[string]any{}
+	if err := json.Unmarshal(m.Value, &mm); err != nil {
+		t.Fatal(err)
 	}
 	if v := mm["key"]; v != "value" {
 		t.Fatalf("got %s want value", v)

--- a/test/maps/azalias/polymorphic_helpers_test.go
+++ b/test/maps/azalias/polymorphic_helpers_test.go
@@ -96,7 +96,7 @@ func TestInterfaceRoundTrip(t *testing.T) {
 	props1 := ScheduleCreateOrUpdateProperties{
 		Aliases:     []*string{to.Ptr("foo")},
 		Description: to.Ptr("funky"),
-		Interval:    false,
+		Interval:    []byte("false"),
 		StartTime:   to.Ptr(time.Now().UTC()),
 	}
 	b, err := json.Marshal(props1)
@@ -114,14 +114,8 @@ func TestInterfaceRoundTrip(t *testing.T) {
 	if *props1.Description != *props2.Description {
 		t.Fatalf("expected %v, got %v", *props1.Description, *props2.Description)
 	}
-	i1, ok := props1.Interval.(bool)
-	if !ok {
-		t.Fatalf("unexpected type %T", props1.Interval)
-	}
-	i2, ok := props2.Interval.(bool)
-	if !ok {
-		t.Fatalf("unexpected type %T", props2.Interval)
-	}
+	i1 := string(props1.Interval)
+	i2 := string(props2.Interval)
 	if i1 != i2 {
 		t.Fatalf("expected %v, got %v", props1.Interval, props2.Interval)
 	}

--- a/test/maps/azalias/zz_models.go
+++ b/test/maps/azalias/zz_models.go
@@ -75,7 +75,7 @@ type GeoJSONFeature struct {
 	ID *string `json:"id,omitempty"`
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties any `json:"properties,omitempty"`
+	Properties []byte `json:"properties,omitempty"`
 
 	// test enum with a default
 	Setting *DataSetting `json:"setting,omitempty"`
@@ -98,7 +98,7 @@ type GeoJSONFeatureData struct {
 	ID *string `json:"id,omitempty"`
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties any `json:"properties,omitempty"`
+	Properties []byte `json:"properties,omitempty"`
 
 	// test enum with a default
 	Setting *DataSetting `json:"setting,omitempty"`
@@ -153,13 +153,13 @@ type ListResponse struct {
 
 type ParameterMetadataValue struct {
 	// a JSON object
-	Value any `json:"value,omitempty"`
+	Value []byte `json:"value,omitempty"`
 }
 
 // ParameterValuesValue - The value of a parameter.
 type ParameterValuesValue struct {
 	// The value of the parameter.
-	Value any `json:"value,omitempty"`
+	Value []byte `json:"value,omitempty"`
 }
 
 type PolicyAssignmentProperties struct {
@@ -182,8 +182,16 @@ type ScheduleCreateOrUpdateProperties struct {
 	Description *string `json:"description,omitempty"`
 
 	// Gets or sets the interval of the schedule.
-	Interval any `json:"interval,omitempty"`
+	Interval []byte `json:"interval,omitempty"`
 
 	// Gets or sets the start time of the schedule.
 	StartTime *time.Time `json:"startTime,omitempty"`
+}
+
+type TypeWithRawJSON struct {
+	// any JSON object
+	AnyObject []byte `json:"anyObject,omitempty"`
+
+	// any valid JSON
+	Anything []byte `json:"anything,omitempty"`
 }

--- a/test/maps/azalias/zz_models_serde.go
+++ b/test/maps/azalias/zz_models_serde.go
@@ -95,7 +95,7 @@ func (g GeoJSONFeature) MarshalJSON() ([]byte, error) {
 	}
 	populate(objectMap, "featureType", g.FeatureType)
 	populate(objectMap, "id", g.ID)
-	populate(objectMap, "properties", &g.Properties)
+	populate(objectMap, "properties", json.RawMessage(g.Properties))
 	if g.Setting == nil {
 		g.Setting = to.Ptr(DataSettingTwo)
 	}
@@ -120,7 +120,7 @@ func (g *GeoJSONFeature) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &g.ID)
 			delete(rawMsg, key)
 		case "properties":
-			err = unpopulate(val, "Properties", &g.Properties)
+			g.Properties = val
 			delete(rawMsg, key)
 		case "setting":
 			err = unpopulate(val, "Setting", &g.Setting)
@@ -144,7 +144,7 @@ func (g GeoJSONFeatureData) MarshalJSON() ([]byte, error) {
 	}
 	populate(objectMap, "featureType", g.FeatureType)
 	populate(objectMap, "id", g.ID)
-	populate(objectMap, "properties", &g.Properties)
+	populate(objectMap, "properties", json.RawMessage(g.Properties))
 	if g.Setting == nil {
 		g.Setting = to.Ptr(DataSettingTwo)
 	}
@@ -168,7 +168,7 @@ func (g *GeoJSONFeatureData) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &g.ID)
 			delete(rawMsg, key)
 		case "properties":
-			err = unpopulate(val, "Properties", &g.Properties)
+			g.Properties = val
 			delete(rawMsg, key)
 		case "setting":
 			err = unpopulate(val, "Setting", &g.Setting)
@@ -285,7 +285,7 @@ func (l *ListResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParameterMetadataValue.
 func (p ParameterMetadataValue) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", &p.Value)
+	populate(objectMap, "value", json.RawMessage(p.Value))
 	return json.Marshal(objectMap)
 }
 
@@ -299,7 +299,7 @@ func (p *ParameterMetadataValue) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "value":
-			err = unpopulate(val, "Value", &p.Value)
+			p.Value = val
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -312,7 +312,7 @@ func (p *ParameterMetadataValue) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParameterValuesValue.
 func (p ParameterValuesValue) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", &p.Value)
+	populate(objectMap, "value", json.RawMessage(p.Value))
 	return json.Marshal(objectMap)
 }
 
@@ -326,7 +326,7 @@ func (p *ParameterValuesValue) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "value":
-			err = unpopulate(val, "Value", &p.Value)
+			p.Value = val
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -376,7 +376,7 @@ func (s ScheduleCreateOrUpdateProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "aliases", s.Aliases)
 	populate(objectMap, "description", s.Description)
-	populate(objectMap, "interval", &s.Interval)
+	populate(objectMap, "interval", json.RawMessage(s.Interval))
 	populateTimeRFC3339(objectMap, "startTime", s.StartTime)
 	return json.Marshal(objectMap)
 }
@@ -397,7 +397,7 @@ func (s *ScheduleCreateOrUpdateProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Description", &s.Description)
 			delete(rawMsg, key)
 		case "interval":
-			err = unpopulate(val, "Interval", &s.Interval)
+			s.Interval = val
 			delete(rawMsg, key)
 		case "startTime":
 			err = unpopulateTimeRFC3339(val, "StartTime", &s.StartTime)
@@ -405,6 +405,37 @@ func (s *ScheduleCreateOrUpdateProperties) UnmarshalJSON(data []byte) error {
 		}
 		if err != nil {
 			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
+// MarshalJSON implements the json.Marshaller interface for type TypeWithRawJSON.
+func (t TypeWithRawJSON) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "anyObject", json.RawMessage(t.AnyObject))
+	populate(objectMap, "anything", json.RawMessage(t.Anything))
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type TypeWithRawJSON.
+func (t *TypeWithRawJSON) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", t, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "anyObject":
+			t.AnyObject = val
+			delete(rawMsg, key)
+		case "anything":
+			t.Anything = val
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", t, err)
 		}
 	}
 	return nil

--- a/test/swagger/alias.json
+++ b/test/swagger/alias.json
@@ -605,6 +605,18 @@
           "description": "a JSON object"
         }
       }
+    },
+    "TypeWithRawJSON": {
+      "type": "object",
+      "properties": {
+        "anything": {
+          "description": "any valid JSON"
+        },
+        "anyObject": {
+          "type": "object",
+          "description": "any JSON object"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
When enabled (off by default), schema types Any and AnyObject are emitted as []byte indicating they're raw JSON.