### PR TITLE
Use clients from azcore

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -70,7 +70,7 @@ help-content:
         description: Optional prefix to file names. For example, if you set your file prefix to "zzz_", all generated code files will begin with "zzz_".
       - key: export-clients
         type: boolean
-        description: Indicates if generated clients are to be exported.  Default to true for ARM, false for data-plane.
+        description: Indicates if generated clients are to be exported.  Default is true.
       - key: module-version
         description: When --azure-arm is true, semantic version to include in generated telemetryInfo constant without the leading 'v' (e.g. 1.2.3).
         type: string

--- a/src/generator/gomod.ts
+++ b/src/generator/gomod.ts
@@ -12,7 +12,7 @@ import { lt, toSemver } from '@azure-tools/codegen';
 export async function generateGoModFile(session: Session<CodeModel>, existingGoMod: string): Promise<string> {
   // here we specify the minimum version of azcore as required by the code generator.
   // the version can be overwritten by passing the --azcore-version switch during generation.
-  const version = await session.getValue('azcore-version', '1.0.0');
+  const version = await session.getValue('azcore-version', '1.3.0');
   if (!version.match(/^\d+\.\d+\.\d+(?:-[a-zA-Z0-9_.-]+)?$/)) {
     throw new Error(`azcore version ${version} must in the format major.minor.patch[-beta.N]`);
   }

--- a/src/transform/namer.ts
+++ b/src/transform/namer.ts
@@ -81,8 +81,6 @@ export async function namer(session: Session<CodeModel>) {
   model.language.go!.openApiType = specType;
   const azureARM = await session.getValue('azure-arm', false);
   model.language.go!.azureARM = azureARM;
-  const exportClients = await session.getValue('export-clients', false);
-  model.language.go!.exportClients = exportClients;
   const headAsBoolean = await session.getValue('head-as-boolean', false);
   model.language.go!.headAsBoolean = headAsBoolean;
   const groupParameters = await session.getValue('group-parameters', true);
@@ -165,7 +163,6 @@ export async function namer(session: Session<CodeModel>) {
     clientNames.add(group.language.go!.clientName);
   }
 
-  const exportClient = session.model.language.go!.openApiType === 'arm' || exportClients;
   // fix up stuttering client names and operation names
   for (const group of values(model.operationGroups)) {
     const groupDetails = <Language>group.language.go;
@@ -176,10 +173,6 @@ export async function namer(session: Session<CodeModel>) {
       throw new Error(`client ${originalName} was renamed to ${groupDetails.clientName} which collides with an existing client name`);
     }
     groupDetails.clientCtorName = `New${groupDetails.clientName}`;
-    if (!exportClient) {
-      groupDetails.clientName = ensureNameCase(groupDetails.clientName, true);
-      groupDetails.clientCtorName = uncapitalize(groupDetails.clientCtorName);
-    }
     for (const op of values(group.operations)) {
       const details = <OperationNaming>op.language.go;
       // propagate these settings to each operation for ease of access

--- a/test/acr/2021-07-01/azacr/go.mod
+++ b/test/acr/2021-07-01/azacr/go.mod
@@ -2,10 +2,10 @@ module azacr
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/acr/2021-07-01/azacr/go.sum
+++ b/test/acr/2021-07-01/azacr/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/acr/2021-07-01/azacr/zz_containerregistry_client.go
+++ b/test/acr/2021-07-01/azacr/zz_containerregistry_client.go
@@ -12,6 +12,7 @@ package azacr
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,37 +21,26 @@ import (
 	"strings"
 )
 
-type containerRegistryClient struct {
+// ContainerRegistryClient contains the methods for the ContainerRegistry group.
+// Don't use this type directly, use a constructor function instead.
+type ContainerRegistryClient struct {
+	internal   *azcore.Client
 	endpoint   string
 	apiVersion *string
-	pl         runtime.Pipeline
-}
-
-// newContainerRegistryClient creates a new instance of containerRegistryClient with the specified values.
-//   - endpoint - Registry login URL
-//   - apiVersion - Api Version. Specifying any value will set the value to 2021-07-01.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newContainerRegistryClient(endpoint string, apiVersion *string, pl runtime.Pipeline) *containerRegistryClient {
-	client := &containerRegistryClient{
-		endpoint:   endpoint,
-		apiVersion: apiVersion,
-		pl:         pl,
-	}
-	return client
 }
 
 // CheckDockerV2Support - Tells whether this Docker Registry instance supports Docker Registry HTTP API v2
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2021-07-01
-//   - options - ContainerRegistryClientCheckDockerV2SupportOptions contains the optional parameters for the containerRegistryClient.CheckDockerV2Support
+//   - options - ContainerRegistryClientCheckDockerV2SupportOptions contains the optional parameters for the ContainerRegistryClient.CheckDockerV2Support
 //     method.
-func (client *containerRegistryClient) CheckDockerV2Support(ctx context.Context, options *ContainerRegistryClientCheckDockerV2SupportOptions) (ContainerRegistryClientCheckDockerV2SupportResponse, error) {
+func (client *ContainerRegistryClient) CheckDockerV2Support(ctx context.Context, options *ContainerRegistryClientCheckDockerV2SupportOptions) (ContainerRegistryClientCheckDockerV2SupportResponse, error) {
 	req, err := client.checkDockerV2SupportCreateRequest(ctx, options)
 	if err != nil {
 		return ContainerRegistryClientCheckDockerV2SupportResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientCheckDockerV2SupportResponse{}, err
 	}
@@ -61,7 +51,7 @@ func (client *containerRegistryClient) CheckDockerV2Support(ctx context.Context,
 }
 
 // checkDockerV2SupportCreateRequest creates the CheckDockerV2Support request.
-func (client *containerRegistryClient) checkDockerV2SupportCreateRequest(ctx context.Context, options *ContainerRegistryClientCheckDockerV2SupportOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) checkDockerV2SupportCreateRequest(ctx context.Context, options *ContainerRegistryClientCheckDockerV2SupportOptions) (*policy.Request, error) {
 	urlPath := "/v2/"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -78,14 +68,14 @@ func (client *containerRegistryClient) checkDockerV2SupportCreateRequest(ctx con
 //   - name - Name of the image (including the namespace)
 //   - reference - A tag or a digest, pointing to a specific image
 //   - payload - Manifest body, can take v1 or v2 values depending on accept header
-//   - options - ContainerRegistryClientCreateManifestOptions contains the optional parameters for the containerRegistryClient.CreateManifest
+//   - options - ContainerRegistryClientCreateManifestOptions contains the optional parameters for the ContainerRegistryClient.CreateManifest
 //     method.
-func (client *containerRegistryClient) CreateManifest(ctx context.Context, name string, reference string, payload Manifest, options *ContainerRegistryClientCreateManifestOptions) (ContainerRegistryClientCreateManifestResponse, error) {
+func (client *ContainerRegistryClient) CreateManifest(ctx context.Context, name string, reference string, payload Manifest, options *ContainerRegistryClientCreateManifestOptions) (ContainerRegistryClientCreateManifestResponse, error) {
 	req, err := client.createManifestCreateRequest(ctx, name, reference, payload, options)
 	if err != nil {
 		return ContainerRegistryClientCreateManifestResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientCreateManifestResponse{}, err
 	}
@@ -96,7 +86,7 @@ func (client *containerRegistryClient) CreateManifest(ctx context.Context, name 
 }
 
 // createManifestCreateRequest creates the CreateManifest request.
-func (client *containerRegistryClient) createManifestCreateRequest(ctx context.Context, name string, reference string, payload Manifest, options *ContainerRegistryClientCreateManifestOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) createManifestCreateRequest(ctx context.Context, name string, reference string, payload Manifest, options *ContainerRegistryClientCreateManifestOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/manifests/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -115,7 +105,7 @@ func (client *containerRegistryClient) createManifestCreateRequest(ctx context.C
 }
 
 // createManifestHandleResponse handles the CreateManifest response.
-func (client *containerRegistryClient) createManifestHandleResponse(resp *http.Response) (ContainerRegistryClientCreateManifestResponse, error) {
+func (client *ContainerRegistryClient) createManifestHandleResponse(resp *http.Response) (ContainerRegistryClientCreateManifestResponse, error) {
 	result := ContainerRegistryClientCreateManifestResponse{}
 	if val := resp.Header.Get("Docker-Content-Digest"); val != "" {
 		result.DockerContentDigest = &val
@@ -144,14 +134,14 @@ func (client *containerRegistryClient) createManifestHandleResponse(resp *http.R
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - reference - Digest of a BLOB
-//   - options - ContainerRegistryClientDeleteManifestOptions contains the optional parameters for the containerRegistryClient.DeleteManifest
+//   - options - ContainerRegistryClientDeleteManifestOptions contains the optional parameters for the ContainerRegistryClient.DeleteManifest
 //     method.
-func (client *containerRegistryClient) DeleteManifest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteManifestOptions) (ContainerRegistryClientDeleteManifestResponse, error) {
+func (client *ContainerRegistryClient) DeleteManifest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteManifestOptions) (ContainerRegistryClientDeleteManifestResponse, error) {
 	req, err := client.deleteManifestCreateRequest(ctx, name, reference, options)
 	if err != nil {
 		return ContainerRegistryClientDeleteManifestResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientDeleteManifestResponse{}, err
 	}
@@ -162,7 +152,7 @@ func (client *containerRegistryClient) DeleteManifest(ctx context.Context, name 
 }
 
 // deleteManifestCreateRequest creates the DeleteManifest request.
-func (client *containerRegistryClient) deleteManifestCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteManifestOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) deleteManifestCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteManifestOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/manifests/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -185,14 +175,14 @@ func (client *containerRegistryClient) deleteManifestCreateRequest(ctx context.C
 //
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
-//   - options - ContainerRegistryClientDeleteRepositoryOptions contains the optional parameters for the containerRegistryClient.DeleteRepository
+//   - options - ContainerRegistryClientDeleteRepositoryOptions contains the optional parameters for the ContainerRegistryClient.DeleteRepository
 //     method.
-func (client *containerRegistryClient) DeleteRepository(ctx context.Context, name string, options *ContainerRegistryClientDeleteRepositoryOptions) (ContainerRegistryClientDeleteRepositoryResponse, error) {
+func (client *ContainerRegistryClient) DeleteRepository(ctx context.Context, name string, options *ContainerRegistryClientDeleteRepositoryOptions) (ContainerRegistryClientDeleteRepositoryResponse, error) {
 	req, err := client.deleteRepositoryCreateRequest(ctx, name, options)
 	if err != nil {
 		return ContainerRegistryClientDeleteRepositoryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientDeleteRepositoryResponse{}, err
 	}
@@ -203,7 +193,7 @@ func (client *containerRegistryClient) DeleteRepository(ctx context.Context, nam
 }
 
 // deleteRepositoryCreateRequest creates the DeleteRepository request.
-func (client *containerRegistryClient) deleteRepositoryCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientDeleteRepositoryOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) deleteRepositoryCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientDeleteRepositoryOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -223,7 +213,7 @@ func (client *containerRegistryClient) deleteRepositoryCreateRequest(ctx context
 }
 
 // deleteRepositoryHandleResponse handles the DeleteRepository response.
-func (client *containerRegistryClient) deleteRepositoryHandleResponse(resp *http.Response) (ContainerRegistryClientDeleteRepositoryResponse, error) {
+func (client *ContainerRegistryClient) deleteRepositoryHandleResponse(resp *http.Response) (ContainerRegistryClientDeleteRepositoryResponse, error) {
 	result := ContainerRegistryClientDeleteRepositoryResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DeleteRepositoryResult); err != nil {
 		return ContainerRegistryClientDeleteRepositoryResponse{}, err
@@ -237,14 +227,14 @@ func (client *containerRegistryClient) deleteRepositoryHandleResponse(resp *http
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - reference - Tag name
-//   - options - ContainerRegistryClientDeleteTagOptions contains the optional parameters for the containerRegistryClient.DeleteTag
+//   - options - ContainerRegistryClientDeleteTagOptions contains the optional parameters for the ContainerRegistryClient.DeleteTag
 //     method.
-func (client *containerRegistryClient) DeleteTag(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteTagOptions) (ContainerRegistryClientDeleteTagResponse, error) {
+func (client *ContainerRegistryClient) DeleteTag(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteTagOptions) (ContainerRegistryClientDeleteTagResponse, error) {
 	req, err := client.deleteTagCreateRequest(ctx, name, reference, options)
 	if err != nil {
 		return ContainerRegistryClientDeleteTagResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientDeleteTagResponse{}, err
 	}
@@ -255,7 +245,7 @@ func (client *containerRegistryClient) DeleteTag(ctx context.Context, name strin
 }
 
 // deleteTagCreateRequest creates the DeleteTag request.
-func (client *containerRegistryClient) deleteTagCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteTagOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) deleteTagCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientDeleteTagOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_tags/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -284,14 +274,14 @@ func (client *containerRegistryClient) deleteTagCreateRequest(ctx context.Contex
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - reference - A tag or a digest, pointing to a specific image
-//   - options - ContainerRegistryClientGetManifestOptions contains the optional parameters for the containerRegistryClient.GetManifest
+//   - options - ContainerRegistryClientGetManifestOptions contains the optional parameters for the ContainerRegistryClient.GetManifest
 //     method.
-func (client *containerRegistryClient) GetManifest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetManifestOptions) (ContainerRegistryClientGetManifestResponse, error) {
+func (client *ContainerRegistryClient) GetManifest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetManifestOptions) (ContainerRegistryClientGetManifestResponse, error) {
 	req, err := client.getManifestCreateRequest(ctx, name, reference, options)
 	if err != nil {
 		return ContainerRegistryClientGetManifestResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientGetManifestResponse{}, err
 	}
@@ -302,7 +292,7 @@ func (client *containerRegistryClient) GetManifest(ctx context.Context, name str
 }
 
 // getManifestCreateRequest creates the GetManifest request.
-func (client *containerRegistryClient) getManifestCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetManifestOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getManifestCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetManifestOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/manifests/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -324,7 +314,7 @@ func (client *containerRegistryClient) getManifestCreateRequest(ctx context.Cont
 }
 
 // getManifestHandleResponse handles the GetManifest response.
-func (client *containerRegistryClient) getManifestHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestResponse, error) {
+func (client *ContainerRegistryClient) getManifestHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestResponse, error) {
 	result := ContainerRegistryClientGetManifestResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ManifestWrapper); err != nil {
 		return ContainerRegistryClientGetManifestResponse{}, err
@@ -338,14 +328,14 @@ func (client *containerRegistryClient) getManifestHandleResponse(resp *http.Resp
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
-//   - options - ContainerRegistryClientGetManifestPropertiesOptions contains the optional parameters for the containerRegistryClient.GetManifestProperties
+//   - options - ContainerRegistryClientGetManifestPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetManifestProperties
 //     method.
-func (client *containerRegistryClient) GetManifestProperties(ctx context.Context, name string, digest string, options *ContainerRegistryClientGetManifestPropertiesOptions) (ContainerRegistryClientGetManifestPropertiesResponse, error) {
+func (client *ContainerRegistryClient) GetManifestProperties(ctx context.Context, name string, digest string, options *ContainerRegistryClientGetManifestPropertiesOptions) (ContainerRegistryClientGetManifestPropertiesResponse, error) {
 	req, err := client.getManifestPropertiesCreateRequest(ctx, name, digest, options)
 	if err != nil {
 		return ContainerRegistryClientGetManifestPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientGetManifestPropertiesResponse{}, err
 	}
@@ -356,7 +346,7 @@ func (client *containerRegistryClient) GetManifestProperties(ctx context.Context
 }
 
 // getManifestPropertiesCreateRequest creates the GetManifestProperties request.
-func (client *containerRegistryClient) getManifestPropertiesCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryClientGetManifestPropertiesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getManifestPropertiesCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryClientGetManifestPropertiesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_manifests/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -380,7 +370,7 @@ func (client *containerRegistryClient) getManifestPropertiesCreateRequest(ctx co
 }
 
 // getManifestPropertiesHandleResponse handles the GetManifestProperties response.
-func (client *containerRegistryClient) getManifestPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestPropertiesResponse, error) {
+func (client *ContainerRegistryClient) getManifestPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestPropertiesResponse, error) {
 	result := ContainerRegistryClientGetManifestPropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArtifactManifestProperties); err != nil {
 		return ContainerRegistryClientGetManifestPropertiesResponse{}, err
@@ -392,9 +382,9 @@ func (client *containerRegistryClient) getManifestPropertiesHandleResponse(resp 
 //
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
-//   - options - ContainerRegistryClientGetManifestsOptions contains the optional parameters for the containerRegistryClient.NewGetManifestsPager
+//   - options - ContainerRegistryClientGetManifestsOptions contains the optional parameters for the ContainerRegistryClient.NewGetManifestsPager
 //     method.
-func (client *containerRegistryClient) NewGetManifestsPager(name string, options *ContainerRegistryClientGetManifestsOptions) *runtime.Pager[ContainerRegistryClientGetManifestsResponse] {
+func (client *ContainerRegistryClient) NewGetManifestsPager(name string, options *ContainerRegistryClientGetManifestsOptions) *runtime.Pager[ContainerRegistryClientGetManifestsResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainerRegistryClientGetManifestsResponse]{
 		More: func(page ContainerRegistryClientGetManifestsResponse) bool {
 			return page.Link != nil && len(*page.Link) > 0
@@ -410,7 +400,7 @@ func (client *containerRegistryClient) NewGetManifestsPager(name string, options
 			if err != nil {
 				return ContainerRegistryClientGetManifestsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ContainerRegistryClientGetManifestsResponse{}, err
 			}
@@ -423,7 +413,7 @@ func (client *containerRegistryClient) NewGetManifestsPager(name string, options
 }
 
 // getManifestsCreateRequest creates the GetManifests request.
-func (client *containerRegistryClient) getManifestsCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetManifestsOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getManifestsCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetManifestsOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_manifests"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -452,7 +442,7 @@ func (client *containerRegistryClient) getManifestsCreateRequest(ctx context.Con
 }
 
 // getManifestsHandleResponse handles the GetManifests response.
-func (client *containerRegistryClient) getManifestsHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestsResponse, error) {
+func (client *ContainerRegistryClient) getManifestsHandleResponse(resp *http.Response) (ContainerRegistryClientGetManifestsResponse, error) {
 	result := ContainerRegistryClientGetManifestsResponse{}
 	if val := resp.Header.Get("Link"); val != "" {
 		result.Link = &val
@@ -468,14 +458,14 @@ func (client *containerRegistryClient) getManifestsHandleResponse(resp *http.Res
 //
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
-//   - options - ContainerRegistryClientGetPropertiesOptions contains the optional parameters for the containerRegistryClient.GetProperties
+//   - options - ContainerRegistryClientGetPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetProperties
 //     method.
-func (client *containerRegistryClient) GetProperties(ctx context.Context, name string, options *ContainerRegistryClientGetPropertiesOptions) (ContainerRegistryClientGetPropertiesResponse, error) {
+func (client *ContainerRegistryClient) GetProperties(ctx context.Context, name string, options *ContainerRegistryClientGetPropertiesOptions) (ContainerRegistryClientGetPropertiesResponse, error) {
 	req, err := client.getPropertiesCreateRequest(ctx, name, options)
 	if err != nil {
 		return ContainerRegistryClientGetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientGetPropertiesResponse{}, err
 	}
@@ -486,7 +476,7 @@ func (client *containerRegistryClient) GetProperties(ctx context.Context, name s
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *containerRegistryClient) getPropertiesCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetPropertiesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getPropertiesCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetPropertiesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -506,7 +496,7 @@ func (client *containerRegistryClient) getPropertiesCreateRequest(ctx context.Co
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *containerRegistryClient) getPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetPropertiesResponse, error) {
+func (client *ContainerRegistryClient) getPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetPropertiesResponse, error) {
 	result := ContainerRegistryClientGetPropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerRepositoryProperties); err != nil {
 		return ContainerRegistryClientGetPropertiesResponse{}, err
@@ -517,9 +507,9 @@ func (client *containerRegistryClient) getPropertiesHandleResponse(resp *http.Re
 // NewGetRepositoriesPager - List repositories
 //
 // Generated from API version 2021-07-01
-//   - options - ContainerRegistryClientGetRepositoriesOptions contains the optional parameters for the containerRegistryClient.NewGetRepositoriesPager
+//   - options - ContainerRegistryClientGetRepositoriesOptions contains the optional parameters for the ContainerRegistryClient.NewGetRepositoriesPager
 //     method.
-func (client *containerRegistryClient) NewGetRepositoriesPager(options *ContainerRegistryClientGetRepositoriesOptions) *runtime.Pager[ContainerRegistryClientGetRepositoriesResponse] {
+func (client *ContainerRegistryClient) NewGetRepositoriesPager(options *ContainerRegistryClientGetRepositoriesOptions) *runtime.Pager[ContainerRegistryClientGetRepositoriesResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainerRegistryClientGetRepositoriesResponse]{
 		More: func(page ContainerRegistryClientGetRepositoriesResponse) bool {
 			return page.Link != nil && len(*page.Link) > 0
@@ -535,7 +525,7 @@ func (client *containerRegistryClient) NewGetRepositoriesPager(options *Containe
 			if err != nil {
 				return ContainerRegistryClientGetRepositoriesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ContainerRegistryClientGetRepositoriesResponse{}, err
 			}
@@ -548,7 +538,7 @@ func (client *containerRegistryClient) NewGetRepositoriesPager(options *Containe
 }
 
 // getRepositoriesCreateRequest creates the GetRepositories request.
-func (client *containerRegistryClient) getRepositoriesCreateRequest(ctx context.Context, options *ContainerRegistryClientGetRepositoriesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getRepositoriesCreateRequest(ctx context.Context, options *ContainerRegistryClientGetRepositoriesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/_catalog"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -570,7 +560,7 @@ func (client *containerRegistryClient) getRepositoriesCreateRequest(ctx context.
 }
 
 // getRepositoriesHandleResponse handles the GetRepositories response.
-func (client *containerRegistryClient) getRepositoriesHandleResponse(resp *http.Response) (ContainerRegistryClientGetRepositoriesResponse, error) {
+func (client *ContainerRegistryClient) getRepositoriesHandleResponse(resp *http.Response) (ContainerRegistryClientGetRepositoriesResponse, error) {
 	result := ContainerRegistryClientGetRepositoriesResponse{}
 	if val := resp.Header.Get("Link"); val != "" {
 		result.Link = &val
@@ -587,14 +577,14 @@ func (client *containerRegistryClient) getRepositoriesHandleResponse(resp *http.
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - reference - Tag name
-//   - options - ContainerRegistryClientGetTagPropertiesOptions contains the optional parameters for the containerRegistryClient.GetTagProperties
+//   - options - ContainerRegistryClientGetTagPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetTagProperties
 //     method.
-func (client *containerRegistryClient) GetTagProperties(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetTagPropertiesOptions) (ContainerRegistryClientGetTagPropertiesResponse, error) {
+func (client *ContainerRegistryClient) GetTagProperties(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetTagPropertiesOptions) (ContainerRegistryClientGetTagPropertiesResponse, error) {
 	req, err := client.getTagPropertiesCreateRequest(ctx, name, reference, options)
 	if err != nil {
 		return ContainerRegistryClientGetTagPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientGetTagPropertiesResponse{}, err
 	}
@@ -605,7 +595,7 @@ func (client *containerRegistryClient) GetTagProperties(ctx context.Context, nam
 }
 
 // getTagPropertiesCreateRequest creates the GetTagProperties request.
-func (client *containerRegistryClient) getTagPropertiesCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetTagPropertiesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getTagPropertiesCreateRequest(ctx context.Context, name string, reference string, options *ContainerRegistryClientGetTagPropertiesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_tags/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -629,7 +619,7 @@ func (client *containerRegistryClient) getTagPropertiesCreateRequest(ctx context
 }
 
 // getTagPropertiesHandleResponse handles the GetTagProperties response.
-func (client *containerRegistryClient) getTagPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetTagPropertiesResponse, error) {
+func (client *ContainerRegistryClient) getTagPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientGetTagPropertiesResponse, error) {
 	result := ContainerRegistryClientGetTagPropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArtifactTagProperties); err != nil {
 		return ContainerRegistryClientGetTagPropertiesResponse{}, err
@@ -641,9 +631,9 @@ func (client *containerRegistryClient) getTagPropertiesHandleResponse(resp *http
 //
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
-//   - options - ContainerRegistryClientGetTagsOptions contains the optional parameters for the containerRegistryClient.NewGetTagsPager
+//   - options - ContainerRegistryClientGetTagsOptions contains the optional parameters for the ContainerRegistryClient.NewGetTagsPager
 //     method.
-func (client *containerRegistryClient) NewGetTagsPager(name string, options *ContainerRegistryClientGetTagsOptions) *runtime.Pager[ContainerRegistryClientGetTagsResponse] {
+func (client *ContainerRegistryClient) NewGetTagsPager(name string, options *ContainerRegistryClientGetTagsOptions) *runtime.Pager[ContainerRegistryClientGetTagsResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainerRegistryClientGetTagsResponse]{
 		More: func(page ContainerRegistryClientGetTagsResponse) bool {
 			return page.Link != nil && len(*page.Link) > 0
@@ -659,7 +649,7 @@ func (client *containerRegistryClient) NewGetTagsPager(name string, options *Con
 			if err != nil {
 				return ContainerRegistryClientGetTagsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ContainerRegistryClientGetTagsResponse{}, err
 			}
@@ -672,7 +662,7 @@ func (client *containerRegistryClient) NewGetTagsPager(name string, options *Con
 }
 
 // getTagsCreateRequest creates the GetTags request.
-func (client *containerRegistryClient) getTagsCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetTagsOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) getTagsCreateRequest(ctx context.Context, name string, options *ContainerRegistryClientGetTagsOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_tags"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -704,7 +694,7 @@ func (client *containerRegistryClient) getTagsCreateRequest(ctx context.Context,
 }
 
 // getTagsHandleResponse handles the GetTags response.
-func (client *containerRegistryClient) getTagsHandleResponse(resp *http.Response) (ContainerRegistryClientGetTagsResponse, error) {
+func (client *ContainerRegistryClient) getTagsHandleResponse(resp *http.Response) (ContainerRegistryClientGetTagsResponse, error) {
 	result := ContainerRegistryClientGetTagsResponse{}
 	if val := resp.Header.Get("Link"); val != "" {
 		result.Link = &val
@@ -722,14 +712,14 @@ func (client *containerRegistryClient) getTagsHandleResponse(resp *http.Response
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
 //   - value - Manifest attribute value
-//   - options - ContainerRegistryClientUpdateManifestPropertiesOptions contains the optional parameters for the containerRegistryClient.UpdateManifestProperties
+//   - options - ContainerRegistryClientUpdateManifestPropertiesOptions contains the optional parameters for the ContainerRegistryClient.UpdateManifestProperties
 //     method.
-func (client *containerRegistryClient) UpdateManifestProperties(ctx context.Context, name string, digest string, value ManifestWriteableProperties, options *ContainerRegistryClientUpdateManifestPropertiesOptions) (ContainerRegistryClientUpdateManifestPropertiesResponse, error) {
+func (client *ContainerRegistryClient) UpdateManifestProperties(ctx context.Context, name string, digest string, value ManifestWriteableProperties, options *ContainerRegistryClientUpdateManifestPropertiesOptions) (ContainerRegistryClientUpdateManifestPropertiesResponse, error) {
 	req, err := client.updateManifestPropertiesCreateRequest(ctx, name, digest, value, options)
 	if err != nil {
 		return ContainerRegistryClientUpdateManifestPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientUpdateManifestPropertiesResponse{}, err
 	}
@@ -740,7 +730,7 @@ func (client *containerRegistryClient) UpdateManifestProperties(ctx context.Cont
 }
 
 // updateManifestPropertiesCreateRequest creates the UpdateManifestProperties request.
-func (client *containerRegistryClient) updateManifestPropertiesCreateRequest(ctx context.Context, name string, digest string, value ManifestWriteableProperties, options *ContainerRegistryClientUpdateManifestPropertiesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) updateManifestPropertiesCreateRequest(ctx context.Context, name string, digest string, value ManifestWriteableProperties, options *ContainerRegistryClientUpdateManifestPropertiesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_manifests/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -764,7 +754,7 @@ func (client *containerRegistryClient) updateManifestPropertiesCreateRequest(ctx
 }
 
 // updateManifestPropertiesHandleResponse handles the UpdateManifestProperties response.
-func (client *containerRegistryClient) updateManifestPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdateManifestPropertiesResponse, error) {
+func (client *ContainerRegistryClient) updateManifestPropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdateManifestPropertiesResponse, error) {
 	result := ContainerRegistryClientUpdateManifestPropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArtifactManifestProperties); err != nil {
 		return ContainerRegistryClientUpdateManifestPropertiesResponse{}, err
@@ -778,14 +768,14 @@ func (client *containerRegistryClient) updateManifestPropertiesHandleResponse(re
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - value - Repository attribute value
-//   - options - ContainerRegistryClientUpdatePropertiesOptions contains the optional parameters for the containerRegistryClient.UpdateProperties
+//   - options - ContainerRegistryClientUpdatePropertiesOptions contains the optional parameters for the ContainerRegistryClient.UpdateProperties
 //     method.
-func (client *containerRegistryClient) UpdateProperties(ctx context.Context, name string, value RepositoryWriteableProperties, options *ContainerRegistryClientUpdatePropertiesOptions) (ContainerRegistryClientUpdatePropertiesResponse, error) {
+func (client *ContainerRegistryClient) UpdateProperties(ctx context.Context, name string, value RepositoryWriteableProperties, options *ContainerRegistryClientUpdatePropertiesOptions) (ContainerRegistryClientUpdatePropertiesResponse, error) {
 	req, err := client.updatePropertiesCreateRequest(ctx, name, value, options)
 	if err != nil {
 		return ContainerRegistryClientUpdatePropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientUpdatePropertiesResponse{}, err
 	}
@@ -796,7 +786,7 @@ func (client *containerRegistryClient) UpdateProperties(ctx context.Context, nam
 }
 
 // updatePropertiesCreateRequest creates the UpdateProperties request.
-func (client *containerRegistryClient) updatePropertiesCreateRequest(ctx context.Context, name string, value RepositoryWriteableProperties, options *ContainerRegistryClientUpdatePropertiesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) updatePropertiesCreateRequest(ctx context.Context, name string, value RepositoryWriteableProperties, options *ContainerRegistryClientUpdatePropertiesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -816,7 +806,7 @@ func (client *containerRegistryClient) updatePropertiesCreateRequest(ctx context
 }
 
 // updatePropertiesHandleResponse handles the UpdateProperties response.
-func (client *containerRegistryClient) updatePropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdatePropertiesResponse, error) {
+func (client *ContainerRegistryClient) updatePropertiesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdatePropertiesResponse, error) {
 	result := ContainerRegistryClientUpdatePropertiesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ContainerRepositoryProperties); err != nil {
 		return ContainerRegistryClientUpdatePropertiesResponse{}, err
@@ -831,14 +821,14 @@ func (client *containerRegistryClient) updatePropertiesHandleResponse(resp *http
 //   - name - Name of the image (including the namespace)
 //   - reference - Tag name
 //   - value - Tag attribute value
-//   - options - ContainerRegistryClientUpdateTagAttributesOptions contains the optional parameters for the containerRegistryClient.UpdateTagAttributes
+//   - options - ContainerRegistryClientUpdateTagAttributesOptions contains the optional parameters for the ContainerRegistryClient.UpdateTagAttributes
 //     method.
-func (client *containerRegistryClient) UpdateTagAttributes(ctx context.Context, name string, reference string, value TagWriteableProperties, options *ContainerRegistryClientUpdateTagAttributesOptions) (ContainerRegistryClientUpdateTagAttributesResponse, error) {
+func (client *ContainerRegistryClient) UpdateTagAttributes(ctx context.Context, name string, reference string, value TagWriteableProperties, options *ContainerRegistryClientUpdateTagAttributesOptions) (ContainerRegistryClientUpdateTagAttributesResponse, error) {
 	req, err := client.updateTagAttributesCreateRequest(ctx, name, reference, value, options)
 	if err != nil {
 		return ContainerRegistryClientUpdateTagAttributesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryClientUpdateTagAttributesResponse{}, err
 	}
@@ -849,7 +839,7 @@ func (client *containerRegistryClient) UpdateTagAttributes(ctx context.Context, 
 }
 
 // updateTagAttributesCreateRequest creates the UpdateTagAttributes request.
-func (client *containerRegistryClient) updateTagAttributesCreateRequest(ctx context.Context, name string, reference string, value TagWriteableProperties, options *ContainerRegistryClientUpdateTagAttributesOptions) (*policy.Request, error) {
+func (client *ContainerRegistryClient) updateTagAttributesCreateRequest(ctx context.Context, name string, reference string, value TagWriteableProperties, options *ContainerRegistryClientUpdateTagAttributesOptions) (*policy.Request, error) {
 	urlPath := "/acr/v1/{name}/_tags/{reference}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -873,7 +863,7 @@ func (client *containerRegistryClient) updateTagAttributesCreateRequest(ctx cont
 }
 
 // updateTagAttributesHandleResponse handles the UpdateTagAttributes response.
-func (client *containerRegistryClient) updateTagAttributesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdateTagAttributesResponse, error) {
+func (client *ContainerRegistryClient) updateTagAttributesHandleResponse(resp *http.Response) (ContainerRegistryClientUpdateTagAttributesResponse, error) {
 	result := ContainerRegistryClientUpdateTagAttributesResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ArtifactTagProperties); err != nil {
 		return ContainerRegistryClientUpdateTagAttributesResponse{}, err

--- a/test/acr/2021-07-01/azacr/zz_containerregistryblob_client.go
+++ b/test/acr/2021-07-01/azacr/zz_containerregistryblob_client.go
@@ -12,6 +12,7 @@ package azacr
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -21,20 +22,11 @@ import (
 	"strings"
 )
 
-type containerRegistryBlobClient struct {
+// ContainerRegistryBlobClient contains the methods for the ContainerRegistryBlob group.
+// Don't use this type directly, use a constructor function instead.
+type ContainerRegistryBlobClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newContainerRegistryBlobClient creates a new instance of containerRegistryBlobClient with the specified values.
-//   - endpoint - Registry login URL
-//   - pl - the pipeline used for sending requests and handling responses.
-func newContainerRegistryBlobClient(endpoint string, pl runtime.Pipeline) *containerRegistryBlobClient {
-	client := &containerRegistryBlobClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // CancelUpload - Cancel outstanding upload processes, releasing associated resources. If this is not called, the unfinished
@@ -43,14 +35,14 @@ func newContainerRegistryBlobClient(endpoint string, pl runtime.Pipeline) *conta
 //
 // Generated from API version 2021-07-01
 //   - location - Link acquired from upload start or previous chunk. Note, do not include initial / (must do substring(1) )
-//   - options - ContainerRegistryBlobClientCancelUploadOptions contains the optional parameters for the containerRegistryBlobClient.CancelUpload
+//   - options - ContainerRegistryBlobClientCancelUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.CancelUpload
 //     method.
-func (client *containerRegistryBlobClient) CancelUpload(ctx context.Context, location string, options *ContainerRegistryBlobClientCancelUploadOptions) (ContainerRegistryBlobClientCancelUploadResponse, error) {
+func (client *ContainerRegistryBlobClient) CancelUpload(ctx context.Context, location string, options *ContainerRegistryBlobClientCancelUploadOptions) (ContainerRegistryBlobClientCancelUploadResponse, error) {
 	req, err := client.cancelUploadCreateRequest(ctx, location, options)
 	if err != nil {
 		return ContainerRegistryBlobClientCancelUploadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientCancelUploadResponse{}, err
 	}
@@ -61,7 +53,7 @@ func (client *containerRegistryBlobClient) CancelUpload(ctx context.Context, loc
 }
 
 // cancelUploadCreateRequest creates the CancelUpload request.
-func (client *containerRegistryBlobClient) cancelUploadCreateRequest(ctx context.Context, location string, options *ContainerRegistryBlobClientCancelUploadOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) cancelUploadCreateRequest(ctx context.Context, location string, options *ContainerRegistryBlobClientCancelUploadOptions) (*policy.Request, error) {
 	urlPath := "/{nextBlobUuidLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{nextBlobUuidLink}", location)
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -78,14 +70,14 @@ func (client *containerRegistryBlobClient) cancelUploadCreateRequest(ctx context
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
-//   - options - ContainerRegistryBlobClientCheckBlobExistsOptions contains the optional parameters for the containerRegistryBlobClient.CheckBlobExists
+//   - options - ContainerRegistryBlobClientCheckBlobExistsOptions contains the optional parameters for the ContainerRegistryBlobClient.CheckBlobExists
 //     method.
-func (client *containerRegistryBlobClient) CheckBlobExists(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientCheckBlobExistsOptions) (ContainerRegistryBlobClientCheckBlobExistsResponse, error) {
+func (client *ContainerRegistryBlobClient) CheckBlobExists(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientCheckBlobExistsOptions) (ContainerRegistryBlobClientCheckBlobExistsResponse, error) {
 	req, err := client.checkBlobExistsCreateRequest(ctx, name, digest, options)
 	if err != nil {
 		return ContainerRegistryBlobClientCheckBlobExistsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientCheckBlobExistsResponse{}, err
 	}
@@ -96,7 +88,7 @@ func (client *containerRegistryBlobClient) CheckBlobExists(ctx context.Context, 
 }
 
 // checkBlobExistsCreateRequest creates the CheckBlobExists request.
-func (client *containerRegistryBlobClient) checkBlobExistsCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientCheckBlobExistsOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) checkBlobExistsCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientCheckBlobExistsOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -115,7 +107,7 @@ func (client *containerRegistryBlobClient) checkBlobExistsCreateRequest(ctx cont
 }
 
 // checkBlobExistsHandleResponse handles the CheckBlobExists response.
-func (client *containerRegistryBlobClient) checkBlobExistsHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCheckBlobExistsResponse, error) {
+func (client *ContainerRegistryBlobClient) checkBlobExistsHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCheckBlobExistsResponse, error) {
 	result := ContainerRegistryBlobClientCheckBlobExistsResponse{}
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
@@ -137,14 +129,14 @@ func (client *containerRegistryBlobClient) checkBlobExistsHandleResponse(resp *h
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
 //   - rangeParam - Format : bytes=-, HTTP Range header specifying blob chunk.
-//   - options - ContainerRegistryBlobClientCheckChunkExistsOptions contains the optional parameters for the containerRegistryBlobClient.CheckChunkExists
+//   - options - ContainerRegistryBlobClientCheckChunkExistsOptions contains the optional parameters for the ContainerRegistryBlobClient.CheckChunkExists
 //     method.
-func (client *containerRegistryBlobClient) CheckChunkExists(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientCheckChunkExistsOptions) (ContainerRegistryBlobClientCheckChunkExistsResponse, error) {
+func (client *ContainerRegistryBlobClient) CheckChunkExists(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientCheckChunkExistsOptions) (ContainerRegistryBlobClientCheckChunkExistsResponse, error) {
 	req, err := client.checkChunkExistsCreateRequest(ctx, name, digest, rangeParam, options)
 	if err != nil {
 		return ContainerRegistryBlobClientCheckChunkExistsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientCheckChunkExistsResponse{}, err
 	}
@@ -155,7 +147,7 @@ func (client *containerRegistryBlobClient) CheckChunkExists(ctx context.Context,
 }
 
 // checkChunkExistsCreateRequest creates the CheckChunkExists request.
-func (client *containerRegistryBlobClient) checkChunkExistsCreateRequest(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientCheckChunkExistsOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) checkChunkExistsCreateRequest(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientCheckChunkExistsOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -175,7 +167,7 @@ func (client *containerRegistryBlobClient) checkChunkExistsCreateRequest(ctx con
 }
 
 // checkChunkExistsHandleResponse handles the CheckChunkExists response.
-func (client *containerRegistryBlobClient) checkChunkExistsHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCheckChunkExistsResponse, error) {
+func (client *ContainerRegistryBlobClient) checkChunkExistsHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCheckChunkExistsResponse, error) {
 	result := ContainerRegistryBlobClientCheckChunkExistsResponse{}
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
@@ -198,14 +190,14 @@ func (client *containerRegistryBlobClient) checkChunkExistsHandleResponse(resp *
 //   - digest - Digest of a BLOB
 //   - location - Link acquired from upload start or previous chunk. Note, do not include initial / (must do substring(1) )
 //   - value - Optional raw data of blob
-//   - options - ContainerRegistryBlobClientCompleteUploadOptions contains the optional parameters for the containerRegistryBlobClient.CompleteUpload
+//   - options - ContainerRegistryBlobClientCompleteUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.CompleteUpload
 //     method.
-func (client *containerRegistryBlobClient) CompleteUpload(ctx context.Context, digest string, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientCompleteUploadOptions) (ContainerRegistryBlobClientCompleteUploadResponse, error) {
+func (client *ContainerRegistryBlobClient) CompleteUpload(ctx context.Context, digest string, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientCompleteUploadOptions) (ContainerRegistryBlobClientCompleteUploadResponse, error) {
 	req, err := client.completeUploadCreateRequest(ctx, digest, location, value, options)
 	if err != nil {
 		return ContainerRegistryBlobClientCompleteUploadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientCompleteUploadResponse{}, err
 	}
@@ -216,7 +208,7 @@ func (client *containerRegistryBlobClient) CompleteUpload(ctx context.Context, d
 }
 
 // completeUploadCreateRequest creates the CompleteUpload request.
-func (client *containerRegistryBlobClient) completeUploadCreateRequest(ctx context.Context, digest string, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientCompleteUploadOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) completeUploadCreateRequest(ctx context.Context, digest string, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientCompleteUploadOptions) (*policy.Request, error) {
 	urlPath := "/{nextBlobUuidLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{nextBlobUuidLink}", location)
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
@@ -231,7 +223,7 @@ func (client *containerRegistryBlobClient) completeUploadCreateRequest(ctx conte
 }
 
 // completeUploadHandleResponse handles the CompleteUpload response.
-func (client *containerRegistryBlobClient) completeUploadHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCompleteUploadResponse, error) {
+func (client *ContainerRegistryBlobClient) completeUploadHandleResponse(resp *http.Response) (ContainerRegistryBlobClientCompleteUploadResponse, error) {
 	result := ContainerRegistryBlobClientCompleteUploadResponse{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -251,14 +243,14 @@ func (client *containerRegistryBlobClient) completeUploadHandleResponse(resp *ht
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
-//   - options - ContainerRegistryBlobClientDeleteBlobOptions contains the optional parameters for the containerRegistryBlobClient.DeleteBlob
+//   - options - ContainerRegistryBlobClientDeleteBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.DeleteBlob
 //     method.
-func (client *containerRegistryBlobClient) DeleteBlob(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientDeleteBlobOptions) (ContainerRegistryBlobClientDeleteBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) DeleteBlob(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientDeleteBlobOptions) (ContainerRegistryBlobClientDeleteBlobResponse, error) {
 	req, err := client.deleteBlobCreateRequest(ctx, name, digest, options)
 	if err != nil {
 		return ContainerRegistryBlobClientDeleteBlobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientDeleteBlobResponse{}, err
 	}
@@ -269,7 +261,7 @@ func (client *containerRegistryBlobClient) DeleteBlob(ctx context.Context, name 
 }
 
 // deleteBlobCreateRequest creates the DeleteBlob request.
-func (client *containerRegistryBlobClient) deleteBlobCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientDeleteBlobOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) deleteBlobCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientDeleteBlobOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -289,7 +281,7 @@ func (client *containerRegistryBlobClient) deleteBlobCreateRequest(ctx context.C
 }
 
 // deleteBlobHandleResponse handles the DeleteBlob response.
-func (client *containerRegistryBlobClient) deleteBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientDeleteBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) deleteBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientDeleteBlobResponse, error) {
 	result := ContainerRegistryBlobClientDeleteBlobResponse{Body: resp.Body}
 	if val := resp.Header.Get("Docker-Content-Digest"); val != "" {
 		result.DockerContentDigest = &val
@@ -303,14 +295,14 @@ func (client *containerRegistryBlobClient) deleteBlobHandleResponse(resp *http.R
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
-//   - options - ContainerRegistryBlobClientGetBlobOptions contains the optional parameters for the containerRegistryBlobClient.GetBlob
+//   - options - ContainerRegistryBlobClientGetBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.GetBlob
 //     method.
-func (client *containerRegistryBlobClient) GetBlob(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientGetBlobOptions) (ContainerRegistryBlobClientGetBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) GetBlob(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientGetBlobOptions) (ContainerRegistryBlobClientGetBlobResponse, error) {
 	req, err := client.getBlobCreateRequest(ctx, name, digest, options)
 	if err != nil {
 		return ContainerRegistryBlobClientGetBlobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientGetBlobResponse{}, err
 	}
@@ -321,7 +313,7 @@ func (client *containerRegistryBlobClient) GetBlob(ctx context.Context, name str
 }
 
 // getBlobCreateRequest creates the GetBlob request.
-func (client *containerRegistryBlobClient) getBlobCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientGetBlobOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) getBlobCreateRequest(ctx context.Context, name string, digest string, options *ContainerRegistryBlobClientGetBlobOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -341,7 +333,7 @@ func (client *containerRegistryBlobClient) getBlobCreateRequest(ctx context.Cont
 }
 
 // getBlobHandleResponse handles the GetBlob response.
-func (client *containerRegistryBlobClient) getBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) getBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetBlobResponse, error) {
 	result := ContainerRegistryBlobClientGetBlobResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
@@ -365,14 +357,14 @@ func (client *containerRegistryBlobClient) getBlobHandleResponse(resp *http.Resp
 //   - name - Name of the image (including the namespace)
 //   - digest - Digest of a BLOB
 //   - rangeParam - Format : bytes=-, HTTP Range header specifying blob chunk.
-//   - options - ContainerRegistryBlobClientGetChunkOptions contains the optional parameters for the containerRegistryBlobClient.GetChunk
+//   - options - ContainerRegistryBlobClientGetChunkOptions contains the optional parameters for the ContainerRegistryBlobClient.GetChunk
 //     method.
-func (client *containerRegistryBlobClient) GetChunk(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientGetChunkOptions) (ContainerRegistryBlobClientGetChunkResponse, error) {
+func (client *ContainerRegistryBlobClient) GetChunk(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientGetChunkOptions) (ContainerRegistryBlobClientGetChunkResponse, error) {
 	req, err := client.getChunkCreateRequest(ctx, name, digest, rangeParam, options)
 	if err != nil {
 		return ContainerRegistryBlobClientGetChunkResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientGetChunkResponse{}, err
 	}
@@ -383,7 +375,7 @@ func (client *containerRegistryBlobClient) GetChunk(ctx context.Context, name st
 }
 
 // getChunkCreateRequest creates the GetChunk request.
-func (client *containerRegistryBlobClient) getChunkCreateRequest(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientGetChunkOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) getChunkCreateRequest(ctx context.Context, name string, digest string, rangeParam string, options *ContainerRegistryBlobClientGetChunkOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/{digest}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -404,7 +396,7 @@ func (client *containerRegistryBlobClient) getChunkCreateRequest(ctx context.Con
 }
 
 // getChunkHandleResponse handles the GetChunk response.
-func (client *containerRegistryBlobClient) getChunkHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetChunkResponse, error) {
+func (client *ContainerRegistryBlobClient) getChunkHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetChunkResponse, error) {
 	result := ContainerRegistryBlobClientGetChunkResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Length"); val != "" {
 		contentLength, err := strconv.ParseInt(val, 10, 64)
@@ -425,14 +417,14 @@ func (client *containerRegistryBlobClient) getChunkHandleResponse(resp *http.Res
 //
 // Generated from API version 2021-07-01
 //   - location - Link acquired from upload start or previous chunk. Note, do not include initial / (must do substring(1) )
-//   - options - ContainerRegistryBlobClientGetUploadStatusOptions contains the optional parameters for the containerRegistryBlobClient.GetUploadStatus
+//   - options - ContainerRegistryBlobClientGetUploadStatusOptions contains the optional parameters for the ContainerRegistryBlobClient.GetUploadStatus
 //     method.
-func (client *containerRegistryBlobClient) GetUploadStatus(ctx context.Context, location string, options *ContainerRegistryBlobClientGetUploadStatusOptions) (ContainerRegistryBlobClientGetUploadStatusResponse, error) {
+func (client *ContainerRegistryBlobClient) GetUploadStatus(ctx context.Context, location string, options *ContainerRegistryBlobClientGetUploadStatusOptions) (ContainerRegistryBlobClientGetUploadStatusResponse, error) {
 	req, err := client.getUploadStatusCreateRequest(ctx, location, options)
 	if err != nil {
 		return ContainerRegistryBlobClientGetUploadStatusResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientGetUploadStatusResponse{}, err
 	}
@@ -443,7 +435,7 @@ func (client *containerRegistryBlobClient) GetUploadStatus(ctx context.Context, 
 }
 
 // getUploadStatusCreateRequest creates the GetUploadStatus request.
-func (client *containerRegistryBlobClient) getUploadStatusCreateRequest(ctx context.Context, location string, options *ContainerRegistryBlobClientGetUploadStatusOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) getUploadStatusCreateRequest(ctx context.Context, location string, options *ContainerRegistryBlobClientGetUploadStatusOptions) (*policy.Request, error) {
 	urlPath := "/{nextBlobUuidLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{nextBlobUuidLink}", location)
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -455,7 +447,7 @@ func (client *containerRegistryBlobClient) getUploadStatusCreateRequest(ctx cont
 }
 
 // getUploadStatusHandleResponse handles the GetUploadStatus response.
-func (client *containerRegistryBlobClient) getUploadStatusHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetUploadStatusResponse, error) {
+func (client *ContainerRegistryBlobClient) getUploadStatusHandleResponse(resp *http.Response) (ContainerRegistryBlobClientGetUploadStatusResponse, error) {
 	result := ContainerRegistryBlobClientGetUploadStatusResponse{}
 	if val := resp.Header.Get("Range"); val != "" {
 		result.Range = &val
@@ -473,14 +465,14 @@ func (client *containerRegistryBlobClient) getUploadStatusHandleResponse(resp *h
 //   - name - Name of the image (including the namespace)
 //   - from - Name of the source repository.
 //   - mount - Digest of blob to mount from the source repository.
-//   - options - ContainerRegistryBlobClientMountBlobOptions contains the optional parameters for the containerRegistryBlobClient.MountBlob
+//   - options - ContainerRegistryBlobClientMountBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.MountBlob
 //     method.
-func (client *containerRegistryBlobClient) MountBlob(ctx context.Context, name string, from string, mount string, options *ContainerRegistryBlobClientMountBlobOptions) (ContainerRegistryBlobClientMountBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) MountBlob(ctx context.Context, name string, from string, mount string, options *ContainerRegistryBlobClientMountBlobOptions) (ContainerRegistryBlobClientMountBlobResponse, error) {
 	req, err := client.mountBlobCreateRequest(ctx, name, from, mount, options)
 	if err != nil {
 		return ContainerRegistryBlobClientMountBlobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientMountBlobResponse{}, err
 	}
@@ -491,7 +483,7 @@ func (client *containerRegistryBlobClient) MountBlob(ctx context.Context, name s
 }
 
 // mountBlobCreateRequest creates the MountBlob request.
-func (client *containerRegistryBlobClient) mountBlobCreateRequest(ctx context.Context, name string, from string, mount string, options *ContainerRegistryBlobClientMountBlobOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) mountBlobCreateRequest(ctx context.Context, name string, from string, mount string, options *ContainerRegistryBlobClientMountBlobOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/uploads/"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -510,7 +502,7 @@ func (client *containerRegistryBlobClient) mountBlobCreateRequest(ctx context.Co
 }
 
 // mountBlobHandleResponse handles the MountBlob response.
-func (client *containerRegistryBlobClient) mountBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientMountBlobResponse, error) {
+func (client *ContainerRegistryBlobClient) mountBlobHandleResponse(resp *http.Response) (ContainerRegistryBlobClientMountBlobResponse, error) {
 	result := ContainerRegistryBlobClientMountBlobResponse{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -529,14 +521,14 @@ func (client *containerRegistryBlobClient) mountBlobHandleResponse(resp *http.Re
 //
 // Generated from API version 2021-07-01
 //   - name - Name of the image (including the namespace)
-//   - options - ContainerRegistryBlobClientStartUploadOptions contains the optional parameters for the containerRegistryBlobClient.StartUpload
+//   - options - ContainerRegistryBlobClientStartUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.StartUpload
 //     method.
-func (client *containerRegistryBlobClient) StartUpload(ctx context.Context, name string, options *ContainerRegistryBlobClientStartUploadOptions) (ContainerRegistryBlobClientStartUploadResponse, error) {
+func (client *ContainerRegistryBlobClient) StartUpload(ctx context.Context, name string, options *ContainerRegistryBlobClientStartUploadOptions) (ContainerRegistryBlobClientStartUploadResponse, error) {
 	req, err := client.startUploadCreateRequest(ctx, name, options)
 	if err != nil {
 		return ContainerRegistryBlobClientStartUploadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientStartUploadResponse{}, err
 	}
@@ -547,7 +539,7 @@ func (client *containerRegistryBlobClient) StartUpload(ctx context.Context, name
 }
 
 // startUploadCreateRequest creates the StartUpload request.
-func (client *containerRegistryBlobClient) startUploadCreateRequest(ctx context.Context, name string, options *ContainerRegistryBlobClientStartUploadOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) startUploadCreateRequest(ctx context.Context, name string, options *ContainerRegistryBlobClientStartUploadOptions) (*policy.Request, error) {
 	urlPath := "/v2/{name}/blobs/uploads/"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -562,7 +554,7 @@ func (client *containerRegistryBlobClient) startUploadCreateRequest(ctx context.
 }
 
 // startUploadHandleResponse handles the StartUpload response.
-func (client *containerRegistryBlobClient) startUploadHandleResponse(resp *http.Response) (ContainerRegistryBlobClientStartUploadResponse, error) {
+func (client *ContainerRegistryBlobClient) startUploadHandleResponse(resp *http.Response) (ContainerRegistryBlobClientStartUploadResponse, error) {
 	result := ContainerRegistryBlobClientStartUploadResponse{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val
@@ -582,14 +574,14 @@ func (client *containerRegistryBlobClient) startUploadHandleResponse(resp *http.
 // Generated from API version 2021-07-01
 //   - location - Link acquired from upload start or previous chunk. Note, do not include initial / (must do substring(1) )
 //   - value - Raw data of blob
-//   - options - ContainerRegistryBlobClientUploadChunkOptions contains the optional parameters for the containerRegistryBlobClient.UploadChunk
+//   - options - ContainerRegistryBlobClientUploadChunkOptions contains the optional parameters for the ContainerRegistryBlobClient.UploadChunk
 //     method.
-func (client *containerRegistryBlobClient) UploadChunk(ctx context.Context, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientUploadChunkOptions) (ContainerRegistryBlobClientUploadChunkResponse, error) {
+func (client *ContainerRegistryBlobClient) UploadChunk(ctx context.Context, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientUploadChunkOptions) (ContainerRegistryBlobClientUploadChunkResponse, error) {
 	req, err := client.uploadChunkCreateRequest(ctx, location, value, options)
 	if err != nil {
 		return ContainerRegistryBlobClientUploadChunkResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerRegistryBlobClientUploadChunkResponse{}, err
 	}
@@ -600,7 +592,7 @@ func (client *containerRegistryBlobClient) UploadChunk(ctx context.Context, loca
 }
 
 // uploadChunkCreateRequest creates the UploadChunk request.
-func (client *containerRegistryBlobClient) uploadChunkCreateRequest(ctx context.Context, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientUploadChunkOptions) (*policy.Request, error) {
+func (client *ContainerRegistryBlobClient) uploadChunkCreateRequest(ctx context.Context, location string, value io.ReadSeekCloser, options *ContainerRegistryBlobClientUploadChunkOptions) (*policy.Request, error) {
 	urlPath := "/{nextBlobUuidLink}"
 	urlPath = strings.ReplaceAll(urlPath, "{nextBlobUuidLink}", location)
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.endpoint, urlPath))
@@ -612,7 +604,7 @@ func (client *containerRegistryBlobClient) uploadChunkCreateRequest(ctx context.
 }
 
 // uploadChunkHandleResponse handles the UploadChunk response.
-func (client *containerRegistryBlobClient) uploadChunkHandleResponse(resp *http.Response) (ContainerRegistryBlobClientUploadChunkResponse, error) {
+func (client *ContainerRegistryBlobClient) uploadChunkHandleResponse(resp *http.Response) (ContainerRegistryBlobClientUploadChunkResponse, error) {
 	result := ContainerRegistryBlobClientUploadChunkResponse{}
 	if val := resp.Header.Get("Location"); val != "" {
 		result.Location = &val

--- a/test/acr/2021-07-01/azacr/zz_models.go
+++ b/test/acr/2021-07-01/azacr/zz_models.go
@@ -95,7 +95,7 @@ type ArtifactTagProperties struct {
 	Tag *TagAttributesBase `json:"tag,omitempty" azure:"ro"`
 }
 
-// AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions contains the optional parameters for the authenticationClient.ExchangeAADAccessTokenForAcrRefreshToken
+// AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeAADAccessTokenForAcrRefreshToken
 // method.
 type AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions struct {
 	// AAD access token, mandatory when granttype is accesstokenrefreshtoken or access_token.
@@ -106,128 +106,128 @@ type AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions struct 
 	Tenant *string
 }
 
-// AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenOptions contains the optional parameters for the authenticationClient.ExchangeAcrRefreshTokenForAcrAccessToken
+// AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeAcrRefreshTokenForAcrAccessToken
 // method.
 type AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenOptions struct {
 	// Grant type is expected to be refresh_token
 	GrantType *TokenGrantType
 }
 
-// AuthenticationClientGetAcrAccessTokenFromLoginOptions contains the optional parameters for the authenticationClient.GetAcrAccessTokenFromLogin
+// AuthenticationClientGetAcrAccessTokenFromLoginOptions contains the optional parameters for the AuthenticationClient.GetAcrAccessTokenFromLogin
 // method.
 type AuthenticationClientGetAcrAccessTokenFromLoginOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientCancelUploadOptions contains the optional parameters for the containerRegistryBlobClient.CancelUpload
+// ContainerRegistryBlobClientCancelUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.CancelUpload
 // method.
 type ContainerRegistryBlobClientCancelUploadOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientCheckBlobExistsOptions contains the optional parameters for the containerRegistryBlobClient.CheckBlobExists
+// ContainerRegistryBlobClientCheckBlobExistsOptions contains the optional parameters for the ContainerRegistryBlobClient.CheckBlobExists
 // method.
 type ContainerRegistryBlobClientCheckBlobExistsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientCheckChunkExistsOptions contains the optional parameters for the containerRegistryBlobClient.CheckChunkExists
+// ContainerRegistryBlobClientCheckChunkExistsOptions contains the optional parameters for the ContainerRegistryBlobClient.CheckChunkExists
 // method.
 type ContainerRegistryBlobClientCheckChunkExistsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientCompleteUploadOptions contains the optional parameters for the containerRegistryBlobClient.CompleteUpload
+// ContainerRegistryBlobClientCompleteUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.CompleteUpload
 // method.
 type ContainerRegistryBlobClientCompleteUploadOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientDeleteBlobOptions contains the optional parameters for the containerRegistryBlobClient.DeleteBlob
+// ContainerRegistryBlobClientDeleteBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.DeleteBlob
 // method.
 type ContainerRegistryBlobClientDeleteBlobOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientGetBlobOptions contains the optional parameters for the containerRegistryBlobClient.GetBlob
+// ContainerRegistryBlobClientGetBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.GetBlob
 // method.
 type ContainerRegistryBlobClientGetBlobOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientGetChunkOptions contains the optional parameters for the containerRegistryBlobClient.GetChunk
+// ContainerRegistryBlobClientGetChunkOptions contains the optional parameters for the ContainerRegistryBlobClient.GetChunk
 // method.
 type ContainerRegistryBlobClientGetChunkOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientGetUploadStatusOptions contains the optional parameters for the containerRegistryBlobClient.GetUploadStatus
+// ContainerRegistryBlobClientGetUploadStatusOptions contains the optional parameters for the ContainerRegistryBlobClient.GetUploadStatus
 // method.
 type ContainerRegistryBlobClientGetUploadStatusOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientMountBlobOptions contains the optional parameters for the containerRegistryBlobClient.MountBlob
+// ContainerRegistryBlobClientMountBlobOptions contains the optional parameters for the ContainerRegistryBlobClient.MountBlob
 // method.
 type ContainerRegistryBlobClientMountBlobOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientStartUploadOptions contains the optional parameters for the containerRegistryBlobClient.StartUpload
+// ContainerRegistryBlobClientStartUploadOptions contains the optional parameters for the ContainerRegistryBlobClient.StartUpload
 // method.
 type ContainerRegistryBlobClientStartUploadOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryBlobClientUploadChunkOptions contains the optional parameters for the containerRegistryBlobClient.UploadChunk
+// ContainerRegistryBlobClientUploadChunkOptions contains the optional parameters for the ContainerRegistryBlobClient.UploadChunk
 // method.
 type ContainerRegistryBlobClientUploadChunkOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientCheckDockerV2SupportOptions contains the optional parameters for the containerRegistryClient.CheckDockerV2Support
+// ContainerRegistryClientCheckDockerV2SupportOptions contains the optional parameters for the ContainerRegistryClient.CheckDockerV2Support
 // method.
 type ContainerRegistryClientCheckDockerV2SupportOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientCreateManifestOptions contains the optional parameters for the containerRegistryClient.CreateManifest
+// ContainerRegistryClientCreateManifestOptions contains the optional parameters for the ContainerRegistryClient.CreateManifest
 // method.
 type ContainerRegistryClientCreateManifestOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientDeleteManifestOptions contains the optional parameters for the containerRegistryClient.DeleteManifest
+// ContainerRegistryClientDeleteManifestOptions contains the optional parameters for the ContainerRegistryClient.DeleteManifest
 // method.
 type ContainerRegistryClientDeleteManifestOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientDeleteRepositoryOptions contains the optional parameters for the containerRegistryClient.DeleteRepository
+// ContainerRegistryClientDeleteRepositoryOptions contains the optional parameters for the ContainerRegistryClient.DeleteRepository
 // method.
 type ContainerRegistryClientDeleteRepositoryOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientDeleteTagOptions contains the optional parameters for the containerRegistryClient.DeleteTag method.
+// ContainerRegistryClientDeleteTagOptions contains the optional parameters for the ContainerRegistryClient.DeleteTag method.
 type ContainerRegistryClientDeleteTagOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientGetManifestOptions contains the optional parameters for the containerRegistryClient.GetManifest
+// ContainerRegistryClientGetManifestOptions contains the optional parameters for the ContainerRegistryClient.GetManifest
 // method.
 type ContainerRegistryClientGetManifestOptions struct {
 	// Accept header string delimited by comma. For example, application/vnd.docker.distribution.manifest.v2+json
 	Accept *string
 }
 
-// ContainerRegistryClientGetManifestPropertiesOptions contains the optional parameters for the containerRegistryClient.GetManifestProperties
+// ContainerRegistryClientGetManifestPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetManifestProperties
 // method.
 type ContainerRegistryClientGetManifestPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientGetManifestsOptions contains the optional parameters for the containerRegistryClient.NewGetManifestsPager
+// ContainerRegistryClientGetManifestsOptions contains the optional parameters for the ContainerRegistryClient.NewGetManifestsPager
 // method.
 type ContainerRegistryClientGetManifestsOptions struct {
 	// Query parameter for the last item in previous query. Result set will include values lexically after last.
@@ -238,13 +238,13 @@ type ContainerRegistryClientGetManifestsOptions struct {
 	Orderby *string
 }
 
-// ContainerRegistryClientGetPropertiesOptions contains the optional parameters for the containerRegistryClient.GetProperties
+// ContainerRegistryClientGetPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetProperties
 // method.
 type ContainerRegistryClientGetPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientGetRepositoriesOptions contains the optional parameters for the containerRegistryClient.NewGetRepositoriesPager
+// ContainerRegistryClientGetRepositoriesOptions contains the optional parameters for the ContainerRegistryClient.NewGetRepositoriesPager
 // method.
 type ContainerRegistryClientGetRepositoriesOptions struct {
 	// Query parameter for the last item in previous query. Result set will include values lexically after last.
@@ -253,13 +253,13 @@ type ContainerRegistryClientGetRepositoriesOptions struct {
 	N *int32
 }
 
-// ContainerRegistryClientGetTagPropertiesOptions contains the optional parameters for the containerRegistryClient.GetTagProperties
+// ContainerRegistryClientGetTagPropertiesOptions contains the optional parameters for the ContainerRegistryClient.GetTagProperties
 // method.
 type ContainerRegistryClientGetTagPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientGetTagsOptions contains the optional parameters for the containerRegistryClient.NewGetTagsPager
+// ContainerRegistryClientGetTagsOptions contains the optional parameters for the ContainerRegistryClient.NewGetTagsPager
 // method.
 type ContainerRegistryClientGetTagsOptions struct {
 	// filter by digest
@@ -272,19 +272,19 @@ type ContainerRegistryClientGetTagsOptions struct {
 	Orderby *string
 }
 
-// ContainerRegistryClientUpdateManifestPropertiesOptions contains the optional parameters for the containerRegistryClient.UpdateManifestProperties
+// ContainerRegistryClientUpdateManifestPropertiesOptions contains the optional parameters for the ContainerRegistryClient.UpdateManifestProperties
 // method.
 type ContainerRegistryClientUpdateManifestPropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientUpdatePropertiesOptions contains the optional parameters for the containerRegistryClient.UpdateProperties
+// ContainerRegistryClientUpdatePropertiesOptions contains the optional parameters for the ContainerRegistryClient.UpdateProperties
 // method.
 type ContainerRegistryClientUpdatePropertiesOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerRegistryClientUpdateTagAttributesOptions contains the optional parameters for the containerRegistryClient.UpdateTagAttributes
+// ContainerRegistryClientUpdateTagAttributesOptions contains the optional parameters for the ContainerRegistryClient.UpdateTagAttributes
 // method.
 type ContainerRegistryClientUpdateTagAttributesOptions struct {
 	// placeholder for future optional parameters

--- a/test/acr/2021-07-01/azacr/zz_response_types.go
+++ b/test/acr/2021-07-01/azacr/zz_response_types.go
@@ -11,27 +11,27 @@ package azacr
 
 import "io"
 
-// AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenResponse contains the response from method authenticationClient.ExchangeAADAccessTokenForAcrRefreshToken.
+// AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenResponse contains the response from method AuthenticationClient.ExchangeAADAccessTokenForAcrRefreshToken.
 type AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenResponse struct {
 	RefreshToken
 }
 
-// AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenResponse contains the response from method authenticationClient.ExchangeAcrRefreshTokenForAcrAccessToken.
+// AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenResponse contains the response from method AuthenticationClient.ExchangeAcrRefreshTokenForAcrAccessToken.
 type AuthenticationClientExchangeAcrRefreshTokenForAcrAccessTokenResponse struct {
 	AccessToken
 }
 
-// AuthenticationClientGetAcrAccessTokenFromLoginResponse contains the response from method authenticationClient.GetAcrAccessTokenFromLogin.
+// AuthenticationClientGetAcrAccessTokenFromLoginResponse contains the response from method AuthenticationClient.GetAcrAccessTokenFromLogin.
 type AuthenticationClientGetAcrAccessTokenFromLoginResponse struct {
 	AccessToken
 }
 
-// ContainerRegistryBlobClientCancelUploadResponse contains the response from method containerRegistryBlobClient.CancelUpload.
+// ContainerRegistryBlobClientCancelUploadResponse contains the response from method ContainerRegistryBlobClient.CancelUpload.
 type ContainerRegistryBlobClientCancelUploadResponse struct {
 	// placeholder for future response values
 }
 
-// ContainerRegistryBlobClientCheckBlobExistsResponse contains the response from method containerRegistryBlobClient.CheckBlobExists.
+// ContainerRegistryBlobClientCheckBlobExistsResponse contains the response from method ContainerRegistryBlobClient.CheckBlobExists.
 type ContainerRegistryBlobClientCheckBlobExistsResponse struct {
 	// ContentLength contains the information returned from the Content-Length header response.
 	ContentLength *int64
@@ -40,7 +40,7 @@ type ContainerRegistryBlobClientCheckBlobExistsResponse struct {
 	DockerContentDigest *string
 }
 
-// ContainerRegistryBlobClientCheckChunkExistsResponse contains the response from method containerRegistryBlobClient.CheckChunkExists.
+// ContainerRegistryBlobClientCheckChunkExistsResponse contains the response from method ContainerRegistryBlobClient.CheckChunkExists.
 type ContainerRegistryBlobClientCheckChunkExistsResponse struct {
 	// ContentLength contains the information returned from the Content-Length header response.
 	ContentLength *int64
@@ -49,7 +49,7 @@ type ContainerRegistryBlobClientCheckChunkExistsResponse struct {
 	ContentRange *string
 }
 
-// ContainerRegistryBlobClientCompleteUploadResponse contains the response from method containerRegistryBlobClient.CompleteUpload.
+// ContainerRegistryBlobClientCompleteUploadResponse contains the response from method ContainerRegistryBlobClient.CompleteUpload.
 type ContainerRegistryBlobClientCompleteUploadResponse struct {
 	// DockerContentDigest contains the information returned from the Docker-Content-Digest header response.
 	DockerContentDigest *string
@@ -61,7 +61,7 @@ type ContainerRegistryBlobClientCompleteUploadResponse struct {
 	Range *string
 }
 
-// ContainerRegistryBlobClientDeleteBlobResponse contains the response from method containerRegistryBlobClient.DeleteBlob.
+// ContainerRegistryBlobClientDeleteBlobResponse contains the response from method ContainerRegistryBlobClient.DeleteBlob.
 type ContainerRegistryBlobClientDeleteBlobResponse struct {
 	// Body contains the streaming response.
 	Body io.ReadCloser
@@ -70,7 +70,7 @@ type ContainerRegistryBlobClientDeleteBlobResponse struct {
 	DockerContentDigest *string
 }
 
-// ContainerRegistryBlobClientGetBlobResponse contains the response from method containerRegistryBlobClient.GetBlob.
+// ContainerRegistryBlobClientGetBlobResponse contains the response from method ContainerRegistryBlobClient.GetBlob.
 type ContainerRegistryBlobClientGetBlobResponse struct {
 	// Body contains the streaming response.
 	Body io.ReadCloser
@@ -82,7 +82,7 @@ type ContainerRegistryBlobClientGetBlobResponse struct {
 	DockerContentDigest *string
 }
 
-// ContainerRegistryBlobClientGetChunkResponse contains the response from method containerRegistryBlobClient.GetChunk.
+// ContainerRegistryBlobClientGetChunkResponse contains the response from method ContainerRegistryBlobClient.GetChunk.
 type ContainerRegistryBlobClientGetChunkResponse struct {
 	// Body contains the streaming response.
 	Body io.ReadCloser
@@ -94,7 +94,7 @@ type ContainerRegistryBlobClientGetChunkResponse struct {
 	ContentRange *string
 }
 
-// ContainerRegistryBlobClientGetUploadStatusResponse contains the response from method containerRegistryBlobClient.GetUploadStatus.
+// ContainerRegistryBlobClientGetUploadStatusResponse contains the response from method ContainerRegistryBlobClient.GetUploadStatus.
 type ContainerRegistryBlobClientGetUploadStatusResponse struct {
 	// DockerUploadUUID contains the information returned from the Docker-Upload-UUID header response.
 	DockerUploadUUID *string
@@ -103,7 +103,7 @@ type ContainerRegistryBlobClientGetUploadStatusResponse struct {
 	Range *string
 }
 
-// ContainerRegistryBlobClientMountBlobResponse contains the response from method containerRegistryBlobClient.MountBlob.
+// ContainerRegistryBlobClientMountBlobResponse contains the response from method ContainerRegistryBlobClient.MountBlob.
 type ContainerRegistryBlobClientMountBlobResponse struct {
 	// DockerContentDigest contains the information returned from the Docker-Content-Digest header response.
 	DockerContentDigest *string
@@ -115,7 +115,7 @@ type ContainerRegistryBlobClientMountBlobResponse struct {
 	Location *string
 }
 
-// ContainerRegistryBlobClientStartUploadResponse contains the response from method containerRegistryBlobClient.StartUpload.
+// ContainerRegistryBlobClientStartUploadResponse contains the response from method ContainerRegistryBlobClient.StartUpload.
 type ContainerRegistryBlobClientStartUploadResponse struct {
 	// DockerUploadUUID contains the information returned from the Docker-Upload-UUID header response.
 	DockerUploadUUID *string
@@ -127,7 +127,7 @@ type ContainerRegistryBlobClientStartUploadResponse struct {
 	Range *string
 }
 
-// ContainerRegistryBlobClientUploadChunkResponse contains the response from method containerRegistryBlobClient.UploadChunk.
+// ContainerRegistryBlobClientUploadChunkResponse contains the response from method ContainerRegistryBlobClient.UploadChunk.
 type ContainerRegistryBlobClientUploadChunkResponse struct {
 	// DockerUploadUUID contains the information returned from the Docker-Upload-UUID header response.
 	DockerUploadUUID *string
@@ -139,12 +139,12 @@ type ContainerRegistryBlobClientUploadChunkResponse struct {
 	Range *string
 }
 
-// ContainerRegistryClientCheckDockerV2SupportResponse contains the response from method containerRegistryClient.CheckDockerV2Support.
+// ContainerRegistryClientCheckDockerV2SupportResponse contains the response from method ContainerRegistryClient.CheckDockerV2Support.
 type ContainerRegistryClientCheckDockerV2SupportResponse struct {
 	// placeholder for future response values
 }
 
-// ContainerRegistryClientCreateManifestResponse contains the response from method containerRegistryClient.CreateManifest.
+// ContainerRegistryClientCreateManifestResponse contains the response from method ContainerRegistryClient.CreateManifest.
 type ContainerRegistryClientCreateManifestResponse struct {
 	// ContentLength contains the information returned from the Content-Length header response.
 	ContentLength *int64
@@ -159,73 +159,73 @@ type ContainerRegistryClientCreateManifestResponse struct {
 	RawJSON []byte
 }
 
-// ContainerRegistryClientDeleteManifestResponse contains the response from method containerRegistryClient.DeleteManifest.
+// ContainerRegistryClientDeleteManifestResponse contains the response from method ContainerRegistryClient.DeleteManifest.
 type ContainerRegistryClientDeleteManifestResponse struct {
 	// placeholder for future response values
 }
 
-// ContainerRegistryClientDeleteRepositoryResponse contains the response from method containerRegistryClient.DeleteRepository.
+// ContainerRegistryClientDeleteRepositoryResponse contains the response from method ContainerRegistryClient.DeleteRepository.
 type ContainerRegistryClientDeleteRepositoryResponse struct {
 	DeleteRepositoryResult
 }
 
-// ContainerRegistryClientDeleteTagResponse contains the response from method containerRegistryClient.DeleteTag.
+// ContainerRegistryClientDeleteTagResponse contains the response from method ContainerRegistryClient.DeleteTag.
 type ContainerRegistryClientDeleteTagResponse struct {
 	// placeholder for future response values
 }
 
-// ContainerRegistryClientGetManifestPropertiesResponse contains the response from method containerRegistryClient.GetManifestProperties.
+// ContainerRegistryClientGetManifestPropertiesResponse contains the response from method ContainerRegistryClient.GetManifestProperties.
 type ContainerRegistryClientGetManifestPropertiesResponse struct {
 	ArtifactManifestProperties
 }
 
-// ContainerRegistryClientGetManifestResponse contains the response from method containerRegistryClient.GetManifest.
+// ContainerRegistryClientGetManifestResponse contains the response from method ContainerRegistryClient.GetManifest.
 type ContainerRegistryClientGetManifestResponse struct {
 	ManifestWrapper
 }
 
-// ContainerRegistryClientGetManifestsResponse contains the response from method containerRegistryClient.NewGetManifestsPager.
+// ContainerRegistryClientGetManifestsResponse contains the response from method ContainerRegistryClient.NewGetManifestsPager.
 type ContainerRegistryClientGetManifestsResponse struct {
 	Manifests
 	// Link contains the information returned from the Link header response.
 	Link *string
 }
 
-// ContainerRegistryClientGetPropertiesResponse contains the response from method containerRegistryClient.GetProperties.
+// ContainerRegistryClientGetPropertiesResponse contains the response from method ContainerRegistryClient.GetProperties.
 type ContainerRegistryClientGetPropertiesResponse struct {
 	ContainerRepositoryProperties
 }
 
-// ContainerRegistryClientGetRepositoriesResponse contains the response from method containerRegistryClient.NewGetRepositoriesPager.
+// ContainerRegistryClientGetRepositoriesResponse contains the response from method ContainerRegistryClient.NewGetRepositoriesPager.
 type ContainerRegistryClientGetRepositoriesResponse struct {
 	Repositories
 	// Link contains the information returned from the Link header response.
 	Link *string
 }
 
-// ContainerRegistryClientGetTagPropertiesResponse contains the response from method containerRegistryClient.GetTagProperties.
+// ContainerRegistryClientGetTagPropertiesResponse contains the response from method ContainerRegistryClient.GetTagProperties.
 type ContainerRegistryClientGetTagPropertiesResponse struct {
 	ArtifactTagProperties
 }
 
-// ContainerRegistryClientGetTagsResponse contains the response from method containerRegistryClient.NewGetTagsPager.
+// ContainerRegistryClientGetTagsResponse contains the response from method ContainerRegistryClient.NewGetTagsPager.
 type ContainerRegistryClientGetTagsResponse struct {
 	TagList
 	// Link contains the information returned from the Link header response.
 	Link *string
 }
 
-// ContainerRegistryClientUpdateManifestPropertiesResponse contains the response from method containerRegistryClient.UpdateManifestProperties.
+// ContainerRegistryClientUpdateManifestPropertiesResponse contains the response from method ContainerRegistryClient.UpdateManifestProperties.
 type ContainerRegistryClientUpdateManifestPropertiesResponse struct {
 	ArtifactManifestProperties
 }
 
-// ContainerRegistryClientUpdatePropertiesResponse contains the response from method containerRegistryClient.UpdateProperties.
+// ContainerRegistryClientUpdatePropertiesResponse contains the response from method ContainerRegistryClient.UpdateProperties.
 type ContainerRegistryClientUpdatePropertiesResponse struct {
 	ContainerRepositoryProperties
 }
 
-// ContainerRegistryClientUpdateTagAttributesResponse contains the response from method containerRegistryClient.UpdateTagAttributes.
+// ContainerRegistryClientUpdateTagAttributesResponse contains the response from method ContainerRegistryClient.UpdateTagAttributes.
 type ContainerRegistryClientUpdateTagAttributesResponse struct {
 	ArtifactTagProperties
 }

--- a/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
+++ b/test/autorest/additionalpropsgroup/additionalpropsgroup_test.go
@@ -16,14 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPetsClient() *PetsClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPetsClient(pl)
+func newPetsClient(t *testing.T) *PetsClient {
+	client, err := NewPetsClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+// NewPetsClient creates a new instance of PetsClient with the specified values.
+func NewPetsClient(options *azcore.ClientOptions) (*PetsClient, error) {
+	cl, err := azcore.NewClient("additionalpropsgroup.PetsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &PetsClient{
+		internal: cl,
+	}
+	return client, nil
 }
 
 // CreateAPInProperties - Create a Pet which contains more properties than what is defined.
 func TestCreateAPInProperties(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateAPInProperties(context.Background(), PetAPInProperties{
 		ID:   to.Ptr[int32](4),
 		Name: to.Ptr("Bunny"),
@@ -50,7 +63,7 @@ func TestCreateAPInProperties(t *testing.T) {
 
 // CreateAPInPropertiesWithAPString - Create a Pet which contains more properties than what is defined.
 func TestCreateAPInPropertiesWithAPString(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateAPInPropertiesWithAPString(context.Background(), PetAPInPropertiesWithAPString{
 		ID:            to.Ptr[int32](5),
 		Name:          to.Ptr("Funny"),
@@ -89,7 +102,7 @@ func TestCreateAPInPropertiesWithAPString(t *testing.T) {
 
 // CreateAPObject - Create a Pet which contains more properties than what is defined.
 func TestCreateAPObject(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateAPObject(context.Background(), PetAPObject{
 		ID:   to.Ptr[int32](2),
 		Name: to.Ptr("Hira"),
@@ -132,7 +145,7 @@ func TestCreateAPObject(t *testing.T) {
 
 // CreateAPString - Create a Pet which contains more properties than what is defined.
 func TestCreateAPString(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateAPString(context.Background(), PetAPString{
 		ID:   to.Ptr[int32](3),
 		Name: to.Ptr("Tommy"),
@@ -159,7 +172,7 @@ func TestCreateAPString(t *testing.T) {
 
 // CreateAPTrue - Create a Pet which contains more properties than what is defined.
 func TestCreateAPTrue(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateAPTrue(context.Background(), PetAPTrue{
 		ID:   to.Ptr[int32](1),
 		Name: to.Ptr("Puppy"),
@@ -188,7 +201,7 @@ func TestCreateAPTrue(t *testing.T) {
 
 // CreateCatAPTrue - Create a CatAPTrue which contains more properties than what is defined.
 func TestCreateCatAPTrue(t *testing.T) {
-	client := newPetsClient()
+	client := newPetsClient(t)
 	result, err := client.CreateCatAPTrue(context.Background(), CatAPTrue{
 		ID:   to.Ptr[int32](1),
 		Name: to.Ptr("Lisa"),

--- a/test/autorest/additionalpropsgroup/zz_pets_client.go
+++ b/test/autorest/additionalpropsgroup/zz_pets_client.go
@@ -11,24 +11,16 @@ package additionalpropsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // PetsClient contains the methods for the Pets group.
-// Don't use this type directly, use NewPetsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PetsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPetsClient creates a new instance of PetsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPetsClient(pl runtime.Pipeline) *PetsClient {
-	client := &PetsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // CreateAPInProperties - Create a Pet which contains more properties than what is defined.
@@ -42,7 +34,7 @@ func (client *PetsClient) CreateAPInProperties(ctx context.Context, createParame
 	if err != nil {
 		return PetsClientCreateAPInPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateAPInPropertiesResponse{}, err
 	}
@@ -83,7 +75,7 @@ func (client *PetsClient) CreateAPInPropertiesWithAPString(ctx context.Context, 
 	if err != nil {
 		return PetsClientCreateAPInPropertiesWithAPStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateAPInPropertiesWithAPStringResponse{}, err
 	}
@@ -123,7 +115,7 @@ func (client *PetsClient) CreateAPObject(ctx context.Context, createParameters P
 	if err != nil {
 		return PetsClientCreateAPObjectResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateAPObjectResponse{}, err
 	}
@@ -163,7 +155,7 @@ func (client *PetsClient) CreateAPString(ctx context.Context, createParameters P
 	if err != nil {
 		return PetsClientCreateAPStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateAPStringResponse{}, err
 	}
@@ -203,7 +195,7 @@ func (client *PetsClient) CreateAPTrue(ctx context.Context, createParameters Pet
 	if err != nil {
 		return PetsClientCreateAPTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateAPTrueResponse{}, err
 	}
@@ -243,7 +235,7 @@ func (client *PetsClient) CreateCatAPTrue(ctx context.Context, createParameters 
 	if err != nil {
 		return PetsClientCreateCatAPTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetsClientCreateCatAPTrueResponse{}, err
 	}

--- a/test/autorest/arraygroup/arraygroup_test.go
+++ b/test/autorest/arraygroup/arraygroup_test.go
@@ -16,14 +16,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newArrayClient() *ArrayClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewArrayClient(pl)
+func newArrayClient(t *testing.T) *ArrayClient {
+	client, err := NewArrayClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+// NewArrayClient creates a new instance of ArrayClient with the specified values.
+func NewArrayClient(options *azcore.ClientOptions) (*ArrayClient, error) {
+	cl, err := azcore.NewClient("arraygroup.ArrayClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &ArrayClient{
+		internal: cl,
+	}
+	return client, nil
 }
 
 // GetArrayEmpty - Get an empty array []
 func TestGetArrayEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetArrayEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp.StringArrayArray)
@@ -34,7 +47,7 @@ func TestGetArrayEmpty(t *testing.T) {
 
 // GetArrayItemEmpty - Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
 func TestGetArrayItemEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetArrayItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
@@ -48,7 +61,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 
 // GetArrayItemNull - Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
 func TestGetArrayItemNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetArrayItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
@@ -62,7 +75,7 @@ func TestGetArrayItemNull(t *testing.T) {
 
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetArrayNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Nil(t, resp.StringArrayArray)
@@ -70,7 +83,7 @@ func TestGetArrayNull(t *testing.T) {
 
 // GetArrayValid - Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestGetArrayValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetArrayValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArrayArray, [][]*string{
@@ -85,7 +98,7 @@ func TestGetArrayValid(t *testing.T) {
 // GetBase64URL - Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with the items base64url encoded
 func TestGetBase64URL(t *testing.T) {
 	t.Skip("decoding fails")
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetBase64URL(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.ByteArrayArray, [][]byte{
@@ -100,7 +113,7 @@ func TestGetBase64URL(t *testing.T) {
 // GetBooleanInvalidNull - Get boolean array value [true, null, false]
 func TestGetBooleanInvalidNull(t *testing.T) {
 	t.Skip("unmarshalling succeeds")
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetBooleanInvalidNull(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -108,7 +121,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 
 // GetBooleanInvalidString - Get boolean array value [true, 'boolean', false]
 func TestGetBooleanInvalidString(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetBooleanInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -116,7 +129,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 
 // GetBooleanTfft - Get boolean array value [true, false, false, true]
 func TestGetBooleanTfft(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetBooleanTfft(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.BoolArray, to.SliceOfPtrs(true, false, false, true)); r != "" {
@@ -127,7 +140,7 @@ func TestGetBooleanTfft(t *testing.T) {
 // GetByteInvalidNull - Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
 func TestGetByteInvalidNull(t *testing.T) {
 	t.Skip("needs investigation")
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetByteInvalidNull(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -135,7 +148,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 
 // GetByteValid - Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetByteValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.ByteArrayArray, [][]byte{
@@ -149,7 +162,7 @@ func TestGetByteValid(t *testing.T) {
 
 // GetComplexEmpty - Get empty array of complex type []
 func TestGetComplexEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetComplexEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp.ProductArray)
@@ -160,7 +173,7 @@ func TestGetComplexEmpty(t *testing.T) {
 
 // GetComplexItemEmpty - Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5, 'string': '6'}]
 func TestGetComplexItemEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetComplexItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.ProductArray, []*Product{
@@ -174,7 +187,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 
 // GetComplexItemNull - Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5, 'string': '6'}]
 func TestGetComplexItemNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetComplexItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.ProductArray, []*Product{
@@ -188,7 +201,7 @@ func TestGetComplexItemNull(t *testing.T) {
 
 // GetComplexNull - Get array of complex type null value
 func TestGetComplexNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetComplexNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Nil(t, resp.ProductArray)
@@ -196,7 +209,7 @@ func TestGetComplexNull(t *testing.T) {
 
 // GetComplexValid - Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestGetComplexValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetComplexValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.ProductArray, []*Product{
@@ -210,7 +223,7 @@ func TestGetComplexValid(t *testing.T) {
 
 // GetDateInvalidChars - Get date array value ['2011-03-22', 'date']
 func TestGetDateInvalidChars(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateInvalidChars(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -218,7 +231,7 @@ func TestGetDateInvalidChars(t *testing.T) {
 
 // GetDateInvalidNull - Get date array value ['2012-01-01', null, '1776-07-04']
 func TestGetDateInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	v1 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -234,7 +247,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 
 // GetDateTimeInvalidChars - Get date array value ['2000-12-01t00:00:01z', 'date-time']
 func TestGetDateTimeInvalidChars(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateTimeInvalidChars(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -242,7 +255,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 
 // GetDateTimeInvalidNull - Get date array value ['2000-12-01t00:00:01z', null]
 func TestGetDateTimeInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
@@ -256,7 +269,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 
 // GetDateTimeRFC1123Valid - Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateTimeRFC1123Valid(context.Background(), nil)
 	require.NoError(t, err)
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
@@ -273,7 +286,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 
 // GetDateTimeValid - Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 func TestGetDateTimeValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateTimeValid(context.Background(), nil)
 	require.NoError(t, err)
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
@@ -290,7 +303,7 @@ func TestGetDateTimeValid(t *testing.T) {
 
 // GetDateValid - Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
 func TestGetDateValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDateValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.TimeArray, to.SliceOfPtrs(
@@ -304,7 +317,7 @@ func TestGetDateValid(t *testing.T) {
 
 // GetDictionaryEmpty - Get an array of Dictionaries of type <string, string> with value []
 func TestGetDictionaryEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDictionaryEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{}); r != "" {
@@ -314,7 +327,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 
 // GetDictionaryItemEmpty - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDictionaryItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
@@ -336,7 +349,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 
 // GetDictionaryItemNull - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryItemNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDictionaryItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
@@ -358,7 +371,7 @@ func TestGetDictionaryItemNull(t *testing.T) {
 
 // GetDictionaryNull - Get an array of Dictionaries with value null
 func TestGetDictionaryNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDictionaryNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Nil(t, resp.MapOfStringArray)
@@ -366,7 +379,7 @@ func TestGetDictionaryNull(t *testing.T) {
 
 // GetDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestGetDictionaryValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDictionaryValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.MapOfStringArray, []map[string]*string{
@@ -392,7 +405,7 @@ func TestGetDictionaryValid(t *testing.T) {
 
 // GetDoubleInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetDoubleInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Float64Array, []*float64{
@@ -406,7 +419,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 
 // GetDoubleInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetDoubleInvalidString(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDoubleInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -414,7 +427,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 
 // GetDoubleValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetDoubleValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDoubleValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Float64Array, to.SliceOfPtrs[float64](0, -0.01, -1.2e20)); r != "" {
@@ -424,7 +437,7 @@ func TestGetDoubleValid(t *testing.T) {
 
 // GetDurationValid - Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestGetDurationValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetDurationValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArray, to.SliceOfPtrs("P123DT22H14M12.011S", "P5DT1H0M0S")); r != "" {
@@ -434,7 +447,7 @@ func TestGetDurationValid(t *testing.T) {
 
 // GetEmpty - Get empty array value []
 func TestGetEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, resp.Int32Array)
@@ -445,7 +458,7 @@ func TestGetEmpty(t *testing.T) {
 
 // GetEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetEnumValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetEnumValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.FooEnumArray, []*FooEnum{
@@ -456,7 +469,7 @@ func TestGetEnumValid(t *testing.T) {
 
 // GetFloatInvalidNull - Get float array value [0.0, null, -1.2e20]
 func TestGetFloatInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Float32Array, []*float32{
@@ -470,7 +483,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 
 // GetFloatInvalidString - Get boolean array value [1.0, 'number', 0.0]
 func TestGetFloatInvalidString(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetFloatInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -478,7 +491,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 
 // GetFloatValid - Get float array value [0, -0.01, 1.2e20]
 func TestGetFloatValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetFloatValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Float32Array, to.SliceOfPtrs[float32](0, -0.01, -1.2e20)); r != "" {
@@ -488,7 +501,7 @@ func TestGetFloatValid(t *testing.T) {
 
 // GetIntInvalidNull - Get integer array value [1, null, 0]
 func TestGetIntInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetIntInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Int32Array, []*int32{
@@ -502,7 +515,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 
 // GetIntInvalidString - Get integer array value [1, 'integer', 0]
 func TestGetIntInvalidString(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetIntInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -510,7 +523,7 @@ func TestGetIntInvalidString(t *testing.T) {
 
 // GetIntegerValid - Get integer array value [1, -1, 3, 300]
 func TestGetIntegerValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetIntegerValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Int32Array, to.SliceOfPtrs[int32](1, -1, 3, 300)); r != "" {
@@ -520,7 +533,7 @@ func TestGetIntegerValid(t *testing.T) {
 
 // GetInvalid - Get invalid array [1, 2, 3
 func TestGetInvalid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -528,7 +541,7 @@ func TestGetInvalid(t *testing.T) {
 
 // GetLongInvalidNull - Get long array value [1, null, 0]
 func TestGetLongInvalidNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetLongInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Int64Array, []*int64{
@@ -542,7 +555,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 
 // GetLongInvalidString - Get long array value [1, 'integer', 0]
 func TestGetLongInvalidString(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetLongInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -550,7 +563,7 @@ func TestGetLongInvalidString(t *testing.T) {
 
 // GetLongValid - Get integer array value [1, -1, 3, 300]
 func TestGetLongValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetLongValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Int64Array, to.SliceOfPtrs[int64](1, -1, 3, 300)); r != "" {
@@ -560,7 +573,7 @@ func TestGetLongValid(t *testing.T) {
 
 // GetNull - Get null array value
 func TestGetNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Nil(t, resp.Int32Array)
@@ -568,7 +581,7 @@ func TestGetNull(t *testing.T) {
 
 // GetStringEnumValid - Get enum array value ['foo1', 'foo2', 'foo3']
 func TestGetStringEnumValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetStringEnumValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Enum0Array, []*Enum0{
@@ -579,7 +592,7 @@ func TestGetStringEnumValid(t *testing.T) {
 
 // GetStringValid - Get string array value ['foo1', 'foo2', 'foo3']
 func TestGetStringValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetStringValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArray, to.SliceOfPtrs("foo1", "foo2", "foo3")); r != "" {
@@ -589,7 +602,7 @@ func TestGetStringValid(t *testing.T) {
 
 // GetStringWithInvalid - Get string array value ['foo', 123, 'foo2']
 func TestGetStringWithInvalid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetStringWithInvalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -597,7 +610,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 
 // GetStringWithNull - Get string array value ['foo', null, 'foo2']
 func TestGetStringWithNull(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetStringWithNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArray, []*string{to.Ptr("foo"), nil, to.Ptr("foo2")}); r != "" {
@@ -612,7 +625,7 @@ func TestGetUUIDInvalidChars(t *testing.T) {
 
 // GetUUIDValid - Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestGetUUIDValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.GetUUIDValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.StringArray, to.SliceOfPtrs("6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205")); r != "" {
@@ -622,7 +635,7 @@ func TestGetUUIDValid(t *testing.T) {
 
 // PutArrayValid - Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
 func TestPutArrayValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutArrayValid(context.Background(), [][]*string{
 		to.SliceOfPtrs("1", "2", "3"),
 		to.SliceOfPtrs("4", "5", "6"),
@@ -634,7 +647,7 @@ func TestPutArrayValid(t *testing.T) {
 
 // PutBooleanTfft - Set array value empty [true, false, false, true]
 func TestPutBooleanTfft(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutBooleanTfft(context.Background(), to.SliceOfPtrs(true, false, false, true), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -642,7 +655,7 @@ func TestPutBooleanTfft(t *testing.T) {
 
 // PutByteValid - Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded in base 64
 func TestPutByteValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutByteValid(context.Background(), [][]byte{
 		{0xFF, 0xFF, 0xFF, 0xFA},
 		{0x01, 0x02, 0x03},
@@ -654,7 +667,7 @@ func TestPutByteValid(t *testing.T) {
 
 // PutComplexValid - Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
 func TestPutComplexValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutComplexValid(context.Background(), []*Product{
 		{Integer: to.Ptr[int32](1), String: to.Ptr("2")},
 		{Integer: to.Ptr[int32](3), String: to.Ptr("4")},
@@ -666,7 +679,7 @@ func TestPutComplexValid(t *testing.T) {
 
 // PutDateTimeRFC1123Valid - Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct 1492 10:15:01 GMT']
 func TestPutDateTimeRFC1123Valid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	v1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	v2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	v3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
@@ -677,7 +690,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 
 // PutDateTimeValid - Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00', '1492-10-12T10:15:01-08:00']
 func TestPutDateTimeValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	v1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	v2, _ := time.Parse(time.RFC3339, "1980-01-02T00:11:35Z")
 	v3, _ := time.Parse(time.RFC3339, "1492-10-12T10:15:01Z")
@@ -688,7 +701,7 @@ func TestPutDateTimeValid(t *testing.T) {
 
 // PutDateValid - Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
 func TestPutDateValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutDateValid(context.Background(), to.SliceOfPtrs(time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC),
 		time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC),
 		time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)), nil)
@@ -698,7 +711,7 @@ func TestPutDateValid(t *testing.T) {
 
 // PutDictionaryValid - Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3': 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
 func TestPutDictionaryValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutDictionaryValid(context.Background(), []map[string]*string{
 		{
 			"1": to.Ptr("one"),
@@ -722,7 +735,7 @@ func TestPutDictionaryValid(t *testing.T) {
 
 // PutDoubleValid - Set array value [0, -0.01, 1.2e20]
 func TestPutDoubleValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutDoubleValid(context.Background(), to.SliceOfPtrs[float64](0, -0.01, -1.2e20), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -730,7 +743,7 @@ func TestPutDoubleValid(t *testing.T) {
 
 // PutDurationValid - Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
 func TestPutDurationValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutDurationValid(context.Background(), to.SliceOfPtrs("P123DT22H14M12.011S", "P5DT1H"), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -738,7 +751,7 @@ func TestPutDurationValid(t *testing.T) {
 
 // PutEmpty - Set array value empty []
 func TestPutEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutEmpty(context.Background(), []*string{}, nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -746,7 +759,7 @@ func TestPutEmpty(t *testing.T) {
 
 // PutEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutEnumValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutEnumValid(context.Background(), []*FooEnum{
 		to.Ptr(FooEnumFoo1), to.Ptr(FooEnumFoo2), to.Ptr(FooEnumFoo3)}, nil)
 	require.NoError(t, err)
@@ -755,7 +768,7 @@ func TestPutEnumValid(t *testing.T) {
 
 // PutFloatValid - Set array value [0, -0.01, 1.2e20]
 func TestPutFloatValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutFloatValid(context.Background(), to.SliceOfPtrs[float32](0, -0.01, -1.2e20), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -763,7 +776,7 @@ func TestPutFloatValid(t *testing.T) {
 
 // PutIntegerValid - Set array value empty [1, -1, 3, 300]
 func TestPutIntegerValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutIntegerValid(context.Background(), to.SliceOfPtrs[int32](1, -1, 3, 300), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -771,7 +784,7 @@ func TestPutIntegerValid(t *testing.T) {
 
 // PutLongValid - Set array value empty [1, -1, 3, 300]
 func TestPutLongValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutLongValid(context.Background(), to.SliceOfPtrs[int64](1, -1, 3, 300), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -779,7 +792,7 @@ func TestPutLongValid(t *testing.T) {
 
 // PutStringEnumValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringEnumValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutStringEnumValid(context.Background(), []*Enum1{
 		to.Ptr(Enum1Foo1), to.Ptr(Enum1Foo2), to.Ptr(Enum1Foo3)}, nil)
 	require.NoError(t, err)
@@ -788,7 +801,7 @@ func TestPutStringEnumValid(t *testing.T) {
 
 // PutStringValid - Set array value ['foo1', 'foo2', 'foo3']
 func TestPutStringValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutStringValid(context.Background(), to.SliceOfPtrs("foo1", "foo2", "foo3"), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -796,7 +809,7 @@ func TestPutStringValid(t *testing.T) {
 
 // PutUUIDValid - Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
 func TestPutUUIDValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	resp, err := client.PutUUIDValid(context.Background(), to.SliceOfPtrs("6dcc7237-45fe-45c4-8a6b-3a8a3f625652", "d1399005-30f7-40d6-8da6-dd7c89ad34db", "f42f6aa1-a5bc-4ddf-907e-5f915de43205"), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)

--- a/test/autorest/arraygroup/zz_array_client.go
+++ b/test/autorest/arraygroup/zz_array_client.go
@@ -11,6 +11,7 @@ package arraygroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // ArrayClient contains the methods for the Array group.
-// Don't use this type directly, use NewArrayClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ArrayClient struct {
-	pl runtime.Pipeline
-}
-
-// NewArrayClient creates a new instance of ArrayClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewArrayClient(pl runtime.Pipeline) *ArrayClient {
-	client := &ArrayClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetArrayEmpty - Get an empty array []
@@ -42,7 +34,7 @@ func (client *ArrayClient) GetArrayEmpty(ctx context.Context, options *ArrayClie
 	if err != nil {
 		return ArrayClientGetArrayEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetArrayEmptyResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *ArrayClient) GetArrayItemEmpty(ctx context.Context, options *Array
 	if err != nil {
 		return ArrayClientGetArrayItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetArrayItemEmptyResponse{}, err
 	}
@@ -122,7 +114,7 @@ func (client *ArrayClient) GetArrayItemNull(ctx context.Context, options *ArrayC
 	if err != nil {
 		return ArrayClientGetArrayItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetArrayItemNullResponse{}, err
 	}
@@ -162,7 +154,7 @@ func (client *ArrayClient) GetArrayNull(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetArrayNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetArrayNullResponse{}, err
 	}
@@ -202,7 +194,7 @@ func (client *ArrayClient) GetArrayValid(ctx context.Context, options *ArrayClie
 	if err != nil {
 		return ArrayClientGetArrayValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetArrayValidResponse{}, err
 	}
@@ -243,7 +235,7 @@ func (client *ArrayClient) GetBase64URL(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetBase64URLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetBase64URLResponse{}, err
 	}
@@ -284,7 +276,7 @@ func (client *ArrayClient) GetBooleanInvalidNull(ctx context.Context, options *A
 	if err != nil {
 		return ArrayClientGetBooleanInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetBooleanInvalidNullResponse{}, err
 	}
@@ -325,7 +317,7 @@ func (client *ArrayClient) GetBooleanInvalidString(ctx context.Context, options 
 	if err != nil {
 		return ArrayClientGetBooleanInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetBooleanInvalidStringResponse{}, err
 	}
@@ -365,7 +357,7 @@ func (client *ArrayClient) GetBooleanTfft(ctx context.Context, options *ArrayCli
 	if err != nil {
 		return ArrayClientGetBooleanTfftResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetBooleanTfftResponse{}, err
 	}
@@ -406,7 +398,7 @@ func (client *ArrayClient) GetByteInvalidNull(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetByteInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetByteInvalidNullResponse{}, err
 	}
@@ -446,7 +438,7 @@ func (client *ArrayClient) GetByteValid(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetByteValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetByteValidResponse{}, err
 	}
@@ -486,7 +478,7 @@ func (client *ArrayClient) GetComplexEmpty(ctx context.Context, options *ArrayCl
 	if err != nil {
 		return ArrayClientGetComplexEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetComplexEmptyResponse{}, err
 	}
@@ -528,7 +520,7 @@ func (client *ArrayClient) GetComplexItemEmpty(ctx context.Context, options *Arr
 	if err != nil {
 		return ArrayClientGetComplexItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetComplexItemEmptyResponse{}, err
 	}
@@ -570,7 +562,7 @@ func (client *ArrayClient) GetComplexItemNull(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetComplexItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetComplexItemNullResponse{}, err
 	}
@@ -610,7 +602,7 @@ func (client *ArrayClient) GetComplexNull(ctx context.Context, options *ArrayCli
 	if err != nil {
 		return ArrayClientGetComplexNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetComplexNullResponse{}, err
 	}
@@ -651,7 +643,7 @@ func (client *ArrayClient) GetComplexValid(ctx context.Context, options *ArrayCl
 	if err != nil {
 		return ArrayClientGetComplexValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetComplexValidResponse{}, err
 	}
@@ -692,7 +684,7 @@ func (client *ArrayClient) GetDateInvalidChars(ctx context.Context, options *Arr
 	if err != nil {
 		return ArrayClientGetDateInvalidCharsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateInvalidCharsResponse{}, err
 	}
@@ -739,7 +731,7 @@ func (client *ArrayClient) GetDateInvalidNull(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetDateInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateInvalidNullResponse{}, err
 	}
@@ -786,7 +778,7 @@ func (client *ArrayClient) GetDateTimeInvalidChars(ctx context.Context, options 
 	if err != nil {
 		return ArrayClientGetDateTimeInvalidCharsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateTimeInvalidCharsResponse{}, err
 	}
@@ -833,7 +825,7 @@ func (client *ArrayClient) GetDateTimeInvalidNull(ctx context.Context, options *
 	if err != nil {
 		return ArrayClientGetDateTimeInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateTimeInvalidNullResponse{}, err
 	}
@@ -881,7 +873,7 @@ func (client *ArrayClient) GetDateTimeRFC1123Valid(ctx context.Context, options 
 	if err != nil {
 		return ArrayClientGetDateTimeRFC1123ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateTimeRFC1123ValidResponse{}, err
 	}
@@ -927,7 +919,7 @@ func (client *ArrayClient) GetDateTimeValid(ctx context.Context, options *ArrayC
 	if err != nil {
 		return ArrayClientGetDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateTimeValidResponse{}, err
 	}
@@ -973,7 +965,7 @@ func (client *ArrayClient) GetDateValid(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDateValidResponse{}, err
 	}
@@ -1020,7 +1012,7 @@ func (client *ArrayClient) GetDictionaryEmpty(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetDictionaryEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDictionaryEmptyResponse{}, err
 	}
@@ -1062,7 +1054,7 @@ func (client *ArrayClient) GetDictionaryItemEmpty(ctx context.Context, options *
 	if err != nil {
 		return ArrayClientGetDictionaryItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDictionaryItemEmptyResponse{}, err
 	}
@@ -1104,7 +1096,7 @@ func (client *ArrayClient) GetDictionaryItemNull(ctx context.Context, options *A
 	if err != nil {
 		return ArrayClientGetDictionaryItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDictionaryItemNullResponse{}, err
 	}
@@ -1144,7 +1136,7 @@ func (client *ArrayClient) GetDictionaryNull(ctx context.Context, options *Array
 	if err != nil {
 		return ArrayClientGetDictionaryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDictionaryNullResponse{}, err
 	}
@@ -1186,7 +1178,7 @@ func (client *ArrayClient) GetDictionaryValid(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetDictionaryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDictionaryValidResponse{}, err
 	}
@@ -1227,7 +1219,7 @@ func (client *ArrayClient) GetDoubleInvalidNull(ctx context.Context, options *Ar
 	if err != nil {
 		return ArrayClientGetDoubleInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDoubleInvalidNullResponse{}, err
 	}
@@ -1268,7 +1260,7 @@ func (client *ArrayClient) GetDoubleInvalidString(ctx context.Context, options *
 	if err != nil {
 		return ArrayClientGetDoubleInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDoubleInvalidStringResponse{}, err
 	}
@@ -1308,7 +1300,7 @@ func (client *ArrayClient) GetDoubleValid(ctx context.Context, options *ArrayCli
 	if err != nil {
 		return ArrayClientGetDoubleValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDoubleValidResponse{}, err
 	}
@@ -1348,7 +1340,7 @@ func (client *ArrayClient) GetDurationValid(ctx context.Context, options *ArrayC
 	if err != nil {
 		return ArrayClientGetDurationValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetDurationValidResponse{}, err
 	}
@@ -1388,7 +1380,7 @@ func (client *ArrayClient) GetEmpty(ctx context.Context, options *ArrayClientGet
 	if err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
@@ -1428,7 +1420,7 @@ func (client *ArrayClient) GetEnumValid(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetEnumValidResponse{}, err
 	}
@@ -1469,7 +1461,7 @@ func (client *ArrayClient) GetFloatInvalidNull(ctx context.Context, options *Arr
 	if err != nil {
 		return ArrayClientGetFloatInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetFloatInvalidNullResponse{}, err
 	}
@@ -1510,7 +1502,7 @@ func (client *ArrayClient) GetFloatInvalidString(ctx context.Context, options *A
 	if err != nil {
 		return ArrayClientGetFloatInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetFloatInvalidStringResponse{}, err
 	}
@@ -1550,7 +1542,7 @@ func (client *ArrayClient) GetFloatValid(ctx context.Context, options *ArrayClie
 	if err != nil {
 		return ArrayClientGetFloatValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetFloatValidResponse{}, err
 	}
@@ -1590,7 +1582,7 @@ func (client *ArrayClient) GetIntInvalidNull(ctx context.Context, options *Array
 	if err != nil {
 		return ArrayClientGetIntInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetIntInvalidNullResponse{}, err
 	}
@@ -1631,7 +1623,7 @@ func (client *ArrayClient) GetIntInvalidString(ctx context.Context, options *Arr
 	if err != nil {
 		return ArrayClientGetIntInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetIntInvalidStringResponse{}, err
 	}
@@ -1671,7 +1663,7 @@ func (client *ArrayClient) GetIntegerValid(ctx context.Context, options *ArrayCl
 	if err != nil {
 		return ArrayClientGetIntegerValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetIntegerValidResponse{}, err
 	}
@@ -1711,7 +1703,7 @@ func (client *ArrayClient) GetInvalid(ctx context.Context, options *ArrayClientG
 	if err != nil {
 		return ArrayClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetInvalidResponse{}, err
 	}
@@ -1752,7 +1744,7 @@ func (client *ArrayClient) GetLongInvalidNull(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetLongInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetLongInvalidNullResponse{}, err
 	}
@@ -1793,7 +1785,7 @@ func (client *ArrayClient) GetLongInvalidString(ctx context.Context, options *Ar
 	if err != nil {
 		return ArrayClientGetLongInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetLongInvalidStringResponse{}, err
 	}
@@ -1833,7 +1825,7 @@ func (client *ArrayClient) GetLongValid(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetLongValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetLongValidResponse{}, err
 	}
@@ -1873,7 +1865,7 @@ func (client *ArrayClient) GetNull(ctx context.Context, options *ArrayClientGetN
 	if err != nil {
 		return ArrayClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetNullResponse{}, err
 	}
@@ -1914,7 +1906,7 @@ func (client *ArrayClient) GetStringEnumValid(ctx context.Context, options *Arra
 	if err != nil {
 		return ArrayClientGetStringEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetStringEnumValidResponse{}, err
 	}
@@ -1954,7 +1946,7 @@ func (client *ArrayClient) GetStringValid(ctx context.Context, options *ArrayCli
 	if err != nil {
 		return ArrayClientGetStringValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetStringValidResponse{}, err
 	}
@@ -1995,7 +1987,7 @@ func (client *ArrayClient) GetStringWithInvalid(ctx context.Context, options *Ar
 	if err != nil {
 		return ArrayClientGetStringWithInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetStringWithInvalidResponse{}, err
 	}
@@ -2035,7 +2027,7 @@ func (client *ArrayClient) GetStringWithNull(ctx context.Context, options *Array
 	if err != nil {
 		return ArrayClientGetStringWithNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetStringWithNullResponse{}, err
 	}
@@ -2076,7 +2068,7 @@ func (client *ArrayClient) GetUUIDInvalidChars(ctx context.Context, options *Arr
 	if err != nil {
 		return ArrayClientGetUUIDInvalidCharsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetUUIDInvalidCharsResponse{}, err
 	}
@@ -2116,7 +2108,7 @@ func (client *ArrayClient) GetUUIDValid(ctx context.Context, options *ArrayClien
 	if err != nil {
 		return ArrayClientGetUUIDValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetUUIDValidResponse{}, err
 	}
@@ -2156,7 +2148,7 @@ func (client *ArrayClient) PutArrayValid(ctx context.Context, arrayBody [][]*str
 	if err != nil {
 		return ArrayClientPutArrayValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutArrayValidResponse{}, err
 	}
@@ -2187,7 +2179,7 @@ func (client *ArrayClient) PutBooleanTfft(ctx context.Context, arrayBody []*bool
 	if err != nil {
 		return ArrayClientPutBooleanTfftResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutBooleanTfftResponse{}, err
 	}
@@ -2219,7 +2211,7 @@ func (client *ArrayClient) PutByteValid(ctx context.Context, arrayBody [][]byte,
 	if err != nil {
 		return ArrayClientPutByteValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutByteValidResponse{}, err
 	}
@@ -2251,7 +2243,7 @@ func (client *ArrayClient) PutComplexValid(ctx context.Context, arrayBody []*Pro
 	if err != nil {
 		return ArrayClientPutComplexValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutComplexValidResponse{}, err
 	}
@@ -2284,7 +2276,7 @@ func (client *ArrayClient) PutDateTimeRFC1123Valid(ctx context.Context, arrayBod
 	if err != nil {
 		return ArrayClientPutDateTimeRFC1123ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDateTimeRFC1123ValidResponse{}, err
 	}
@@ -2319,7 +2311,7 @@ func (client *ArrayClient) PutDateTimeValid(ctx context.Context, arrayBody []*ti
 	if err != nil {
 		return ArrayClientPutDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDateTimeValidResponse{}, err
 	}
@@ -2350,7 +2342,7 @@ func (client *ArrayClient) PutDateValid(ctx context.Context, arrayBody []*time.T
 	if err != nil {
 		return ArrayClientPutDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDateValidResponse{}, err
 	}
@@ -2387,7 +2379,7 @@ func (client *ArrayClient) PutDictionaryValid(ctx context.Context, arrayBody []m
 	if err != nil {
 		return ArrayClientPutDictionaryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDictionaryValidResponse{}, err
 	}
@@ -2418,7 +2410,7 @@ func (client *ArrayClient) PutDoubleValid(ctx context.Context, arrayBody []*floa
 	if err != nil {
 		return ArrayClientPutDoubleValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDoubleValidResponse{}, err
 	}
@@ -2449,7 +2441,7 @@ func (client *ArrayClient) PutDurationValid(ctx context.Context, arrayBody []*st
 	if err != nil {
 		return ArrayClientPutDurationValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutDurationValidResponse{}, err
 	}
@@ -2480,7 +2472,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, arrayBody []*string, op
 	if err != nil {
 		return ArrayClientPutEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutEmptyResponse{}, err
 	}
@@ -2511,7 +2503,7 @@ func (client *ArrayClient) PutEnumValid(ctx context.Context, arrayBody []*FooEnu
 	if err != nil {
 		return ArrayClientPutEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutEnumValidResponse{}, err
 	}
@@ -2542,7 +2534,7 @@ func (client *ArrayClient) PutFloatValid(ctx context.Context, arrayBody []*float
 	if err != nil {
 		return ArrayClientPutFloatValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutFloatValidResponse{}, err
 	}
@@ -2573,7 +2565,7 @@ func (client *ArrayClient) PutIntegerValid(ctx context.Context, arrayBody []*int
 	if err != nil {
 		return ArrayClientPutIntegerValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutIntegerValidResponse{}, err
 	}
@@ -2604,7 +2596,7 @@ func (client *ArrayClient) PutLongValid(ctx context.Context, arrayBody []*int64,
 	if err != nil {
 		return ArrayClientPutLongValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutLongValidResponse{}, err
 	}
@@ -2636,7 +2628,7 @@ func (client *ArrayClient) PutStringEnumValid(ctx context.Context, arrayBody []*
 	if err != nil {
 		return ArrayClientPutStringEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutStringEnumValidResponse{}, err
 	}
@@ -2667,7 +2659,7 @@ func (client *ArrayClient) PutStringValid(ctx context.Context, arrayBody []*stri
 	if err != nil {
 		return ArrayClientPutStringValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutStringValidResponse{}, err
 	}
@@ -2698,7 +2690,7 @@ func (client *ArrayClient) PutUUIDValid(ctx context.Context, arrayBody []*string
 	if err != nil {
 		return ArrayClientPutUUIDValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutUUIDValidResponse{}, err
 	}

--- a/test/autorest/azurereportgroup/custom_client.go
+++ b/test/autorest/azurereportgroup/custom_client.go
@@ -1,0 +1,25 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azurereportgroup
+
+import (
+	"generatortests"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewAutoRestReportServiceForAzureClient(options *azcore.ClientOptions) (*AutoRestReportServiceForAzureClient, error) {
+	cl, err := azcore.NewClient("azurereportgroup.AutoRestReportServiceForAzureClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &AutoRestReportServiceForAzureClient{
+		internal: cl,
+	}
+	return client, nil
+}

--- a/test/autorest/azurereportgroup/zz_autorestreportserviceforazure_client.go
+++ b/test/autorest/azurereportgroup/zz_autorestreportserviceforazure_client.go
@@ -11,24 +11,16 @@ package azurereportgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // AutoRestReportServiceForAzureClient contains the methods for the AutoRestReportServiceForAzure group.
-// Don't use this type directly, use NewAutoRestReportServiceForAzureClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type AutoRestReportServiceForAzureClient struct {
-	pl runtime.Pipeline
-}
-
-// NewAutoRestReportServiceForAzureClient creates a new instance of AutoRestReportServiceForAzureClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewAutoRestReportServiceForAzureClient(pl runtime.Pipeline) *AutoRestReportServiceForAzureClient {
-	client := &AutoRestReportServiceForAzureClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetReport - Get test coverage report
@@ -42,7 +34,7 @@ func (client *AutoRestReportServiceForAzureClient) GetReport(ctx context.Context
 	if err != nil {
 		return AutoRestReportServiceForAzureClientGetReportResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestReportServiceForAzureClientGetReportResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/apiversiondefault_test.go
+++ b/test/autorest/azurespecialsgroup/apiversiondefault_test.go
@@ -13,14 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newAPIVersionDefaultClient() *APIVersionDefaultClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewAPIVersionDefaultClient(pl)
+func newAPIVersionDefaultClient(t *testing.T) *APIVersionDefaultClient {
+	client, err := NewAPIVersionDefaultClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewAPIVersionDefaultClient(options *azcore.ClientOptions) (*APIVersionDefaultClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.APIVersionDefaultClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &APIVersionDefaultClient{internal: client}, nil
 }
 
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
-	client := newAPIVersionDefaultClient()
+	client := newAPIVersionDefaultClient(t)
 	result, err := client.GetMethodGlobalNotProvidedValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -28,7 +37,7 @@ func TestGetMethodGlobalNotProvidedValid(t *testing.T) {
 
 // GetMethodGlobalValid - GET method with api-version modeled in global settings.
 func TestGetMethodGlobalValid(t *testing.T) {
-	client := newAPIVersionDefaultClient()
+	client := newAPIVersionDefaultClient(t)
 	result, err := client.GetMethodGlobalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -36,7 +45,7 @@ func TestGetMethodGlobalValid(t *testing.T) {
 
 // GetPathGlobalValid - GET method with api-version modeled in global settings.
 func TestGetPathGlobalValid(t *testing.T) {
-	client := newAPIVersionDefaultClient()
+	client := newAPIVersionDefaultClient(t)
 	result, err := client.GetPathGlobalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -44,7 +53,7 @@ func TestGetPathGlobalValid(t *testing.T) {
 
 // GetSwaggerGlobalValid - GET method with api-version modeled in global settings.
 func TestGetSwaggerGlobalValid(t *testing.T) {
-	client := newAPIVersionDefaultClient()
+	client := newAPIVersionDefaultClient(t)
 	result, err := client.GetSwaggerGlobalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/azurespecialsgroup/apiversionlocal_test.go
+++ b/test/autorest/azurespecialsgroup/apiversionlocal_test.go
@@ -13,14 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newAPIVersionLocalClient() *APIVersionLocalClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewAPIVersionLocalClient(pl)
+func newAPIVersionLocalClient(t *testing.T) *APIVersionLocalClient {
+	client, err := NewAPIVersionLocalClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewAPIVersionLocalClient(options *azcore.ClientOptions) (*APIVersionLocalClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.APIVersionLocalClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &APIVersionLocalClient{internal: client}, nil
 }
 
 // GetMethodLocalNull - Get method with api-version modeled in the method.  pass in api-version = null to succeed
 func TestGetMethodLocalNull(t *testing.T) {
-	client := newAPIVersionLocalClient()
+	client := newAPIVersionLocalClient(t)
 	result, err := client.GetMethodLocalNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -28,7 +37,7 @@ func TestGetMethodLocalNull(t *testing.T) {
 
 // GetMethodLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetMethodLocalValid(t *testing.T) {
-	client := newAPIVersionLocalClient()
+	client := newAPIVersionLocalClient(t)
 	result, err := client.GetMethodLocalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -36,7 +45,7 @@ func TestGetMethodLocalValid(t *testing.T) {
 
 // GetPathLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetPathLocalValid(t *testing.T) {
-	client := newAPIVersionLocalClient()
+	client := newAPIVersionLocalClient(t)
 	result, err := client.GetPathLocalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -44,7 +53,7 @@ func TestGetPathLocalValid(t *testing.T) {
 
 // GetSwaggerLocalValid - Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
 func TestGetSwaggerLocalValid(t *testing.T) {
-	client := newAPIVersionLocalClient()
+	client := newAPIVersionLocalClient(t)
 	result, err := client.GetSwaggerLocalValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/azurespecialsgroup/headers_test.go
+++ b/test/autorest/azurespecialsgroup/headers_test.go
@@ -15,14 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHeaderClient() *HeaderClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHeaderClient(pl)
+func newHeaderClient(t *testing.T) *HeaderClient {
+	client, err := NewHeaderClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHeaderClient(options *azcore.ClientOptions) (*HeaderClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.HeaderClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HeaderClient{internal: client}, nil
 }
 
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestID(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.CustomNamedRequestID(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.FooRequestID, to.Ptr("123")); r != "" {
@@ -32,7 +41,7 @@ func TestCustomNamedRequestID(t *testing.T) {
 
 // CustomNamedRequestIDHead - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
 func TestCustomNamedRequestIDHead(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.CustomNamedRequestIDHead(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -45,7 +54,7 @@ func TestCustomNamedRequestIDHead(t *testing.T) {
 
 // CustomNamedRequestIDParamGrouping - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request, via a parameter group
 func TestCustomNamedRequestIDParamGrouping(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.CustomNamedRequestIDParamGrouping(context.Background(), HeaderClientCustomNamedRequestIDParamGroupingParameters{
 		FooClientRequestID: "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0",
 	}, nil)

--- a/test/autorest/azurespecialsgroup/odata_test.go
+++ b/test/autorest/azurespecialsgroup/odata_test.go
@@ -14,14 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newODataClient() *ODataClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewODataClient(pl)
+func newODataClient(t *testing.T) *ODataClient {
+	client, err := NewODataClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewODataClient(options *azcore.ClientOptions) (*ODataClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.ODataClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ODataClient{internal: client}, nil
 }
 
 // GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
 func TestGetWithFilter(t *testing.T) {
-	client := newODataClient()
+	client := newODataClient(t)
 	result, err := client.GetWithFilter(context.Background(), &ODataClientGetWithFilterOptions{
 		Filter:  to.Ptr("id gt 5 and name eq 'foo'"),
 		Orderby: to.Ptr("id"),

--- a/test/autorest/azurespecialsgroup/skipurlencoding_test.go
+++ b/test/autorest/azurespecialsgroup/skipurlencoding_test.go
@@ -13,14 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newSkipURLEncodingClient() *SkipURLEncodingClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewSkipURLEncodingClient(pl)
+func newSkipURLEncodingClient(t *testing.T) *SkipURLEncodingClient {
+	client, err := NewSkipURLEncodingClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewSkipURLEncodingClient(options *azcore.ClientOptions) (*SkipURLEncodingClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.SkipURLEncodingClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &SkipURLEncodingClient{internal: client}, nil
 }
 
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetMethodPathValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetMethodPathValid(context.Background(), "path1/path2/path3", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -28,7 +37,7 @@ func TestGetMethodPathValid(t *testing.T) {
 
 // GetMethodQueryNull - Get method with unencoded query parameter with value null
 func TestGetMethodQueryNull(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetMethodQueryNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -36,7 +45,7 @@ func TestGetMethodQueryNull(t *testing.T) {
 
 // GetMethodQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetMethodQueryValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetMethodQueryValid(context.Background(), "value1&q2=value2&q3=value3", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -44,7 +53,7 @@ func TestGetMethodQueryValid(t *testing.T) {
 
 // GetPathQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetPathQueryValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetPathQueryValid(context.Background(), "value1&q2=value2&q3=value3", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -52,7 +61,7 @@ func TestGetPathQueryValid(t *testing.T) {
 
 // GetPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetPathValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetPathValid(context.Background(), "path1/path2/path3", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -60,7 +69,7 @@ func TestGetPathValid(t *testing.T) {
 
 // GetSwaggerPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
 func TestGetSwaggerPathValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetSwaggerPathValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -68,7 +77,7 @@ func TestGetSwaggerPathValid(t *testing.T) {
 
 // GetSwaggerQueryValid - Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
 func TestGetSwaggerQueryValid(t *testing.T) {
-	client := newSkipURLEncodingClient()
+	client := newSkipURLEncodingClient(t)
 	result, err := client.GetSwaggerQueryValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptionincredentials_test.go
@@ -14,14 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newSubscriptionInCredentialsClient() *SubscriptionInCredentialsClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewSubscriptionInCredentialsClient("1234-5678-9012-3456", pl)
+func newSubscriptionInCredentialsClient(t *testing.T) *SubscriptionInCredentialsClient {
+	client, err := NewSubscriptionInCredentialsClient("1234-5678-9012-3456", nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewSubscriptionInCredentialsClient(subscriptionID string, options *azcore.ClientOptions) (*SubscriptionInCredentialsClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.SubscriptionInCredentialsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionInCredentialsClient{
+		subscriptionID: subscriptionID,
+		internal:       client,
+	}, nil
 }
 
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalNotProvidedValid(t *testing.T) {
-	client := newSubscriptionInCredentialsClient()
+	client := newSubscriptionInCredentialsClient(t)
 	result, err := client.PostMethodGlobalNotProvidedValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), nil)
@@ -36,7 +48,7 @@ func TestPostMethodGlobalNull(t *testing.T) {
 
 // PostMethodGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostMethodGlobalValid(t *testing.T) {
-	client := newSubscriptionInCredentialsClient()
+	client := newSubscriptionInCredentialsClient(t)
 	result, err := client.PostMethodGlobalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), nil)
@@ -46,7 +58,7 @@ func TestPostMethodGlobalValid(t *testing.T) {
 
 // PostPathGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostPathGlobalValid(t *testing.T) {
-	client := newSubscriptionInCredentialsClient()
+	client := newSubscriptionInCredentialsClient(t)
 	result, err := client.PostPathGlobalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), nil)
@@ -56,7 +68,7 @@ func TestPostPathGlobalValid(t *testing.T) {
 
 // PostSwaggerGlobalValid - POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to '1234-5678-9012-3456' to succeed
 func TestPostSwaggerGlobalValid(t *testing.T) {
-	client := newSubscriptionInCredentialsClient()
+	client := newSubscriptionInCredentialsClient(t)
 	result, err := client.PostSwaggerGlobalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), nil)

--- a/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
+++ b/test/autorest/azurespecialsgroup/subscriptioninmethod_test.go
@@ -14,9 +14,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newSubscriptionInMethodClient() *SubscriptionInMethodClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewSubscriptionInMethodClient(pl)
+func newSubscriptionInMethodClient(t *testing.T) *SubscriptionInMethodClient {
+	client, err := NewSubscriptionInMethodClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewSubscriptionInMethodClient(options *azcore.ClientOptions) (*SubscriptionInMethodClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.SubscriptionInMethodClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &SubscriptionInMethodClient{internal: client}, nil
 }
 
 // PostMethodLocalNull - POST method with subscriptionId modeled in the method.  pass in subscription id = null, client-side validation should prevent you from making this call
@@ -26,7 +35,7 @@ func TestPostMethodLocalNull(t *testing.T) {
 
 // PostMethodLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostMethodLocalValid(t *testing.T) {
-	client := newSubscriptionInMethodClient()
+	client := newSubscriptionInMethodClient(t)
 	result, err := client.PostMethodLocalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), "1234-5678-9012-3456", nil)
@@ -36,7 +45,7 @@ func TestPostMethodLocalValid(t *testing.T) {
 
 // PostPathLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostPathLocalValid(t *testing.T) {
-	client := newSubscriptionInMethodClient()
+	client := newSubscriptionInMethodClient(t)
 	result, err := client.PostPathLocalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), "1234-5678-9012-3456", nil)
@@ -46,7 +55,7 @@ func TestPostPathLocalValid(t *testing.T) {
 
 // PostSwaggerLocalValid - POST method with subscriptionId modeled in the method.  pass in subscription id = '1234-5678-9012-3456' to succeed
 func TestPostSwaggerLocalValid(t *testing.T) {
-	client := newSubscriptionInMethodClient()
+	client := newSubscriptionInMethodClient(t)
 	result, err := client.PostSwaggerLocalValid(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), "1234-5678-9012-3456", nil)

--- a/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
+++ b/test/autorest/azurespecialsgroup/xmsclientrequestid_test.go
@@ -14,14 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newXMSClientRequestIDClient() *XMSClientRequestIDClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewXMSClientRequestIDClient(pl)
+func newXMSClientRequestIDClient(t *testing.T) *XMSClientRequestIDClient {
+	client, err := NewXMSClientRequestIDClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewXMSClientRequestIDClient(options *azcore.ClientOptions) (*XMSClientRequestIDClient, error) {
+	client, err := azcore.NewClient("azurespecialsgroup.XMSClientRequestIDClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &XMSClientRequestIDClient{internal: client}, nil
 }
 
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestGet(t *testing.T) {
-	client := newXMSClientRequestIDClient()
+	client := newXMSClientRequestIDClient(t)
 	result, err := client.Get(runtime.WithHTTPHeader(context.Background(), http.Header{
 		"x-ms-client-request-id": []string{"9C4D50EE-2D56-4CD3-8152-34347DC9F2B0"},
 	}), nil)
@@ -31,7 +40,7 @@ func TestGet(t *testing.T) {
 
 // ParamGet - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
 func TestParamGet(t *testing.T) {
-	client := newXMSClientRequestIDClient()
+	client := newXMSClientRequestIDClient(t)
 	result, err := client.ParamGet(context.Background(), "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/azurespecialsgroup/zz_apiversiondefault_client.go
+++ b/test/autorest/azurespecialsgroup/zz_apiversiondefault_client.go
@@ -11,24 +11,16 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // APIVersionDefaultClient contains the methods for the APIVersionDefault group.
-// Don't use this type directly, use NewAPIVersionDefaultClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type APIVersionDefaultClient struct {
-	pl runtime.Pipeline
-}
-
-// NewAPIVersionDefaultClient creates a new instance of APIVersionDefaultClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewAPIVersionDefaultClient(pl runtime.Pipeline) *APIVersionDefaultClient {
-	client := &APIVersionDefaultClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetMethodGlobalNotProvidedValid - GET method with api-version modeled in global settings.
@@ -42,7 +34,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalNotProvidedValid(ctx conte
 	if err != nil {
 		return APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionDefaultClientGetMethodGlobalNotProvidedValidResponse{}, err
 	}
@@ -77,7 +69,7 @@ func (client *APIVersionDefaultClient) GetMethodGlobalValid(ctx context.Context,
 	if err != nil {
 		return APIVersionDefaultClientGetMethodGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionDefaultClientGetMethodGlobalValidResponse{}, err
 	}
@@ -112,7 +104,7 @@ func (client *APIVersionDefaultClient) GetPathGlobalValid(ctx context.Context, o
 	if err != nil {
 		return APIVersionDefaultClientGetPathGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionDefaultClientGetPathGlobalValidResponse{}, err
 	}
@@ -147,7 +139,7 @@ func (client *APIVersionDefaultClient) GetSwaggerGlobalValid(ctx context.Context
 	if err != nil {
 		return APIVersionDefaultClientGetSwaggerGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionDefaultClientGetSwaggerGlobalValidResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_apiversionlocal_client.go
+++ b/test/autorest/azurespecialsgroup/zz_apiversionlocal_client.go
@@ -11,24 +11,16 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // APIVersionLocalClient contains the methods for the APIVersionLocal group.
-// Don't use this type directly, use NewAPIVersionLocalClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type APIVersionLocalClient struct {
-	pl runtime.Pipeline
-}
-
-// NewAPIVersionLocalClient creates a new instance of APIVersionLocalClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewAPIVersionLocalClient(pl runtime.Pipeline) *APIVersionLocalClient {
-	client := &APIVersionLocalClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetMethodLocalNull - Get method with api-version modeled in the method. pass in api-version = null to succeed
@@ -42,7 +34,7 @@ func (client *APIVersionLocalClient) GetMethodLocalNull(ctx context.Context, opt
 	if err != nil {
 		return APIVersionLocalClientGetMethodLocalNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionLocalClientGetMethodLocalNullResponse{}, err
 	}
@@ -79,7 +71,7 @@ func (client *APIVersionLocalClient) GetMethodLocalValid(ctx context.Context, op
 	if err != nil {
 		return APIVersionLocalClientGetMethodLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionLocalClientGetMethodLocalValidResponse{}, err
 	}
@@ -114,7 +106,7 @@ func (client *APIVersionLocalClient) GetPathLocalValid(ctx context.Context, opti
 	if err != nil {
 		return APIVersionLocalClientGetPathLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionLocalClientGetPathLocalValidResponse{}, err
 	}
@@ -149,7 +141,7 @@ func (client *APIVersionLocalClient) GetSwaggerLocalValid(ctx context.Context, o
 	if err != nil {
 		return APIVersionLocalClientGetSwaggerLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return APIVersionLocalClientGetSwaggerLocalValidResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_header_client.go
+++ b/test/autorest/azurespecialsgroup/zz_header_client.go
@@ -11,24 +11,16 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HeaderClient contains the methods for the Header group.
-// Don't use this type directly, use NewHeaderClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HeaderClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHeaderClient creates a new instance of HeaderClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHeaderClient(pl runtime.Pipeline) *HeaderClient {
-	client := &HeaderClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // CustomNamedRequestID - Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
@@ -43,7 +35,7 @@ func (client *HeaderClient) CustomNamedRequestID(ctx context.Context, fooClientR
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDResponse{}, err
 	}
@@ -85,7 +77,7 @@ func (client *HeaderClient) CustomNamedRequestIDHead(ctx context.Context, fooCli
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDHeadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDHeadResponse{}, err
 	}
@@ -131,7 +123,7 @@ func (client *HeaderClient) CustomNamedRequestIDParamGrouping(ctx context.Contex
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDParamGroupingResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientCustomNamedRequestIDParamGroupingResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_odata_client.go
+++ b/test/autorest/azurespecialsgroup/zz_odata_client.go
@@ -11,6 +11,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // ODataClient contains the methods for the OData group.
-// Don't use this type directly, use NewODataClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ODataClient struct {
-	pl runtime.Pipeline
-}
-
-// NewODataClient creates a new instance of ODataClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewODataClient(pl runtime.Pipeline) *ODataClient {
-	client := &ODataClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetWithFilter - Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
@@ -42,7 +34,7 @@ func (client *ODataClient) GetWithFilter(ctx context.Context, options *ODataClie
 	if err != nil {
 		return ODataClientGetWithFilterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ODataClientGetWithFilterResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_skipurlencoding_client.go
+++ b/test/autorest/azurespecialsgroup/zz_skipurlencoding_client.go
@@ -11,6 +11,7 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // SkipURLEncodingClient contains the methods for the SkipURLEncoding group.
-// Don't use this type directly, use NewSkipURLEncodingClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type SkipURLEncodingClient struct {
-	pl runtime.Pipeline
-}
-
-// NewSkipURLEncodingClient creates a new instance of SkipURLEncodingClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewSkipURLEncodingClient(pl runtime.Pipeline) *SkipURLEncodingClient {
-	client := &SkipURLEncodingClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetMethodPathValid - Get method with unencoded path parameter with value 'path1/path2/path3'
@@ -44,7 +36,7 @@ func (client *SkipURLEncodingClient) GetMethodPathValid(ctx context.Context, une
 	if err != nil {
 		return SkipURLEncodingClientGetMethodPathValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetMethodPathValidResponse{}, err
 	}
@@ -77,7 +69,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryNull(ctx context.Context, opt
 	if err != nil {
 		return SkipURLEncodingClientGetMethodQueryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetMethodQueryNullResponse{}, err
 	}
@@ -115,7 +107,7 @@ func (client *SkipURLEncodingClient) GetMethodQueryValid(ctx context.Context, q1
 	if err != nil {
 		return SkipURLEncodingClientGetMethodQueryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetMethodQueryValidResponse{}, err
 	}
@@ -151,7 +143,7 @@ func (client *SkipURLEncodingClient) GetPathQueryValid(ctx context.Context, q1 s
 	if err != nil {
 		return SkipURLEncodingClientGetPathQueryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetPathQueryValidResponse{}, err
 	}
@@ -187,7 +179,7 @@ func (client *SkipURLEncodingClient) GetPathValid(ctx context.Context, unencoded
 	if err != nil {
 		return SkipURLEncodingClientGetPathValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetPathValidResponse{}, err
 	}
@@ -220,7 +212,7 @@ func (client *SkipURLEncodingClient) GetSwaggerPathValid(ctx context.Context, op
 	if err != nil {
 		return SkipURLEncodingClientGetSwaggerPathValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetSwaggerPathValidResponse{}, err
 	}
@@ -253,7 +245,7 @@ func (client *SkipURLEncodingClient) GetSwaggerQueryValid(ctx context.Context, o
 	if err != nil {
 		return SkipURLEncodingClientGetSwaggerQueryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SkipURLEncodingClientGetSwaggerQueryValidResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_subscriptionincredentials_client.go
+++ b/test/autorest/azurespecialsgroup/zz_subscriptionincredentials_client.go
@@ -12,6 +12,7 @@ package azurespecialsgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,21 +21,10 @@ import (
 )
 
 // SubscriptionInCredentialsClient contains the methods for the SubscriptionInCredentials group.
-// Don't use this type directly, use NewSubscriptionInCredentialsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type SubscriptionInCredentialsClient struct {
+	internal       *azcore.Client
 	subscriptionID string
-	pl             runtime.Pipeline
-}
-
-// NewSubscriptionInCredentialsClient creates a new instance of SubscriptionInCredentialsClient with the specified values.
-//   - subscriptionID - The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewSubscriptionInCredentialsClient(subscriptionID string, pl runtime.Pipeline) *SubscriptionInCredentialsClient {
-	client := &SubscriptionInCredentialsClient{
-		subscriptionID: subscriptionID,
-		pl:             pl,
-	}
-	return client
 }
 
 // PostMethodGlobalNotProvidedValid - POST method with subscriptionId modeled in credentials. Set the credential subscriptionId
@@ -49,7 +39,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNotProvidedValid(
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalNotProvidedValidResponse{}, err
 	}
@@ -89,7 +79,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalNull(ctx context.
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalNullResponse{}, err
 	}
@@ -126,7 +116,7 @@ func (client *SubscriptionInCredentialsClient) PostMethodGlobalValid(ctx context
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInCredentialsClientPostMethodGlobalValidResponse{}, err
 	}
@@ -163,7 +153,7 @@ func (client *SubscriptionInCredentialsClient) PostPathGlobalValid(ctx context.C
 	if err != nil {
 		return SubscriptionInCredentialsClientPostPathGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInCredentialsClientPostPathGlobalValidResponse{}, err
 	}
@@ -200,7 +190,7 @@ func (client *SubscriptionInCredentialsClient) PostSwaggerGlobalValid(ctx contex
 	if err != nil {
 		return SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInCredentialsClientPostSwaggerGlobalValidResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_subscriptioninmethod_client.go
+++ b/test/autorest/azurespecialsgroup/zz_subscriptioninmethod_client.go
@@ -12,6 +12,7 @@ package azurespecialsgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // SubscriptionInMethodClient contains the methods for the SubscriptionInMethod group.
-// Don't use this type directly, use NewSubscriptionInMethodClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type SubscriptionInMethodClient struct {
-	pl runtime.Pipeline
-}
-
-// NewSubscriptionInMethodClient creates a new instance of SubscriptionInMethodClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewSubscriptionInMethodClient(pl runtime.Pipeline) *SubscriptionInMethodClient {
-	client := &SubscriptionInMethodClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // PostMethodLocalNull - POST method with subscriptionId modeled in the method. pass in subscription id = null, client-side
@@ -47,7 +39,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalNull(ctx context.Contex
 	if err != nil {
 		return SubscriptionInMethodClientPostMethodLocalNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInMethodClientPostMethodLocalNullResponse{}, err
 	}
@@ -85,7 +77,7 @@ func (client *SubscriptionInMethodClient) PostMethodLocalValid(ctx context.Conte
 	if err != nil {
 		return SubscriptionInMethodClientPostMethodLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInMethodClientPostMethodLocalValidResponse{}, err
 	}
@@ -123,7 +115,7 @@ func (client *SubscriptionInMethodClient) PostPathLocalValid(ctx context.Context
 	if err != nil {
 		return SubscriptionInMethodClientPostPathLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInMethodClientPostPathLocalValidResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *SubscriptionInMethodClient) PostSwaggerLocalValid(ctx context.Cont
 	if err != nil {
 		return SubscriptionInMethodClientPostSwaggerLocalValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubscriptionInMethodClientPostSwaggerLocalValidResponse{}, err
 	}

--- a/test/autorest/azurespecialsgroup/zz_xmsclientrequestid_client.go
+++ b/test/autorest/azurespecialsgroup/zz_xmsclientrequestid_client.go
@@ -11,24 +11,16 @@ package azurespecialsgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // XMSClientRequestIDClient contains the methods for the XMSClientRequestID group.
-// Don't use this type directly, use NewXMSClientRequestIDClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type XMSClientRequestIDClient struct {
-	pl runtime.Pipeline
-}
-
-// NewXMSClientRequestIDClient creates a new instance of XMSClientRequestIDClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewXMSClientRequestIDClient(pl runtime.Pipeline) *XMSClientRequestIDClient {
-	client := &XMSClientRequestIDClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Get - Get method that overwrites x-ms-client-request header with value 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -41,7 +33,7 @@ func (client *XMSClientRequestIDClient) Get(ctx context.Context, options *XMSCli
 	if err != nil {
 		return XMSClientRequestIDClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMSClientRequestIDClientGetResponse{}, err
 	}
@@ -73,7 +65,7 @@ func (client *XMSClientRequestIDClient) ParamGet(ctx context.Context, xmsClientR
 	if err != nil {
 		return XMSClientRequestIDClientParamGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMSClientRequestIDClientParamGetResponse{}, err
 	}

--- a/test/autorest/binarygroup/binarygroup_test.go
+++ b/test/autorest/binarygroup/binarygroup_test.go
@@ -16,20 +16,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newBinaryGroupClient() *UploadClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewUploadClient(pl)
+func newUploadClient(t *testing.T) *UploadClient {
+	client, err := NewUploadClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewUploadClient(options *azcore.ClientOptions) (*UploadClient, error) {
+	client, err := azcore.NewClient("binarygroup.UploadClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &UploadClient{internal: client}, nil
 }
 
 func TestBinary(t *testing.T) {
-	client := newBinaryGroupClient()
+	client := newUploadClient(t)
 	resp, err := client.Binary(context.Background(), streaming.NopCloser(bytes.NewReader([]byte{0xff, 0xfe, 0xfd})), nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
 }
 
 func TestFile(t *testing.T) {
-	client := newBinaryGroupClient()
+	client := newUploadClient(t)
 	jsonFile := strings.NewReader(`{ "more": "cowbell" }`)
 	resp, err := client.File(context.Background(), streaming.NopCloser(jsonFile), nil)
 	require.NoError(t, err)

--- a/test/autorest/binarygroup/zz_upload_client.go
+++ b/test/autorest/binarygroup/zz_upload_client.go
@@ -11,6 +11,7 @@ package binarygroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -18,18 +19,9 @@ import (
 )
 
 // UploadClient contains the methods for the Upload group.
-// Don't use this type directly, use NewUploadClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type UploadClient struct {
-	pl runtime.Pipeline
-}
-
-// NewUploadClient creates a new instance of UploadClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewUploadClient(pl runtime.Pipeline) *UploadClient {
-	client := &UploadClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Binary - Uploading binary file
@@ -43,7 +35,7 @@ func (client *UploadClient) Binary(ctx context.Context, fileParam io.ReadSeekClo
 	if err != nil {
 		return UploadClientBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return UploadClientBinaryResponse{}, err
 	}
@@ -74,7 +66,7 @@ func (client *UploadClient) File(ctx context.Context, fileParam io.ReadSeekClose
 	if err != nil {
 		return UploadClientFileResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return UploadClientFileResponse{}, err
 	}

--- a/test/autorest/booleangroup/booleangroup_test.go
+++ b/test/autorest/booleangroup/booleangroup_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newBoolClient() *BoolClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewBoolClient(pl)
+func newBoolClient(t *testing.T) *BoolClient {
+	client, err := NewBoolClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewBoolClient(options *azcore.ClientOptions) (*BoolClient, error) {
+	client, err := azcore.NewClient("booleangroup.BoolClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &BoolClient{internal: client}, nil
 }
 
 func TestGetTrue(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.GetTrue(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(true)); r != "" {
@@ -30,7 +39,7 @@ func TestGetTrue(t *testing.T) {
 }
 
 func TestGetFalse(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.GetFalse(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(false)); r != "" {
@@ -39,7 +48,7 @@ func TestGetFalse(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, (*bool)(nil)); r != "" {
@@ -48,7 +57,7 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetInvalid(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.GetInvalid(context.Background(), nil)
 	// TODO: verify error response is clear and actionable
 	require.Error(t, err)
@@ -56,14 +65,14 @@ func TestGetInvalid(t *testing.T) {
 }
 
 func TestPutTrue(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.PutTrue(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPutFalse(t *testing.T) {
-	client := newBoolClient()
+	client := newBoolClient(t)
 	result, err := client.PutFalse(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/booleangroup/zz_bool_client.go
+++ b/test/autorest/booleangroup/zz_bool_client.go
@@ -11,24 +11,16 @@ package booleangroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // BoolClient contains the methods for the Bool group.
-// Don't use this type directly, use NewBoolClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type BoolClient struct {
-	pl runtime.Pipeline
-}
-
-// NewBoolClient creates a new instance of BoolClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewBoolClient(pl runtime.Pipeline) *BoolClient {
-	client := &BoolClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetFalse - Get false Boolean value
@@ -41,7 +33,7 @@ func (client *BoolClient) GetFalse(ctx context.Context, options *BoolClientGetFa
 	if err != nil {
 		return BoolClientGetFalseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientGetFalseResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *BoolClient) GetInvalid(ctx context.Context, options *BoolClientGet
 	if err != nil {
 		return BoolClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientGetInvalidResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *BoolClient) GetNull(ctx context.Context, options *BoolClientGetNul
 	if err != nil {
 		return BoolClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientGetNullResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *BoolClient) GetTrue(ctx context.Context, options *BoolClientGetTru
 	if err != nil {
 		return BoolClientGetTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientGetTrueResponse{}, err
 	}
@@ -201,7 +193,7 @@ func (client *BoolClient) PutFalse(ctx context.Context, options *BoolClientPutFa
 	if err != nil {
 		return BoolClientPutFalseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientPutFalseResponse{}, err
 	}
@@ -232,7 +224,7 @@ func (client *BoolClient) PutTrue(ctx context.Context, options *BoolClientPutTru
 	if err != nil {
 		return BoolClientPutTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BoolClientPutTrueResponse{}, err
 	}

--- a/test/autorest/bytegroup/zz_byte_client.go
+++ b/test/autorest/bytegroup/zz_byte_client.go
@@ -11,24 +11,16 @@ package bytegroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // ByteClient contains the methods for the Byte group.
-// Don't use this type directly, use NewByteClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ByteClient struct {
-	pl runtime.Pipeline
-}
-
-// NewByteClient creates a new instance of ByteClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewByteClient(pl runtime.Pipeline) *ByteClient {
-	client := &ByteClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmpty - Get empty byte value ”
@@ -41,7 +33,7 @@ func (client *ByteClient) GetEmpty(ctx context.Context, options *ByteClientGetEm
 	if err != nil {
 		return ByteClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ByteClientGetEmptyResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *ByteClient) GetInvalid(ctx context.Context, options *ByteClientGet
 	if err != nil {
 		return ByteClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ByteClientGetInvalidResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *ByteClient) GetNonASCII(ctx context.Context, options *ByteClientGe
 	if err != nil {
 		return ByteClientGetNonASCIIResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ByteClientGetNonASCIIResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *ByteClient) GetNull(ctx context.Context, options *ByteClientGetNul
 	if err != nil {
 		return ByteClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ByteClientGetNullResponse{}, err
 	}
@@ -202,7 +194,7 @@ func (client *ByteClient) PutNonASCII(ctx context.Context, byteBody []byte, opti
 	if err != nil {
 		return ByteClientPutNonASCIIResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ByteClientPutNonASCIIResponse{}, err
 	}

--- a/test/autorest/complexgroup/array_test.go
+++ b/test/autorest/complexgroup/array_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newArrayClient() *ArrayClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewArrayClient(pl)
+func newArrayClient(t *testing.T) *ArrayClient {
+	client, err := NewArrayClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewArrayClient(options *azcore.ClientOptions) (*ArrayClient, error) {
+	client, err := azcore.NewClient("complexgroup.ArrayClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ArrayClient{internal: client}, nil
 }
 
 func TestArrayGetEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	result, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.ArrayWrapper, ArrayWrapper{
@@ -32,7 +41,7 @@ func TestArrayGetEmpty(t *testing.T) {
 }
 
 func TestArrayGetNotProvided(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	result, err := client.GetNotProvided(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.ArrayWrapper, ArrayWrapper{}); r != "" {
@@ -41,7 +50,7 @@ func TestArrayGetNotProvided(t *testing.T) {
 }
 
 func TestArrayGetValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.ArrayWrapper, ArrayWrapper{
@@ -58,14 +67,14 @@ func TestArrayGetValid(t *testing.T) {
 }
 
 func TestArrayPutEmpty(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	result, err := client.PutEmpty(context.Background(), ArrayWrapper{Array: []*string{}}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestArrayPutValid(t *testing.T) {
-	client := newArrayClient()
+	client := newArrayClient(t)
 	result, err := client.PutValid(context.Background(), ArrayWrapper{Array: []*string{
 		to.Ptr("1, 2, 3, 4"),
 		to.Ptr(""),

--- a/test/autorest/complexgroup/basic_test.go
+++ b/test/autorest/complexgroup/basic_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newBasicClient() *BasicClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewBasicClient(pl)
+func newBasicClient(t *testing.T) *BasicClient {
+	client, err := NewBasicClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewBasicClient(options *azcore.ClientOptions) (*BasicClient, error) {
+	client, err := azcore.NewClient("complexgroup.BasicClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &BasicClient{internal: client}, nil
 }
 
 func TestBasicGetValid(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Basic, Basic{ID: to.Ptr[int32](2), Name: to.Ptr("abc"), Color: to.Ptr(CMYKColorsYELLOW)}); r != "" {
@@ -30,7 +39,7 @@ func TestBasicGetValid(t *testing.T) {
 }
 
 func TestBasicPutValid(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.PutValid(context.Background(), Basic{
 		ID:    to.Ptr[int32](2),
 		Name:  to.Ptr("abc"),
@@ -41,7 +50,7 @@ func TestBasicPutValid(t *testing.T) {
 }
 
 func TestBasicGetInvalid(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 	if r := cmp.Diff(result, BasicClientGetInvalidResponse{}); r != "" {
@@ -50,7 +59,7 @@ func TestBasicGetInvalid(t *testing.T) {
 }
 
 func TestBasicGetEmpty(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Basic, Basic{}); r != "" {
@@ -59,7 +68,7 @@ func TestBasicGetEmpty(t *testing.T) {
 }
 
 func TestBasicGetNull(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Basic, Basic{}); r != "" {
@@ -68,7 +77,7 @@ func TestBasicGetNull(t *testing.T) {
 }
 
 func TestBasicGetNotProvided(t *testing.T) {
-	client := newBasicClient()
+	client := newBasicClient(t)
 	result, err := client.GetNotProvided(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Basic, Basic{}); r != "" {

--- a/test/autorest/complexgroup/dictionary_test.go
+++ b/test/autorest/complexgroup/dictionary_test.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newDictionaryClient() *DictionaryClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewDictionaryClient(pl)
+func newDictionaryClient(t *testing.T) *DictionaryClient {
+	client, err := NewDictionaryClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewDictionaryClient(options *azcore.ClientOptions) (*DictionaryClient, error) {
+	client, err := azcore.NewClient("complexgroup.DictionaryClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &DictionaryClient{internal: client}, nil
 }
 
 func TestDictionaryGetEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	result, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DictionaryWrapper, DictionaryWrapper{DefaultProgram: map[string]*string{}}); r != "" {
@@ -29,7 +38,7 @@ func TestDictionaryGetEmpty(t *testing.T) {
 }
 
 func TestDictionaryGetNotProvided(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	result, err := client.GetNotProvided(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DictionaryWrapper, DictionaryWrapper{}); r != "" {
@@ -38,7 +47,7 @@ func TestDictionaryGetNotProvided(t *testing.T) {
 }
 
 func TestDictionaryGetNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DictionaryWrapper, DictionaryWrapper{}); r != "" {
@@ -47,7 +56,7 @@ func TestDictionaryGetNull(t *testing.T) {
 }
 
 func TestDictionaryGetValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
@@ -58,14 +67,14 @@ func TestDictionaryGetValid(t *testing.T) {
 }
 
 func TestDictionaryPutEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	result, err := client.PutEmpty(context.Background(), DictionaryWrapper{DefaultProgram: map[string]*string{}}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestDictionaryPutValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	s1, s2, s3, s4 := "notepad", "mspaint", "excel", ""
 	result, err := client.PutValid(context.Background(), DictionaryWrapper{DefaultProgram: map[string]*string{"txt": &s1, "bmp": &s2, "xls": &s3, "exe": &s4, "": nil}}, nil)
 	require.NoError(t, err)

--- a/test/autorest/complexgroup/inheritance_test.go
+++ b/test/autorest/complexgroup/inheritance_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newInheritanceClient() *InheritanceClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewInheritanceClient(pl)
+func newInheritanceClient(t *testing.T) *InheritanceClient {
+	client, err := NewInheritanceClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewInheritanceClient(options *azcore.ClientOptions) (*InheritanceClient, error) {
+	client, err := azcore.NewClient("complexgroup.InheritanceClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &InheritanceClient{internal: client}, nil
 }
 
 func TestInheritanceGetValid(t *testing.T) {
-	client := newInheritanceClient()
+	client := newInheritanceClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Siamese, Siamese{
@@ -47,7 +56,7 @@ func TestInheritanceGetValid(t *testing.T) {
 }
 
 func TestInheritancePutValid(t *testing.T) {
-	client := newInheritanceClient()
+	client := newInheritanceClient(t)
 	result, err := client.PutValid(context.Background(), Siamese{
 		ID:    to.Ptr[int32](2),
 		Name:  to.Ptr("Siameeee"),

--- a/test/autorest/complexgroup/polymorphicrecursive_test.go
+++ b/test/autorest/complexgroup/polymorphicrecursive_test.go
@@ -16,14 +16,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPolymorphicrecursiveClient() *PolymorphicrecursiveClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPolymorphicrecursiveClient(pl)
+func newPolymorphicrecursiveClient(t *testing.T) *PolymorphicrecursiveClient {
+	client, err := NewPolymorphicrecursiveClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPolymorphicrecursiveClient(options *azcore.ClientOptions) (*PolymorphicrecursiveClient, error) {
+	client, err := azcore.NewClient("complexgroup.PolymorphicrecursiveClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PolymorphicrecursiveClient{internal: client}, nil
 }
 
 // GetValid - Get complex types that are polymorphic and have recursive references
 func TestGetValid(t *testing.T) {
-	client := newPolymorphicrecursiveClient()
+	client := newPolymorphicrecursiveClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
@@ -94,7 +103,7 @@ func TestGetValid(t *testing.T) {
 
 // PutValid - Put complex types that are polymorphic and have recursive references
 func TestPutValid(t *testing.T) {
-	client := newPolymorphicrecursiveClient()
+	client := newPolymorphicrecursiveClient(t)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
 	result, err := client.PutValid(context.Background(), &Salmon{

--- a/test/autorest/complexgroup/polymorphism_test.go
+++ b/test/autorest/complexgroup/polymorphism_test.go
@@ -16,14 +16,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPolymorphismClient() *PolymorphismClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPolymorphismClient(pl)
+func newPolymorphismClient(t *testing.T) *PolymorphismClient {
+	client, err := NewPolymorphismClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPolymorphismClient(options *azcore.ClientOptions) (*PolymorphismClient, error) {
+	client, err := azcore.NewClient("complexgroup.PolymorphismClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PolymorphismClient{internal: client}, nil
 }
 
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
 func TestPolymorphismGetComplicated(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.GetComplicated(context.Background(), nil)
 	require.NoError(t, err)
 	salmon, ok := result.SalmonClassification.(*SmartSalmon)
@@ -154,7 +163,7 @@ func TestPolymorphismGetComplicated(t *testing.T) {
 
 // GetComposedWithDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.
 func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.GetComposedWithDiscriminator(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DotFishMarket, DotFishMarket{
@@ -205,7 +214,7 @@ func TestPolymorphismGetComposedWithDiscriminator(t *testing.T) {
 
 // GetComposedWithoutDiscriminator - Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.
 func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.GetComposedWithoutDiscriminator(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DotFishMarket, DotFishMarket{
@@ -244,7 +253,7 @@ func TestPolymorphismGetComposedWithoutDiscriminator(t *testing.T) {
 
 // GetDotSyntax - Get complex types that are polymorphic, JSON key contains a dot
 func TestPolymorphismGetDotSyntax(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.GetDotSyntax(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DotFishClassification, &DotSalmon{
@@ -259,7 +268,7 @@ func TestPolymorphismGetDotSyntax(t *testing.T) {
 
 // GetValid - Get complex types that are polymorphic
 func TestPolymorphismGetValid(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	salmon, ok := result.FishClassification.(*Salmon)
@@ -311,7 +320,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	result, err := client.PutComplicated(context.Background(), &SmartSalmon{
 		Fishtype: to.Ptr("smart_salmon"),
 		Length:   to.Ptr[float32](1),
@@ -363,7 +372,7 @@ func TestPolymorphismPutComplicated(t *testing.T) {
 
 // PutMissingDiscriminator - Put complex types that are polymorphic, omitting the discriminator
 func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)
@@ -436,7 +445,7 @@ func TestPolymorphismPutMissingDiscriminator(t *testing.T) {
 
 // PutValid - Put complex types that are polymorphic
 func TestPolymorphismPutValid(t *testing.T) {
-	client := newPolymorphismClient()
+	client := newPolymorphismClient(t)
 	goblinBday := time.Date(2015, time.August, 8, 0, 0, 0, 0, time.UTC)
 	sawBday := time.Date(1900, time.January, 5, 1, 0, 0, 0, time.UTC)
 	sharkBday := time.Date(2012, time.January, 5, 1, 0, 0, 0, time.UTC)

--- a/test/autorest/complexgroup/primitive_test.go
+++ b/test/autorest/complexgroup/primitive_test.go
@@ -17,13 +17,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPrimitiveClient() *PrimitiveClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPrimitiveClient(pl)
+func newPrimitiveClient(t *testing.T) *PrimitiveClient {
+	client, err := NewPrimitiveClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPrimitiveClient(options *azcore.ClientOptions) (*PrimitiveClient, error) {
+	client, err := azcore.NewClient("complexgroup.PrimitiveClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PrimitiveClient{internal: client}, nil
 }
 
 func TestPrimitiveGetInt(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetInt(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.IntWrapper, IntWrapper{Field1: to.Ptr[int32](-1), Field2: to.Ptr[int32](2)}); r != "" {
@@ -32,7 +41,7 @@ func TestPrimitiveGetInt(t *testing.T) {
 }
 
 func TestPrimitivePutInt(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, b := int32(-1), int32(2)
 	result, err := client.PutInt(context.Background(), IntWrapper{Field1: &a, Field2: &b}, nil)
 	require.NoError(t, err)
@@ -40,7 +49,7 @@ func TestPrimitivePutInt(t *testing.T) {
 }
 
 func TestPrimitiveGetLong(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetLong(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.LongWrapper, LongWrapper{
@@ -52,7 +61,7 @@ func TestPrimitiveGetLong(t *testing.T) {
 }
 
 func TestPrimitivePutLong(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, b := int64(1099511627775), int64(-999511627788)
 	result, err := client.PutLong(context.Background(), LongWrapper{Field1: &a, Field2: &b}, nil)
 	require.NoError(t, err)
@@ -60,7 +69,7 @@ func TestPrimitivePutLong(t *testing.T) {
 }
 
 func TestPrimitiveGetFloat(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetFloat(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.FloatWrapper, FloatWrapper{
@@ -72,7 +81,7 @@ func TestPrimitiveGetFloat(t *testing.T) {
 }
 
 func TestPrimitivePutFloat(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, b := float32(1.05), float32(-0.003)
 	result, err := client.PutFloat(context.Background(), FloatWrapper{Field1: &a, Field2: &b}, nil)
 	require.NoError(t, err)
@@ -80,7 +89,7 @@ func TestPrimitivePutFloat(t *testing.T) {
 }
 
 func TestPrimitiveGetDouble(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetDouble(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DoubleWrapper, DoubleWrapper{
@@ -92,7 +101,7 @@ func TestPrimitiveGetDouble(t *testing.T) {
 }
 
 func TestPrimitivePutDouble(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, b := float64(3e-100), float64(-0.000000000000000000000000000000000000000000000000000000005)
 	result, err := client.PutDouble(context.Background(), DoubleWrapper{Field1: &a, Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose: &b}, nil)
 	require.NoError(t, err)
@@ -100,7 +109,7 @@ func TestPrimitivePutDouble(t *testing.T) {
 }
 
 func TestPrimitiveGetBool(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetBool(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.BooleanWrapper, BooleanWrapper{
@@ -112,7 +121,7 @@ func TestPrimitiveGetBool(t *testing.T) {
 }
 
 func TestPrimitiveGetByte(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetByte(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.ByteWrapper, ByteWrapper{Field: []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}}); r != "" {
@@ -121,7 +130,7 @@ func TestPrimitiveGetByte(t *testing.T) {
 }
 
 func TestPrimitivePutBool(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, b := true, false
 	result, err := client.PutBool(context.Background(), BooleanWrapper{FieldTrue: &a, FieldFalse: &b}, nil)
 	require.NoError(t, err)
@@ -144,14 +153,14 @@ func TestByteWrapperJSONNull(t *testing.T) {
 }
 
 func TestPrimitivePutByte(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.PutByte(context.Background(), ByteWrapper{Field: []byte{255, 254, 253, 252, 0, 250, 249, 248, 247, 246}}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPrimitiveGetString(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetString(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.StringWrapper, StringWrapper{
@@ -163,7 +172,7 @@ func TestPrimitiveGetString(t *testing.T) {
 }
 
 func TestPrimitivePutString(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	var c *string
 	a, b, c := "goodrequest", "", nil
 	result, err := client.PutString(context.Background(), StringWrapper{Field: &a, Empty: &b, Null: c}, nil)
@@ -172,7 +181,7 @@ func TestPrimitivePutString(t *testing.T) {
 }
 
 func TestPrimitiveGetDate(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetDate(context.Background(), nil)
 	require.NoError(t, err)
 	a, err := time.Parse("2006-01-02", "0001-01-01")
@@ -186,7 +195,7 @@ func TestPrimitiveGetDate(t *testing.T) {
 }
 
 func TestPrimitivePutDate(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	a, err := time.Parse("2006-01-02", "0001-01-01")
 	require.NoError(t, err)
 	b, err := time.Parse("2006-01-02", "2016-02-29")
@@ -197,7 +206,7 @@ func TestPrimitivePutDate(t *testing.T) {
 }
 
 func TestPrimitiveGetDuration(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetDuration(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.DurationWrapper, DurationWrapper{
@@ -208,14 +217,14 @@ func TestPrimitiveGetDuration(t *testing.T) {
 }
 
 func TestPrimitivePutDuration(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.PutDuration(context.Background(), DurationWrapper{Field: to.Ptr("P123DT22H14M12.011S")}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPrimitiveGetDateTime(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	f, _ := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
@@ -229,7 +238,7 @@ func TestPrimitiveGetDateTime(t *testing.T) {
 }
 
 func TestPrimitiveGetDateTimeRFC1123(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	result, err := client.GetDateTimeRFC1123(context.Background(), nil)
 	require.NoError(t, err)
 	f, _ := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
@@ -243,7 +252,7 @@ func TestPrimitiveGetDateTimeRFC1123(t *testing.T) {
 }
 
 func TestPrimitivePutDateTime(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	f, _ := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	n, _ := time.Parse(time.RFC3339, "2015-05-18T18:38:00Z")
 	result, err := client.PutDateTime(context.Background(), DatetimeWrapper{
@@ -255,7 +264,7 @@ func TestPrimitivePutDateTime(t *testing.T) {
 }
 
 func TestPrimitivePutDateTimeRFC1123(t *testing.T) {
-	client := newPrimitiveClient()
+	client := newPrimitiveClient(t)
 	f, _ := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
 	n, _ := time.Parse(time.RFC1123, "Mon, 18 May 2015 11:38:00 GMT")
 	result, err := client.PutDateTimeRFC1123(context.Background(), Datetimerfc1123Wrapper{

--- a/test/autorest/complexgroup/readonlyproperty_test.go
+++ b/test/autorest/complexgroup/readonlyproperty_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newReadonlypropertyClient() *ReadonlypropertyClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewReadonlypropertyClient(pl)
+func newReadonlypropertyClient(t *testing.T) *ReadonlypropertyClient {
+	client, err := NewReadonlypropertyClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewReadonlypropertyClient(options *azcore.ClientOptions) (*ReadonlypropertyClient, error) {
+	client, err := azcore.NewClient("complexgroup.ReadonlypropertyClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ReadonlypropertyClient{internal: client}, nil
 }
 
 func TestReadonlypropertyGetValid(t *testing.T) {
-	client := newReadonlypropertyClient()
+	client := newReadonlypropertyClient(t)
 	result, err := client.GetValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.ReadonlyObj, ReadonlyObj{ID: to.Ptr("1234"), Size: to.Ptr[int32](2)}); r != "" {
@@ -30,9 +39,8 @@ func TestReadonlypropertyGetValid(t *testing.T) {
 }
 
 func TestReadonlypropertyPutValid(t *testing.T) {
-	client := newReadonlypropertyClient()
-	id, size := "1234", int32(2)
-	result, err := client.PutValid(context.Background(), ReadonlyObj{ID: &id, Size: &size}, nil)
+	client := newReadonlypropertyClient(t)
+	result, err := client.PutValid(context.Background(), ReadonlyObj{Size: to.Ptr[int32](2)}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }

--- a/test/autorest/complexgroup/zz_array_client.go
+++ b/test/autorest/complexgroup/zz_array_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // ArrayClient contains the methods for the Array group.
-// Don't use this type directly, use NewArrayClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ArrayClient struct {
-	pl runtime.Pipeline
-}
-
-// NewArrayClient creates a new instance of ArrayClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewArrayClient(pl runtime.Pipeline) *ArrayClient {
-	client := &ArrayClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmpty - Get complex types with array property which is empty
@@ -41,7 +33,7 @@ func (client *ArrayClient) GetEmpty(ctx context.Context, options *ArrayClientGet
 	if err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetEmptyResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *ArrayClient) GetNotProvided(ctx context.Context, options *ArrayCli
 	if err != nil {
 		return ArrayClientGetNotProvidedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetNotProvidedResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *ArrayClient) GetValid(ctx context.Context, options *ArrayClientGet
 	if err != nil {
 		return ArrayClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientGetValidResponse{}, err
 	}
@@ -162,7 +154,7 @@ func (client *ArrayClient) PutEmpty(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return ArrayClientPutEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutEmptyResponse{}, err
 	}
@@ -195,7 +187,7 @@ func (client *ArrayClient) PutValid(ctx context.Context, complexBody ArrayWrappe
 	if err != nil {
 		return ArrayClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ArrayClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_basic_client.go
+++ b/test/autorest/complexgroup/zz_basic_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // BasicClient contains the methods for the Basic group.
-// Don't use this type directly, use NewBasicClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type BasicClient struct {
-	pl runtime.Pipeline
-}
-
-// NewBasicClient creates a new instance of BasicClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewBasicClient(pl runtime.Pipeline) *BasicClient {
-	client := &BasicClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmpty - Get a basic complex type that is empty
@@ -41,7 +33,7 @@ func (client *BasicClient) GetEmpty(ctx context.Context, options *BasicClientGet
 	if err != nil {
 		return BasicClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientGetEmptyResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *BasicClient) GetInvalid(ctx context.Context, options *BasicClientG
 	if err != nil {
 		return BasicClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientGetInvalidResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *BasicClient) GetNotProvided(ctx context.Context, options *BasicCli
 	if err != nil {
 		return BasicClientGetNotProvidedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientGetNotProvidedResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *BasicClient) GetNull(ctx context.Context, options *BasicClientGetN
 	if err != nil {
 		return BasicClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientGetNullResponse{}, err
 	}
@@ -201,7 +193,7 @@ func (client *BasicClient) GetValid(ctx context.Context, options *BasicClientGet
 	if err != nil {
 		return BasicClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientGetValidResponse{}, err
 	}
@@ -242,7 +234,7 @@ func (client *BasicClient) PutValid(ctx context.Context, complexBody Basic, opti
 	if err != nil {
 		return BasicClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BasicClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_dictionary_client.go
+++ b/test/autorest/complexgroup/zz_dictionary_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // DictionaryClient contains the methods for the Dictionary group.
-// Don't use this type directly, use NewDictionaryClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type DictionaryClient struct {
-	pl runtime.Pipeline
-}
-
-// NewDictionaryClient creates a new instance of DictionaryClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDictionaryClient(pl runtime.Pipeline) *DictionaryClient {
-	client := &DictionaryClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmpty - Get complex types with dictionary property which is empty
@@ -41,7 +33,7 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context, options *Dictionar
 	if err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *DictionaryClient) GetNotProvided(ctx context.Context, options *Dic
 	if err != nil {
 		return DictionaryClientGetNotProvidedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetNotProvidedResponse{}, err
 	}
@@ -122,7 +114,7 @@ func (client *DictionaryClient) GetNull(ctx context.Context, options *Dictionary
 	if err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
@@ -162,7 +154,7 @@ func (client *DictionaryClient) GetValid(ctx context.Context, options *Dictionar
 	if err != nil {
 		return DictionaryClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetValidResponse{}, err
 	}
@@ -203,7 +195,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return DictionaryClientPutEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutEmptyResponse{}, err
 	}
@@ -236,7 +228,7 @@ func (client *DictionaryClient) PutValid(ctx context.Context, complexBody Dictio
 	if err != nil {
 		return DictionaryClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_flattencomplex_client.go
+++ b/test/autorest/complexgroup/zz_flattencomplex_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // FlattencomplexClient contains the methods for the Flattencomplex group.
-// Don't use this type directly, use NewFlattencomplexClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type FlattencomplexClient struct {
-	pl runtime.Pipeline
-}
-
-// NewFlattencomplexClient creates a new instance of FlattencomplexClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewFlattencomplexClient(pl runtime.Pipeline) *FlattencomplexClient {
-	client := &FlattencomplexClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetValid -
@@ -41,7 +33,7 @@ func (client *FlattencomplexClient) GetValid(ctx context.Context, options *Flatt
 	if err != nil {
 		return FlattencomplexClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FlattencomplexClientGetValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_inheritance_client.go
+++ b/test/autorest/complexgroup/zz_inheritance_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // InheritanceClient contains the methods for the Inheritance group.
-// Don't use this type directly, use NewInheritanceClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type InheritanceClient struct {
-	pl runtime.Pipeline
-}
-
-// NewInheritanceClient creates a new instance of InheritanceClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewInheritanceClient(pl runtime.Pipeline) *InheritanceClient {
-	client := &InheritanceClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetValid - Get complex types that extend others
@@ -41,7 +33,7 @@ func (client *InheritanceClient) GetValid(ctx context.Context, options *Inherita
 	if err != nil {
 		return InheritanceClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return InheritanceClientGetValidResponse{}, err
 	}
@@ -84,7 +76,7 @@ func (client *InheritanceClient) PutValid(ctx context.Context, complexBody Siame
 	if err != nil {
 		return InheritanceClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return InheritanceClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_polymorphicrecursive_client.go
+++ b/test/autorest/complexgroup/zz_polymorphicrecursive_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // PolymorphicrecursiveClient contains the methods for the Polymorphicrecursive group.
-// Don't use this type directly, use NewPolymorphicrecursiveClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PolymorphicrecursiveClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPolymorphicrecursiveClient creates a new instance of PolymorphicrecursiveClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPolymorphicrecursiveClient(pl runtime.Pipeline) *PolymorphicrecursiveClient {
-	client := &PolymorphicrecursiveClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetValid - Get complex types that are polymorphic and have recursive references
@@ -42,7 +34,7 @@ func (client *PolymorphicrecursiveClient) GetValid(ctx context.Context, options 
 	if err != nil {
 		return PolymorphicrecursiveClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphicrecursiveClientGetValidResponse{}, err
 	}
@@ -90,7 +82,7 @@ func (client *PolymorphicrecursiveClient) PutValid(ctx context.Context, complexB
 	if err != nil {
 		return PolymorphicrecursiveClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphicrecursiveClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_polymorphism_client.go
+++ b/test/autorest/complexgroup/zz_polymorphism_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // PolymorphismClient contains the methods for the Polymorphism group.
-// Don't use this type directly, use NewPolymorphismClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PolymorphismClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPolymorphismClient creates a new instance of PolymorphismClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPolymorphismClient(pl runtime.Pipeline) *PolymorphismClient {
-	client := &PolymorphismClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetComplicated - Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
@@ -42,7 +34,7 @@ func (client *PolymorphismClient) GetComplicated(ctx context.Context, options *P
 	if err != nil {
 		return PolymorphismClientGetComplicatedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientGetComplicatedResponse{}, err
 	}
@@ -85,7 +77,7 @@ func (client *PolymorphismClient) GetComposedWithDiscriminator(ctx context.Conte
 	if err != nil {
 		return PolymorphismClientGetComposedWithDiscriminatorResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientGetComposedWithDiscriminatorResponse{}, err
 	}
@@ -128,7 +120,7 @@ func (client *PolymorphismClient) GetComposedWithoutDiscriminator(ctx context.Co
 	if err != nil {
 		return PolymorphismClientGetComposedWithoutDiscriminatorResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientGetComposedWithoutDiscriminatorResponse{}, err
 	}
@@ -169,7 +161,7 @@ func (client *PolymorphismClient) GetDotSyntax(ctx context.Context, options *Pol
 	if err != nil {
 		return PolymorphismClientGetDotSyntaxResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientGetDotSyntaxResponse{}, err
 	}
@@ -209,7 +201,7 @@ func (client *PolymorphismClient) GetValid(ctx context.Context, options *Polymor
 	if err != nil {
 		return PolymorphismClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientGetValidResponse{}, err
 	}
@@ -250,7 +242,7 @@ func (client *PolymorphismClient) PutComplicated(ctx context.Context, complexBod
 	if err != nil {
 		return PolymorphismClientPutComplicatedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientPutComplicatedResponse{}, err
 	}
@@ -282,7 +274,7 @@ func (client *PolymorphismClient) PutMissingDiscriminator(ctx context.Context, c
 	if err != nil {
 		return PolymorphismClientPutMissingDiscriminatorResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientPutMissingDiscriminatorResponse{}, err
 	}
@@ -328,7 +320,7 @@ func (client *PolymorphismClient) PutValid(ctx context.Context, complexBody Fish
 	if err != nil {
 		return PolymorphismClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientPutValidResponse{}, err
 	}
@@ -366,7 +358,7 @@ func (client *PolymorphismClient) PutValidMissingRequired(ctx context.Context, c
 	if err != nil {
 		return PolymorphismClientPutValidMissingRequiredResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PolymorphismClientPutValidMissingRequiredResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_primitive_client.go
+++ b/test/autorest/complexgroup/zz_primitive_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // PrimitiveClient contains the methods for the Primitive group.
-// Don't use this type directly, use NewPrimitiveClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PrimitiveClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPrimitiveClient creates a new instance of PrimitiveClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPrimitiveClient(pl runtime.Pipeline) *PrimitiveClient {
-	client := &PrimitiveClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetBool - Get complex types with bool properties
@@ -41,7 +33,7 @@ func (client *PrimitiveClient) GetBool(ctx context.Context, options *PrimitiveCl
 	if err != nil {
 		return PrimitiveClientGetBoolResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetBoolResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *PrimitiveClient) GetByte(ctx context.Context, options *PrimitiveCl
 	if err != nil {
 		return PrimitiveClientGetByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetByteResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *PrimitiveClient) GetDate(ctx context.Context, options *PrimitiveCl
 	if err != nil {
 		return PrimitiveClientGetDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetDateResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *PrimitiveClient) GetDateTime(ctx context.Context, options *Primiti
 	if err != nil {
 		return PrimitiveClientGetDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetDateTimeResponse{}, err
 	}
@@ -202,7 +194,7 @@ func (client *PrimitiveClient) GetDateTimeRFC1123(ctx context.Context, options *
 	if err != nil {
 		return PrimitiveClientGetDateTimeRFC1123Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetDateTimeRFC1123Response{}, err
 	}
@@ -242,7 +234,7 @@ func (client *PrimitiveClient) GetDouble(ctx context.Context, options *Primitive
 	if err != nil {
 		return PrimitiveClientGetDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetDoubleResponse{}, err
 	}
@@ -282,7 +274,7 @@ func (client *PrimitiveClient) GetDuration(ctx context.Context, options *Primiti
 	if err != nil {
 		return PrimitiveClientGetDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetDurationResponse{}, err
 	}
@@ -322,7 +314,7 @@ func (client *PrimitiveClient) GetFloat(ctx context.Context, options *PrimitiveC
 	if err != nil {
 		return PrimitiveClientGetFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetFloatResponse{}, err
 	}
@@ -362,7 +354,7 @@ func (client *PrimitiveClient) GetInt(ctx context.Context, options *PrimitiveCli
 	if err != nil {
 		return PrimitiveClientGetIntResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetIntResponse{}, err
 	}
@@ -402,7 +394,7 @@ func (client *PrimitiveClient) GetLong(ctx context.Context, options *PrimitiveCl
 	if err != nil {
 		return PrimitiveClientGetLongResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetLongResponse{}, err
 	}
@@ -442,7 +434,7 @@ func (client *PrimitiveClient) GetString(ctx context.Context, options *Primitive
 	if err != nil {
 		return PrimitiveClientGetStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientGetStringResponse{}, err
 	}
@@ -483,7 +475,7 @@ func (client *PrimitiveClient) PutBool(ctx context.Context, complexBody BooleanW
 	if err != nil {
 		return PrimitiveClientPutBoolResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutBoolResponse{}, err
 	}
@@ -515,7 +507,7 @@ func (client *PrimitiveClient) PutByte(ctx context.Context, complexBody ByteWrap
 	if err != nil {
 		return PrimitiveClientPutByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutByteResponse{}, err
 	}
@@ -547,7 +539,7 @@ func (client *PrimitiveClient) PutDate(ctx context.Context, complexBody DateWrap
 	if err != nil {
 		return PrimitiveClientPutDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutDateResponse{}, err
 	}
@@ -579,7 +571,7 @@ func (client *PrimitiveClient) PutDateTime(ctx context.Context, complexBody Date
 	if err != nil {
 		return PrimitiveClientPutDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutDateTimeResponse{}, err
 	}
@@ -612,7 +604,7 @@ func (client *PrimitiveClient) PutDateTimeRFC1123(ctx context.Context, complexBo
 	if err != nil {
 		return PrimitiveClientPutDateTimeRFC1123Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutDateTimeRFC1123Response{}, err
 	}
@@ -644,7 +636,7 @@ func (client *PrimitiveClient) PutDouble(ctx context.Context, complexBody Double
 	if err != nil {
 		return PrimitiveClientPutDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutDoubleResponse{}, err
 	}
@@ -676,7 +668,7 @@ func (client *PrimitiveClient) PutDuration(ctx context.Context, complexBody Dura
 	if err != nil {
 		return PrimitiveClientPutDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutDurationResponse{}, err
 	}
@@ -708,7 +700,7 @@ func (client *PrimitiveClient) PutFloat(ctx context.Context, complexBody FloatWr
 	if err != nil {
 		return PrimitiveClientPutFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutFloatResponse{}, err
 	}
@@ -740,7 +732,7 @@ func (client *PrimitiveClient) PutInt(ctx context.Context, complexBody IntWrappe
 	if err != nil {
 		return PrimitiveClientPutIntResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutIntResponse{}, err
 	}
@@ -772,7 +764,7 @@ func (client *PrimitiveClient) PutLong(ctx context.Context, complexBody LongWrap
 	if err != nil {
 		return PrimitiveClientPutLongResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutLongResponse{}, err
 	}
@@ -804,7 +796,7 @@ func (client *PrimitiveClient) PutString(ctx context.Context, complexBody String
 	if err != nil {
 		return PrimitiveClientPutStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrimitiveClientPutStringResponse{}, err
 	}

--- a/test/autorest/complexgroup/zz_readonlyproperty_client.go
+++ b/test/autorest/complexgroup/zz_readonlyproperty_client.go
@@ -11,24 +11,16 @@ package complexgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // ReadonlypropertyClient contains the methods for the Readonlyproperty group.
-// Don't use this type directly, use NewReadonlypropertyClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ReadonlypropertyClient struct {
-	pl runtime.Pipeline
-}
-
-// NewReadonlypropertyClient creates a new instance of ReadonlypropertyClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewReadonlypropertyClient(pl runtime.Pipeline) *ReadonlypropertyClient {
-	client := &ReadonlypropertyClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetValid - Get complex types that have readonly properties
@@ -42,7 +34,7 @@ func (client *ReadonlypropertyClient) GetValid(ctx context.Context, options *Rea
 	if err != nil {
 		return ReadonlypropertyClientGetValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ReadonlypropertyClientGetValidResponse{}, err
 	}
@@ -83,7 +75,7 @@ func (client *ReadonlypropertyClient) PutValid(ctx context.Context, complexBody 
 	if err != nil {
 		return ReadonlypropertyClientPutValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ReadonlypropertyClientPutValidResponse{}, err
 	}

--- a/test/autorest/complexmodelgroup/complexmodelgroup_test.go
+++ b/test/autorest/complexmodelgroup/complexmodelgroup_test.go
@@ -13,25 +13,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newComplexModelClient() *ComplexModelClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewComplexModelClient(pl)
+func newComplexModelClient(t *testing.T) *ComplexModelClient {
+	client, err := NewComplexModelClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewComplexModelClient(options *azcore.ClientOptions) (*ComplexModelClient, error) {
+	client, err := azcore.NewClient("complexmodelgroup.ComplexModelClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ComplexModelClient{internal: client}, nil
 }
 
 func TestCreate(t *testing.T) {
-	client := newComplexModelClient()
+	client := newComplexModelClient(t)
 	_, err := client.Create(context.Background(), "sub", "rg", CatalogDictionaryOfArray{}, nil)
 	require.Error(t, err)
 }
 
 func TestList(t *testing.T) {
-	client := newComplexModelClient()
+	client := newComplexModelClient(t)
 	_, err := client.List(context.Background(), "", nil)
 	require.Error(t, err)
 }
 
 func TestUpdate(t *testing.T) {
-	client := newComplexModelClient()
+	client := newComplexModelClient(t)
 	_, err := client.Update(context.Background(), "", "", CatalogArrayOfDictionary{}, nil)
 	require.Error(t, err)
 }

--- a/test/autorest/complexmodelgroup/zz_complexmodel_client.go
+++ b/test/autorest/complexmodelgroup/zz_complexmodel_client.go
@@ -12,6 +12,7 @@ package complexmodelgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // ComplexModelClient contains the methods for the ComplexModelClient group.
-// Don't use this type directly, use NewComplexModelClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ComplexModelClient struct {
-	pl runtime.Pipeline
-}
-
-// NewComplexModelClient creates a new instance of ComplexModelClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewComplexModelClient(pl runtime.Pipeline) *ComplexModelClient {
-	client := &ComplexModelClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Create - Resets products.
@@ -47,7 +39,7 @@ func (client *ComplexModelClient) Create(ctx context.Context, subscriptionID str
 	if err != nil {
 		return ComplexModelClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ComplexModelClientCreateResponse{}, err
 	}
@@ -101,7 +93,7 @@ func (client *ComplexModelClient) List(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return ComplexModelClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ComplexModelClientListResponse{}, err
 	}
@@ -152,7 +144,7 @@ func (client *ComplexModelClient) Update(ctx context.Context, subscriptionID str
 	if err != nil {
 		return ComplexModelClientUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ComplexModelClientUpdateResponse{}, err
 	}

--- a/test/autorest/covreport/main.go
+++ b/test/autorest/covreport/main.go
@@ -9,20 +9,22 @@ import (
 	"generatortests/azurereportgroup"
 	"generatortests/reportgroup"
 	"sort"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
 // generate autorest test server coverage report
 func main() {
-	pl := runtime.NewPipeline("covreport", "v0.1.0", runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	vanillaClient := reportgroup.NewAutoRestReportServiceClient(pl)
+	vanillaClient, err := reportgroup.NewAutoRestReportServiceClient(nil)
+	if err != nil {
+		panic(err)
+	}
 	vanillaReport, err := vanillaClient.GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)
 	}
-	azureClient := azurereportgroup.NewAutoRestReportServiceForAzureClient(pl)
+	azureClient, err := azurereportgroup.NewAutoRestReportServiceForAzureClient(nil)
+	if err != nil {
+		panic(err)
+	}
 	azureReport, err := azureClient.GetReport(context.Background(), nil)
 	if err != nil {
 		panic(err)

--- a/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
+++ b/test/autorest/custombaseurlgroup/custombaseurlgroup_test.go
@@ -14,13 +14,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPathsClient() *PathsClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPathsClient(to.Ptr(":3000"), pl)
+func newPathsClient(t *testing.T) *PathsClient {
+	client, err := NewPathsClient(to.Ptr(":3000"), nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPathsClient(host *string, options *azcore.ClientOptions) (*PathsClient, error) {
+	client, err := azcore.NewClient("custombaseurlgroup.PathsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	if host == nil {
+		host = to.Ptr("host")
+	}
+	return &PathsClient{internal: client, host: *host}, nil
 }
 
 func TestGetEmpty(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetEmpty(context.Background(), "localhost", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/custombaseurlgroup/zz_paths_client.go
+++ b/test/autorest/custombaseurlgroup/zz_paths_client.go
@@ -11,6 +11,7 @@ package custombaseurlgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,24 +19,10 @@ import (
 )
 
 // PathsClient contains the methods for the Paths group.
-// Don't use this type directly, use NewPathsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PathsClient struct {
-	host string
-	pl   runtime.Pipeline
-}
-
-// NewPathsClient creates a new instance of PathsClient with the specified values.
-//   - host - A string value that is used as a global part of the parameterized host
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPathsClient(host *string, pl runtime.Pipeline) *PathsClient {
-	client := &PathsClient{
-		host: "host",
-		pl:   pl,
-	}
-	if host != nil {
-		client.host = *host
-	}
-	return client
+	internal *azcore.Client
+	host     string
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
@@ -49,7 +36,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, accountName string, opt
 	if err != nil {
 		return PathsClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetEmptyResponse{}, err
 	}

--- a/test/autorest/dategroup/date_test.go
+++ b/test/autorest/dategroup/date_test.go
@@ -15,20 +15,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newDateClient() *DateClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewDateClient(pl)
+func newDateClient(t *testing.T) *DateClient {
+	client, err := NewDateClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewDateClient(options *azcore.ClientOptions) (*DateClient, error) {
+	client, err := azcore.NewClient("dategroup.DateClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &DateClient{internal: client}, nil
 }
 
 func TestGetInvalidDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetInvalidDate(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
 }
 
 func TestGetMaxDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetMaxDate(context.Background(), nil)
 	require.NoError(t, err)
 	dt := time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
@@ -38,7 +47,7 @@ func TestGetMaxDate(t *testing.T) {
 }
 
 func TestGetMinDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetMinDate(context.Background(), nil)
 	require.NoError(t, err)
 	dt := time.Date(0001, 01, 01, 0, 0, 0, 0, time.UTC)
@@ -48,7 +57,7 @@ func TestGetMinDate(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Value != nil {
@@ -57,21 +66,21 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetOverflowDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetOverflowDate(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
 }
 
 func TestGetUnderflowDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	resp, err := client.GetUnderflowDate(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
 }
 
 func TestPutMaxDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	dt := time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC)
 	result, err := client.PutMaxDate(context.Background(), dt, nil)
 	require.NoError(t, err)
@@ -79,7 +88,7 @@ func TestPutMaxDate(t *testing.T) {
 }
 
 func TestPutMinDate(t *testing.T) {
-	client := newDateClient()
+	client := newDateClient(t)
 	dt := time.Date(0001, 01, 01, 0, 0, 0, 0, time.UTC)
 	result, err := client.PutMinDate(context.Background(), dt, nil)
 	require.NoError(t, err)

--- a/test/autorest/dategroup/zz_date_client.go
+++ b/test/autorest/dategroup/zz_date_client.go
@@ -11,6 +11,7 @@ package dategroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // DateClient contains the methods for the Date group.
-// Don't use this type directly, use NewDateClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type DateClient struct {
-	pl runtime.Pipeline
-}
-
-// NewDateClient creates a new instance of DateClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDateClient(pl runtime.Pipeline) *DateClient {
-	client := &DateClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetInvalidDate - Get invalid date value
@@ -42,7 +34,7 @@ func (client *DateClient) GetInvalidDate(ctx context.Context, options *DateClien
 	if err != nil {
 		return DateClientGetInvalidDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetInvalidDateResponse{}, err
 	}
@@ -84,7 +76,7 @@ func (client *DateClient) GetMaxDate(ctx context.Context, options *DateClientGet
 	if err != nil {
 		return DateClientGetMaxDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetMaxDateResponse{}, err
 	}
@@ -126,7 +118,7 @@ func (client *DateClient) GetMinDate(ctx context.Context, options *DateClientGet
 	if err != nil {
 		return DateClientGetMinDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetMinDateResponse{}, err
 	}
@@ -168,7 +160,7 @@ func (client *DateClient) GetNull(ctx context.Context, options *DateClientGetNul
 	if err != nil {
 		return DateClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetNullResponse{}, err
 	}
@@ -210,7 +202,7 @@ func (client *DateClient) GetOverflowDate(ctx context.Context, options *DateClie
 	if err != nil {
 		return DateClientGetOverflowDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetOverflowDateResponse{}, err
 	}
@@ -252,7 +244,7 @@ func (client *DateClient) GetUnderflowDate(ctx context.Context, options *DateCli
 	if err != nil {
 		return DateClientGetUnderflowDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientGetUnderflowDateResponse{}, err
 	}
@@ -295,7 +287,7 @@ func (client *DateClient) PutMaxDate(ctx context.Context, dateBody time.Time, op
 	if err != nil {
 		return DateClientPutMaxDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientPutMaxDateResponse{}, err
 	}
@@ -327,7 +319,7 @@ func (client *DateClient) PutMinDate(ctx context.Context, dateBody time.Time, op
 	if err != nil {
 		return DateClientPutMinDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DateClientPutMinDateResponse{}, err
 	}

--- a/test/autorest/datetimegroup/datetimegroup_test.go
+++ b/test/autorest/datetimegroup/datetimegroup_test.go
@@ -15,19 +15,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newDatetimeClient() *DatetimeClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewDatetimeClient(pl)
+func newDatetimeClient(t *testing.T) *DatetimeClient {
+	client, err := NewDatetimeClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewDatetimeClient(options *azcore.ClientOptions) (*DatetimeClient, error) {
+	client, err := azcore.NewClient("datetimegroup.DatetimeClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &DatetimeClient{internal: client}, nil
 }
 
 func TestGetInvalid(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	_, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalNegativeOffsetLowercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999-14:00")
@@ -38,7 +47,7 @@ func TestGetLocalNegativeOffsetLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalNegativeOffsetMinDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00-14:00")
@@ -49,7 +58,7 @@ func TestGetLocalNegativeOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalNegativeOffsetUppercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999-14:00")
@@ -60,7 +69,7 @@ func TestGetLocalNegativeOffsetUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalPositiveOffsetLowercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999+14:00")
@@ -71,7 +80,7 @@ func TestGetLocalPositiveOffsetLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalPositiveOffsetMinDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00+14:00")
@@ -82,7 +91,7 @@ func TestGetLocalPositiveOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalNoOffsetMinDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
@@ -93,7 +102,7 @@ func TestGetLocalNoOffsetMinDateTime(t *testing.T) {
 }
 
 func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetLocalPositiveOffsetUppercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999+14:00")
@@ -104,7 +113,7 @@ func TestGetLocalPositiveOffsetUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetNull(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Value != nil {
@@ -114,19 +123,19 @@ func TestGetNull(t *testing.T) {
 
 func TestGetOverflow(t *testing.T) {
 	t.Skip("API doesn't actually overflow")
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	_, err := client.GetOverflow(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestGetUnderflow(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	_, err := client.GetUnderflow(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetUTCLowercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999Z")
@@ -137,7 +146,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUTCMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetUTCMinDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
@@ -148,7 +157,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 }
 
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetUTCUppercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999Z")
@@ -159,7 +168,7 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUTCUppercaseMaxDateTime7Digits(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	result, err := client.GetUTCUppercaseMaxDateTime7Digits(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.9999999Z")
@@ -170,7 +179,7 @@ func TestGetUTCUppercaseMaxDateTime7Digits(t *testing.T) {
 }
 
 func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999-14:00")
 	require.NoError(t, err)
 	result, err := client.PutLocalNegativeOffsetMaxDateTime(context.Background(), body, nil)
@@ -179,7 +188,7 @@ func TestPutLocalNegativeOffsetMaxDateTime(t *testing.T) {
 }
 
 func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00-14:00")
 	require.NoError(t, err)
 	result, err := client.PutLocalNegativeOffsetMinDateTime(context.Background(), body, nil)
@@ -188,7 +197,7 @@ func TestPutLocalNegativeOffsetMinDateTime(t *testing.T) {
 }
 
 func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999+14:00")
 	require.NoError(t, err)
 	result, err := client.PutLocalPositiveOffsetMaxDateTime(context.Background(), body, nil)
@@ -197,7 +206,7 @@ func TestPutLocalPositiveOffsetMaxDateTime(t *testing.T) {
 }
 
 func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00+14:00")
 	require.NoError(t, err)
 	result, err := client.PutLocalPositiveOffsetMinDateTime(context.Background(), body, nil)
@@ -206,7 +215,7 @@ func TestPutLocalPositiveOffsetMinDateTime(t *testing.T) {
 }
 
 func TestPutUTCMaxDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.999Z")
 	require.NoError(t, err)
 	result, err := client.PutUTCMaxDateTime(context.Background(), body, nil)
@@ -215,7 +224,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 }
 
 func TestPutUTCMaxDateTime7Digits(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "9999-12-31T23:59:59.9999999Z")
 	require.NoError(t, err)
 	result, err := client.PutUTCMaxDateTime7Digits(context.Background(), body, nil)
@@ -224,7 +233,7 @@ func TestPutUTCMaxDateTime7Digits(t *testing.T) {
 }
 
 func TestPutUTCMinDateTime(t *testing.T) {
-	client := newDatetimeClient()
+	client := newDatetimeClient(t)
 	body, err := time.Parse(time.RFC3339, "0001-01-01T00:00:00Z")
 	require.NoError(t, err)
 	result, err := client.PutUTCMinDateTime(context.Background(), body, nil)

--- a/test/autorest/datetimegroup/zz_datetime_client.go
+++ b/test/autorest/datetimegroup/zz_datetime_client.go
@@ -11,6 +11,7 @@ package datetimegroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // DatetimeClient contains the methods for the Datetime group.
-// Don't use this type directly, use NewDatetimeClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type DatetimeClient struct {
-	pl runtime.Pipeline
-}
-
-// NewDatetimeClient creates a new instance of DatetimeClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDatetimeClient(pl runtime.Pipeline) *DatetimeClient {
-	client := &DatetimeClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetInvalid - Get invalid datetime value
@@ -42,7 +34,7 @@ func (client *DatetimeClient) GetInvalid(ctx context.Context, options *DatetimeC
 	if err != nil {
 		return DatetimeClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetInvalidResponse{}, err
 	}
@@ -85,7 +77,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetLowercaseMaxDateTime(ctx con
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetLowercaseMaxDateTimeResponse{}, err
 	}
@@ -128,7 +120,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetMinDateTimeResponse{}, err
 	}
@@ -171,7 +163,7 @@ func (client *DatetimeClient) GetLocalNegativeOffsetUppercaseMaxDateTime(ctx con
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalNegativeOffsetUppercaseMaxDateTimeResponse{}, err
 	}
@@ -214,7 +206,7 @@ func (client *DatetimeClient) GetLocalNoOffsetMinDateTime(ctx context.Context, o
 	if err != nil {
 		return DatetimeClientGetLocalNoOffsetMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalNoOffsetMinDateTimeResponse{}, err
 	}
@@ -257,7 +249,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetLowercaseMaxDateTime(ctx con
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetLowercaseMaxDateTimeResponse{}, err
 	}
@@ -300,7 +292,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetMinDateTimeResponse{}, err
 	}
@@ -343,7 +335,7 @@ func (client *DatetimeClient) GetLocalPositiveOffsetUppercaseMaxDateTime(ctx con
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetLocalPositiveOffsetUppercaseMaxDateTimeResponse{}, err
 	}
@@ -385,7 +377,7 @@ func (client *DatetimeClient) GetNull(ctx context.Context, options *DatetimeClie
 	if err != nil {
 		return DatetimeClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetNullResponse{}, err
 	}
@@ -427,7 +419,7 @@ func (client *DatetimeClient) GetOverflow(ctx context.Context, options *Datetime
 	if err != nil {
 		return DatetimeClientGetOverflowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetOverflowResponse{}, err
 	}
@@ -470,7 +462,7 @@ func (client *DatetimeClient) GetUTCLowercaseMaxDateTime(ctx context.Context, op
 	if err != nil {
 		return DatetimeClientGetUTCLowercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetUTCLowercaseMaxDateTimeResponse{}, err
 	}
@@ -513,7 +505,7 @@ func (client *DatetimeClient) GetUTCMinDateTime(ctx context.Context, options *Da
 	if err != nil {
 		return DatetimeClientGetUTCMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetUTCMinDateTimeResponse{}, err
 	}
@@ -556,7 +548,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime(ctx context.Context, op
 	if err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTimeResponse{}, err
 	}
@@ -600,7 +592,7 @@ func (client *DatetimeClient) GetUTCUppercaseMaxDateTime7Digits(ctx context.Cont
 	if err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetUTCUppercaseMaxDateTime7DigitsResponse{}, err
 	}
@@ -642,7 +634,7 @@ func (client *DatetimeClient) GetUnderflow(ctx context.Context, options *Datetim
 	if err != nil {
 		return DatetimeClientGetUnderflowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientGetUnderflowResponse{}, err
 	}
@@ -686,7 +678,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutLocalNegativeOffsetMaxDateTimeResponse{}, err
 	}
@@ -719,7 +711,7 @@ func (client *DatetimeClient) PutLocalNegativeOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutLocalNegativeOffsetMinDateTimeResponse{}, err
 	}
@@ -752,7 +744,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMaxDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutLocalPositiveOffsetMaxDateTimeResponse{}, err
 	}
@@ -785,7 +777,7 @@ func (client *DatetimeClient) PutLocalPositiveOffsetMinDateTime(ctx context.Cont
 	if err != nil {
 		return DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutLocalPositiveOffsetMinDateTimeResponse{}, err
 	}
@@ -818,7 +810,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return DatetimeClientPutUTCMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutUTCMaxDateTimeResponse{}, err
 	}
@@ -852,7 +844,7 @@ func (client *DatetimeClient) PutUTCMaxDateTime7Digits(ctx context.Context, date
 	if err != nil {
 		return DatetimeClientPutUTCMaxDateTime7DigitsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutUTCMaxDateTime7DigitsResponse{}, err
 	}
@@ -885,7 +877,7 @@ func (client *DatetimeClient) PutUTCMinDateTime(ctx context.Context, datetimeBod
 	if err != nil {
 		return DatetimeClientPutUTCMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatetimeClientPutUTCMinDateTimeResponse{}, err
 	}

--- a/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
+++ b/test/autorest/datetimerfc1123group/datetimerfc1123group_test.go
@@ -15,19 +15,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newDatetimerfc1123Client() *Datetimerfc1123Client {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewDatetimerfc1123Client(pl)
+func newDatetimerfc1123Client(t *testing.T) *Datetimerfc1123Client {
+	client, err := NewDatetimerfc1123Client(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewDatetimerfc1123Client(options *azcore.ClientOptions) (*Datetimerfc1123Client, error) {
+	client, err := azcore.NewClient("datetimerfc1123group.Datetimerfc1123Client", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &Datetimerfc1123Client{internal: client}, nil
 }
 
 func TestGetInvalid(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	_, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestGetNull(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Value != nil {
@@ -36,14 +45,14 @@ func TestGetNull(t *testing.T) {
 }
 
 func TestGetOverflow(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	_, err := client.GetOverflow(context.Background(), nil)
 	require.Error(t, err)
 }
 
 // GetUTCLowercaseMaxDateTime - Get max datetime value fri, 31 dec 9999 23:59:59 gmt
 func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	result, err := client.GetUTCLowercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC1123, "Fri, 31 Dec 9999 23:59:59 GMT")
@@ -55,7 +64,7 @@ func TestGetUTCLowercaseMaxDateTime(t *testing.T) {
 
 // GetUTCMinDateTime - Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func TestGetUTCMinDateTime(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	result, err := client.GetUTCMinDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
@@ -67,7 +76,7 @@ func TestGetUTCMinDateTime(t *testing.T) {
 
 // GetUTCUppercaseMaxDateTime - Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
 func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	result, err := client.GetUTCUppercaseMaxDateTime(context.Background(), nil)
 	require.NoError(t, err)
 	expected, err := time.Parse(time.RFC1123, "FRI, 31 DEC 9999 23:59:59 GMT")
@@ -78,14 +87,14 @@ func TestGetUTCUppercaseMaxDateTime(t *testing.T) {
 }
 
 func TestGetUnderflow(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	_, err := client.GetUnderflow(context.Background(), nil)
 	require.Error(t, err)
 }
 
 // PutUTCMaxDateTime - Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
 func TestPutUTCMaxDateTime(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	body, err := time.Parse(time.RFC1123, "Fri, 31 Dec 9999 23:59:59 GMT")
 	require.NoError(t, err)
 	result, err := client.PutUTCMaxDateTime(context.Background(), body, nil)
@@ -95,7 +104,7 @@ func TestPutUTCMaxDateTime(t *testing.T) {
 
 // PutUTCMinDateTime - Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
 func TestPutUTCMinDateTime(t *testing.T) {
-	client := newDatetimerfc1123Client()
+	client := newDatetimerfc1123Client(t)
 	body, err := time.Parse(time.RFC1123, "Mon, 01 Jan 0001 00:00:00 GMT")
 	require.NoError(t, err)
 	result, err := client.PutUTCMinDateTime(context.Background(), body, nil)

--- a/test/autorest/datetimerfc1123group/zz_datetimerfc1123_client.go
+++ b/test/autorest/datetimerfc1123group/zz_datetimerfc1123_client.go
@@ -11,6 +11,7 @@ package datetimerfc1123group
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // Datetimerfc1123Client contains the methods for the Datetimerfc1123 group.
-// Don't use this type directly, use NewDatetimerfc1123Client() instead.
+// Don't use this type directly, use a constructor function instead.
 type Datetimerfc1123Client struct {
-	pl runtime.Pipeline
-}
-
-// NewDatetimerfc1123Client creates a new instance of Datetimerfc1123Client with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDatetimerfc1123Client(pl runtime.Pipeline) *Datetimerfc1123Client {
-	client := &Datetimerfc1123Client{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetInvalid - Get invalid datetime value
@@ -43,7 +35,7 @@ func (client *Datetimerfc1123Client) GetInvalid(ctx context.Context, options *Da
 	if err != nil {
 		return Datetimerfc1123ClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetInvalidResponse{}, err
 	}
@@ -85,7 +77,7 @@ func (client *Datetimerfc1123Client) GetNull(ctx context.Context, options *Datet
 	if err != nil {
 		return Datetimerfc1123ClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetNullResponse{}, err
 	}
@@ -128,7 +120,7 @@ func (client *Datetimerfc1123Client) GetOverflow(ctx context.Context, options *D
 	if err != nil {
 		return Datetimerfc1123ClientGetOverflowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetOverflowResponse{}, err
 	}
@@ -171,7 +163,7 @@ func (client *Datetimerfc1123Client) GetUTCLowercaseMaxDateTime(ctx context.Cont
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCLowercaseMaxDateTimeResponse{}, err
 	}
@@ -214,7 +206,7 @@ func (client *Datetimerfc1123Client) GetUTCMinDateTime(ctx context.Context, opti
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCMinDateTimeResponse{}, err
 	}
@@ -257,7 +249,7 @@ func (client *Datetimerfc1123Client) GetUTCUppercaseMaxDateTime(ctx context.Cont
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetUTCUppercaseMaxDateTimeResponse{}, err
 	}
@@ -300,7 +292,7 @@ func (client *Datetimerfc1123Client) GetUnderflow(ctx context.Context, options *
 	if err != nil {
 		return Datetimerfc1123ClientGetUnderflowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientGetUnderflowResponse{}, err
 	}
@@ -344,7 +336,7 @@ func (client *Datetimerfc1123Client) PutUTCMaxDateTime(ctx context.Context, date
 	if err != nil {
 		return Datetimerfc1123ClientPutUTCMaxDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientPutUTCMaxDateTimeResponse{}, err
 	}
@@ -378,7 +370,7 @@ func (client *Datetimerfc1123Client) PutUTCMinDateTime(ctx context.Context, date
 	if err != nil {
 		return Datetimerfc1123ClientPutUTCMinDateTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return Datetimerfc1123ClientPutUTCMinDateTimeResponse{}, err
 	}

--- a/test/autorest/dictionarygroup/dictionarygroup_test.go
+++ b/test/autorest/dictionarygroup/dictionarygroup_test.go
@@ -16,14 +16,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newDictionaryClient() *DictionaryClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewDictionaryClient(pl)
+func newDictionaryClient(t *testing.T) *DictionaryClient {
+	client, err := NewDictionaryClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewDictionaryClient(options *azcore.ClientOptions) (*DictionaryClient, error) {
+	client, err := azcore.NewClient("dictionarygroup.DictionaryClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &DictionaryClient{internal: client}, nil
 }
 
 // GetArrayEmpty - Get an empty dictionary {}
 func TestGetArrayEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetArrayEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(len(resp.Value), 0); r != "" {
@@ -33,7 +42,7 @@ func TestGetArrayEmpty(t *testing.T) {
 
 // GetArrayItemEmpty - Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
 func TestGetArrayItemEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetArrayItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string][]*string{
@@ -47,7 +56,7 @@ func TestGetArrayItemEmpty(t *testing.T) {
 
 // GetArrayItemNull - Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
 func TestGetArrayItemNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetArrayItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	// TODO: this should technically fail since there's no x-nullable
@@ -62,7 +71,7 @@ func TestGetArrayItemNull(t *testing.T) {
 
 // GetArrayNull - Get a null array
 func TestGetArrayNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetArrayNull(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Value != nil {
@@ -72,7 +81,7 @@ func TestGetArrayNull(t *testing.T) {
 
 // GetArrayValid - Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestGetArrayValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetArrayValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string][]*string{
@@ -87,7 +96,7 @@ func TestGetArrayValid(t *testing.T) {
 // GetBase64URL - Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test string", "2": "Lorem ipsum"}
 func TestGetBase64URL(t *testing.T) {
 	t.Skip("unmarshalling fails")
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetBase64URL(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string][]byte{
@@ -101,7 +110,7 @@ func TestGetBase64URL(t *testing.T) {
 
 // GetBooleanInvalidNull - Get boolean dictionary value {"0": true, "1": null, "2": false }
 func TestGetBooleanInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetBooleanInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*bool{
@@ -115,7 +124,7 @@ func TestGetBooleanInvalidNull(t *testing.T) {
 
 // GetBooleanInvalidString - Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
 func TestGetBooleanInvalidString(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetBooleanInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -123,7 +132,7 @@ func TestGetBooleanInvalidString(t *testing.T) {
 
 // GetBooleanTfft - Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
 func TestGetBooleanTfft(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetBooleanTfft(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*bool{
@@ -138,7 +147,7 @@ func TestGetBooleanTfft(t *testing.T) {
 
 // GetByteInvalidNull - Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
 func TestGetByteInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetByteInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string][]byte{
@@ -151,7 +160,7 @@ func TestGetByteInvalidNull(t *testing.T) {
 
 // GetByteValid - Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each item encoded in base64
 func TestGetByteValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetByteValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string][]byte{
@@ -165,7 +174,7 @@ func TestGetByteValid(t *testing.T) {
 
 // GetComplexEmpty - Get empty dictionary of complex type {}
 func TestGetComplexEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetComplexEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*Widget{}); r != "" {
@@ -175,7 +184,7 @@ func TestGetComplexEmpty(t *testing.T) {
 
 // GetComplexItemEmpty - Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexItemEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetComplexItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*Widget{
@@ -189,7 +198,7 @@ func TestGetComplexItemEmpty(t *testing.T) {
 
 // GetComplexItemNull - Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexItemNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetComplexItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*Widget{
@@ -203,7 +212,7 @@ func TestGetComplexItemNull(t *testing.T) {
 
 // GetComplexNull - Get dictionary of complex type null value
 func TestGetComplexNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetComplexNull(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Value != nil {
@@ -213,7 +222,7 @@ func TestGetComplexNull(t *testing.T) {
 
 // GetComplexValid - Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestGetComplexValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetComplexValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*Widget{
@@ -227,7 +236,7 @@ func TestGetComplexValid(t *testing.T) {
 
 // GetDateInvalidChars - Get date dictionary value {"0": "2011-03-22", "1": "date"}
 func TestGetDateInvalidChars(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateInvalidChars(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -235,7 +244,7 @@ func TestGetDateInvalidChars(t *testing.T) {
 
 // GetDateInvalidNull - Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
 func TestGetDateInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	v1 := time.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -251,7 +260,7 @@ func TestGetDateInvalidNull(t *testing.T) {
 
 // GetDateTimeInvalidChars - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
 func TestGetDateTimeInvalidChars(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateTimeInvalidChars(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -259,7 +268,7 @@ func TestGetDateTimeInvalidChars(t *testing.T) {
 
 // GetDateTimeInvalidNull - Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
 func TestGetDateTimeInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateTimeInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
@@ -273,7 +282,7 @@ func TestGetDateTimeInvalidNull(t *testing.T) {
 
 // GetDateTimeRFC1123Valid - Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
 func TestGetDateTimeRFC1123Valid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateTimeRFC1123Valid(context.Background(), nil)
 	require.NoError(t, err)
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
@@ -290,7 +299,7 @@ func TestGetDateTimeRFC1123Valid(t *testing.T) {
 
 // GetDateTimeValid - Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 func TestGetDateTimeValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateTimeValid(context.Background(), nil)
 	require.NoError(t, err)
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
@@ -307,7 +316,7 @@ func TestGetDateTimeValid(t *testing.T) {
 
 // GetDateValid - Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
 func TestGetDateValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDateValid(context.Background(), nil)
 	require.NoError(t, err)
 	dt1 := time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC)
@@ -324,7 +333,7 @@ func TestGetDateValid(t *testing.T) {
 
 // GetDictionaryEmpty - Get an dictionaries of dictionaries of type <string, string> with value {}
 func TestGetDictionaryEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDictionaryEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]map[string]*string{}); r != "" {
@@ -334,7 +343,7 @@ func TestGetDictionaryEmpty(t *testing.T) {
 
 // GetDictionaryItemEmpty - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestGetDictionaryItemEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDictionaryItemEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
@@ -356,7 +365,7 @@ func TestGetDictionaryItemEmpty(t *testing.T) {
 
 // GetDictionaryItemNull - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestGetDictionaryItemNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDictionaryItemNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
@@ -378,7 +387,7 @@ func TestGetDictionaryItemNull(t *testing.T) {
 
 // GetDictionaryNull - Get an dictionaries of dictionaries with value null
 func TestGetDictionaryNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDictionaryNull(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Value != nil {
@@ -388,7 +397,7 @@ func TestGetDictionaryNull(t *testing.T) {
 
 // GetDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestGetDictionaryValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDictionaryValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]map[string]*string{
@@ -414,7 +423,7 @@ func TestGetDictionaryValid(t *testing.T) {
 
 // GetDoubleInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetDoubleInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDoubleInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*float64{
@@ -428,7 +437,7 @@ func TestGetDoubleInvalidNull(t *testing.T) {
 
 // GetDoubleInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetDoubleInvalidString(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDoubleInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -436,7 +445,7 @@ func TestGetDoubleInvalidString(t *testing.T) {
 
 // GetDoubleValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetDoubleValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDoubleValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*float64{
@@ -450,7 +459,7 @@ func TestGetDoubleValid(t *testing.T) {
 
 // GetDurationValid - Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestGetDurationValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetDurationValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*string{
@@ -463,7 +472,7 @@ func TestGetDurationValid(t *testing.T) {
 
 // GetEmpty - Get empty dictionary value {}
 func TestGetEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if len(resp.Value) != 0 {
@@ -473,7 +482,7 @@ func TestGetEmpty(t *testing.T) {
 
 // GetEmptyStringKey - Get Dictionary with key as empty string
 func TestGetEmptyStringKey(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetEmptyStringKey(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*string{"": to.Ptr("val1")}); r != "" {
@@ -483,7 +492,7 @@ func TestGetEmptyStringKey(t *testing.T) {
 
 // GetFloatInvalidNull - Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
 func TestGetFloatInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetFloatInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*float32{
@@ -497,7 +506,7 @@ func TestGetFloatInvalidNull(t *testing.T) {
 
 // GetFloatInvalidString - Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
 func TestGetFloatInvalidString(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetFloatInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -505,7 +514,7 @@ func TestGetFloatInvalidString(t *testing.T) {
 
 // GetFloatValid - Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestGetFloatValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetFloatValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*float32{
@@ -519,7 +528,7 @@ func TestGetFloatValid(t *testing.T) {
 
 // GetIntInvalidNull - Get integer dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetIntInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetIntInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*int32{
@@ -533,7 +542,7 @@ func TestGetIntInvalidNull(t *testing.T) {
 
 // GetIntInvalidString - Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetIntInvalidString(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetIntInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -541,7 +550,7 @@ func TestGetIntInvalidString(t *testing.T) {
 
 // GetIntegerValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetIntegerValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetIntegerValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*int32{
@@ -556,7 +565,7 @@ func TestGetIntegerValid(t *testing.T) {
 
 // GetInvalid - Get invalid Dictionary value
 func TestGetInvalid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -564,7 +573,7 @@ func TestGetInvalid(t *testing.T) {
 
 // GetLongInvalidNull - Get long dictionary value {"0": 1, "1": null, "2": 0}
 func TestGetLongInvalidNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetLongInvalidNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*int64{
@@ -578,7 +587,7 @@ func TestGetLongInvalidNull(t *testing.T) {
 
 // GetLongInvalidString - Get long dictionary value {"0": 1, "1": "integer", "2": 0}
 func TestGetLongInvalidString(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetLongInvalidString(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -586,7 +595,7 @@ func TestGetLongInvalidString(t *testing.T) {
 
 // GetLongValid - Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestGetLongValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetLongValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*int64{
@@ -601,7 +610,7 @@ func TestGetLongValid(t *testing.T) {
 
 // GetNull - Get null dictionary value
 func TestGetNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Value != nil {
@@ -611,7 +620,7 @@ func TestGetNull(t *testing.T) {
 
 // GetNullKey - Get Dictionary with null key
 func TestGetNullKey(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetNullKey(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -619,7 +628,7 @@ func TestGetNullKey(t *testing.T) {
 
 // GetNullValue - Get Dictionary with null value
 func TestGetNullValue(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetNullValue(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*string{
@@ -631,7 +640,7 @@ func TestGetNullValue(t *testing.T) {
 
 // GetStringValid - Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestGetStringValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetStringValid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*string{
@@ -645,7 +654,7 @@ func TestGetStringValid(t *testing.T) {
 
 // GetStringWithInvalid - Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
 func TestGetStringWithInvalid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetStringWithInvalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, resp)
@@ -653,7 +662,7 @@ func TestGetStringWithInvalid(t *testing.T) {
 
 // GetStringWithNull - Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
 func TestGetStringWithNull(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.GetStringWithNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(resp.Value, map[string]*string{
@@ -667,7 +676,7 @@ func TestGetStringWithNull(t *testing.T) {
 
 // PutArrayValid - Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}
 func TestPutArrayValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutArrayValid(context.Background(), map[string][]*string{
 		"0": to.SliceOfPtrs("1", "2", "3"),
 		"1": to.SliceOfPtrs("4", "5", "6"),
@@ -679,7 +688,7 @@ func TestPutArrayValid(t *testing.T) {
 
 // PutBooleanTfft - Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
 func TestPutBooleanTfft(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutBooleanTfft(context.Background(), map[string]*bool{
 		"0": to.Ptr(true),
 		"1": to.Ptr(false),
@@ -692,7 +701,7 @@ func TestPutBooleanTfft(t *testing.T) {
 
 // PutByteValid - Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with each elementencoded in base 64
 func TestPutByteValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutByteValid(context.Background(), map[string][]byte{
 		"0": {255, 255, 255, 250},
 		"1": {1, 2, 3},
@@ -704,7 +713,7 @@ func TestPutByteValid(t *testing.T) {
 
 // PutComplexValid - Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
 func TestPutComplexValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutComplexValid(context.Background(), map[string]*Widget{
 		"0": {Integer: to.Ptr[int32](1), String: to.Ptr("2")},
 		"1": {Integer: to.Ptr[int32](3), String: to.Ptr("4")},
@@ -716,7 +725,7 @@ func TestPutComplexValid(t *testing.T) {
 
 // PutDateTimeRFC1123Valid - Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
 func TestPutDateTimeRFC1123Valid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	dt1, _ := time.Parse(time.RFC1123, "Fri, 01 Dec 2000 00:00:01 GMT")
 	dt2, _ := time.Parse(time.RFC1123, "Wed, 02 Jan 1980 00:11:35 GMT")
 	dt3, _ := time.Parse(time.RFC1123, "Wed, 12 Oct 1492 10:15:01 GMT")
@@ -731,7 +740,7 @@ func TestPutDateTimeRFC1123Valid(t *testing.T) {
 
 // PutDateTimeValid - Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}
 func TestPutDateTimeValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	dt1, _ := time.Parse(time.RFC3339, "2000-12-01T00:00:01Z")
 	dt2, _ := time.Parse(time.RFC3339, "1980-01-01T23:11:35Z")
 	dt3, _ := time.Parse(time.RFC3339, "1492-10-12T18:15:01Z")
@@ -746,7 +755,7 @@ func TestPutDateTimeValid(t *testing.T) {
 
 // PutDateValid - Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
 func TestPutDateValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	d1 := time.Date(2000, 12, 01, 0, 0, 0, 0, time.UTC)
 	d2 := time.Date(1980, 01, 02, 0, 0, 0, 0, time.UTC)
 	d3 := time.Date(1492, 10, 12, 0, 0, 0, 0, time.UTC)
@@ -761,7 +770,7 @@ func TestPutDateValid(t *testing.T) {
 
 // PutDictionaryValid - Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
 func TestPutDictionaryValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutDictionaryValid(context.Background(), map[string]map[string]*string{
 		"0": {
 			"1": to.Ptr("one"),
@@ -785,7 +794,7 @@ func TestPutDictionaryValid(t *testing.T) {
 
 // PutDoubleValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutDoubleValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutDoubleValid(context.Background(), map[string]*float64{
 		"0": to.Ptr[float64](0),
 		"1": to.Ptr[float64](-0.01),
@@ -797,7 +806,7 @@ func TestPutDoubleValid(t *testing.T) {
 
 // PutDurationValid - Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
 func TestPutDurationValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutDurationValid(context.Background(), map[string]*string{
 		"0": to.Ptr("P123DT22H14M12.011S"),
 		"1": to.Ptr("P5DT1H"),
@@ -808,7 +817,7 @@ func TestPutDurationValid(t *testing.T) {
 
 // PutEmpty - Set dictionary value empty {}
 func TestPutEmpty(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutEmpty(context.Background(), map[string]*string{}, nil)
 	require.NoError(t, err)
 	require.Zero(t, resp)
@@ -816,7 +825,7 @@ func TestPutEmpty(t *testing.T) {
 
 // PutFloatValid - Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
 func TestPutFloatValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutFloatValid(context.Background(), map[string]*float32{
 		"0": to.Ptr[float32](0),
 		"1": to.Ptr[float32](-0.01),
@@ -828,7 +837,7 @@ func TestPutFloatValid(t *testing.T) {
 
 // PutIntegerValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutIntegerValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutIntegerValid(context.Background(), map[string]*int32{
 		"0": to.Ptr[int32](1),
 		"1": to.Ptr[int32](-1),
@@ -841,7 +850,7 @@ func TestPutIntegerValid(t *testing.T) {
 
 // PutLongValid - Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
 func TestPutLongValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutLongValid(context.Background(), map[string]*int64{
 		"0": to.Ptr[int64](1),
 		"1": to.Ptr[int64](-1),
@@ -854,7 +863,7 @@ func TestPutLongValid(t *testing.T) {
 
 // PutStringValid - Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
 func TestPutStringValid(t *testing.T) {
-	client := newDictionaryClient()
+	client := newDictionaryClient(t)
 	resp, err := client.PutStringValid(context.Background(), map[string]*string{
 		"0": to.Ptr("foo1"),
 		"1": to.Ptr("foo2"),

--- a/test/autorest/dictionarygroup/zz_dictionary_client.go
+++ b/test/autorest/dictionarygroup/zz_dictionary_client.go
@@ -11,6 +11,7 @@ package dictionarygroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // DictionaryClient contains the methods for the Dictionary group.
-// Don't use this type directly, use NewDictionaryClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type DictionaryClient struct {
-	pl runtime.Pipeline
-}
-
-// NewDictionaryClient creates a new instance of DictionaryClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDictionaryClient(pl runtime.Pipeline) *DictionaryClient {
-	client := &DictionaryClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetArrayEmpty - Get an empty dictionary {}
@@ -43,7 +35,7 @@ func (client *DictionaryClient) GetArrayEmpty(ctx context.Context, options *Dict
 	if err != nil {
 		return DictionaryClientGetArrayEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetArrayEmptyResponse{}, err
 	}
@@ -84,7 +76,7 @@ func (client *DictionaryClient) GetArrayItemEmpty(ctx context.Context, options *
 	if err != nil {
 		return DictionaryClientGetArrayItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetArrayItemEmptyResponse{}, err
 	}
@@ -125,7 +117,7 @@ func (client *DictionaryClient) GetArrayItemNull(ctx context.Context, options *D
 	if err != nil {
 		return DictionaryClientGetArrayItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetArrayItemNullResponse{}, err
 	}
@@ -165,7 +157,7 @@ func (client *DictionaryClient) GetArrayNull(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetArrayNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetArrayNullResponse{}, err
 	}
@@ -206,7 +198,7 @@ func (client *DictionaryClient) GetArrayValid(ctx context.Context, options *Dict
 	if err != nil {
 		return DictionaryClientGetArrayValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetArrayValidResponse{}, err
 	}
@@ -247,7 +239,7 @@ func (client *DictionaryClient) GetBase64URL(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetBase64URLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetBase64URLResponse{}, err
 	}
@@ -288,7 +280,7 @@ func (client *DictionaryClient) GetBooleanInvalidNull(ctx context.Context, optio
 	if err != nil {
 		return DictionaryClientGetBooleanInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetBooleanInvalidNullResponse{}, err
 	}
@@ -329,7 +321,7 @@ func (client *DictionaryClient) GetBooleanInvalidString(ctx context.Context, opt
 	if err != nil {
 		return DictionaryClientGetBooleanInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetBooleanInvalidStringResponse{}, err
 	}
@@ -370,7 +362,7 @@ func (client *DictionaryClient) GetBooleanTfft(ctx context.Context, options *Dic
 	if err != nil {
 		return DictionaryClientGetBooleanTfftResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetBooleanTfftResponse{}, err
 	}
@@ -411,7 +403,7 @@ func (client *DictionaryClient) GetByteInvalidNull(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetByteInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetByteInvalidNullResponse{}, err
 	}
@@ -452,7 +444,7 @@ func (client *DictionaryClient) GetByteValid(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetByteValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetByteValidResponse{}, err
 	}
@@ -493,7 +485,7 @@ func (client *DictionaryClient) GetComplexEmpty(ctx context.Context, options *Di
 	if err != nil {
 		return DictionaryClientGetComplexEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetComplexEmptyResponse{}, err
 	}
@@ -535,7 +527,7 @@ func (client *DictionaryClient) GetComplexItemEmpty(ctx context.Context, options
 	if err != nil {
 		return DictionaryClientGetComplexItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetComplexItemEmptyResponse{}, err
 	}
@@ -577,7 +569,7 @@ func (client *DictionaryClient) GetComplexItemNull(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetComplexItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetComplexItemNullResponse{}, err
 	}
@@ -618,7 +610,7 @@ func (client *DictionaryClient) GetComplexNull(ctx context.Context, options *Dic
 	if err != nil {
 		return DictionaryClientGetComplexNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetComplexNullResponse{}, err
 	}
@@ -660,7 +652,7 @@ func (client *DictionaryClient) GetComplexValid(ctx context.Context, options *Di
 	if err != nil {
 		return DictionaryClientGetComplexValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetComplexValidResponse{}, err
 	}
@@ -701,7 +693,7 @@ func (client *DictionaryClient) GetDateInvalidChars(ctx context.Context, options
 	if err != nil {
 		return DictionaryClientGetDateInvalidCharsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateInvalidCharsResponse{}, err
 	}
@@ -748,7 +740,7 @@ func (client *DictionaryClient) GetDateInvalidNull(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetDateInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateInvalidNullResponse{}, err
 	}
@@ -795,7 +787,7 @@ func (client *DictionaryClient) GetDateTimeInvalidChars(ctx context.Context, opt
 	if err != nil {
 		return DictionaryClientGetDateTimeInvalidCharsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateTimeInvalidCharsResponse{}, err
 	}
@@ -842,7 +834,7 @@ func (client *DictionaryClient) GetDateTimeInvalidNull(ctx context.Context, opti
 	if err != nil {
 		return DictionaryClientGetDateTimeInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateTimeInvalidNullResponse{}, err
 	}
@@ -890,7 +882,7 @@ func (client *DictionaryClient) GetDateTimeRFC1123Valid(ctx context.Context, opt
 	if err != nil {
 		return DictionaryClientGetDateTimeRFC1123ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateTimeRFC1123ValidResponse{}, err
 	}
@@ -938,7 +930,7 @@ func (client *DictionaryClient) GetDateTimeValid(ctx context.Context, options *D
 	if err != nil {
 		return DictionaryClientGetDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateTimeValidResponse{}, err
 	}
@@ -984,7 +976,7 @@ func (client *DictionaryClient) GetDateValid(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDateValidResponse{}, err
 	}
@@ -1031,7 +1023,7 @@ func (client *DictionaryClient) GetDictionaryEmpty(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetDictionaryEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDictionaryEmptyResponse{}, err
 	}
@@ -1073,7 +1065,7 @@ func (client *DictionaryClient) GetDictionaryItemEmpty(ctx context.Context, opti
 	if err != nil {
 		return DictionaryClientGetDictionaryItemEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDictionaryItemEmptyResponse{}, err
 	}
@@ -1115,7 +1107,7 @@ func (client *DictionaryClient) GetDictionaryItemNull(ctx context.Context, optio
 	if err != nil {
 		return DictionaryClientGetDictionaryItemNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDictionaryItemNullResponse{}, err
 	}
@@ -1156,7 +1148,7 @@ func (client *DictionaryClient) GetDictionaryNull(ctx context.Context, options *
 	if err != nil {
 		return DictionaryClientGetDictionaryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDictionaryNullResponse{}, err
 	}
@@ -1198,7 +1190,7 @@ func (client *DictionaryClient) GetDictionaryValid(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetDictionaryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDictionaryValidResponse{}, err
 	}
@@ -1239,7 +1231,7 @@ func (client *DictionaryClient) GetDoubleInvalidNull(ctx context.Context, option
 	if err != nil {
 		return DictionaryClientGetDoubleInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDoubleInvalidNullResponse{}, err
 	}
@@ -1280,7 +1272,7 @@ func (client *DictionaryClient) GetDoubleInvalidString(ctx context.Context, opti
 	if err != nil {
 		return DictionaryClientGetDoubleInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDoubleInvalidStringResponse{}, err
 	}
@@ -1321,7 +1313,7 @@ func (client *DictionaryClient) GetDoubleValid(ctx context.Context, options *Dic
 	if err != nil {
 		return DictionaryClientGetDoubleValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDoubleValidResponse{}, err
 	}
@@ -1362,7 +1354,7 @@ func (client *DictionaryClient) GetDurationValid(ctx context.Context, options *D
 	if err != nil {
 		return DictionaryClientGetDurationValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetDurationValidResponse{}, err
 	}
@@ -1402,7 +1394,7 @@ func (client *DictionaryClient) GetEmpty(ctx context.Context, options *Dictionar
 	if err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetEmptyResponse{}, err
 	}
@@ -1443,7 +1435,7 @@ func (client *DictionaryClient) GetEmptyStringKey(ctx context.Context, options *
 	if err != nil {
 		return DictionaryClientGetEmptyStringKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetEmptyStringKeyResponse{}, err
 	}
@@ -1484,7 +1476,7 @@ func (client *DictionaryClient) GetFloatInvalidNull(ctx context.Context, options
 	if err != nil {
 		return DictionaryClientGetFloatInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetFloatInvalidNullResponse{}, err
 	}
@@ -1525,7 +1517,7 @@ func (client *DictionaryClient) GetFloatInvalidString(ctx context.Context, optio
 	if err != nil {
 		return DictionaryClientGetFloatInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetFloatInvalidStringResponse{}, err
 	}
@@ -1566,7 +1558,7 @@ func (client *DictionaryClient) GetFloatValid(ctx context.Context, options *Dict
 	if err != nil {
 		return DictionaryClientGetFloatValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetFloatValidResponse{}, err
 	}
@@ -1607,7 +1599,7 @@ func (client *DictionaryClient) GetIntInvalidNull(ctx context.Context, options *
 	if err != nil {
 		return DictionaryClientGetIntInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetIntInvalidNullResponse{}, err
 	}
@@ -1648,7 +1640,7 @@ func (client *DictionaryClient) GetIntInvalidString(ctx context.Context, options
 	if err != nil {
 		return DictionaryClientGetIntInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetIntInvalidStringResponse{}, err
 	}
@@ -1689,7 +1681,7 @@ func (client *DictionaryClient) GetIntegerValid(ctx context.Context, options *Di
 	if err != nil {
 		return DictionaryClientGetIntegerValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetIntegerValidResponse{}, err
 	}
@@ -1729,7 +1721,7 @@ func (client *DictionaryClient) GetInvalid(ctx context.Context, options *Diction
 	if err != nil {
 		return DictionaryClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetInvalidResponse{}, err
 	}
@@ -1770,7 +1762,7 @@ func (client *DictionaryClient) GetLongInvalidNull(ctx context.Context, options 
 	if err != nil {
 		return DictionaryClientGetLongInvalidNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetLongInvalidNullResponse{}, err
 	}
@@ -1811,7 +1803,7 @@ func (client *DictionaryClient) GetLongInvalidString(ctx context.Context, option
 	if err != nil {
 		return DictionaryClientGetLongInvalidStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetLongInvalidStringResponse{}, err
 	}
@@ -1851,7 +1843,7 @@ func (client *DictionaryClient) GetLongValid(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetLongValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetLongValidResponse{}, err
 	}
@@ -1891,7 +1883,7 @@ func (client *DictionaryClient) GetNull(ctx context.Context, options *Dictionary
 	if err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetNullResponse{}, err
 	}
@@ -1931,7 +1923,7 @@ func (client *DictionaryClient) GetNullKey(ctx context.Context, options *Diction
 	if err != nil {
 		return DictionaryClientGetNullKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetNullKeyResponse{}, err
 	}
@@ -1971,7 +1963,7 @@ func (client *DictionaryClient) GetNullValue(ctx context.Context, options *Dicti
 	if err != nil {
 		return DictionaryClientGetNullValueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetNullValueResponse{}, err
 	}
@@ -2012,7 +2004,7 @@ func (client *DictionaryClient) GetStringValid(ctx context.Context, options *Dic
 	if err != nil {
 		return DictionaryClientGetStringValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetStringValidResponse{}, err
 	}
@@ -2053,7 +2045,7 @@ func (client *DictionaryClient) GetStringWithInvalid(ctx context.Context, option
 	if err != nil {
 		return DictionaryClientGetStringWithInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetStringWithInvalidResponse{}, err
 	}
@@ -2094,7 +2086,7 @@ func (client *DictionaryClient) GetStringWithNull(ctx context.Context, options *
 	if err != nil {
 		return DictionaryClientGetStringWithNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientGetStringWithNullResponse{}, err
 	}
@@ -2135,7 +2127,7 @@ func (client *DictionaryClient) PutArrayValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return DictionaryClientPutArrayValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutArrayValidResponse{}, err
 	}
@@ -2167,7 +2159,7 @@ func (client *DictionaryClient) PutBooleanTfft(ctx context.Context, arrayBody ma
 	if err != nil {
 		return DictionaryClientPutBooleanTfftResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutBooleanTfftResponse{}, err
 	}
@@ -2199,7 +2191,7 @@ func (client *DictionaryClient) PutByteValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return DictionaryClientPutByteValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutByteValidResponse{}, err
 	}
@@ -2232,7 +2224,7 @@ func (client *DictionaryClient) PutComplexValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return DictionaryClientPutComplexValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutComplexValidResponse{}, err
 	}
@@ -2265,7 +2257,7 @@ func (client *DictionaryClient) PutDateTimeRFC1123Valid(ctx context.Context, arr
 	if err != nil {
 		return DictionaryClientPutDateTimeRFC1123ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDateTimeRFC1123ValidResponse{}, err
 	}
@@ -2301,7 +2293,7 @@ func (client *DictionaryClient) PutDateTimeValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return DictionaryClientPutDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDateTimeValidResponse{}, err
 	}
@@ -2336,7 +2328,7 @@ func (client *DictionaryClient) PutDateValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return DictionaryClientPutDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDateValidResponse{}, err
 	}
@@ -2373,7 +2365,7 @@ func (client *DictionaryClient) PutDictionaryValid(ctx context.Context, arrayBod
 	if err != nil {
 		return DictionaryClientPutDictionaryValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDictionaryValidResponse{}, err
 	}
@@ -2405,7 +2397,7 @@ func (client *DictionaryClient) PutDoubleValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return DictionaryClientPutDoubleValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDoubleValidResponse{}, err
 	}
@@ -2437,7 +2429,7 @@ func (client *DictionaryClient) PutDurationValid(ctx context.Context, arrayBody 
 	if err != nil {
 		return DictionaryClientPutDurationValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutDurationValidResponse{}, err
 	}
@@ -2468,7 +2460,7 @@ func (client *DictionaryClient) PutEmpty(ctx context.Context, arrayBody map[stri
 	if err != nil {
 		return DictionaryClientPutEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutEmptyResponse{}, err
 	}
@@ -2500,7 +2492,7 @@ func (client *DictionaryClient) PutFloatValid(ctx context.Context, arrayBody map
 	if err != nil {
 		return DictionaryClientPutFloatValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutFloatValidResponse{}, err
 	}
@@ -2532,7 +2524,7 @@ func (client *DictionaryClient) PutIntegerValid(ctx context.Context, arrayBody m
 	if err != nil {
 		return DictionaryClientPutIntegerValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutIntegerValidResponse{}, err
 	}
@@ -2563,7 +2555,7 @@ func (client *DictionaryClient) PutLongValid(ctx context.Context, arrayBody map[
 	if err != nil {
 		return DictionaryClientPutLongValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutLongValidResponse{}, err
 	}
@@ -2595,7 +2587,7 @@ func (client *DictionaryClient) PutStringValid(ctx context.Context, arrayBody ma
 	if err != nil {
 		return DictionaryClientPutStringValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DictionaryClientPutStringValidResponse{}, err
 	}

--- a/test/autorest/durationgroup/zz_duration_client.go
+++ b/test/autorest/durationgroup/zz_duration_client.go
@@ -11,24 +11,16 @@ package durationgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // DurationClient contains the methods for the Duration group.
-// Don't use this type directly, use NewDurationClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type DurationClient struct {
-	pl runtime.Pipeline
-}
-
-// NewDurationClient creates a new instance of DurationClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewDurationClient(pl runtime.Pipeline) *DurationClient {
-	client := &DurationClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetInvalid - Get an invalid duration value
@@ -41,7 +33,7 @@ func (client *DurationClient) GetInvalid(ctx context.Context, options *DurationC
 	if err != nil {
 		return DurationClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DurationClientGetInvalidResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *DurationClient) GetNull(ctx context.Context, options *DurationClie
 	if err != nil {
 		return DurationClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DurationClientGetNullResponse{}, err
 	}
@@ -122,7 +114,7 @@ func (client *DurationClient) GetPositiveDuration(ctx context.Context, options *
 	if err != nil {
 		return DurationClientGetPositiveDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DurationClientGetPositiveDurationResponse{}, err
 	}
@@ -164,7 +156,7 @@ func (client *DurationClient) PutPositiveDuration(ctx context.Context, durationB
 	if err != nil {
 		return DurationClientPutPositiveDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DurationClientPutPositiveDurationResponse{}, err
 	}

--- a/test/autorest/errorsgroup/zz_pet_client.go
+++ b/test/autorest/errorsgroup/zz_pet_client.go
@@ -12,6 +12,7 @@ package errorsgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // PetClient contains the methods for the Pet group.
-// Don't use this type directly, use NewPetClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PetClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPetClient creates a new instance of PetClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPetClient(pl runtime.Pipeline) *PetClient {
-	client := &PetClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // DoSomething - Asks pet to do something
@@ -45,7 +37,7 @@ func (client *PetClient) DoSomething(ctx context.Context, whatAction string, opt
 	if err != nil {
 		return PetClientDoSomethingResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetClientDoSomethingResponse{}, err
 	}
@@ -90,7 +82,7 @@ func (client *PetClient) GetPetByID(ctx context.Context, petID string, options *
 	if err != nil {
 		return PetClientGetPetByIDResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetClientGetPetByIDResponse{}, err
 	}
@@ -135,7 +127,7 @@ func (client *PetClient) HasModelsParam(ctx context.Context, options *PetClientH
 	if err != nil {
 		return PetClientHasModelsParamResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetClientHasModelsParamResponse{}, err
 	}

--- a/test/autorest/extenumsgroup/extenumsgroup_test.go
+++ b/test/autorest/extenumsgroup/extenumsgroup_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPetClient() *PetClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPetClient(pl)
+func newPetClient(t *testing.T) *PetClient {
+	client, err := NewPetClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPetClient(options *azcore.ClientOptions) (*PetClient, error) {
+	client, err := azcore.NewClient("extenumsgroup.PetClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PetClient{internal: client}, nil
 }
 
 func TestAddPet(t *testing.T) {
-	client := newPetClient()
+	client := newPetClient(t)
 	result, err := client.AddPet(context.Background(), &PetClientAddPetOptions{
 		PetParam: &Pet{
 			Name: to.Ptr("Retriever"),
@@ -36,7 +45,7 @@ func TestAddPet(t *testing.T) {
 }
 
 func TestGetByPetIDExpected(t *testing.T) {
-	client := newPetClient()
+	client := newPetClient(t)
 	result, err := client.GetByPetID(context.Background(), "tommy", nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Pet, Pet{
@@ -49,7 +58,7 @@ func TestGetByPetIDExpected(t *testing.T) {
 }
 
 func TestGetByPetIDUnexpected(t *testing.T) {
-	client := newPetClient()
+	client := newPetClient(t)
 	result, err := client.GetByPetID(context.Background(), "casper", nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Pet, Pet{
@@ -62,7 +71,7 @@ func TestGetByPetIDUnexpected(t *testing.T) {
 }
 
 func TestGetByPetIDAllowed(t *testing.T) {
-	client := newPetClient()
+	client := newPetClient(t)
 	result, err := client.GetByPetID(context.Background(), "scooby", nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Pet, Pet{

--- a/test/autorest/extenumsgroup/zz_pet_client.go
+++ b/test/autorest/extenumsgroup/zz_pet_client.go
@@ -12,6 +12,7 @@ package extenumsgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // PetClient contains the methods for the Pet group.
-// Don't use this type directly, use NewPetClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PetClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPetClient creates a new instance of PetClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPetClient(pl runtime.Pipeline) *PetClient {
-	client := &PetClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // AddPet - add pet
@@ -44,7 +36,7 @@ func (client *PetClient) AddPet(ctx context.Context, options *PetClientAddPetOpt
 	if err != nil {
 		return PetClientAddPetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetClientAddPetResponse{}, err
 	}
@@ -88,7 +80,7 @@ func (client *PetClient) GetByPetID(ctx context.Context, petID string, options *
 	if err != nil {
 		return PetClientGetByPetIDResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PetClientGetByPetIDResponse{}, err
 	}

--- a/test/autorest/filegroup/filegroup_test.go
+++ b/test/autorest/filegroup/filegroup_test.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newFilesClient() *FilesClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewFilesClient(pl)
+func newFilesClient(t *testing.T) *FilesClient {
+	client, err := NewFilesClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewFilesClient(options *azcore.ClientOptions) (*FilesClient, error) {
+	client, err := azcore.NewClient("filegroup.FilesClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &FilesClient{internal: client}, nil
 }
 
 func TestGetEmptyFile(t *testing.T) {
-	client := newFilesClient()
+	client := newFilesClient(t)
 	result, err := client.GetEmptyFile(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Body == nil {
@@ -30,7 +39,7 @@ func TestGetEmptyFile(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	client := newFilesClient()
+	client := newFilesClient(t)
 	result, err := client.GetFile(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Body == nil {
@@ -46,7 +55,7 @@ func TestGetFile(t *testing.T) {
 
 func TestGetFileLarge(t *testing.T) {
 	t.Skip("test is unreliable, can fail when running on a machine with low memory")
-	client := newFilesClient()
+	client := newFilesClient(t)
 	result, err := client.GetFileLarge(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Body == nil {

--- a/test/autorest/filegroup/zz_files_client.go
+++ b/test/autorest/filegroup/zz_files_client.go
@@ -11,24 +11,16 @@ package filegroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // FilesClient contains the methods for the Files group.
-// Don't use this type directly, use NewFilesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type FilesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewFilesClient creates a new instance of FilesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewFilesClient(pl runtime.Pipeline) *FilesClient {
-	client := &FilesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmptyFile - Get empty file
@@ -41,7 +33,7 @@ func (client *FilesClient) GetEmptyFile(ctx context.Context, options *FilesClien
 	if err != nil {
 		return FilesClientGetEmptyFileResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FilesClientGetEmptyFileResponse{}, err
 	}
@@ -73,7 +65,7 @@ func (client *FilesClient) GetFile(ctx context.Context, options *FilesClientGetF
 	if err != nil {
 		return FilesClientGetFileResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FilesClientGetFileResponse{}, err
 	}
@@ -105,7 +97,7 @@ func (client *FilesClient) GetFileLarge(ctx context.Context, options *FilesClien
 	if err != nil {
 		return FilesClientGetFileLargeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FilesClientGetFileLargeResponse{}, err
 	}

--- a/test/autorest/formdatagroup/zz_formdata_client.go
+++ b/test/autorest/formdatagroup/zz_formdata_client.go
@@ -11,6 +11,7 @@ package formdatagroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -18,18 +19,9 @@ import (
 )
 
 // FormdataClient contains the methods for the Formdata group.
-// Don't use this type directly, use NewFormdataClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type FormdataClient struct {
-	pl runtime.Pipeline
-}
-
-// NewFormdataClient creates a new instance of FormdataClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewFormdataClient(pl runtime.Pipeline) *FormdataClient {
-	client := &FormdataClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // UploadFile - Upload file
@@ -44,7 +36,7 @@ func (client *FormdataClient) UploadFile(ctx context.Context, fileContent io.Rea
 	if err != nil {
 		return FormdataClientUploadFileResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FormdataClientUploadFileResponse{}, err
 	}
@@ -84,7 +76,7 @@ func (client *FormdataClient) UploadFileViaBody(ctx context.Context, fileContent
 	if err != nil {
 		return FormdataClientUploadFileViaBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FormdataClientUploadFileViaBodyResponse{}, err
 	}
@@ -117,7 +109,7 @@ func (client *FormdataClient) UploadFiles(ctx context.Context, fileContent []io.
 	if err != nil {
 		return FormdataClientUploadFilesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FormdataClientUploadFilesResponse{}, err
 	}

--- a/test/autorest/go.mod
+++ b/test/autorest/go.mod
@@ -3,13 +3,13 @@ module generatortests
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 	github.com/google/go-cmp v0.5.4
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect

--- a/test/autorest/go.sum
+++ b/test/autorest/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=

--- a/test/autorest/headergroup/headergroup_test.go
+++ b/test/autorest/headergroup/headergroup_test.go
@@ -17,13 +17,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHeaderClient() *HeaderClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHeaderClient(pl)
+func newHeaderClient(t *testing.T) *HeaderClient {
+	client, err := NewHeaderClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHeaderClient(options *azcore.ClientOptions) (*HeaderClient, error) {
+	client, err := azcore.NewClient("headergroup.HeaderClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HeaderClient{internal: client}, nil
 }
 
 func TestHeaderCustomRequestID(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	header := http.Header{}
 	header.Set("x-ms-client-request-id", "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0")
 	result, err := client.CustomRequestID(runtime.WithHTTPHeader(context.Background(), header), nil)
@@ -32,7 +41,7 @@ func TestHeaderCustomRequestID(t *testing.T) {
 }
 
 func TestHeaderParamBool(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamBool(context.Background(), "true", true, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -43,14 +52,14 @@ func TestHeaderParamBool(t *testing.T) {
 }
 
 func TestHeaderParamByte(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamByte(context.Background(), "valid", []byte("啊齄丂狛狜隣郎隣兀﨩"), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHeaderParamDate(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	val, err := time.Parse("2006-01-02", "2010-01-01")
 	require.NoError(t, err)
 	result, err := client.ParamDate(context.Background(), "valid", val, nil)
@@ -59,7 +68,7 @@ func TestHeaderParamDate(t *testing.T) {
 }
 
 func TestHeaderParamDatetime(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	val, err := time.Parse("2006-01-02T15:04:05Z", "2010-01-01T12:34:56Z")
 	require.NoError(t, err)
 	result, err := client.ParamDatetime(context.Background(), "valid", val, nil)
@@ -68,7 +77,7 @@ func TestHeaderParamDatetime(t *testing.T) {
 }
 
 func TestHeaderParamDatetimeRFC1123(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	val, err := time.Parse(time.RFC1123, "Wed, 01 Jan 2010 12:34:56 GMT")
 	require.NoError(t, err)
 	result, err := client.ParamDatetimeRFC1123(context.Background(), "valid", &HeaderClientParamDatetimeRFC1123Options{Value: &val})
@@ -77,7 +86,7 @@ func TestHeaderParamDatetimeRFC1123(t *testing.T) {
 }
 
 func TestHeaderParamDouble(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamDouble(context.Background(), "positive", 7e120, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -88,14 +97,14 @@ func TestHeaderParamDouble(t *testing.T) {
 }
 
 func TestHeaderParamDuration(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamDuration(context.Background(), "valid", "P123DT22H14M12.011S", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHeaderParamEnum(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	val := GreyscaleColorsGREY
 	result, err := client.ParamEnum(context.Background(), "valid", &HeaderClientParamEnumOptions{Value: &val})
 	require.NoError(t, err)
@@ -107,7 +116,7 @@ func TestHeaderParamEnum(t *testing.T) {
 }
 
 // func TestHeaderParamExistingKey(t *testing.T) {
-// 	client := newHeaderClient()
+// 	client := newHeaderClient(t)
 // 	result, err := client.ParamExistingKey(context.Background(), "overwrite")
 // 	if err != nil {
 // 		t.Fatalf("ParamExistingKey: %v", err)
@@ -118,7 +127,7 @@ func TestHeaderParamEnum(t *testing.T) {
 // }
 
 func TestHeaderParamFloat(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamFloat(context.Background(), "positive", 0.07, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -129,7 +138,7 @@ func TestHeaderParamFloat(t *testing.T) {
 }
 
 func TestHeaderParamInteger(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamInteger(context.Background(), "positive", 1, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -140,7 +149,7 @@ func TestHeaderParamInteger(t *testing.T) {
 }
 
 func TestHeaderParamLong(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamLong(context.Background(), "positive", 105, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -151,14 +160,14 @@ func TestHeaderParamLong(t *testing.T) {
 }
 
 func TestHeaderParamProtectedKey(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ParamProtectedKey(context.Background(), "text/html", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHeaderParamString(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	val := "The quick brown fox jumps over the lazy dog"
 	result, err := client.ParamString(context.Background(), "valid", &HeaderClientParamStringOptions{Value: &val})
 	require.NoError(t, err)
@@ -175,7 +184,7 @@ func TestHeaderParamString(t *testing.T) {
 }
 
 func TestHeaderResponseBool(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseBool(context.Background(), "true", nil)
 	require.NoError(t, err)
 	val := true
@@ -191,7 +200,7 @@ func TestHeaderResponseBool(t *testing.T) {
 }
 
 func TestHeaderResponseByte(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseByte(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	val := []byte("啊齄丂狛狜隣郎隣兀﨩")
@@ -201,7 +210,7 @@ func TestHeaderResponseByte(t *testing.T) {
 }
 
 func TestHeaderResponseDate(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseDate(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	val, err := time.Parse("2006-01-02", "2010-01-01")
@@ -219,7 +228,7 @@ func TestHeaderResponseDate(t *testing.T) {
 }
 
 func TestHeaderResponseDatetime(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseDatetime(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	val, err := time.Parse(time.RFC3339, "2010-01-01T12:34:56Z")
@@ -237,7 +246,7 @@ func TestHeaderResponseDatetime(t *testing.T) {
 }
 
 func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseDatetimeRFC1123(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	val, err := time.Parse(time.RFC1123, "Wed, 01 Jan 2010 12:34:56 GMT")
@@ -255,7 +264,7 @@ func TestHeaderResponseDatetimeRFC1123(t *testing.T) {
 }
 
 func TestHeaderResponseDouble(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseDouble(context.Background(), "positive", nil)
 	require.NoError(t, err)
 	if *result.Value != 7e120 {
@@ -270,7 +279,7 @@ func TestHeaderResponseDouble(t *testing.T) {
 }
 
 func TestHeaderResponseDuration(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseDuration(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr("P123DT22H14M12.011S")); r != "" {
@@ -279,7 +288,7 @@ func TestHeaderResponseDuration(t *testing.T) {
 }
 
 func TestHeaderResponseEnum(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseEnum(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	val := GreyscaleColors("GREY")
@@ -292,7 +301,7 @@ func TestHeaderResponseEnum(t *testing.T) {
 }
 
 func TestHeaderResponseExistingKey(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseExistingKey(context.Background(), nil)
 	require.NoError(t, err)
 	if *result.UserAgent != "overwrite" {
@@ -301,7 +310,7 @@ func TestHeaderResponseExistingKey(t *testing.T) {
 }
 
 func TestHeaderResponseFloat(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseFloat(context.Background(), "positive", nil)
 	require.NoError(t, err)
 	if *result.Value != 0.07 {
@@ -316,7 +325,7 @@ func TestHeaderResponseFloat(t *testing.T) {
 }
 
 func TestHeaderResponseInteger(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseInteger(context.Background(), "positive", nil)
 	require.NoError(t, err)
 	if *result.Value != 1 {
@@ -331,7 +340,7 @@ func TestHeaderResponseInteger(t *testing.T) {
 }
 
 func TestHeaderResponseLong(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseLong(context.Background(), "positive", nil)
 	require.NoError(t, err)
 	if *result.Value != 105 {
@@ -346,7 +355,7 @@ func TestHeaderResponseLong(t *testing.T) {
 }
 
 func TestHeaderResponseProtectedKey(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseProtectedKey(context.Background(), nil)
 	require.NoError(t, err)
 	if *result.ContentType != "text/html; charset=utf-8" {
@@ -355,7 +364,7 @@ func TestHeaderResponseProtectedKey(t *testing.T) {
 }
 
 func TestHeaderResponseString(t *testing.T) {
-	client := newHeaderClient()
+	client := newHeaderClient(t)
 	result, err := client.ResponseString(context.Background(), "valid", nil)
 	require.NoError(t, err)
 	if *result.Value != "The quick brown fox jumps over the lazy dog" {

--- a/test/autorest/headergroup/zz_header_client.go
+++ b/test/autorest/headergroup/zz_header_client.go
@@ -12,6 +12,7 @@ package headergroup
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // HeaderClient contains the methods for the Header group.
-// Don't use this type directly, use NewHeaderClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HeaderClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHeaderClient creates a new instance of HeaderClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHeaderClient(pl runtime.Pipeline) *HeaderClient {
-	client := &HeaderClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // CustomRequestID - Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
@@ -44,7 +36,7 @@ func (client *HeaderClient) CustomRequestID(ctx context.Context, options *Header
 	if err != nil {
 		return HeaderClientCustomRequestIDResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientCustomRequestIDResponse{}, err
 	}
@@ -77,7 +69,7 @@ func (client *HeaderClient) ParamBool(ctx context.Context, scenario string, valu
 	if err != nil {
 		return HeaderClientParamBoolResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamBoolResponse{}, err
 	}
@@ -112,7 +104,7 @@ func (client *HeaderClient) ParamByte(ctx context.Context, scenario string, valu
 	if err != nil {
 		return HeaderClientParamByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamByteResponse{}, err
 	}
@@ -148,7 +140,7 @@ func (client *HeaderClient) ParamDate(ctx context.Context, scenario string, valu
 	if err != nil {
 		return HeaderClientParamDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamDateResponse{}, err
 	}
@@ -184,7 +176,7 @@ func (client *HeaderClient) ParamDatetime(ctx context.Context, scenario string, 
 	if err != nil {
 		return HeaderClientParamDatetimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamDatetimeResponse{}, err
 	}
@@ -220,7 +212,7 @@ func (client *HeaderClient) ParamDatetimeRFC1123(ctx context.Context, scenario s
 	if err != nil {
 		return HeaderClientParamDatetimeRFC1123Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamDatetimeRFC1123Response{}, err
 	}
@@ -258,7 +250,7 @@ func (client *HeaderClient) ParamDouble(ctx context.Context, scenario string, va
 	if err != nil {
 		return HeaderClientParamDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamDoubleResponse{}, err
 	}
@@ -293,7 +285,7 @@ func (client *HeaderClient) ParamDuration(ctx context.Context, scenario string, 
 	if err != nil {
 		return HeaderClientParamDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamDurationResponse{}, err
 	}
@@ -328,7 +320,7 @@ func (client *HeaderClient) ParamEnum(ctx context.Context, scenario string, opti
 	if err != nil {
 		return HeaderClientParamEnumResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamEnumResponse{}, err
 	}
@@ -364,7 +356,7 @@ func (client *HeaderClient) ParamExistingKey(ctx context.Context, userAgent stri
 	if err != nil {
 		return HeaderClientParamExistingKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamExistingKeyResponse{}, err
 	}
@@ -399,7 +391,7 @@ func (client *HeaderClient) ParamFloat(ctx context.Context, scenario string, val
 	if err != nil {
 		return HeaderClientParamFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamFloatResponse{}, err
 	}
@@ -435,7 +427,7 @@ func (client *HeaderClient) ParamInteger(ctx context.Context, scenario string, v
 	if err != nil {
 		return HeaderClientParamIntegerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamIntegerResponse{}, err
 	}
@@ -471,7 +463,7 @@ func (client *HeaderClient) ParamLong(ctx context.Context, scenario string, valu
 	if err != nil {
 		return HeaderClientParamLongResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamLongResponse{}, err
 	}
@@ -506,7 +498,7 @@ func (client *HeaderClient) ParamProtectedKey(ctx context.Context, contentType s
 	if err != nil {
 		return HeaderClientParamProtectedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamProtectedKeyResponse{}, err
 	}
@@ -540,7 +532,7 @@ func (client *HeaderClient) ParamString(ctx context.Context, scenario string, op
 	if err != nil {
 		return HeaderClientParamStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientParamStringResponse{}, err
 	}
@@ -576,7 +568,7 @@ func (client *HeaderClient) ResponseBool(ctx context.Context, scenario string, o
 	if err != nil {
 		return HeaderClientResponseBoolResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseBoolResponse{}, err
 	}
@@ -622,7 +614,7 @@ func (client *HeaderClient) ResponseByte(ctx context.Context, scenario string, o
 	if err != nil {
 		return HeaderClientResponseByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseByteResponse{}, err
 	}
@@ -668,7 +660,7 @@ func (client *HeaderClient) ResponseDate(ctx context.Context, scenario string, o
 	if err != nil {
 		return HeaderClientResponseDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseDateResponse{}, err
 	}
@@ -714,7 +706,7 @@ func (client *HeaderClient) ResponseDatetime(ctx context.Context, scenario strin
 	if err != nil {
 		return HeaderClientResponseDatetimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseDatetimeResponse{}, err
 	}
@@ -762,7 +754,7 @@ func (client *HeaderClient) ResponseDatetimeRFC1123(ctx context.Context, scenari
 	if err != nil {
 		return HeaderClientResponseDatetimeRFC1123Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseDatetimeRFC1123Response{}, err
 	}
@@ -808,7 +800,7 @@ func (client *HeaderClient) ResponseDouble(ctx context.Context, scenario string,
 	if err != nil {
 		return HeaderClientResponseDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseDoubleResponse{}, err
 	}
@@ -854,7 +846,7 @@ func (client *HeaderClient) ResponseDuration(ctx context.Context, scenario strin
 	if err != nil {
 		return HeaderClientResponseDurationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseDurationResponse{}, err
 	}
@@ -896,7 +888,7 @@ func (client *HeaderClient) ResponseEnum(ctx context.Context, scenario string, o
 	if err != nil {
 		return HeaderClientResponseEnumResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseEnumResponse{}, err
 	}
@@ -938,7 +930,7 @@ func (client *HeaderClient) ResponseExistingKey(ctx context.Context, options *He
 	if err != nil {
 		return HeaderClientResponseExistingKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseExistingKeyResponse{}, err
 	}
@@ -979,7 +971,7 @@ func (client *HeaderClient) ResponseFloat(ctx context.Context, scenario string, 
 	if err != nil {
 		return HeaderClientResponseFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseFloatResponse{}, err
 	}
@@ -1026,7 +1018,7 @@ func (client *HeaderClient) ResponseInteger(ctx context.Context, scenario string
 	if err != nil {
 		return HeaderClientResponseIntegerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseIntegerResponse{}, err
 	}
@@ -1073,7 +1065,7 @@ func (client *HeaderClient) ResponseLong(ctx context.Context, scenario string, o
 	if err != nil {
 		return HeaderClientResponseLongResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseLongResponse{}, err
 	}
@@ -1119,7 +1111,7 @@ func (client *HeaderClient) ResponseProtectedKey(ctx context.Context, options *H
 	if err != nil {
 		return HeaderClientResponseProtectedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseProtectedKeyResponse{}, err
 	}
@@ -1160,7 +1152,7 @@ func (client *HeaderClient) ResponseString(ctx context.Context, scenario string,
 	if err != nil {
 		return HeaderClientResponseStringResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HeaderClientResponseStringResponse{}, err
 	}

--- a/test/autorest/headgroup/headgroup_test.go
+++ b/test/autorest/headgroup/headgroup_test.go
@@ -13,14 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPSuccessOperationsClient() *HTTPSuccessClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHTTPSuccessClient(pl)
+func newHTTPSuccessClient(t *testing.T) *HTTPSuccessClient {
+	client, err := NewHTTPSuccessClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPSuccessClient(options *azcore.ClientOptions) (*HTTPSuccessClient, error) {
+	client, err := azcore.NewClient("headgroup.HTTPSuccessClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPSuccessClient{internal: client}, nil
 }
 
 // Head200 - Return 200 status code if successful
 func TestHead200(t *testing.T) {
-	client := newHTTPSuccessOperationsClient()
+	client := newHTTPSuccessClient(t)
 	resp, err := client.Head200(context.Background(), nil)
 	require.NoError(t, err)
 	if !resp.Success {
@@ -30,7 +39,7 @@ func TestHead200(t *testing.T) {
 
 // Head204 - Return 204 status code if successful
 func TestHead204(t *testing.T) {
-	client := newHTTPSuccessOperationsClient()
+	client := newHTTPSuccessClient(t)
 	resp, err := client.Head204(context.Background(), nil)
 	require.NoError(t, err)
 	if !resp.Success {
@@ -40,7 +49,7 @@ func TestHead204(t *testing.T) {
 
 // Head404 - Return 404 status code if successful
 func TestHead404(t *testing.T) {
-	client := newHTTPSuccessOperationsClient()
+	client := newHTTPSuccessClient(t)
 	resp, err := client.Head404(context.Background(), nil)
 	require.NoError(t, err)
 	if resp.Success {

--- a/test/autorest/headgroup/zz_httpsuccess_client.go
+++ b/test/autorest/headgroup/zz_httpsuccess_client.go
@@ -11,24 +11,16 @@ package headgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPSuccessClient contains the methods for the HTTPSuccess group.
-// Don't use this type directly, use NewHTTPSuccessClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPSuccessClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPSuccessClient creates a new instance of HTTPSuccessClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPSuccessClient(pl runtime.Pipeline) *HTTPSuccessClient {
-	client := &HTTPSuccessClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Head200 - Return 200 status code if successful
@@ -40,7 +32,7 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
@@ -69,7 +61,7 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
@@ -98,7 +90,7 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpclientfailure_test.go
@@ -9,197 +9,208 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPClientFailureClient() *HTTPClientFailureClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &policy.ClientOptions{
+func newHTTPClientFailureClient(t *testing.T) *HTTPClientFailureClient {
+	options := policy.ClientOptions{
 		Retry: policy.RetryOptions{
 			MaxRetryDelay: 2 * time.Second,
 		},
-	})
-	return NewHTTPClientFailureClient(pl)
+	}
+	client, err := NewHTTPClientFailureClient(&options)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPClientFailureClient(options *azcore.ClientOptions) (*HTTPClientFailureClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPClientFailureClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPClientFailureClient{internal: client}, nil
 }
 
 func TestHTTPClientFailureDelete400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Delete400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureDelete407(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Delete407(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureDelete417(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Delete417(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet402(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get402(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet403(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get403(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet411(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get411(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet412(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get412(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureGet416(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Get416(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureHead400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Head400(context.Background(), nil)
 	require.Error(t, err)
 	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead401(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Head401(context.Background(), nil)
 	require.Error(t, err)
 	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead410(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Head410(context.Background(), nil)
 	require.Error(t, err)
 	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureHead429(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Head429(context.Background(), nil)
 	require.Error(t, err)
 	require.False(t, result.Success)
 }
 
 func TestHTTPClientFailureOptions400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Options400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureOptions403(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Options403(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailureOptions412(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Options412(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePatch400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Patch400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePatch405(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Patch405(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePatch414(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Patch414(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePost400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Post400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePost406(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Post406(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePost415(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Post415(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePut400(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Put400(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePut404(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Put404(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePut409(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Put409(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPClientFailurePut413(t *testing.T) {
-	client := newHTTPClientFailureClient()
+	client := newHTTPClientFailureClient(t)
 	result, err := client.Put413(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpfailure_test.go
@@ -13,27 +13,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPFailureClient() *HTTPFailureClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHTTPFailureClient(pl)
+func newHTTPFailureClient(t *testing.T) *HTTPFailureClient {
+	client, err := NewHTTPFailureClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPFailureClient(options *azcore.ClientOptions) (*HTTPFailureClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPFailureClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPFailureClient{internal: client}, nil
 }
 
 func TestHTTPFailureGetEmptyError(t *testing.T) {
-	client := newHTTPFailureClient()
+	client := newHTTPFailureClient(t)
 	result, err := client.GetEmptyError(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPFailureGetNoModelEmpty(t *testing.T) {
-	client := newHTTPFailureClient()
+	client := newHTTPFailureClient(t)
 	result, err := client.GetNoModelEmpty(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPFailureGetNoModelError(t *testing.T) {
-	client := newHTTPFailureClient()
+	client := newHTTPFailureClient(t)
 	result, err := client.GetNoModelError(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpmultipleresponses_test.go
@@ -18,14 +18,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newMultipleResponsesClient() *MultipleResponsesClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewMultipleResponsesClient(pl)
+func newMultipleResponsesClient(t *testing.T) *MultipleResponsesClient {
+	client, err := NewMultipleResponsesClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewMultipleResponsesClient(options *azcore.ClientOptions) (*MultipleResponsesClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.MultipleResponsesClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &MultipleResponsesClient{internal: client}, nil
 }
 
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model201ModelDefaultError200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	switch x := result.Value.(type) {
@@ -42,7 +51,7 @@ func TestGet200Model201ModelDefaultError200Valid(t *testing.T) {
 
 // Get200Model201ModelDefaultError201Valid - Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
 func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model201ModelDefaultError201Valid(context.Background(), nil)
 	require.NoError(t, err)
 	r, ok := result.Value.(B)
@@ -59,7 +68,7 @@ func TestGet200Model201ModelDefaultError201Valid(t *testing.T) {
 
 // Get200Model201ModelDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200Model201ModelDefaultError400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model201ModelDefaultError400Valid(context.Background(), nil)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
@@ -84,7 +93,7 @@ ERROR CODE UNAVAILABLE
 
 // Get200Model204NoModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model204NoModelDefaultError200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.MyException, MyException{
@@ -96,7 +105,7 @@ func TestGet200Model204NoModelDefaultError200Valid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError201Invalid - Send a 201 response with valid payload: {'statusCode': '201'}
 func TestGet200Model204NoModelDefaultError201Invalid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model204NoModelDefaultError201Invalid(context.Background(), nil)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
@@ -120,7 +129,7 @@ ERROR CODE UNAVAILABLE
 
 // Get200Model204NoModelDefaultError202None - Send a 202 response with no payload:
 func TestGet200Model204NoModelDefaultError202None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model204NoModelDefaultError202None(context.Background(), nil)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
@@ -142,7 +151,7 @@ Response contained no body
 
 // Get200Model204NoModelDefaultError204Valid - Send a 204 response with no payload
 func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model204NoModelDefaultError204Valid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -153,7 +162,7 @@ func TestGet200Model204NoModelDefaultError204Valid(t *testing.T) {
 
 // Get200Model204NoModelDefaultError400Valid - Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
 func TestGet200Model204NoModelDefaultError400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200Model204NoModelDefaultError400Valid(context.Background(), nil)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
@@ -183,7 +192,7 @@ func TestGet200ModelA200Invalid(t *testing.T) {
 
 // Get200ModelA200None - Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A
 func TestGet200ModelA200None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA200None(context.Background(), nil)
 	require.NoError(t, err)
 	if !reflect.ValueOf(result.MyException).IsZero() {
@@ -193,7 +202,7 @@ func TestGet200ModelA200None(t *testing.T) {
 
 // Get200ModelA200Valid - Send a 200 response with payload {'statusCode': '200'}
 func TestGet200ModelA200Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.MyException, MyException{
@@ -205,7 +214,7 @@ func TestGet200ModelA200Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	r, ok := result.Value.(MyException)
@@ -221,7 +230,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError200Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError201Valid - Send a 200 response with valid payload: {'httpCode': '201'}
 func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError201Valid(context.Background(), nil)
 	require.NoError(t, err)
 	r, ok := result.Value.(C)
@@ -237,7 +246,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError201Valid(t *testing.T) {
 
 // Get200ModelA201ModelC404ModelDDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet200ModelA201ModelC404ModelDDefaultError400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError400Valid(context.Background(), nil)
 	var respErr *azcore.ResponseError
 	if !errors.As(err, &respErr) {
@@ -262,7 +271,7 @@ ERROR CODE UNAVAILABLE
 
 // Get200ModelA201ModelC404ModelDDefaultError404Valid - Send a 200 response with valid payload: {'httpStatusCode': '404'}
 func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA201ModelC404ModelDDefaultError404Valid(context.Background(), nil)
 	require.NoError(t, err)
 	r, ok := result.Value.(D)
@@ -278,7 +287,7 @@ func TestGet200ModelA201ModelC404ModelDDefaultError404Valid(t *testing.T) {
 
 // Get200ModelA202Valid - Send a 202 response with payload {'statusCode': '202'}
 func TestGet200ModelA202Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.MyException, MyException{
@@ -295,7 +304,7 @@ func TestGet200ModelA400Invalid(t *testing.T) {
 
 // Get200ModelA400None - Send a 400 response with no payload client should treat as an http error with no error model
 func TestGet200ModelA400None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA400None(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -303,7 +312,7 @@ func TestGet200ModelA400None(t *testing.T) {
 
 // Get200ModelA400Valid - Send a 200 response with payload {'statusCode': '400'}
 func TestGet200ModelA400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get200ModelA400Valid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -311,7 +320,7 @@ func TestGet200ModelA400Valid(t *testing.T) {
 
 // Get202None204NoneDefaultError202None - Send a 202 response with no payload
 func TestGet202None204NoneDefaultError202None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultError202None(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -319,7 +328,7 @@ func TestGet202None204NoneDefaultError202None(t *testing.T) {
 
 // Get202None204NoneDefaultError204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultError204None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultError204None(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -327,7 +336,7 @@ func TestGet202None204NoneDefaultError204None(t *testing.T) {
 
 // Get202None204NoneDefaultError400Valid - Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
 func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultError400Valid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -335,7 +344,7 @@ func TestGet202None204NoneDefaultError400Valid(t *testing.T) {
 
 // Get202None204NoneDefaultNone202Invalid - Send a 202 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultNone202Invalid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -343,7 +352,7 @@ func TestGet202None204NoneDefaultNone202Invalid(t *testing.T) {
 
 // Get202None204NoneDefaultNone204None - Send a 204 response with no payload
 func TestGet202None204NoneDefaultNone204None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultNone204None(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -351,7 +360,7 @@ func TestGet202None204NoneDefaultNone204None(t *testing.T) {
 
 // Get202None204NoneDefaultNone400Invalid - Send a 400 response with an unexpected payload {'property': 'value'}
 func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultNone400Invalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -359,7 +368,7 @@ func TestGet202None204NoneDefaultNone400Invalid(t *testing.T) {
 
 // Get202None204NoneDefaultNone400None - Send a 400 response with no payload
 func TestGet202None204NoneDefaultNone400None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.Get202None204NoneDefaultNone400None(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -367,7 +376,7 @@ func TestGet202None204NoneDefaultNone400None(t *testing.T) {
 
 // GetDefaultModelA200None - Send a 200 response with no payload
 func TestGetDefaultModelA200None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultModelA200None(context.Background(), nil)
 	require.NoError(t, err)
 	if !reflect.ValueOf(result.MyException).IsZero() {
@@ -377,7 +386,7 @@ func TestGetDefaultModelA200None(t *testing.T) {
 
 // GetDefaultModelA200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
 func TestGetDefaultModelA200Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultModelA200Valid(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.MyException, MyException{
@@ -389,7 +398,7 @@ func TestGetDefaultModelA200Valid(t *testing.T) {
 
 // GetDefaultModelA400None - Send a 400 response with no payload
 func TestGetDefaultModelA400None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultModelA400None(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -397,7 +406,7 @@ func TestGetDefaultModelA400None(t *testing.T) {
 
 // GetDefaultModelA400Valid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultModelA400Valid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultModelA400Valid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -410,7 +419,7 @@ func TestGetDefaultNone200Invalid(t *testing.T) {
 
 // GetDefaultNone200None - Send a 200 response with no payload
 func TestGetDefaultNone200None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultNone200None(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -418,7 +427,7 @@ func TestGetDefaultNone200None(t *testing.T) {
 
 // GetDefaultNone400Invalid - Send a 400 response with valid payload: {'statusCode': '400'}
 func TestGetDefaultNone400Invalid(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultNone400Invalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -426,7 +435,7 @@ func TestGetDefaultNone400Invalid(t *testing.T) {
 
 // GetDefaultNone400None - Send a 400 response with no payload
 func TestGetDefaultNone400None(t *testing.T) {
-	client := newMultipleResponsesClient()
+	client := newMultipleResponsesClient(t)
 	result, err := client.GetDefaultNone400None(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpredirects_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpredirects_test.go
@@ -13,13 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPRedirectsClient() *HTTPRedirectsClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHTTPRedirectsClient(pl)
+func newHTTPRedirectsClient(t *testing.T) *HTTPRedirectsClient {
+	client, err := NewHTTPRedirectsClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPRedirectsClient(options *azcore.ClientOptions) (*HTTPRedirectsClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPRedirectsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPRedirectsClient{internal: client}, nil
 }
 
 func TestHTTPRedirectsDelete307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Delete307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -27,28 +36,28 @@ func TestHTTPRedirectsDelete307(t *testing.T) {
 
 func TestHTTPRedirectsGet300(t *testing.T) {
 	t.Skip("does not automatically redirect")
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Get300(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsGet301(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Get301(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsGet302(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Get302(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsGet307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Get307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -56,14 +65,14 @@ func TestHTTPRedirectsGet307(t *testing.T) {
 
 func TestHTTPRedirectsHead300(t *testing.T) {
 	t.Skip("does not automatically redirect")
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Head300(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsHead301(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Head301(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -72,7 +81,7 @@ func TestHTTPRedirectsHead301(t *testing.T) {
 }
 
 func TestHTTPRedirectsHead302(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Head302(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -81,7 +90,7 @@ func TestHTTPRedirectsHead302(t *testing.T) {
 }
 
 func TestHTTPRedirectsHead307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Head307(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -91,7 +100,7 @@ func TestHTTPRedirectsHead307(t *testing.T) {
 
 func TestHTTPRedirectsOptions307(t *testing.T) {
 	t.Skip("receive a status code of 204 which is not expected")
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Options307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -99,28 +108,28 @@ func TestHTTPRedirectsOptions307(t *testing.T) {
 
 func TestHTTPRedirectsPatch302(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Patch302(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsPatch307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Patch307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsPost303(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Post303(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsPost307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Post307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -128,14 +137,14 @@ func TestHTTPRedirectsPost307(t *testing.T) {
 
 func TestHTTPRedirectsPut301(t *testing.T) {
 	t.Skip("HTTP client automatically redirects, test server doesn't expect it")
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Put301(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRedirectsPut307(t *testing.T) {
-	client := newHTTPRedirectsClient()
+	client := newHTTPRedirectsClient(t)
 	result, err := client.Put307(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpretry_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpretry_test.go
@@ -17,12 +17,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPRetryClient() *HTTPRetryClient {
+func newHTTPRetryClient(t *testing.T) *HTTPRetryClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = 10 * time.Millisecond
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
-	return NewHTTPRetryClient(pl)
+	client, err := NewHTTPRetryClient(&options)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPRetryClient(options *azcore.ClientOptions) (*HTTPRetryClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPRetryClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPRetryClient{internal: client}, nil
 }
 
 func httpClientWithCookieJar() policy.Transporter {
@@ -35,21 +44,21 @@ func httpClientWithCookieJar() policy.Transporter {
 }
 
 func TestHTTPRetryDelete503(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Delete503(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryGet502(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Get502(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryHead408(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Head408(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -59,42 +68,42 @@ func TestHTTPRetryHead408(t *testing.T) {
 
 func TestHTTPRetryOptions502(t *testing.T) {
 	t.Skip("options method not enabled by test server")
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Options502(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryPatch500(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Patch500(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryPatch504(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Patch504(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryPost503(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Post503(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryPut500(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Put500(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPRetryPut504(t *testing.T) {
-	client := newHTTPRetryClient()
+	client := newHTTPRetryClient(t)
 	result, err := client.Put504(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpserverfailure_test.go
@@ -13,34 +13,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPServerFailureClient() *HTTPServerFailureClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHTTPServerFailureClient(pl)
+func newHTTPServerFailureClient(t *testing.T) *HTTPServerFailureClient {
+	client, err := NewHTTPServerFailureClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPServerFailureClient(options *azcore.ClientOptions) (*HTTPServerFailureClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPServerFailureClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPServerFailureClient{internal: client}, nil
 }
 
 func TestHTTPServerFailureDelete505(t *testing.T) {
-	client := newHTTPServerFailureClient()
+	client := newHTTPServerFailureClient(t)
 	result, err := client.Delete505(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPServerFailureGet501(t *testing.T) {
-	client := newHTTPServerFailureClient()
+	client := newHTTPServerFailureClient(t)
 	result, err := client.Get501(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPServerFailureHead501(t *testing.T) {
-	client := newHTTPServerFailureClient()
+	client := newHTTPServerFailureClient(t)
 	result, err := client.Head501(context.Background(), nil)
 	require.Error(t, err)
 	require.False(t, result.Success)
 }
 
 func TestHTTPServerFailurePost505(t *testing.T) {
-	client := newHTTPServerFailureClient()
+	client := newHTTPServerFailureClient(t)
 	result, err := client.Post505(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
+++ b/test/autorest/httpinfrastructuregroup/httpsuccess_test.go
@@ -13,34 +13,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newHTTPSuccessClient() *HTTPSuccessClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewHTTPSuccessClient(pl)
+func newHTTPSuccessClient(t *testing.T) *HTTPSuccessClient {
+	client, err := NewHTTPSuccessClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewHTTPSuccessClient(options *azcore.ClientOptions) (*HTTPSuccessClient, error) {
+	client, err := azcore.NewClient("httpinfrastructuregroup.HTTPSuccessClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &HTTPSuccessClient{internal: client}, nil
 }
 
 func TestHTTPSuccessDelete200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Delete200(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessDelete202(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Delete202(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessDelete204(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Delete204(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessGet200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Get200(context.Background(), nil)
 	require.NoError(t, err)
 	if !*result.Value {
@@ -49,7 +58,7 @@ func TestHTTPSuccessGet200(t *testing.T) {
 }
 
 func TestHTTPSuccessHead200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Head200(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -58,7 +67,7 @@ func TestHTTPSuccessHead200(t *testing.T) {
 }
 
 func TestHTTPSuccessHead204(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Head204(context.Background(), nil)
 	require.NoError(t, err)
 	if !result.Success {
@@ -67,7 +76,7 @@ func TestHTTPSuccessHead204(t *testing.T) {
 }
 
 func TestHTTPSuccessHead404(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Head404(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Success {
@@ -77,84 +86,84 @@ func TestHTTPSuccessHead404(t *testing.T) {
 
 func TestHTTPSuccessOptions200(t *testing.T) {
 	t.Skip("options method not enabled by test server")
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Options200(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPatch200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Patch200(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPatch202(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Patch202(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPatch204(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Patch204(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPost200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Post200(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPost201(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Post201(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPost202(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Post202(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPost204(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Post204(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPut200(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Put200(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPut201(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Put201(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPut202(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Put202(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestHTTPSuccessPut204(t *testing.T) {
-	client := newHTTPSuccessClient()
+	client := newHTTPSuccessClient(t)
 	result, err := client.Put204(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/httpinfrastructuregroup/zz_httpclientfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpclientfailure_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPClientFailureClient contains the methods for the HTTPClientFailure group.
-// Don't use this type directly, use NewHTTPClientFailureClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPClientFailureClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPClientFailureClient creates a new instance of HTTPClientFailureClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPClientFailureClient(pl runtime.Pipeline) *HTTPClientFailureClient {
-	client := &HTTPClientFailureClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Delete400 - Return 400 status code - should be represented in the client as an error
@@ -42,7 +34,7 @@ func (client *HTTPClientFailureClient) Delete400(ctx context.Context, options *H
 	if err != nil {
 		return HTTPClientFailureClientDelete400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientDelete400Response{}, err
 	}
@@ -74,7 +66,7 @@ func (client *HTTPClientFailureClient) Delete407(ctx context.Context, options *H
 	if err != nil {
 		return HTTPClientFailureClientDelete407Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientDelete407Response{}, err
 	}
@@ -106,7 +98,7 @@ func (client *HTTPClientFailureClient) Delete417(ctx context.Context, options *H
 	if err != nil {
 		return HTTPClientFailureClientDelete417Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientDelete417Response{}, err
 	}
@@ -138,7 +130,7 @@ func (client *HTTPClientFailureClient) Get400(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet400Response{}, err
 	}
@@ -170,7 +162,7 @@ func (client *HTTPClientFailureClient) Get402(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet402Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet402Response{}, err
 	}
@@ -202,7 +194,7 @@ func (client *HTTPClientFailureClient) Get403(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet403Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet403Response{}, err
 	}
@@ -234,7 +226,7 @@ func (client *HTTPClientFailureClient) Get411(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet411Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet411Response{}, err
 	}
@@ -266,7 +258,7 @@ func (client *HTTPClientFailureClient) Get412(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet412Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet412Response{}, err
 	}
@@ -298,7 +290,7 @@ func (client *HTTPClientFailureClient) Get416(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientGet416Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientGet416Response{}, err
 	}
@@ -329,7 +321,7 @@ func (client *HTTPClientFailureClient) Head400(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientHead400Response{}, err
 	}
@@ -360,7 +352,7 @@ func (client *HTTPClientFailureClient) Head401(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead401Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientHead401Response{}, err
 	}
@@ -391,7 +383,7 @@ func (client *HTTPClientFailureClient) Head410(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead410Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientHead410Response{}, err
 	}
@@ -422,7 +414,7 @@ func (client *HTTPClientFailureClient) Head429(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientHead429Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientHead429Response{}, err
 	}
@@ -454,7 +446,7 @@ func (client *HTTPClientFailureClient) Options400(ctx context.Context, options *
 	if err != nil {
 		return HTTPClientFailureClientOptions400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientOptions400Response{}, err
 	}
@@ -486,7 +478,7 @@ func (client *HTTPClientFailureClient) Options403(ctx context.Context, options *
 	if err != nil {
 		return HTTPClientFailureClientOptions403Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientOptions403Response{}, err
 	}
@@ -518,7 +510,7 @@ func (client *HTTPClientFailureClient) Options412(ctx context.Context, options *
 	if err != nil {
 		return HTTPClientFailureClientOptions412Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientOptions412Response{}, err
 	}
@@ -550,7 +542,7 @@ func (client *HTTPClientFailureClient) Patch400(ctx context.Context, options *HT
 	if err != nil {
 		return HTTPClientFailureClientPatch400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPatch400Response{}, err
 	}
@@ -582,7 +574,7 @@ func (client *HTTPClientFailureClient) Patch405(ctx context.Context, options *HT
 	if err != nil {
 		return HTTPClientFailureClientPatch405Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPatch405Response{}, err
 	}
@@ -614,7 +606,7 @@ func (client *HTTPClientFailureClient) Patch414(ctx context.Context, options *HT
 	if err != nil {
 		return HTTPClientFailureClientPatch414Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPatch414Response{}, err
 	}
@@ -646,7 +638,7 @@ func (client *HTTPClientFailureClient) Post400(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientPost400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPost400Response{}, err
 	}
@@ -678,7 +670,7 @@ func (client *HTTPClientFailureClient) Post406(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientPost406Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPost406Response{}, err
 	}
@@ -710,7 +702,7 @@ func (client *HTTPClientFailureClient) Post415(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPClientFailureClientPost415Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPost415Response{}, err
 	}
@@ -742,7 +734,7 @@ func (client *HTTPClientFailureClient) Put400(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientPut400Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPut400Response{}, err
 	}
@@ -774,7 +766,7 @@ func (client *HTTPClientFailureClient) Put404(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientPut404Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPut404Response{}, err
 	}
@@ -806,7 +798,7 @@ func (client *HTTPClientFailureClient) Put409(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientPut409Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPut409Response{}, err
 	}
@@ -838,7 +830,7 @@ func (client *HTTPClientFailureClient) Put413(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPClientFailureClientPut413Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPClientFailureClientPut413Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_httpfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpfailure_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPFailureClient contains the methods for the HTTPFailure group.
-// Don't use this type directly, use NewHTTPFailureClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPFailureClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPFailureClient creates a new instance of HTTPFailureClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPFailureClient(pl runtime.Pipeline) *HTTPFailureClient {
-	client := &HTTPFailureClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetEmptyError - Get empty error form server
@@ -42,7 +34,7 @@ func (client *HTTPFailureClient) GetEmptyError(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPFailureClientGetEmptyErrorResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPFailureClientGetEmptyErrorResponse{}, err
 	}
@@ -83,7 +75,7 @@ func (client *HTTPFailureClient) GetNoModelEmpty(ctx context.Context, options *H
 	if err != nil {
 		return HTTPFailureClientGetNoModelEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPFailureClientGetNoModelEmptyResponse{}, err
 	}
@@ -124,7 +116,7 @@ func (client *HTTPFailureClient) GetNoModelError(ctx context.Context, options *H
 	if err != nil {
 		return HTTPFailureClientGetNoModelErrorResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPFailureClientGetNoModelErrorResponse{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_httpredirects_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpredirects_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPRedirectsClient contains the methods for the HTTPRedirects group.
-// Don't use this type directly, use NewHTTPRedirectsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPRedirectsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPRedirectsClient creates a new instance of HTTPRedirectsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPRedirectsClient(pl runtime.Pipeline) *HTTPRedirectsClient {
-	client := &HTTPRedirectsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Delete307 - Delete redirected with 307, resulting in a 200 after redirect
@@ -41,7 +33,7 @@ func (client *HTTPRedirectsClient) Delete307(ctx context.Context, options *HTTPR
 	if err != nil {
 		return HTTPRedirectsClientDelete307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientDelete307Response{}, err
 	}
@@ -72,7 +64,7 @@ func (client *HTTPRedirectsClient) Get300(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientGet300Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientGet300Response{}, err
 	}
@@ -115,7 +107,7 @@ func (client *HTTPRedirectsClient) Get301(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientGet301Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientGet301Response{}, err
 	}
@@ -146,7 +138,7 @@ func (client *HTTPRedirectsClient) Get302(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientGet302Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientGet302Response{}, err
 	}
@@ -177,7 +169,7 @@ func (client *HTTPRedirectsClient) Get307(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientGet307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientGet307Response{}, err
 	}
@@ -207,7 +199,7 @@ func (client *HTTPRedirectsClient) Head300(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead300Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientHead300Response{}, err
 	}
@@ -247,7 +239,7 @@ func (client *HTTPRedirectsClient) Head301(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead301Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientHead301Response{}, err
 	}
@@ -277,7 +269,7 @@ func (client *HTTPRedirectsClient) Head302(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead302Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientHead302Response{}, err
 	}
@@ -307,7 +299,7 @@ func (client *HTTPRedirectsClient) Head307(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientHead307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientHead307Response{}, err
 	}
@@ -339,7 +331,7 @@ func (client *HTTPRedirectsClient) Options307(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPRedirectsClientOptions307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientOptions307Response{}, err
 	}
@@ -371,7 +363,7 @@ func (client *HTTPRedirectsClient) Patch302(ctx context.Context, options *HTTPRe
 	if err != nil {
 		return HTTPRedirectsClientPatch302Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPatch302Response{}, err
 	}
@@ -411,7 +403,7 @@ func (client *HTTPRedirectsClient) Patch307(ctx context.Context, options *HTTPRe
 	if err != nil {
 		return HTTPRedirectsClientPatch307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPatch307Response{}, err
 	}
@@ -443,7 +435,7 @@ func (client *HTTPRedirectsClient) Post303(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientPost303Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPost303Response{}, err
 	}
@@ -483,7 +475,7 @@ func (client *HTTPRedirectsClient) Post307(ctx context.Context, options *HTTPRed
 	if err != nil {
 		return HTTPRedirectsClientPost307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPost307Response{}, err
 	}
@@ -515,7 +507,7 @@ func (client *HTTPRedirectsClient) Put301(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientPut301Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPut301Response{}, err
 	}
@@ -555,7 +547,7 @@ func (client *HTTPRedirectsClient) Put307(ctx context.Context, options *HTTPRedi
 	if err != nil {
 		return HTTPRedirectsClientPut307Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRedirectsClientPut307Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_httpretry_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpretry_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPRetryClient contains the methods for the HTTPRetry group.
-// Don't use this type directly, use NewHTTPRetryClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPRetryClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPRetryClient creates a new instance of HTTPRetryClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPRetryClient(pl runtime.Pipeline) *HTTPRetryClient {
-	client := &HTTPRetryClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Delete503 - Return 503 status code, then 200 after retry
@@ -41,7 +33,7 @@ func (client *HTTPRetryClient) Delete503(ctx context.Context, options *HTTPRetry
 	if err != nil {
 		return HTTPRetryClientDelete503Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientDelete503Response{}, err
 	}
@@ -72,7 +64,7 @@ func (client *HTTPRetryClient) Get502(ctx context.Context, options *HTTPRetryCli
 	if err != nil {
 		return HTTPRetryClientGet502Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientGet502Response{}, err
 	}
@@ -102,7 +94,7 @@ func (client *HTTPRetryClient) Head408(ctx context.Context, options *HTTPRetryCl
 	if err != nil {
 		return HTTPRetryClientHead408Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientHead408Response{}, err
 	}
@@ -133,7 +125,7 @@ func (client *HTTPRetryClient) Options502(ctx context.Context, options *HTTPRetr
 	if err != nil {
 		return HTTPRetryClientOptions502Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientOptions502Response{}, err
 	}
@@ -173,7 +165,7 @@ func (client *HTTPRetryClient) Patch500(ctx context.Context, options *HTTPRetryC
 	if err != nil {
 		return HTTPRetryClientPatch500Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientPatch500Response{}, err
 	}
@@ -204,7 +196,7 @@ func (client *HTTPRetryClient) Patch504(ctx context.Context, options *HTTPRetryC
 	if err != nil {
 		return HTTPRetryClientPatch504Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientPatch504Response{}, err
 	}
@@ -235,7 +227,7 @@ func (client *HTTPRetryClient) Post503(ctx context.Context, options *HTTPRetryCl
 	if err != nil {
 		return HTTPRetryClientPost503Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientPost503Response{}, err
 	}
@@ -266,7 +258,7 @@ func (client *HTTPRetryClient) Put500(ctx context.Context, options *HTTPRetryCli
 	if err != nil {
 		return HTTPRetryClientPut500Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientPut500Response{}, err
 	}
@@ -297,7 +289,7 @@ func (client *HTTPRetryClient) Put504(ctx context.Context, options *HTTPRetryCli
 	if err != nil {
 		return HTTPRetryClientPut504Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPRetryClientPut504Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_httpserverfailure_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpserverfailure_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPServerFailureClient contains the methods for the HTTPServerFailure group.
-// Don't use this type directly, use NewHTTPServerFailureClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPServerFailureClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPServerFailureClient creates a new instance of HTTPServerFailureClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPServerFailureClient(pl runtime.Pipeline) *HTTPServerFailureClient {
-	client := &HTTPServerFailureClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Delete505 - Return 505 status code - should be represented in the client as an error
@@ -42,7 +34,7 @@ func (client *HTTPServerFailureClient) Delete505(ctx context.Context, options *H
 	if err != nil {
 		return HTTPServerFailureClientDelete505Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPServerFailureClientDelete505Response{}, err
 	}
@@ -74,7 +66,7 @@ func (client *HTTPServerFailureClient) Get501(ctx context.Context, options *HTTP
 	if err != nil {
 		return HTTPServerFailureClientGet501Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPServerFailureClientGet501Response{}, err
 	}
@@ -105,7 +97,7 @@ func (client *HTTPServerFailureClient) Head501(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPServerFailureClientHead501Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPServerFailureClientHead501Response{}, err
 	}
@@ -137,7 +129,7 @@ func (client *HTTPServerFailureClient) Post505(ctx context.Context, options *HTT
 	if err != nil {
 		return HTTPServerFailureClientPost505Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPServerFailureClientPost505Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_httpsuccess_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_httpsuccess_client.go
@@ -11,24 +11,16 @@ package httpinfrastructuregroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // HTTPSuccessClient contains the methods for the HTTPSuccess group.
-// Don't use this type directly, use NewHTTPSuccessClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HTTPSuccessClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHTTPSuccessClient creates a new instance of HTTPSuccessClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHTTPSuccessClient(pl runtime.Pipeline) *HTTPSuccessClient {
-	client := &HTTPSuccessClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Delete200 - Delete simple boolean value true returns 200
@@ -41,7 +33,7 @@ func (client *HTTPSuccessClient) Delete200(ctx context.Context, options *HTTPSuc
 	if err != nil {
 		return HTTPSuccessClientDelete200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientDelete200Response{}, err
 	}
@@ -72,7 +64,7 @@ func (client *HTTPSuccessClient) Delete202(ctx context.Context, options *HTTPSuc
 	if err != nil {
 		return HTTPSuccessClientDelete202Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientDelete202Response{}, err
 	}
@@ -103,7 +95,7 @@ func (client *HTTPSuccessClient) Delete204(ctx context.Context, options *HTTPSuc
 	if err != nil {
 		return HTTPSuccessClientDelete204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientDelete204Response{}, err
 	}
@@ -134,7 +126,7 @@ func (client *HTTPSuccessClient) Get200(ctx context.Context, options *HTTPSucces
 	if err != nil {
 		return HTTPSuccessClientGet200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientGet200Response{}, err
 	}
@@ -173,7 +165,7 @@ func (client *HTTPSuccessClient) Head200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead200Response{}, err
 	}
@@ -203,7 +195,7 @@ func (client *HTTPSuccessClient) Head204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead204Response{}, err
 	}
@@ -233,7 +225,7 @@ func (client *HTTPSuccessClient) Head404(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientHead404Response{}, err
 	}
@@ -264,7 +256,7 @@ func (client *HTTPSuccessClient) Options200(ctx context.Context, options *HTTPSu
 	if err != nil {
 		return HTTPSuccessClientOptions200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientOptions200Response{}, err
 	}
@@ -304,7 +296,7 @@ func (client *HTTPSuccessClient) Patch200(ctx context.Context, options *HTTPSucc
 	if err != nil {
 		return HTTPSuccessClientPatch200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPatch200Response{}, err
 	}
@@ -335,7 +327,7 @@ func (client *HTTPSuccessClient) Patch202(ctx context.Context, options *HTTPSucc
 	if err != nil {
 		return HTTPSuccessClientPatch202Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPatch202Response{}, err
 	}
@@ -366,7 +358,7 @@ func (client *HTTPSuccessClient) Patch204(ctx context.Context, options *HTTPSucc
 	if err != nil {
 		return HTTPSuccessClientPatch204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPatch204Response{}, err
 	}
@@ -397,7 +389,7 @@ func (client *HTTPSuccessClient) Post200(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientPost200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPost200Response{}, err
 	}
@@ -428,7 +420,7 @@ func (client *HTTPSuccessClient) Post201(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientPost201Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPost201Response{}, err
 	}
@@ -459,7 +451,7 @@ func (client *HTTPSuccessClient) Post202(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientPost202Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPost202Response{}, err
 	}
@@ -490,7 +482,7 @@ func (client *HTTPSuccessClient) Post204(ctx context.Context, options *HTTPSucce
 	if err != nil {
 		return HTTPSuccessClientPost204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPost204Response{}, err
 	}
@@ -521,7 +513,7 @@ func (client *HTTPSuccessClient) Put200(ctx context.Context, options *HTTPSucces
 	if err != nil {
 		return HTTPSuccessClientPut200Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPut200Response{}, err
 	}
@@ -552,7 +544,7 @@ func (client *HTTPSuccessClient) Put201(ctx context.Context, options *HTTPSucces
 	if err != nil {
 		return HTTPSuccessClientPut201Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPut201Response{}, err
 	}
@@ -583,7 +575,7 @@ func (client *HTTPSuccessClient) Put202(ctx context.Context, options *HTTPSucces
 	if err != nil {
 		return HTTPSuccessClientPut202Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPut202Response{}, err
 	}
@@ -614,7 +606,7 @@ func (client *HTTPSuccessClient) Put204(ctx context.Context, options *HTTPSucces
 	if err != nil {
 		return HTTPSuccessClientPut204Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HTTPSuccessClientPut204Response{}, err
 	}

--- a/test/autorest/httpinfrastructuregroup/zz_multipleresponses_client.go
+++ b/test/autorest/httpinfrastructuregroup/zz_multipleresponses_client.go
@@ -12,24 +12,16 @@ package httpinfrastructuregroup
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // MultipleResponsesClient contains the methods for the MultipleResponses group.
-// Don't use this type directly, use NewMultipleResponsesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type MultipleResponsesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewMultipleResponsesClient creates a new instance of MultipleResponsesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewMultipleResponsesClient(pl runtime.Pipeline) *MultipleResponsesClient {
-	client := &MultipleResponsesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Get200Model201ModelDefaultError200Valid - Send a 200 response with valid payload: {'statusCode': '200'}
@@ -43,7 +35,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError200Valid(c
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError200ValidResponse{}, err
 	}
@@ -98,7 +90,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError201Valid(c
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError201ValidResponse{}, err
 	}
@@ -152,7 +144,7 @@ func (client *MultipleResponsesClient) Get200Model201ModelDefaultError400Valid(c
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model201ModelDefaultError400ValidResponse{}, err
 	}
@@ -206,7 +198,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError200Valid
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError200ValidResponse{}, err
 	}
@@ -247,7 +239,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError201Inval
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError201InvalidResponse{}, err
 	}
@@ -288,7 +280,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError202None(
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError202NoneResponse{}, err
 	}
@@ -329,7 +321,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError204Valid
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError204ValidResponse{}, err
 	}
@@ -371,7 +363,7 @@ func (client *MultipleResponsesClient) Get200Model204NoModelDefaultError400Valid
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200Model204NoModelDefaultError400ValidResponse{}, err
 	}
@@ -412,7 +404,7 @@ func (client *MultipleResponsesClient) Get200ModelA200Invalid(ctx context.Contex
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200InvalidResponse{}, err
 	}
@@ -454,7 +446,7 @@ func (client *MultipleResponsesClient) Get200ModelA200None(ctx context.Context, 
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200NoneResponse{}, err
 	}
@@ -495,7 +487,7 @@ func (client *MultipleResponsesClient) Get200ModelA200Valid(ctx context.Context,
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA200ValidResponse{}, err
 	}
@@ -536,7 +528,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError200ValidResponse{}, err
 	}
@@ -596,7 +588,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError201ValidResponse{}, err
 	}
@@ -657,7 +649,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError400ValidResponse{}, err
 	}
@@ -717,7 +709,7 @@ func (client *MultipleResponsesClient) Get200ModelA201ModelC404ModelDDefaultErro
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA201ModelC404ModelDDefaultError404ValidResponse{}, err
 	}
@@ -777,7 +769,7 @@ func (client *MultipleResponsesClient) Get200ModelA202Valid(ctx context.Context,
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA202ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA202ValidResponse{}, err
 	}
@@ -818,7 +810,7 @@ func (client *MultipleResponsesClient) Get200ModelA400Invalid(ctx context.Contex
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400InvalidResponse{}, err
 	}
@@ -859,7 +851,7 @@ func (client *MultipleResponsesClient) Get200ModelA400None(ctx context.Context, 
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400NoneResponse{}, err
 	}
@@ -900,7 +892,7 @@ func (client *MultipleResponsesClient) Get200ModelA400Valid(ctx context.Context,
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet200ModelA400ValidResponse{}, err
 	}
@@ -941,7 +933,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError202None(ctx 
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError202NoneResponse{}, err
 	}
@@ -973,7 +965,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError204None(ctx 
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError204NoneResponse{}, err
 	}
@@ -1005,7 +997,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultError400Valid(ctx
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultError400ValidResponse{}, err
 	}
@@ -1037,7 +1029,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone202Invalid(ct
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone202InvalidResponse{}, err
 	}
@@ -1068,7 +1060,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone204None(ctx c
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone204NoneResponse{}, err
 	}
@@ -1099,7 +1091,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400Invalid(ct
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400InvalidResponse{}, err
 	}
@@ -1130,7 +1122,7 @@ func (client *MultipleResponsesClient) Get202None204NoneDefaultNone400None(ctx c
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGet202None204NoneDefaultNone400NoneResponse{}, err
 	}
@@ -1161,7 +1153,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200None(ctx context.Conte
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA200NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA200NoneResponse{}, err
 	}
@@ -1202,7 +1194,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA200Valid(ctx context.Cont
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA200ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA200ValidResponse{}, err
 	}
@@ -1243,7 +1235,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400None(ctx context.Conte
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA400NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA400NoneResponse{}, err
 	}
@@ -1275,7 +1267,7 @@ func (client *MultipleResponsesClient) GetDefaultModelA400Valid(ctx context.Cont
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA400ValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultModelA400ValidResponse{}, err
 	}
@@ -1307,7 +1299,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200Invalid(ctx context.Cont
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone200InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone200InvalidResponse{}, err
 	}
@@ -1338,7 +1330,7 @@ func (client *MultipleResponsesClient) GetDefaultNone200None(ctx context.Context
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone200NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone200NoneResponse{}, err
 	}
@@ -1369,7 +1361,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400Invalid(ctx context.Cont
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone400InvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone400InvalidResponse{}, err
 	}
@@ -1400,7 +1392,7 @@ func (client *MultipleResponsesClient) GetDefaultNone400None(ctx context.Context
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone400NoneResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleResponsesClientGetDefaultNone400NoneResponse{}, err
 	}

--- a/test/autorest/integergroup/integergroup_test.go
+++ b/test/autorest/integergroup/integergroup_test.go
@@ -16,27 +16,36 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newIntClient() *IntClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewIntClient(pl)
+func newIntClient(t *testing.T) *IntClient {
+	client, err := NewIntClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewIntClient(options *azcore.ClientOptions) (*IntClient, error) {
+	client, err := azcore.NewClient("integergroup.IntClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &IntClient{internal: client}, nil
 }
 
 func TestIntGetInvalid(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetInvalid(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetInvalidUnixTime(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetInvalidUnixTime(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetNull(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, (*int32)(nil)); r != "" {
@@ -45,7 +54,7 @@ func TestIntGetNull(t *testing.T) {
 }
 
 func TestIntGetNullUnixTime(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetNullUnixTime(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Value != nil {
@@ -54,35 +63,35 @@ func TestIntGetNullUnixTime(t *testing.T) {
 }
 
 func TestIntGetOverflowInt32(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetOverflowInt32(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetOverflowInt64(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetOverflowInt64(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetUnderflowInt32(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetUnderflowInt32(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetUnderflowInt64(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetUnderflowInt64(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntGetUnixTime(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.GetUnixTime(context.Background(), nil)
 	require.NoError(t, err)
 	t1 := time.Unix(1460505600, 0)
@@ -92,35 +101,35 @@ func TestIntGetUnixTime(t *testing.T) {
 }
 
 func TestIntPutMax32(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.PutMax32(context.Background(), math.MaxInt32, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntPutMax64(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.PutMax64(context.Background(), math.MaxInt64, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntPutMin32(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.PutMin32(context.Background(), math.MinInt32, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntPutMin64(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.PutMin64(context.Background(), math.MinInt64, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestIntPutUnixTimeDate(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	t1 := time.Unix(1460505600, 0)
 	result, err := client.PutUnixTimeDate(context.Background(), t1, nil)
 	require.NoError(t, err)

--- a/test/autorest/integergroup/zz_int_client.go
+++ b/test/autorest/integergroup/zz_int_client.go
@@ -11,6 +11,7 @@ package integergroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // IntClient contains the methods for the Int group.
-// Don't use this type directly, use NewIntClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type IntClient struct {
-	pl runtime.Pipeline
-}
-
-// NewIntClient creates a new instance of IntClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewIntClient(pl runtime.Pipeline) *IntClient {
-	client := &IntClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetInvalid - Get invalid Int value
@@ -42,7 +34,7 @@ func (client *IntClient) GetInvalid(ctx context.Context, options *IntClientGetIn
 	if err != nil {
 		return IntClientGetInvalidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetInvalidResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *IntClient) GetInvalidUnixTime(ctx context.Context, options *IntCli
 	if err != nil {
 		return IntClientGetInvalidUnixTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetInvalidUnixTimeResponse{}, err
 	}
@@ -124,7 +116,7 @@ func (client *IntClient) GetNull(ctx context.Context, options *IntClientGetNullO
 	if err != nil {
 		return IntClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetNullResponse{}, err
 	}
@@ -164,7 +156,7 @@ func (client *IntClient) GetNullUnixTime(ctx context.Context, options *IntClient
 	if err != nil {
 		return IntClientGetNullUnixTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetNullUnixTimeResponse{}, err
 	}
@@ -206,7 +198,7 @@ func (client *IntClient) GetOverflowInt32(ctx context.Context, options *IntClien
 	if err != nil {
 		return IntClientGetOverflowInt32Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetOverflowInt32Response{}, err
 	}
@@ -246,7 +238,7 @@ func (client *IntClient) GetOverflowInt64(ctx context.Context, options *IntClien
 	if err != nil {
 		return IntClientGetOverflowInt64Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetOverflowInt64Response{}, err
 	}
@@ -286,7 +278,7 @@ func (client *IntClient) GetUnderflowInt32(ctx context.Context, options *IntClie
 	if err != nil {
 		return IntClientGetUnderflowInt32Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetUnderflowInt32Response{}, err
 	}
@@ -326,7 +318,7 @@ func (client *IntClient) GetUnderflowInt64(ctx context.Context, options *IntClie
 	if err != nil {
 		return IntClientGetUnderflowInt64Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetUnderflowInt64Response{}, err
 	}
@@ -366,7 +358,7 @@ func (client *IntClient) GetUnixTime(ctx context.Context, options *IntClientGetU
 	if err != nil {
 		return IntClientGetUnixTimeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetUnixTimeResponse{}, err
 	}
@@ -409,7 +401,7 @@ func (client *IntClient) PutMax32(ctx context.Context, intBody int32, options *I
 	if err != nil {
 		return IntClientPutMax32Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutMax32Response{}, err
 	}
@@ -441,7 +433,7 @@ func (client *IntClient) PutMax64(ctx context.Context, intBody int64, options *I
 	if err != nil {
 		return IntClientPutMax64Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutMax64Response{}, err
 	}
@@ -473,7 +465,7 @@ func (client *IntClient) PutMin32(ctx context.Context, intBody int32, options *I
 	if err != nil {
 		return IntClientPutMin32Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutMin32Response{}, err
 	}
@@ -505,7 +497,7 @@ func (client *IntClient) PutMin64(ctx context.Context, intBody int64, options *I
 	if err != nil {
 		return IntClientPutMin64Response{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutMin64Response{}, err
 	}
@@ -537,7 +529,7 @@ func (client *IntClient) PutUnixTimeDate(ctx context.Context, intBody time.Time,
 	if err != nil {
 		return IntClientPutUnixTimeDateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutUnixTimeDateResponse{}, err
 	}

--- a/test/autorest/lrogroup/lroretrys_test.go
+++ b/test/autorest/lrogroup/lroretrys_test.go
@@ -16,16 +16,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newLRORetrysClient() *LRORetrysClient {
+func newLRORetrysClient(t *testing.T) *LRORetrysClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
-	return NewLRORetrysClient(pl)
+	client, err := NewLRORetrysClient(&options)
+	require.NoError(t, err)
+	return client
+}
+
+func NewLRORetrysClient(options *azcore.ClientOptions) (*LRORetrysClient, error) {
+	cl, err := azcore.NewClient("lrogroup.LRORetrysClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &LRORetrysClient{
+		internal: cl,
+	}
+	return client, nil
 }
 
 func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginDelete202Retry200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -40,7 +52,7 @@ func TestLRORetrysBeginDelete202Retry200(t *testing.T) {
 }
 
 func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginDeleteAsyncRelativeRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -54,7 +66,7 @@ func TestLRORetrysBeginDeleteAsyncRelativeRetrySucceeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -77,7 +89,7 @@ func TestLRORetrysBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginPost202Retry200(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginPost202Retry200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -91,7 +103,7 @@ func TestLRORetrysBeginPost202Retry200(t *testing.T) {
 }
 
 func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginPostAsyncRelativeRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -105,7 +117,7 @@ func TestLRORetrysBeginPostAsyncRelativeRetrySucceeded(t *testing.T) {
 }
 
 func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -128,7 +140,7 @@ func TestLRORetrysBeginPut201CreatingSucceeded200(t *testing.T) {
 }
 
 func TestLRORetrysBeginPutAsyncRelativeRetrySucceeded(t *testing.T) {
-	op := newLRORetrysClient()
+	op := newLRORetrysClient(t)
 	poller, err := op.BeginPutAsyncRelativeRetrySucceeded(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()

--- a/test/autorest/lrogroup/lros_test.go
+++ b/test/autorest/lrogroup/lros_test.go
@@ -20,12 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newLROSClient() *LROsClient {
+func newLROSClient(t *testing.T) *LROsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
-	return NewLROsClient(pl)
+	client, err := NewLROsClient(&options)
+	require.NoError(t, err)
+	return client
 }
 
 func httpClientWithCookieJar() policy.Transporter {
@@ -37,8 +38,19 @@ func httpClientWithCookieJar() policy.Transporter {
 	return http.DefaultClient
 }
 
+func NewLROsClient(options *azcore.ClientOptions) (*LROsClient, error) {
+	cl, err := azcore.NewClient("lrogroup.LROsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &LROsClient{
+		internal: cl,
+	}
+	return client, nil
+}
+
 func TestLROResumeWrongPoller(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -50,7 +62,7 @@ func TestLROResumeWrongPoller(t *testing.T) {
 }
 
 func TestLROBeginDelete202NoRetry204(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDelete202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -64,7 +76,7 @@ func TestLROBeginDelete202NoRetry204(t *testing.T) {
 }
 
 func TestLROBeginDelete202Retry200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDelete202Retry200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -78,7 +90,7 @@ func TestLROBeginDelete202Retry200(t *testing.T) {
 }
 
 func TestLROBeginDelete204Succeeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	require.NoError(t, err)
 	_, err = poller.ResumeToken()
@@ -88,7 +100,7 @@ func TestLROBeginDelete204Succeeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteAsyncNoHeaderInRetry(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -102,7 +114,7 @@ func TestLROBeginDeleteAsyncNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteAsyncNoRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -116,7 +128,7 @@ func TestLROBeginDeleteAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteAsyncRetryFailed(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -139,7 +151,7 @@ func TestLROBeginDeleteAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteAsyncRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -153,7 +165,7 @@ func TestLROBeginDeleteAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteAsyncRetrycanceled(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -176,7 +188,7 @@ func TestLROBeginDeleteAsyncRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteNoHeaderInRetry(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -190,7 +202,7 @@ func TestLROBeginDeleteNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteProvisioning202Accepted200Succeeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -204,7 +216,7 @@ func TestLROBeginDeleteProvisioning202Accepted200Succeeded(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteProvisioning202DeletingFailed200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -218,7 +230,7 @@ func TestLROBeginDeleteProvisioning202DeletingFailed200(t *testing.T) {
 }
 
 func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginDeleteProvisioning202Deletingcanceled200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -232,7 +244,7 @@ func TestLROBeginDeleteProvisioning202Deletingcanceled200(t *testing.T) {
 }
 
 func TestLROBeginPatch201RetryWithAsyncHeader(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	resp, err := op.BeginPatch201RetryWithAsyncHeader(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	res, err := resp.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: time.Second})
@@ -248,7 +260,7 @@ func TestLROBeginPatch201RetryWithAsyncHeader(t *testing.T) {
 
 func TestLROBeginPatch202RetryWithAsyncAndLocationHeader(t *testing.T) {
 	t.Skip("https://github.com/Azure/autorest.testserver/pull/369")
-	op := newLROSClient()
+	op := newLROSClient(t)
 	resp, err := op.BeginPatch202RetryWithAsyncAndLocationHeader(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	res, err := resp.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: time.Second})
@@ -263,7 +275,7 @@ func TestLROBeginPatch202RetryWithAsyncAndLocationHeader(t *testing.T) {
 }
 
 func TestLROBeginPost200WithPayload(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPost200WithPayload(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -281,7 +293,7 @@ func TestLROBeginPost200WithPayload(t *testing.T) {
 }
 
 func TestLROBeginPost202List(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPost202List(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -299,7 +311,7 @@ func TestLROBeginPost202List(t *testing.T) {
 }
 
 func TestLROBeginPost202NoRetry204(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPost202NoRetry204(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -313,7 +325,7 @@ func TestLROBeginPost202NoRetry204(t *testing.T) {
 }
 
 func TestLROBeginPost202Retry200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPost202Retry200(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -327,7 +339,7 @@ func TestLROBeginPost202Retry200(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostAsyncNoRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -348,7 +360,7 @@ func TestLROBeginPostAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostAsyncRetryFailed(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -371,7 +383,7 @@ func TestLROBeginPostAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostAsyncRetrySucceeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -392,7 +404,7 @@ func TestLROBeginPostAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostAsyncRetrycanceled(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -415,7 +427,7 @@ func TestLROBeginPostAsyncRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGet(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -432,7 +444,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGet(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -450,7 +462,7 @@ func TestLROBeginPostDoubleHeadersFinalAzureHeaderGetDefault(t *testing.T) {
 }
 
 func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPostDoubleHeadersFinalLocationGet(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -468,7 +480,7 @@ func TestLROBeginPostDoubleHeadersFinalLocationGet(t *testing.T) {
 }
 
 func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut200Acceptedcanceled200(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -488,7 +500,7 @@ func TestLROBeginPut200Acceptedcanceled200(t *testing.T) {
 }
 
 func TestLROBeginPut200Succeeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut200Succeeded(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	_, err = poller.ResumeToken()
@@ -505,7 +517,7 @@ func TestLROBeginPut200Succeeded(t *testing.T) {
 }
 
 func TestLROBeginPut200SucceededNoState(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut200SucceededNoState(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	_, err = poller.ResumeToken()
@@ -520,7 +532,7 @@ func TestLROBeginPut200SucceededNoState(t *testing.T) {
 
 // TODO check if this test should actually be returning a 200 or a 204
 func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut200UpdatingSucceeded204(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -541,7 +553,7 @@ func TestLROBeginPut200UpdatingSucceeded204(t *testing.T) {
 }
 
 func TestLROBeginPut201CreatingFailed200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut201CreatingFailed200(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -561,7 +573,7 @@ func TestLROBeginPut201CreatingFailed200(t *testing.T) {
 }
 
 func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut201CreatingSucceeded200(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -582,7 +594,7 @@ func TestLROBeginPut201CreatingSucceeded200(t *testing.T) {
 }
 
 func TestLROBeginPut201Succeeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	resp, err := op.BeginPut201Succeeded(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	res, err := resp.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{Frequency: time.Second})
@@ -597,7 +609,7 @@ func TestLROBeginPut201Succeeded(t *testing.T) {
 }
 
 func TestLROBeginPut202Retry200(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPut202Retry200(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -615,7 +627,7 @@ func TestLROBeginPut202Retry200(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncNoHeaderInRetry(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -636,7 +648,7 @@ func TestLROBeginPutAsyncNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncNoRetrySucceeded(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -657,7 +669,7 @@ func TestLROBeginPutAsyncNoRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncNoRetrycanceled(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -680,7 +692,7 @@ func TestLROBeginPutAsyncNoRetrycanceled(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncNonResource(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncNonResource(context.Background(), SKU{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -698,7 +710,7 @@ func TestLROBeginPutAsyncNonResource(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncRetryFailed(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -721,7 +733,7 @@ func TestLROBeginPutAsyncRetryFailed(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncRetrySucceeded(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -742,7 +754,7 @@ func TestLROBeginPutAsyncRetrySucceeded(t *testing.T) {
 }
 
 func TestLROBeginPutAsyncSubResource(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutAsyncSubResource(context.Background(), SubProduct{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -762,7 +774,7 @@ func TestLROBeginPutAsyncSubResource(t *testing.T) {
 }
 
 func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutNoHeaderInRetry(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -783,7 +795,7 @@ func TestLROBeginPutNoHeaderInRetry(t *testing.T) {
 }
 
 func TestLROBeginPutNonResource(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutNonResource(context.Background(), SKU{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -801,7 +813,7 @@ func TestLROBeginPutNonResource(t *testing.T) {
 }
 
 func TestLROBeginPutSubResource(t *testing.T) {
-	op := newLROSClient()
+	op := newLROSClient(t)
 	poller, err := op.BeginPutSubResource(context.Background(), SubProduct{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()

--- a/test/autorest/lrogroup/lrosadsheader_test.go
+++ b/test/autorest/lrogroup/lrosadsheader_test.go
@@ -14,16 +14,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newLrosaDsClient() *LROSADsClient {
+func newLrosaDsClient(t *testing.T) *LROSADsClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
-	return NewLROSADsClient(pl)
+	client, err := NewLROSADsClient(&options)
+	require.NoError(t, err)
+	return client
+}
+
+func NewLROSADsClient(options *azcore.ClientOptions) (*LROSADsClient, error) {
+	cl, err := azcore.NewClient("lrogroup.LROSADsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &LROSADsClient{
+		internal: cl,
+	}
+	return client, nil
 }
 
 func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginDelete202NonRetry400(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -37,13 +49,13 @@ func TestLROSADSBeginDelete202NonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginDelete202RetryInvalidHeader(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginDelete202RetryInvalidHeader(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginDelete204Succeeded(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -54,7 +66,7 @@ func TestLROSADSBeginDelete204Succeeded(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginDeleteAsyncRelativeRetry400(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -68,13 +80,13 @@ func TestLROSADSBeginDeleteAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginDeleteAsyncRelativeRetryInvalidHeader(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -88,7 +100,7 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginDeleteAsyncRelativeRetryNoStatus(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -102,19 +114,19 @@ func TestLROSADSBeginDeleteAsyncRelativeRetryNoStatus(t *testing.T) {
 }
 
 func TestLROSADSBeginDeleteNonRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginDeleteNonRetry400(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPost202NoLocation(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPost202NoLocation(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPost202NonRetry400(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -128,13 +140,13 @@ func TestLROSADSBeginPost202NonRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPost202RetryInvalidHeader(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPost202RetryInvalidHeader(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPostAsyncRelativeRetry400(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -148,13 +160,13 @@ func TestLROSADSBeginPostAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPostAsyncRelativeRetryInvalidHeader(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPostAsyncRelativeRetryInvalidJSONPolling(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -168,7 +180,7 @@ func TestLROSADSBeginPostAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPostAsyncRelativeRetryNoPayload(context.Background(), nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -182,19 +194,19 @@ func TestLROSADSBeginPostAsyncRelativeRetryNoPayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPostNonRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPostNonRetry400(context.Background(), nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPut200InvalidJSON(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPut200InvalidJSON(context.Background(), Product{}, nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutAsyncRelativeRetry400(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -208,13 +220,13 @@ func TestLROSADSBeginPutAsyncRelativeRetry400(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidHeader(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPutAsyncRelativeRetryInvalidHeader(context.Background(), Product{}, nil)
 	require.Error(t, err)
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutAsyncRelativeRetryInvalidJSONPolling(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -228,7 +240,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryInvalidJSONPolling(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutAsyncRelativeRetryNoStatus(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -242,7 +254,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatus(t *testing.T) {
 }
 
 func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutAsyncRelativeRetryNoStatusPayload(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -256,7 +268,7 @@ func TestLROSADSBeginPutAsyncRelativeRetryNoStatusPayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutError201NoProvisioningStatePayload(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -270,7 +282,7 @@ func TestLROSADSBeginPutError201NoProvisioningStatePayload(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutNonRetry201Creating400(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -284,7 +296,7 @@ func TestLROSADSBeginPutNonRetry201Creating400(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	poller, err := op.BeginPutNonRetry201Creating400InvalidJSON(context.Background(), Product{}, nil)
 	require.NoError(t, err)
 	rt, err := poller.ResumeToken()
@@ -298,7 +310,7 @@ func TestLROSADSBeginPutNonRetry201Creating400InvalidJSON(t *testing.T) {
 }
 
 func TestLROSADSBeginPutNonRetry400(t *testing.T) {
-	op := newLrosaDsClient()
+	op := newLrosaDsClient(t)
 	_, err := op.BeginPutNonRetry400(context.Background(), Product{}, nil)
 	require.Error(t, err)
 }

--- a/test/autorest/lrogroup/lroscustomheader_test.go
+++ b/test/autorest/lrogroup/lroscustomheader_test.go
@@ -17,12 +17,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newLrOSCustomHeaderClient() *LROsCustomHeaderClient {
+func newLrOSCustomHeaderClient(t *testing.T) *LROsCustomHeaderClient {
 	options := azcore.ClientOptions{}
 	options.Retry.RetryDelay = time.Second
 	options.Transport = httpClientWithCookieJar()
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &options)
-	return NewLROsCustomHeaderClient(pl)
+	client, err := NewLROsCustomHeaderClient(&options)
+	require.NoError(t, err)
+	return client
 }
 
 func ctxWithHTTPHeader() context.Context {
@@ -31,9 +32,20 @@ func ctxWithHTTPHeader() context.Context {
 	return runtime.WithHTTPHeader(context.Background(), header)
 }
 
+func NewLROsCustomHeaderClient(options *azcore.ClientOptions) (*LROsCustomHeaderClient, error) {
+	cl, err := azcore.NewClient("lrogroup.LROsCustomHeaderClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &LROsCustomHeaderClient{
+		internal: cl,
+	}
+	return client, nil
+}
+
 // BeginPost202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
 func TestBeginPost202Retry200(t *testing.T) {
-	op := newLrOSCustomHeaderClient()
+	op := newLrOSCustomHeaderClient(t)
 	poller, err := op.BeginPost202Retry200(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
 	tk, err := poller.ResumeToken()
@@ -55,7 +67,7 @@ func TestBeginPost202Retry200(t *testing.T) {
 
 // BeginPostAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running post request, service returns a 202 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
-	op := newLrOSCustomHeaderClient()
+	op := newLrOSCustomHeaderClient(t)
 	poller, err := op.BeginPostAsyncRetrySucceeded(ctxWithHTTPHeader(), nil)
 	require.NoError(t, err)
 	tk, err := poller.ResumeToken()
@@ -77,7 +89,7 @@ func TestBeginPostAsyncRetrySucceeded(t *testing.T) {
 
 // BeginPut201CreatingSucceeded200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
 func TestBeginPut201CreatingSucceeded200(t *testing.T) {
-	op := newLrOSCustomHeaderClient()
+	op := newLrOSCustomHeaderClient(t)
 	poller, err := op.BeginPut201CreatingSucceeded200(ctxWithHTTPHeader(), Product{}, nil)
 	require.NoError(t, err)
 	tk, err := poller.ResumeToken()
@@ -108,7 +120,7 @@ func TestBeginPut201CreatingSucceeded200(t *testing.T) {
 
 // BeginPutAsyncRetrySucceeded - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all requests. Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation header for operation status
 func TestBeginPutAsyncRetrySucceeded(t *testing.T) {
-	op := newLrOSCustomHeaderClient()
+	op := newLrOSCustomHeaderClient(t)
 	poller, err := op.BeginPutAsyncRetrySucceeded(ctxWithHTTPHeader(), Product{}, nil)
 	require.NoError(t, err)
 	tk, err := poller.ResumeToken()

--- a/test/autorest/lrogroup/zz_lroretrys_client.go
+++ b/test/autorest/lrogroup/zz_lroretrys_client.go
@@ -11,24 +11,16 @@ package lrogroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // LRORetrysClient contains the methods for the LRORetrys group.
-// Don't use this type directly, use NewLRORetrysClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type LRORetrysClient struct {
-	pl runtime.Pipeline
-}
-
-// NewLRORetrysClient creates a new instance of LRORetrysClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewLRORetrysClient(pl runtime.Pipeline) *LRORetrysClient {
-	client := &LRORetrysClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BeginDelete202Retry200 - Long running delete request, service returns a 500, then a 202 to the initial request. Polls return
@@ -44,9 +36,9 @@ func (client *LRORetrysClient) BeginDelete202Retry200(ctx context.Context, optio
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientDelete202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientDelete202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientDelete202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientDelete202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -60,7 +52,7 @@ func (client *LRORetrysClient) delete202Retry200(ctx context.Context, options *L
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +86,9 @@ func (client *LRORetrysClient) BeginDeleteAsyncRelativeRetrySucceeded(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -110,7 +102,7 @@ func (client *LRORetrysClient) deleteAsyncRelativeRetrySucceeded(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -146,9 +138,9 @@ func (client *LRORetrysClient) BeginDeleteProvisioning202Accepted200Succeeded(ct
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -164,7 +156,7 @@ func (client *LRORetrysClient) deleteProvisioning202Accepted200Succeeded(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -198,9 +190,9 @@ func (client *LRORetrysClient) BeginPost202Retry200(ctx context.Context, options
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientPost202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientPost202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientPost202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientPost202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -214,7 +206,7 @@ func (client *LRORetrysClient) post202Retry200(ctx context.Context, options *LRO
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -252,9 +244,9 @@ func (client *LRORetrysClient) BeginPostAsyncRelativeRetrySucceeded(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientPostAsyncRelativeRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientPostAsyncRelativeRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientPostAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientPostAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -269,7 +261,7 @@ func (client *LRORetrysClient) postAsyncRelativeRetrySucceeded(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -308,9 +300,9 @@ func (client *LRORetrysClient) BeginPut201CreatingSucceeded200(ctx context.Conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientPut201CreatingSucceeded200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientPut201CreatingSucceeded200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientPut201CreatingSucceeded200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientPut201CreatingSucceeded200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -325,7 +317,7 @@ func (client *LRORetrysClient) put201CreatingSucceeded200(ctx context.Context, p
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -361,9 +353,9 @@ func (client *LRORetrysClient) BeginPutAsyncRelativeRetrySucceeded(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LRORetrysClientPutAsyncRelativeRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LRORetrysClientPutAsyncRelativeRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LRORetrysClientPutAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LRORetrysClientPutAsyncRelativeRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -378,7 +370,7 @@ func (client *LRORetrysClient) putAsyncRelativeRetrySucceeded(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/lrogroup/zz_lros_client.go
+++ b/test/autorest/lrogroup/zz_lros_client.go
@@ -11,24 +11,16 @@ package lrogroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // LROsClient contains the methods for the LROs group.
-// Don't use this type directly, use NewLROsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type LROsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewLROsClient creates a new instance of LROsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewLROsClient(pl runtime.Pipeline) *LROsClient {
-	client := &LROsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BeginDelete202NoRetry204 - Long running delete request, service returns a 202 to the initial request. Polls return this
@@ -44,9 +36,9 @@ func (client *LROsClient) BeginDelete202NoRetry204(ctx context.Context, options 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDelete202NoRetry204Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDelete202NoRetry204Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDelete202NoRetry204Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDelete202NoRetry204Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -60,7 +52,7 @@ func (client *LROsClient) delete202NoRetry204(ctx context.Context, options *LROs
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -94,9 +86,9 @@ func (client *LROsClient) BeginDelete202Retry200(ctx context.Context, options *L
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDelete202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDelete202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDelete202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDelete202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -110,7 +102,7 @@ func (client *LROsClient) delete202Retry200(ctx context.Context, options *LROsCl
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -143,9 +135,9 @@ func (client *LROsClient) BeginDelete204Succeeded(ctx context.Context, options *
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDelete204SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDelete204SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDelete204SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDelete204SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -158,7 +150,7 @@ func (client *LROsClient) delete204Succeeded(ctx context.Context, options *LROsC
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -192,9 +184,9 @@ func (client *LROsClient) BeginDeleteAsyncNoHeaderInRetry(ctx context.Context, o
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteAsyncNoHeaderInRetryResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteAsyncNoHeaderInRetryResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncNoHeaderInRetryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncNoHeaderInRetryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -208,7 +200,7 @@ func (client *LROsClient) deleteAsyncNoHeaderInRetry(ctx context.Context, option
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -242,9 +234,9 @@ func (client *LROsClient) BeginDeleteAsyncNoRetrySucceeded(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteAsyncNoRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteAsyncNoRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncNoRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncNoRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -258,7 +250,7 @@ func (client *LROsClient) deleteAsyncNoRetrySucceeded(ctx context.Context, optio
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -292,9 +284,9 @@ func (client *LROsClient) BeginDeleteAsyncRetryFailed(ctx context.Context, optio
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteAsyncRetryFailedResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteAsyncRetryFailedResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetryFailedResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetryFailedResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -308,7 +300,7 @@ func (client *LROsClient) deleteAsyncRetryFailed(ctx context.Context, options *L
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -342,9 +334,9 @@ func (client *LROsClient) BeginDeleteAsyncRetrySucceeded(ctx context.Context, op
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteAsyncRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteAsyncRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -358,7 +350,7 @@ func (client *LROsClient) deleteAsyncRetrySucceeded(ctx context.Context, options
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -392,9 +384,9 @@ func (client *LROsClient) BeginDeleteAsyncRetrycanceled(ctx context.Context, opt
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteAsyncRetrycanceledResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteAsyncRetrycanceledResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetrycanceledResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteAsyncRetrycanceledResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -408,7 +400,7 @@ func (client *LROsClient) deleteAsyncRetrycanceled(ctx context.Context, options 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -442,9 +434,9 @@ func (client *LROsClient) BeginDeleteNoHeaderInRetry(ctx context.Context, option
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteNoHeaderInRetryResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteNoHeaderInRetryResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteNoHeaderInRetryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteNoHeaderInRetryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -458,7 +450,7 @@ func (client *LROsClient) deleteNoHeaderInRetry(ctx context.Context, options *LR
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -494,9 +486,9 @@ func (client *LROsClient) BeginDeleteProvisioning202Accepted200Succeeded(ctx con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteProvisioning202Accepted200SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteProvisioning202Accepted200SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202Accepted200SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202Accepted200SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -512,7 +504,7 @@ func (client *LROsClient) deleteProvisioning202Accepted200Succeeded(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -548,9 +540,9 @@ func (client *LROsClient) BeginDeleteProvisioning202DeletingFailed200(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteProvisioning202DeletingFailed200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteProvisioning202DeletingFailed200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202DeletingFailed200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202DeletingFailed200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -565,7 +557,7 @@ func (client *LROsClient) deleteProvisioning202DeletingFailed200(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -601,9 +593,9 @@ func (client *LROsClient) BeginDeleteProvisioning202Deletingcanceled200(ctx cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientDeleteProvisioning202Deletingcanceled200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientDeleteProvisioning202Deletingcanceled200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202Deletingcanceled200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientDeleteProvisioning202Deletingcanceled200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -618,7 +610,7 @@ func (client *LROsClient) deleteProvisioning202Deletingcanceled200(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -653,9 +645,9 @@ func (client *LROsClient) BeginPatch200SucceededIgnoreHeaders(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPatch200SucceededIgnoreHeadersResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPatch200SucceededIgnoreHeadersResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPatch200SucceededIgnoreHeadersResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPatch200SucceededIgnoreHeadersResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -669,7 +661,7 @@ func (client *LROsClient) patch200SucceededIgnoreHeaders(ctx context.Context, pr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -704,11 +696,11 @@ func (client *LROsClient) BeginPatch201RetryWithAsyncHeader(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LROsClientPatch201RetryWithAsyncHeaderResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LROsClientPatch201RetryWithAsyncHeaderResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPatch201RetryWithAsyncHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPatch201RetryWithAsyncHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -721,7 +713,7 @@ func (client *LROsClient) patch201RetryWithAsyncHeader(ctx context.Context, prod
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -756,9 +748,9 @@ func (client *LROsClient) BeginPatch202RetryWithAsyncAndLocationHeader(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -772,7 +764,7 @@ func (client *LROsClient) patch202RetryWithAsyncAndLocationHeader(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -806,9 +798,9 @@ func (client *LROsClient) BeginPost200WithPayload(ctx context.Context, options *
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPost200WithPayloadResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPost200WithPayloadResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPost200WithPayloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPost200WithPayloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -822,7 +814,7 @@ func (client *LROsClient) post200WithPayload(ctx context.Context, options *LROsC
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -855,9 +847,9 @@ func (client *LROsClient) BeginPost202List(ctx context.Context, options *LROsCli
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPost202ListResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPost202ListResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPost202ListResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPost202ListResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -871,7 +863,7 @@ func (client *LROsClient) post202List(ctx context.Context, options *LROsClientBe
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -905,9 +897,9 @@ func (client *LROsClient) BeginPost202NoRetry204(ctx context.Context, options *L
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPost202NoRetry204Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPost202NoRetry204Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPost202NoRetry204Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPost202NoRetry204Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -921,7 +913,7 @@ func (client *LROsClient) post202NoRetry204(ctx context.Context, options *LROsCl
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -958,9 +950,9 @@ func (client *LROsClient) BeginPost202Retry200(ctx context.Context, options *LRO
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPost202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPost202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPost202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPost202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -974,7 +966,7 @@ func (client *LROsClient) post202Retry200(ctx context.Context, options *LROsClie
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,9 +1004,9 @@ func (client *LROsClient) BeginPostAsyncNoRetrySucceeded(ctx context.Context, op
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPostAsyncNoRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPostAsyncNoRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncNoRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncNoRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1029,7 +1021,7 @@ func (client *LROsClient) postAsyncNoRetrySucceeded(ctx context.Context, options
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,9 +1059,9 @@ func (client *LROsClient) BeginPostAsyncRetryFailed(ctx context.Context, options
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPostAsyncRetryFailedResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPostAsyncRetryFailedResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetryFailedResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetryFailedResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1084,7 +1076,7 @@ func (client *LROsClient) postAsyncRetryFailed(ctx context.Context, options *LRO
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1122,9 +1114,9 @@ func (client *LROsClient) BeginPostAsyncRetrySucceeded(ctx context.Context, opti
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPostAsyncRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPostAsyncRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1139,7 +1131,7 @@ func (client *LROsClient) postAsyncRetrySucceeded(ctx context.Context, options *
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,9 +1169,9 @@ func (client *LROsClient) BeginPostAsyncRetrycanceled(ctx context.Context, optio
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPostAsyncRetrycanceledResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPostAsyncRetrycanceledResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetrycanceledResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostAsyncRetrycanceledResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1194,7 +1186,7 @@ func (client *LROsClient) postAsyncRetrycanceled(ctx context.Context, options *L
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1231,11 +1223,11 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGet(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1249,7 +1241,7 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGet(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1285,9 +1277,9 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalAzureHeaderGetDefault(ctx c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1302,7 +1294,7 @@ func (client *LROsClient) postDoubleHeadersFinalAzureHeaderGetDefault(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1336,11 +1328,11 @@ func (client *LROsClient) BeginPostDoubleHeadersFinalLocationGet(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LROsClientPostDoubleHeadersFinalLocationGetResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LROsClientPostDoubleHeadersFinalLocationGetResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalLocationGetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPostDoubleHeadersFinalLocationGetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1354,7 +1346,7 @@ func (client *LROsClient) postDoubleHeadersFinalLocationGet(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1390,9 +1382,9 @@ func (client *LROsClient) BeginPut200Acceptedcanceled200(ctx context.Context, pr
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut200Acceptedcanceled200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut200Acceptedcanceled200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut200Acceptedcanceled200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut200Acceptedcanceled200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1407,7 +1399,7 @@ func (client *LROsClient) put200Acceptedcanceled200(ctx context.Context, product
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1442,9 +1434,9 @@ func (client *LROsClient) BeginPut200Succeeded(ctx context.Context, product Prod
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut200SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut200SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut200SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut200SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1458,7 +1450,7 @@ func (client *LROsClient) put200Succeeded(ctx context.Context, product Product, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1493,9 +1485,9 @@ func (client *LROsClient) BeginPut200SucceededNoState(ctx context.Context, produ
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut200SucceededNoStateResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut200SucceededNoStateResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut200SucceededNoStateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut200SucceededNoStateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1509,7 +1501,7 @@ func (client *LROsClient) put200SucceededNoState(ctx context.Context, product Pr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1545,9 +1537,9 @@ func (client *LROsClient) BeginPut200UpdatingSucceeded204(ctx context.Context, p
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut200UpdatingSucceeded204Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut200UpdatingSucceeded204Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut200UpdatingSucceeded204Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut200UpdatingSucceeded204Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1562,7 +1554,7 @@ func (client *LROsClient) put200UpdatingSucceeded204(ctx context.Context, produc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1598,9 +1590,9 @@ func (client *LROsClient) BeginPut201CreatingFailed200(ctx context.Context, prod
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut201CreatingFailed200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut201CreatingFailed200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut201CreatingFailed200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut201CreatingFailed200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1615,7 +1607,7 @@ func (client *LROsClient) put201CreatingFailed200(ctx context.Context, product P
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1651,9 +1643,9 @@ func (client *LROsClient) BeginPut201CreatingSucceeded200(ctx context.Context, p
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut201CreatingSucceeded200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut201CreatingSucceeded200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut201CreatingSucceeded200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut201CreatingSucceeded200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1668,7 +1660,7 @@ func (client *LROsClient) put201CreatingSucceeded200(ctx context.Context, produc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1703,9 +1695,9 @@ func (client *LROsClient) BeginPut201Succeeded(ctx context.Context, product Prod
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut201SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut201SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut201SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut201SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1719,7 +1711,7 @@ func (client *LROsClient) put201Succeeded(ctx context.Context, product Product, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1754,9 +1746,9 @@ func (client *LROsClient) BeginPut202Retry200(ctx context.Context, product Produ
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPut202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPut202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPut202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPut202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1770,7 +1762,7 @@ func (client *LROsClient) put202Retry200(ctx context.Context, product Product, o
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1805,9 +1797,9 @@ func (client *LROsClient) BeginPutAsyncNoHeaderInRetry(ctx context.Context, prod
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncNoHeaderInRetryResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncNoHeaderInRetryResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoHeaderInRetryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoHeaderInRetryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1821,7 +1813,7 @@ func (client *LROsClient) putAsyncNoHeaderInRetry(ctx context.Context, product P
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1857,9 +1849,9 @@ func (client *LROsClient) BeginPutAsyncNoRetrySucceeded(ctx context.Context, pro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncNoRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncNoRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1874,7 +1866,7 @@ func (client *LROsClient) putAsyncNoRetrySucceeded(ctx context.Context, product 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1910,9 +1902,9 @@ func (client *LROsClient) BeginPutAsyncNoRetrycanceled(ctx context.Context, prod
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncNoRetrycanceledResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncNoRetrycanceledResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoRetrycanceledResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNoRetrycanceledResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1927,7 +1919,7 @@ func (client *LROsClient) putAsyncNoRetrycanceled(ctx context.Context, product P
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1961,9 +1953,9 @@ func (client *LROsClient) BeginPutAsyncNonResource(ctx context.Context, sku SKU,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncNonResourceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncNonResourceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNonResourceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncNonResourceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1976,7 +1968,7 @@ func (client *LROsClient) putAsyncNonResource(ctx context.Context, sku SKU, opti
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2012,9 +2004,9 @@ func (client *LROsClient) BeginPutAsyncRetryFailed(ctx context.Context, product 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncRetryFailedResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncRetryFailedResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncRetryFailedResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncRetryFailedResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2029,7 +2021,7 @@ func (client *LROsClient) putAsyncRetryFailed(ctx context.Context, product Produ
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2065,9 +2057,9 @@ func (client *LROsClient) BeginPutAsyncRetrySucceeded(ctx context.Context, produ
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2082,7 +2074,7 @@ func (client *LROsClient) putAsyncRetrySucceeded(ctx context.Context, product Pr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2116,9 +2108,9 @@ func (client *LROsClient) BeginPutAsyncSubResource(ctx context.Context, product 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutAsyncSubResourceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutAsyncSubResourceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncSubResourceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutAsyncSubResourceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2131,7 +2123,7 @@ func (client *LROsClient) putAsyncSubResource(ctx context.Context, product SubPr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2166,9 +2158,9 @@ func (client *LROsClient) BeginPutNoHeaderInRetry(ctx context.Context, product P
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutNoHeaderInRetryResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutNoHeaderInRetryResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutNoHeaderInRetryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutNoHeaderInRetryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2182,7 +2174,7 @@ func (client *LROsClient) putNoHeaderInRetry(ctx context.Context, product Produc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2216,9 +2208,9 @@ func (client *LROsClient) BeginPutNonResource(ctx context.Context, sku SKU, opti
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutNonResourceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutNonResourceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutNonResourceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutNonResourceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2231,7 +2223,7 @@ func (client *LROsClient) putNonResource(ctx context.Context, sku SKU, options *
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -2265,9 +2257,9 @@ func (client *LROsClient) BeginPutSubResource(ctx context.Context, product SubPr
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsClientPutSubResourceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsClientPutSubResourceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsClientPutSubResourceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsClientPutSubResourceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -2280,7 +2272,7 @@ func (client *LROsClient) putSubResource(ctx context.Context, product SubProduct
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/lrogroup/zz_lrosads_client.go
+++ b/test/autorest/lrogroup/zz_lrosads_client.go
@@ -11,24 +11,16 @@ package lrogroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // LROSADsClient contains the methods for the LROSADs group.
-// Don't use this type directly, use NewLROSADsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type LROSADsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewLROSADsClient creates a new instance of LROSADsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewLROSADsClient(pl runtime.Pipeline) *LROSADsClient {
-	client := &LROSADsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BeginDelete202NonRetry400 - Long running delete request, service returns a 202 with a location header
@@ -43,9 +35,9 @@ func (client *LROSADsClient) BeginDelete202NonRetry400(ctx context.Context, opti
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDelete202NonRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDelete202NonRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDelete202NonRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDelete202NonRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -58,7 +50,7 @@ func (client *LROSADsClient) delete202NonRetry400(ctx context.Context, options *
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -92,9 +84,9 @@ func (client *LROSADsClient) BeginDelete202RetryInvalidHeader(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDelete202RetryInvalidHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDelete202RetryInvalidHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDelete202RetryInvalidHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDelete202RetryInvalidHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -108,7 +100,7 @@ func (client *LROSADsClient) delete202RetryInvalidHeader(ctx context.Context, op
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -141,9 +133,9 @@ func (client *LROSADsClient) BeginDelete204Succeeded(ctx context.Context, option
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDelete204SucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDelete204SucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDelete204SucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDelete204SucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -156,7 +148,7 @@ func (client *LROSADsClient) delete204Succeeded(ctx context.Context, options *LR
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,9 +182,9 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetry400(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -206,7 +198,7 @@ func (client *LROSADsClient) deleteAsyncRelativeRetry400(ctx context.Context, op
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -240,9 +232,9 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidHeader(ctx cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -256,7 +248,7 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryInvalidHeader(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -290,9 +282,9 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryInvalidJSONPolling(ctx
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -306,7 +298,7 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryInvalidJSONPolling(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -340,9 +332,9 @@ func (client *LROSADsClient) BeginDeleteAsyncRelativeRetryNoStatus(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -356,7 +348,7 @@ func (client *LROSADsClient) deleteAsyncRelativeRetryNoStatus(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -389,9 +381,9 @@ func (client *LROSADsClient) BeginDeleteNonRetry400(ctx context.Context, options
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientDeleteNonRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientDeleteNonRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteNonRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientDeleteNonRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -404,7 +396,7 @@ func (client *LROSADsClient) deleteNonRetry400(ctx context.Context, options *LRO
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -437,9 +429,9 @@ func (client *LROSADsClient) BeginPost202NoLocation(ctx context.Context, options
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPost202NoLocationResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPost202NoLocationResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPost202NoLocationResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPost202NoLocationResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -452,7 +444,7 @@ func (client *LROSADsClient) post202NoLocation(ctx context.Context, options *LRO
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -488,9 +480,9 @@ func (client *LROSADsClient) BeginPost202NonRetry400(ctx context.Context, option
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPost202NonRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPost202NonRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPost202NonRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPost202NonRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -503,7 +495,7 @@ func (client *LROSADsClient) post202NonRetry400(ctx context.Context, options *LR
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -540,9 +532,9 @@ func (client *LROSADsClient) BeginPost202RetryInvalidHeader(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPost202RetryInvalidHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPost202RetryInvalidHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPost202RetryInvalidHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPost202RetryInvalidHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -556,7 +548,7 @@ func (client *LROSADsClient) post202RetryInvalidHeader(ctx context.Context, opti
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -593,9 +585,9 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetry400(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -609,7 +601,7 @@ func (client *LROSADsClient) postAsyncRelativeRetry400(ctx context.Context, opti
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -647,9 +639,9 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidHeader(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -664,7 +656,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidHeader(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -703,9 +695,9 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryInvalidJSONPolling(ctx c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -720,7 +712,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryInvalidJSONPolling(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -758,9 +750,9 @@ func (client *LROSADsClient) BeginPostAsyncRelativeRetryNoPayload(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryNoPayloadResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPostAsyncRelativeRetryNoPayloadResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryNoPayloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPostAsyncRelativeRetryNoPayloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -775,7 +767,7 @@ func (client *LROSADsClient) postAsyncRelativeRetryNoPayload(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -811,9 +803,9 @@ func (client *LROSADsClient) BeginPostNonRetry400(ctx context.Context, options *
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPostNonRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPostNonRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPostNonRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPostNonRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -826,7 +818,7 @@ func (client *LROSADsClient) postNonRetry400(ctx context.Context, options *LROSA
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -864,9 +856,9 @@ func (client *LROSADsClient) BeginPut200InvalidJSON(ctx context.Context, product
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPut200InvalidJSONResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPut200InvalidJSONResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPut200InvalidJSONResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPut200InvalidJSONResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -880,7 +872,7 @@ func (client *LROSADsClient) put200InvalidJSON(ctx context.Context, product Prod
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -915,9 +907,9 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetry400(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -931,7 +923,7 @@ func (client *LROSADsClient) putAsyncRelativeRetry400(ctx context.Context, produ
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -966,9 +958,9 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidHeader(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -982,7 +974,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidHeader(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1019,9 +1011,9 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryInvalidJSONPolling(ctx co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1036,7 +1028,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryInvalidJSONPolling(ctx context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1072,9 +1064,9 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatus(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryNoStatusResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryNoStatusResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryNoStatusResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryNoStatusResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1089,7 +1081,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatus(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1125,9 +1117,9 @@ func (client *LROSADsClient) BeginPutAsyncRelativeRetryNoStatusPayload(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1142,7 +1134,7 @@ func (client *LROSADsClient) putAsyncRelativeRetryNoStatusPayload(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1177,9 +1169,9 @@ func (client *LROSADsClient) BeginPutError201NoProvisioningStatePayload(ctx cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutError201NoProvisioningStatePayloadResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutError201NoProvisioningStatePayloadResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutError201NoProvisioningStatePayloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutError201NoProvisioningStatePayloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1193,7 +1185,7 @@ func (client *LROSADsClient) putError201NoProvisioningStatePayload(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1228,9 +1220,9 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutNonRetry201Creating400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutNonRetry201Creating400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry201Creating400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry201Creating400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1244,7 +1236,7 @@ func (client *LROSADsClient) putNonRetry201Creating400(ctx context.Context, prod
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1279,9 +1271,9 @@ func (client *LROSADsClient) BeginPutNonRetry201Creating400InvalidJSON(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutNonRetry201Creating400InvalidJSONResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutNonRetry201Creating400InvalidJSONResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry201Creating400InvalidJSONResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry201Creating400InvalidJSONResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1295,7 +1287,7 @@ func (client *LROSADsClient) putNonRetry201Creating400InvalidJSON(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1329,9 +1321,9 @@ func (client *LROSADsClient) BeginPutNonRetry400(ctx context.Context, product Pr
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROSADsClientPutNonRetry400Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROSADsClientPutNonRetry400Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry400Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROSADsClientPutNonRetry400Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1344,7 +1336,7 @@ func (client *LROSADsClient) putNonRetry400(ctx context.Context, product Product
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/lrogroup/zz_lroscustomheader_client.go
+++ b/test/autorest/lrogroup/zz_lroscustomheader_client.go
@@ -11,24 +11,16 @@ package lrogroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // LROsCustomHeaderClient contains the methods for the LROsCustomHeader group.
-// Don't use this type directly, use NewLROsCustomHeaderClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type LROsCustomHeaderClient struct {
-	pl runtime.Pipeline
-}
-
-// NewLROsCustomHeaderClient creates a new instance of LROsCustomHeaderClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewLROsCustomHeaderClient(pl runtime.Pipeline) *LROsCustomHeaderClient {
-	client := &LROsCustomHeaderClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BeginPost202Retry200 - x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required message header for all
@@ -45,9 +37,9 @@ func (client *LROsCustomHeaderClient) BeginPost202Retry200(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsCustomHeaderClientPost202Retry200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsCustomHeaderClientPost202Retry200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPost202Retry200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPost202Retry200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -62,7 +54,7 @@ func (client *LROsCustomHeaderClient) post202Retry200(ctx context.Context, optio
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -100,9 +92,9 @@ func (client *LROsCustomHeaderClient) BeginPostAsyncRetrySucceeded(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsCustomHeaderClientPostAsyncRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsCustomHeaderClientPostAsyncRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPostAsyncRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPostAsyncRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -117,7 +109,7 @@ func (client *LROsCustomHeaderClient) postAsyncRetrySucceeded(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -156,9 +148,9 @@ func (client *LROsCustomHeaderClient) BeginPut201CreatingSucceeded200(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsCustomHeaderClientPut201CreatingSucceeded200Response](resp, client.pl, nil)
+		return runtime.NewPoller[LROsCustomHeaderClientPut201CreatingSucceeded200Response](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPut201CreatingSucceeded200Response](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPut201CreatingSucceeded200Response](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -173,7 +165,7 @@ func (client *LROsCustomHeaderClient) put201CreatingSucceeded200(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -209,9 +201,9 @@ func (client *LROsCustomHeaderClient) BeginPutAsyncRetrySucceeded(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LROsCustomHeaderClientPutAsyncRetrySucceededResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LROsCustomHeaderClientPutAsyncRetrySucceededResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPutAsyncRetrySucceededResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LROsCustomHeaderClientPutAsyncRetrySucceededResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -226,7 +218,7 @@ func (client *LROsCustomHeaderClient) putAsyncRetrySucceeded(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/test/autorest/mediatypesgroup/mediatypesgroup_test.go
+++ b/test/autorest/mediatypesgroup/mediatypesgroup_test.go
@@ -16,13 +16,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newMediaTypesClient() *MediaTypesClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewMediaTypesClient(pl)
+func newMediaTypesClient(t *testing.T) *MediaTypesClient {
+	client, err := NewMediaTypesClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewMediaTypesClient(options *azcore.ClientOptions) (*MediaTypesClient, error) {
+	client, err := azcore.NewClient("mediatypesgroup.MediaTypesClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &MediaTypesClient{internal: client}, nil
 }
 
 func TestAnalyzeBody(t *testing.T) {
-	client := newMediaTypesClient()
+	client := newMediaTypesClient(t)
 	body := streaming.NopCloser(bytes.NewReader([]byte("PDF")))
 	result, err := client.AnalyzeBody(context.Background(), ContentTypeApplicationPDF, &MediaTypesClientAnalyzeBodyOptions{
 		Input: body,
@@ -34,7 +43,7 @@ func TestAnalyzeBody(t *testing.T) {
 }
 
 func TestAnalyzeBodyWithJSON(t *testing.T) {
-	client := newMediaTypesClient()
+	client := newMediaTypesClient(t)
 	body := SourcePath{
 		Source: to.Ptr("test"),
 	}
@@ -46,7 +55,7 @@ func TestAnalyzeBodyWithJSON(t *testing.T) {
 }
 
 func TestContentTypeWithEncoding(t *testing.T) {
-	client := newMediaTypesClient()
+	client := newMediaTypesClient(t)
 	result, err := client.ContentTypeWithEncoding(context.Background(), &MediaTypesClientContentTypeWithEncodingOptions{
 		Input: to.Ptr("foo"),
 	})

--- a/test/autorest/mediatypesgroup/zz_mediatypes_client.go
+++ b/test/autorest/mediatypesgroup/zz_mediatypes_client.go
@@ -11,6 +11,7 @@ package mediatypesgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -20,18 +21,9 @@ import (
 )
 
 // MediaTypesClient contains the methods for the MediaTypesClient group.
-// Don't use this type directly, use NewMediaTypesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type MediaTypesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewMediaTypesClient creates a new instance of MediaTypesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewMediaTypesClient(pl runtime.Pipeline) *MediaTypesClient {
-	client := &MediaTypesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // AnalyzeBody - Analyze body, that could be different media types.
@@ -45,7 +37,7 @@ func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, contentType Con
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyResponse{}, err
 	}
@@ -92,7 +84,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeader(ctx context.Context, c
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, err
 	}
@@ -128,7 +120,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeaderWithJSON(ctx context.Co
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithJSONResponse{}, err
 	}
@@ -162,7 +154,7 @@ func (client *MediaTypesClient) AnalyzeBodyWithJSON(ctx context.Context, options
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyWithJSONResponse{}, err
 	}
@@ -210,7 +202,7 @@ func (client *MediaTypesClient) BinaryBodyWithThreeContentTypes(ctx context.Cont
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesResponse{}, err
 	}
@@ -258,7 +250,7 @@ func (client *MediaTypesClient) BinaryBodyWithTwoContentTypes(ctx context.Contex
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithTwoContentTypesResponse{}, err
 	}
@@ -303,7 +295,7 @@ func (client *MediaTypesClient) ContentTypeWithEncoding(ctx context.Context, opt
 	if err != nil {
 		return MediaTypesClientContentTypeWithEncodingResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientContentTypeWithEncodingResponse{}, err
 	}
@@ -350,7 +342,7 @@ func (client *MediaTypesClient) PutTextAndJSONBody(ctx context.Context, contentT
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyResponse{}, err
 	}

--- a/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
+++ b/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
@@ -11,6 +11,7 @@ package mediatypesgroupwithnormailzedoperationname
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -20,18 +21,9 @@ import (
 )
 
 // MediaTypesClient contains the methods for the MediaTypesClient group.
-// Don't use this type directly, use NewMediaTypesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type MediaTypesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewMediaTypesClient creates a new instance of MediaTypesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewMediaTypesClient(pl runtime.Pipeline) *MediaTypesClient {
-	client := &MediaTypesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // AnalyzeBody - Analyze body, that could be different media types.
@@ -44,7 +36,7 @@ func (client *MediaTypesClient) AnalyzeBody(ctx context.Context, options *MediaT
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyResponse{}, err
 	}
@@ -89,7 +81,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeader(ctx context.Context, o
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderResponse{}, err
 	}
@@ -125,7 +117,7 @@ func (client *MediaTypesClient) AnalyzeBodyNoAcceptHeaderWithBinary(ctx context.
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyNoAcceptHeaderWithBinaryResponse{}, err
 	}
@@ -161,7 +153,7 @@ func (client *MediaTypesClient) AnalyzeBodyWithBinary(ctx context.Context, conte
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyWithBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientAnalyzeBodyWithBinaryResponse{}, err
 	}
@@ -210,7 +202,7 @@ func (client *MediaTypesClient) BinaryBodyWithThreeContentTypesWithBinary(ctx co
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesWithBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithThreeContentTypesWithBinaryResponse{}, err
 	}
@@ -258,7 +250,7 @@ func (client *MediaTypesClient) BinaryBodyWithTwoContentTypesWithBinary(ctx cont
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithTwoContentTypesWithBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientBinaryBodyWithTwoContentTypesWithBinaryResponse{}, err
 	}
@@ -304,7 +296,7 @@ func (client *MediaTypesClient) ContentTypeWithEncodingWithText(ctx context.Cont
 	if err != nil {
 		return MediaTypesClientContentTypeWithEncodingWithTextResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientContentTypeWithEncodingWithTextResponse{}, err
 	}
@@ -351,7 +343,7 @@ func (client *MediaTypesClient) PutTextAndJSONBodyWithText(ctx context.Context, 
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MediaTypesClientPutTextAndJSONBodyWithTextResponse{}, err
 	}

--- a/test/autorest/migroup/migroup_test.go
+++ b/test/autorest/migroup/migroup_test.go
@@ -15,14 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newMultipleInheritanceServiceClient() *MultipleInheritanceServiceClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewMultipleInheritanceServiceClient(pl)
+func newMultipleInheritanceServiceClient(t *testing.T) *MultipleInheritanceServiceClient {
+	client, err := NewMultipleInheritanceServiceClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewMultipleInheritanceServiceClient(options *azcore.ClientOptions) (*MultipleInheritanceServiceClient, error) {
+	client, err := azcore.NewClient("migroup.MultipleInheritanceServiceClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &MultipleInheritanceServiceClient{internal: client}, nil
 }
 
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
 func TestGetCat(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.GetCat(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Cat, Cat{
@@ -37,7 +46,7 @@ func TestGetCat(t *testing.T) {
 
 // GetFeline - Get a feline where meows and hisses are true
 func TestGetFeline(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.GetFeline(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Feline, Feline{
@@ -50,7 +59,7 @@ func TestGetFeline(t *testing.T) {
 
 // GetHorse - Get a horse with name 'Fred' and isAShowHorse true
 func TestGetHorse(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.GetHorse(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Horse, Horse{
@@ -63,7 +72,7 @@ func TestGetHorse(t *testing.T) {
 
 // GetKitten - Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false
 func TestGetKitten(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.GetKitten(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Kitten, Kitten{
@@ -79,7 +88,7 @@ func TestGetKitten(t *testing.T) {
 
 // GetPet - Get a pet with name 'Peanut'
 func TestGetPet(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.GetPet(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Pet, Pet{
@@ -91,7 +100,7 @@ func TestGetPet(t *testing.T) {
 
 // PutCat - Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true
 func TestPutCat(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.PutCat(context.Background(), Cat{
 		Hisses:    to.Ptr(false),
 		Meows:     to.Ptr(true),
@@ -106,7 +115,7 @@ func TestPutCat(t *testing.T) {
 
 // PutFeline - Put a feline who hisses and doesn't meow
 func TestPutFeline(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.PutFeline(context.Background(), Feline{
 		Hisses: to.Ptr(true),
 		Meows:  to.Ptr(false),
@@ -119,7 +128,7 @@ func TestPutFeline(t *testing.T) {
 
 // PutHorse - Put a horse with name 'General' and isAShowHorse false
 func TestPutHorse(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.PutHorse(context.Background(), Horse{
 		Name:         to.Ptr("General"),
 		IsAShowHorse: to.Ptr(false),
@@ -132,7 +141,7 @@ func TestPutHorse(t *testing.T) {
 
 // PutKitten - Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true
 func TestPutKitten(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.PutKitten(context.Background(), Kitten{
 		Hisses:      to.Ptr(false),
 		Meows:       to.Ptr(true),
@@ -148,7 +157,7 @@ func TestPutKitten(t *testing.T) {
 
 // PutPet - Put a pet with name 'Butter'
 func TestPutPet(t *testing.T) {
-	client := newMultipleInheritanceServiceClient()
+	client := newMultipleInheritanceServiceClient(t)
 	result, err := client.PutPet(context.Background(), Pet{
 		Name: to.Ptr("Butter"),
 	}, nil)

--- a/test/autorest/migroup/zz_multipleinheritanceservice_client.go
+++ b/test/autorest/migroup/zz_multipleinheritanceservice_client.go
@@ -11,24 +11,16 @@ package migroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // MultipleInheritanceServiceClient contains the methods for the MultipleInheritanceServiceClient group.
-// Don't use this type directly, use NewMultipleInheritanceServiceClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type MultipleInheritanceServiceClient struct {
-	pl runtime.Pipeline
-}
-
-// NewMultipleInheritanceServiceClient creates a new instance of MultipleInheritanceServiceClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewMultipleInheritanceServiceClient(pl runtime.Pipeline) *MultipleInheritanceServiceClient {
-	client := &MultipleInheritanceServiceClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetCat - Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true
@@ -42,7 +34,7 @@ func (client *MultipleInheritanceServiceClient) GetCat(ctx context.Context, opti
 	if err != nil {
 		return MultipleInheritanceServiceClientGetCatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientGetCatResponse{}, err
 	}
@@ -83,7 +75,7 @@ func (client *MultipleInheritanceServiceClient) GetFeline(ctx context.Context, o
 	if err != nil {
 		return MultipleInheritanceServiceClientGetFelineResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientGetFelineResponse{}, err
 	}
@@ -124,7 +116,7 @@ func (client *MultipleInheritanceServiceClient) GetHorse(ctx context.Context, op
 	if err != nil {
 		return MultipleInheritanceServiceClientGetHorseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientGetHorseResponse{}, err
 	}
@@ -165,7 +157,7 @@ func (client *MultipleInheritanceServiceClient) GetKitten(ctx context.Context, o
 	if err != nil {
 		return MultipleInheritanceServiceClientGetKittenResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientGetKittenResponse{}, err
 	}
@@ -206,7 +198,7 @@ func (client *MultipleInheritanceServiceClient) GetPet(ctx context.Context, opti
 	if err != nil {
 		return MultipleInheritanceServiceClientGetPetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientGetPetResponse{}, err
 	}
@@ -248,7 +240,7 @@ func (client *MultipleInheritanceServiceClient) PutCat(ctx context.Context, cat 
 	if err != nil {
 		return MultipleInheritanceServiceClientPutCatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientPutCatResponse{}, err
 	}
@@ -290,7 +282,7 @@ func (client *MultipleInheritanceServiceClient) PutFeline(ctx context.Context, f
 	if err != nil {
 		return MultipleInheritanceServiceClientPutFelineResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientPutFelineResponse{}, err
 	}
@@ -332,7 +324,7 @@ func (client *MultipleInheritanceServiceClient) PutHorse(ctx context.Context, ho
 	if err != nil {
 		return MultipleInheritanceServiceClientPutHorseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientPutHorseResponse{}, err
 	}
@@ -374,7 +366,7 @@ func (client *MultipleInheritanceServiceClient) PutKitten(ctx context.Context, k
 	if err != nil {
 		return MultipleInheritanceServiceClientPutKittenResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientPutKittenResponse{}, err
 	}
@@ -416,7 +408,7 @@ func (client *MultipleInheritanceServiceClient) PutPet(ctx context.Context, pet 
 	if err != nil {
 		return MultipleInheritanceServiceClientPutPetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return MultipleInheritanceServiceClientPutPetResponse{}, err
 	}

--- a/test/autorest/morecustombaseurigroup/paths_test.go
+++ b/test/autorest/morecustombaseurigroup/paths_test.go
@@ -14,14 +14,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPathsClient() *PathsClient {
-	// dnsSuffix string, subscriptionID string
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPathsClient(to.Ptr(":3000"), "test12", pl)
+func newPathsClient(t *testing.T) *PathsClient {
+	client, err := NewPathsClient("test12", to.Ptr(":3000"), nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPathsClient(subscriptionID string, dnsSuffix *string, options *azcore.ClientOptions) (*PathsClient, error) {
+	client, err := azcore.NewClient("morecustombaseurigroup.PathsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	if dnsSuffix == nil {
+		dnsSuffix = to.Ptr("host")
+	}
+	return &PathsClient{
+		internal:       client,
+		dnsSuffix:      *dnsSuffix,
+		subscriptionID: subscriptionID,
+	}, nil
 }
 
 func TestGetEmpty(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	// vault string, secret string, keyName string, options *PathsGetEmptyOptions
 	result, err := client.GetEmpty(context.Background(), "http://localhost", "", "key1", &PathsClientGetEmptyOptions{
 		KeyVersion: to.Ptr("v1"),

--- a/test/autorest/morecustombaseurigroup/zz_paths_client.go
+++ b/test/autorest/morecustombaseurigroup/zz_paths_client.go
@@ -12,6 +12,7 @@ package morecustombaseurigroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,27 +21,11 @@ import (
 )
 
 // PathsClient contains the methods for the Paths group.
-// Don't use this type directly, use NewPathsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PathsClient struct {
+	internal       *azcore.Client
 	dnsSuffix      string
 	subscriptionID string
-	pl             runtime.Pipeline
-}
-
-// NewPathsClient creates a new instance of PathsClient with the specified values.
-//   - dnsSuffix - A string value that is used as a global part of the parameterized host. Default value 'host'.
-//   - subscriptionID - The subscription id with value 'test12'.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPathsClient(dnsSuffix *string, subscriptionID string, pl runtime.Pipeline) *PathsClient {
-	client := &PathsClient{
-		dnsSuffix:      "host",
-		subscriptionID: subscriptionID,
-		pl:             pl,
-	}
-	if dnsSuffix != nil {
-		client.dnsSuffix = *dnsSuffix
-	}
-	return client
 }
 
 // GetEmpty - Get a 200 to test a valid base uri
@@ -56,7 +41,7 @@ func (client *PathsClient) GetEmpty(ctx context.Context, vault string, secret st
 	if err != nil {
 		return PathsClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetEmptyResponse{}, err
 	}

--- a/test/autorest/nonstringenumgroup/float_test.go
+++ b/test/autorest/nonstringenumgroup/float_test.go
@@ -15,14 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newFloatClient() *FloatClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewFloatClient(pl)
+func newFloatClient(t *testing.T) *FloatClient {
+	client, err := NewFloatClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewFloatClient(options *azcore.ClientOptions) (*FloatClient, error) {
+	client, err := azcore.NewClient("nonstringenumgroup.FloatClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &FloatClient{internal: client}, nil
 }
 
 // Get - Get a float enum
 func TestFloatGet(t *testing.T) {
-	client := newFloatClient()
+	client := newFloatClient(t)
 	result, err := client.Get(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(FloatEnumFourHundredTwentyNine1)); r != "" {
@@ -32,7 +41,7 @@ func TestFloatGet(t *testing.T) {
 
 // Put - Put a float enum
 func TestFloatPut(t *testing.T) {
-	client := newFloatClient()
+	client := newFloatClient(t)
 	result, err := client.Put(context.Background(), FloatEnumTwoHundred4, nil)
 	require.NoError(t, err)
 	if *result.Value != "Nice job posting a float enum" {

--- a/test/autorest/nonstringenumgroup/int_test.go
+++ b/test/autorest/nonstringenumgroup/int_test.go
@@ -15,14 +15,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newIntClient() *IntClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewIntClient(pl)
+func newIntClient(t *testing.T) *IntClient {
+	client, err := NewIntClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewIntClient(options *azcore.ClientOptions) (*IntClient, error) {
+	client, err := azcore.NewClient("nonstringenumgroup.IntClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &IntClient{internal: client}, nil
 }
 
 // Get - Get an int enum
 func TestIntGet(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.Get(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(IntEnumFourHundredTwentyNine)); r != "" {
@@ -32,7 +41,7 @@ func TestIntGet(t *testing.T) {
 
 // Put - Put an int enum
 func TestIntPut(t *testing.T) {
-	client := newIntClient()
+	client := newIntClient(t)
 	result, err := client.Put(context.Background(), IntEnumTwoHundred, nil)
 	require.NoError(t, err)
 	if *result.Value != "Nice job posting an int enum" {

--- a/test/autorest/nonstringenumgroup/zz_float_client.go
+++ b/test/autorest/nonstringenumgroup/zz_float_client.go
@@ -11,24 +11,16 @@ package nonstringenumgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // FloatClient contains the methods for the Float group.
-// Don't use this type directly, use NewFloatClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type FloatClient struct {
-	pl runtime.Pipeline
-}
-
-// NewFloatClient creates a new instance of FloatClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewFloatClient(pl runtime.Pipeline) *FloatClient {
-	client := &FloatClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Get - Get a float enum
@@ -41,7 +33,7 @@ func (client *FloatClient) Get(ctx context.Context, options *FloatClientGetOptio
 	if err != nil {
 		return FloatClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FloatClientGetResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *FloatClient) Put(ctx context.Context, input FloatEnum, options *Fl
 	if err != nil {
 		return FloatClientPutResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FloatClientPutResponse{}, err
 	}

--- a/test/autorest/nonstringenumgroup/zz_int_client.go
+++ b/test/autorest/nonstringenumgroup/zz_int_client.go
@@ -11,24 +11,16 @@ package nonstringenumgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // IntClient contains the methods for the Int group.
-// Don't use this type directly, use NewIntClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type IntClient struct {
-	pl runtime.Pipeline
-}
-
-// NewIntClient creates a new instance of IntClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewIntClient(pl runtime.Pipeline) *IntClient {
-	client := &IntClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Get - Get an int enum
@@ -41,7 +33,7 @@ func (client *IntClient) Get(ctx context.Context, options *IntClientGetOptions) 
 	if err != nil {
 		return IntClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientGetResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *IntClient) Put(ctx context.Context, input IntEnum, options *IntCli
 	if err != nil {
 		return IntClientPutResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntClientPutResponse{}, err
 	}

--- a/test/autorest/numbergroup/numbergroup_test.go
+++ b/test/autorest/numbergroup/numbergroup_test.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newNumberClient() *NumberClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewNumberClient(pl)
+func newNumberClient(t *testing.T) *NumberClient {
+	client, err := NewNumberClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewNumberClient(options *azcore.ClientOptions) (*NumberClient, error) {
+	client, err := azcore.NewClient("numbergroup.NumberClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &NumberClient{internal: client}, nil
 }
 
 func TestNumberGetBigDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := 2.5976931e+101
@@ -30,7 +39,7 @@ func TestNumberGetBigDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDecimalNegativeDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := -99999999.99
@@ -40,7 +49,7 @@ func TestNumberGetBigDecimalNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDecimalPositiveDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := 99999999.99
@@ -50,7 +59,7 @@ func TestNumberGetBigDecimalPositiveDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDouble(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDouble(context.Background(), nil)
 	require.NoError(t, err)
 	val := 2.5976931e+101
@@ -60,7 +69,7 @@ func TestNumberGetBigDouble(t *testing.T) {
 }
 
 func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDoubleNegativeDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := -99999999.99
@@ -70,7 +79,7 @@ func TestNumberGetBigDoubleNegativeDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigDoublePositiveDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := 99999999.99
@@ -80,7 +89,7 @@ func TestNumberGetBigDoublePositiveDecimal(t *testing.T) {
 }
 
 func TestNumberGetBigFloat(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetBigFloat(context.Background(), nil)
 	require.NoError(t, err)
 	val := float32(3.402823e+20)
@@ -90,28 +99,28 @@ func TestNumberGetBigFloat(t *testing.T) {
 }
 
 func TestNumberGetInvalidDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetInvalidDecimal(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberGetInvalidDouble(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetInvalidDouble(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberGetInvalidFloat(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetInvalidFloat(context.Background(), nil)
 	require.Error(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberGetNull(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, (*float32)(nil)); r != "" {
@@ -120,7 +129,7 @@ func TestNumberGetNull(t *testing.T) {
 }
 
 func TestNumberGetSmallDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetSmallDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	val := 2.5976931e-101
@@ -130,7 +139,7 @@ func TestNumberGetSmallDecimal(t *testing.T) {
 }
 
 func TestNumberGetSmallDouble(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetSmallDouble(context.Background(), nil)
 	require.NoError(t, err)
 	val := 2.5976931e-101
@@ -140,7 +149,7 @@ func TestNumberGetSmallDouble(t *testing.T) {
 }
 
 func TestNumberGetSmallFloat(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.GetSmallFloat(context.Background(), nil)
 	require.NoError(t, err)
 	val := 3.402823e-20
@@ -150,70 +159,70 @@ func TestNumberGetSmallFloat(t *testing.T) {
 }
 
 func TestNumberPutBigDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDecimal(context.Background(), 2.5976931e+101, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigDecimalNegativeDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDecimalNegativeDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigDecimalPositiveDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDecimalPositiveDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigDouble(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDouble(context.Background(), 2.5976931e+101, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigDoubleNegativeDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDoubleNegativeDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigDoublePositiveDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigDoublePositiveDecimal(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutBigFloat(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutBigFloat(context.Background(), 3.402823e+20, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutSmallDecimal(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutSmallDecimal(context.Background(), 2.5976931e-101, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutSmallDouble(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutSmallDouble(context.Background(), 2.5976931e-101, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestNumberPutSmallFloat(t *testing.T) {
-	client := newNumberClient()
+	client := newNumberClient(t)
 	result, err := client.PutSmallFloat(context.Background(), 3.402823e-20, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/numbergroup/zz_number_client.go
+++ b/test/autorest/numbergroup/zz_number_client.go
@@ -11,24 +11,16 @@ package numbergroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // NumberClient contains the methods for the Number group.
-// Don't use this type directly, use NewNumberClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type NumberClient struct {
-	pl runtime.Pipeline
-}
-
-// NewNumberClient creates a new instance of NumberClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewNumberClient(pl runtime.Pipeline) *NumberClient {
-	client := &NumberClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetBigDecimal - Get big decimal value 2.5976931e+101
@@ -41,7 +33,7 @@ func (client *NumberClient) GetBigDecimal(ctx context.Context, options *NumberCl
 	if err != nil {
 		return NumberClientGetBigDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDecimalResponse{}, err
 	}
@@ -82,7 +74,7 @@ func (client *NumberClient) GetBigDecimalNegativeDecimal(ctx context.Context, op
 	if err != nil {
 		return NumberClientGetBigDecimalNegativeDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDecimalNegativeDecimalResponse{}, err
 	}
@@ -123,7 +115,7 @@ func (client *NumberClient) GetBigDecimalPositiveDecimal(ctx context.Context, op
 	if err != nil {
 		return NumberClientGetBigDecimalPositiveDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDecimalPositiveDecimalResponse{}, err
 	}
@@ -163,7 +155,7 @@ func (client *NumberClient) GetBigDouble(ctx context.Context, options *NumberCli
 	if err != nil {
 		return NumberClientGetBigDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDoubleResponse{}, err
 	}
@@ -204,7 +196,7 @@ func (client *NumberClient) GetBigDoubleNegativeDecimal(ctx context.Context, opt
 	if err != nil {
 		return NumberClientGetBigDoubleNegativeDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDoubleNegativeDecimalResponse{}, err
 	}
@@ -245,7 +237,7 @@ func (client *NumberClient) GetBigDoublePositiveDecimal(ctx context.Context, opt
 	if err != nil {
 		return NumberClientGetBigDoublePositiveDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigDoublePositiveDecimalResponse{}, err
 	}
@@ -285,7 +277,7 @@ func (client *NumberClient) GetBigFloat(ctx context.Context, options *NumberClie
 	if err != nil {
 		return NumberClientGetBigFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetBigFloatResponse{}, err
 	}
@@ -326,7 +318,7 @@ func (client *NumberClient) GetInvalidDecimal(ctx context.Context, options *Numb
 	if err != nil {
 		return NumberClientGetInvalidDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetInvalidDecimalResponse{}, err
 	}
@@ -366,7 +358,7 @@ func (client *NumberClient) GetInvalidDouble(ctx context.Context, options *Numbe
 	if err != nil {
 		return NumberClientGetInvalidDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetInvalidDoubleResponse{}, err
 	}
@@ -406,7 +398,7 @@ func (client *NumberClient) GetInvalidFloat(ctx context.Context, options *Number
 	if err != nil {
 		return NumberClientGetInvalidFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetInvalidFloatResponse{}, err
 	}
@@ -446,7 +438,7 @@ func (client *NumberClient) GetNull(ctx context.Context, options *NumberClientGe
 	if err != nil {
 		return NumberClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetNullResponse{}, err
 	}
@@ -486,7 +478,7 @@ func (client *NumberClient) GetSmallDecimal(ctx context.Context, options *Number
 	if err != nil {
 		return NumberClientGetSmallDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetSmallDecimalResponse{}, err
 	}
@@ -526,7 +518,7 @@ func (client *NumberClient) GetSmallDouble(ctx context.Context, options *NumberC
 	if err != nil {
 		return NumberClientGetSmallDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetSmallDoubleResponse{}, err
 	}
@@ -566,7 +558,7 @@ func (client *NumberClient) GetSmallFloat(ctx context.Context, options *NumberCl
 	if err != nil {
 		return NumberClientGetSmallFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientGetSmallFloatResponse{}, err
 	}
@@ -607,7 +599,7 @@ func (client *NumberClient) PutBigDecimal(ctx context.Context, numberBody float6
 	if err != nil {
 		return NumberClientPutBigDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDecimalResponse{}, err
 	}
@@ -639,7 +631,7 @@ func (client *NumberClient) PutBigDecimalNegativeDecimal(ctx context.Context, op
 	if err != nil {
 		return NumberClientPutBigDecimalNegativeDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDecimalNegativeDecimalResponse{}, err
 	}
@@ -671,7 +663,7 @@ func (client *NumberClient) PutBigDecimalPositiveDecimal(ctx context.Context, op
 	if err != nil {
 		return NumberClientPutBigDecimalPositiveDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDecimalPositiveDecimalResponse{}, err
 	}
@@ -703,7 +695,7 @@ func (client *NumberClient) PutBigDouble(ctx context.Context, numberBody float64
 	if err != nil {
 		return NumberClientPutBigDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDoubleResponse{}, err
 	}
@@ -735,7 +727,7 @@ func (client *NumberClient) PutBigDoubleNegativeDecimal(ctx context.Context, opt
 	if err != nil {
 		return NumberClientPutBigDoubleNegativeDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDoubleNegativeDecimalResponse{}, err
 	}
@@ -767,7 +759,7 @@ func (client *NumberClient) PutBigDoublePositiveDecimal(ctx context.Context, opt
 	if err != nil {
 		return NumberClientPutBigDoublePositiveDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigDoublePositiveDecimalResponse{}, err
 	}
@@ -799,7 +791,7 @@ func (client *NumberClient) PutBigFloat(ctx context.Context, numberBody float32,
 	if err != nil {
 		return NumberClientPutBigFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutBigFloatResponse{}, err
 	}
@@ -831,7 +823,7 @@ func (client *NumberClient) PutSmallDecimal(ctx context.Context, numberBody floa
 	if err != nil {
 		return NumberClientPutSmallDecimalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutSmallDecimalResponse{}, err
 	}
@@ -863,7 +855,7 @@ func (client *NumberClient) PutSmallDouble(ctx context.Context, numberBody float
 	if err != nil {
 		return NumberClientPutSmallDoubleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutSmallDoubleResponse{}, err
 	}
@@ -895,7 +887,7 @@ func (client *NumberClient) PutSmallFloat(ctx context.Context, numberBody float3
 	if err != nil {
 		return NumberClientPutSmallFloatResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NumberClientPutSmallFloatResponse{}, err
 	}

--- a/test/autorest/objectgroup/objectgroup_test.go
+++ b/test/autorest/objectgroup/objectgroup_test.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newObjectTypeClient() *ObjectTypeClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewObjectTypeClient(pl)
+func newObjectTypeClient(t *testing.T) *ObjectTypeClient {
+	client, err := NewObjectTypeClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewObjectTypeClient(options *azcore.ClientOptions) (*ObjectTypeClient, error) {
+	client, err := azcore.NewClient("objectgroup.ObjectTypeClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ObjectTypeClient{internal: client}, nil
 }
 
 func TestGet(t *testing.T) {
-	client := newObjectTypeClient()
+	client := newObjectTypeClient(t)
 	resp, err := client.Get(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(string(resp.RawJSON), `{ "message": "An object was successfully returned" }`); r != "" {
@@ -29,7 +38,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestPut(t *testing.T) {
-	client := newObjectTypeClient()
+	client := newObjectTypeClient(t)
 	result, err := client.Put(context.Background(), []byte(`{ "foo": "bar" }`), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/objectgroup/zz_objecttype_client.go
+++ b/test/autorest/objectgroup/zz_objecttype_client.go
@@ -12,6 +12,7 @@ package objectgroup
 import (
 	"bytes"
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -19,18 +20,9 @@ import (
 )
 
 // ObjectTypeClient contains the methods for the ObjectTypeClient group.
-// Don't use this type directly, use NewObjectTypeClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ObjectTypeClient struct {
-	pl runtime.Pipeline
-}
-
-// NewObjectTypeClient creates a new instance of ObjectTypeClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewObjectTypeClient(pl runtime.Pipeline) *ObjectTypeClient {
-	client := &ObjectTypeClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Get - Basic get that returns an object. Returns object { 'message': 'An object was successfully returned' }
@@ -43,7 +35,7 @@ func (client *ObjectTypeClient) Get(ctx context.Context, options *ObjectTypeClie
 	if err != nil {
 		return ObjectTypeClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ObjectTypeClientGetResponse{}, err
 	}
@@ -86,7 +78,7 @@ func (client *ObjectTypeClient) Put(ctx context.Context, putObject []byte, optio
 	if err != nil {
 		return ObjectTypeClientPutResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ObjectTypeClientPutResponse{}, err
 	}

--- a/test/autorest/optionalgroup/explicit_test.go
+++ b/test/autorest/optionalgroup/explicit_test.go
@@ -13,83 +13,92 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newExplicitClient() *ExplicitClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewExplicitClient(pl)
+func newExplicitClient(t *testing.T) *ExplicitClient {
+	client, err := NewExplicitClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewExplicitClient(options *azcore.ClientOptions) (*ExplicitClient, error) {
+	client, err := azcore.NewClient("optionalgroup.ExplicitClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ExplicitClient{internal: client}, nil
 }
 
 func TestExplicitPostOptionalArrayHeader(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalArrayHeader(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalArrayParameter(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalArrayParameter(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalArrayProperty(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalArrayProperty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalClassParameter(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalClassParameter(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalClassProperty(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalClassProperty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalIntegerHeader(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalIntegerHeader(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalIntegerParameter(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalIntegerParameter(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalIntegerProperty(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalIntegerProperty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalStringHeader(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalStringHeader(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalStringParameter(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalStringParameter(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestExplicitPostOptionalStringProperty(t *testing.T) {
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostOptionalStringProperty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -98,7 +107,7 @@ func TestExplicitPostOptionalStringProperty(t *testing.T) {
 // TODO the goal of this test is to throw an exception but nils are acceptable for  []strings in go
 func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredArrayHeader(context.Background(), nil, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -107,7 +116,7 @@ func TestExplicitPostRequiredArrayHeader(t *testing.T) {
 // TODO the goal of this test is to throw an exception but nils are acceptable for  []strings in go
 func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredArrayParameter(context.Background(), nil, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -115,7 +124,7 @@ func TestExplicitPostRequiredArrayParameter(t *testing.T) {
 
 func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredArrayProperty(context.Background(), ArrayWrapper{Value: nil}, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -124,7 +133,7 @@ func TestExplicitPostRequiredArrayProperty(t *testing.T) {
 // TODO check this test
 func TestExplicitPostRequiredClassParameter(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredClassParameter(context.Background(), Product{}, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -132,7 +141,7 @@ func TestExplicitPostRequiredClassParameter(t *testing.T) {
 
 func TestExplicitPostRequiredClassProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredClassProperty(context.Background(), ClassWrapper{}, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -141,7 +150,7 @@ func TestExplicitPostRequiredClassProperty(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredIntegerHeader(context.Background(), 0, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -150,7 +159,7 @@ func TestExplicitPostRequiredIntegerHeader(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 	t.Skip("cannot set nil for int32 in Go")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredIntegerParameter(context.Background(), 0, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -159,7 +168,7 @@ func TestExplicitPostRequiredIntegerParameter(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredIntegerProperty(context.Background(), IntWrapper{}, nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -168,7 +177,7 @@ func TestExplicitPostRequiredIntegerProperty(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringHeader(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredStringHeader(context.Background(), "", nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -177,7 +186,7 @@ func TestExplicitPostRequiredStringHeader(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringParameter(t *testing.T) {
 	t.Skip("cannot set nil for string in Go")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredStringParameter(context.Background(), "", nil)
 	require.Error(t, err)
 	require.Zero(t, result)
@@ -186,7 +195,7 @@ func TestExplicitPostRequiredStringParameter(t *testing.T) {
 // TODO check this test is does pass if we query the endpoint but that is not the expected behavior
 func TestExplicitPostRequiredStringProperty(t *testing.T) {
 	t.Skip("are not validating parameters in track2")
-	client := newExplicitClient()
+	client := newExplicitClient(t)
 	result, err := client.PostRequiredStringProperty(context.Background(), StringWrapper{}, nil)
 	require.Error(t, err)
 	require.Zero(t, result)

--- a/test/autorest/optionalgroup/implicit_test.go
+++ b/test/autorest/optionalgroup/implicit_test.go
@@ -13,13 +13,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newImplicitClient() *ImplicitClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewImplicitClient("", "", nil, pl)
+func newImplicitClient(t *testing.T) *ImplicitClient {
+	client, err := NewImplicitClient("", "", nil, nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewImplicitClient(equiredGlobalPath string, requiredGlobalQuery string, optionalGlobalQuery *int32, options *azcore.ClientOptions) (*ImplicitClient, error) {
+	client, err := azcore.NewClient("optionalgroup.ImplicitClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ImplicitClient{internal: client}, nil
 }
 
 func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.GetOptionalGlobalQuery(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -27,7 +36,7 @@ func TestImplicitGetOptionalGlobalQuery(t *testing.T) {
 
 func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.GetRequiredGlobalPath(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -35,7 +44,7 @@ func TestImplicitGetRequiredGlobalPath(t *testing.T) {
 
 func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.GetRequiredGlobalQuery(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -43,28 +52,28 @@ func TestImplicitGetRequiredGlobalQuery(t *testing.T) {
 
 func TestImplicitGetRequiredPath(t *testing.T) {
 	t.Skip("Cannot set nil for string parameter so test invalid for Go")
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.GetRequiredPath(context.Background(), "", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestImplicitPutOptionalBody(t *testing.T) {
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.PutOptionalBody(context.Background(), "", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestImplicitPutOptionalHeader(t *testing.T) {
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.PutOptionalHeader(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestImplicitPutOptionalQuery(t *testing.T) {
-	client := newImplicitClient()
+	client := newImplicitClient(t)
 	result, err := client.PutOptionalQuery(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/optionalgroup/zz_explicit_client.go
+++ b/test/autorest/optionalgroup/zz_explicit_client.go
@@ -11,6 +11,7 @@ package optionalgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -21,18 +22,9 @@ import (
 )
 
 // ExplicitClient contains the methods for the Explicit group.
-// Don't use this type directly, use NewExplicitClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ExplicitClient struct {
-	pl runtime.Pipeline
-}
-
-// NewExplicitClient creates a new instance of ExplicitClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewExplicitClient(pl runtime.Pipeline) *ExplicitClient {
-	client := &ExplicitClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // PostOptionalArrayHeader - Test explicitly optional integer. Please put a header 'headerParameter' => null.
@@ -46,7 +38,7 @@ func (client *ExplicitClient) PostOptionalArrayHeader(ctx context.Context, optio
 	if err != nil {
 		return ExplicitClientPostOptionalArrayHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalArrayHeaderResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *ExplicitClient) PostOptionalArrayParameter(ctx context.Context, op
 	if err != nil {
 		return ExplicitClientPostOptionalArrayParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalArrayParameterResponse{}, err
 	}
@@ -116,7 +108,7 @@ func (client *ExplicitClient) PostOptionalArrayProperty(ctx context.Context, opt
 	if err != nil {
 		return ExplicitClientPostOptionalArrayPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalArrayPropertyResponse{}, err
 	}
@@ -151,7 +143,7 @@ func (client *ExplicitClient) PostOptionalClassParameter(ctx context.Context, op
 	if err != nil {
 		return ExplicitClientPostOptionalClassParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalClassParameterResponse{}, err
 	}
@@ -186,7 +178,7 @@ func (client *ExplicitClient) PostOptionalClassProperty(ctx context.Context, opt
 	if err != nil {
 		return ExplicitClientPostOptionalClassPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalClassPropertyResponse{}, err
 	}
@@ -221,7 +213,7 @@ func (client *ExplicitClient) PostOptionalIntegerHeader(ctx context.Context, opt
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerHeaderResponse{}, err
 	}
@@ -256,7 +248,7 @@ func (client *ExplicitClient) PostOptionalIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerParameterResponse{}, err
 	}
@@ -291,7 +283,7 @@ func (client *ExplicitClient) PostOptionalIntegerProperty(ctx context.Context, o
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalIntegerPropertyResponse{}, err
 	}
@@ -326,7 +318,7 @@ func (client *ExplicitClient) PostOptionalStringHeader(ctx context.Context, opti
 	if err != nil {
 		return ExplicitClientPostOptionalStringHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalStringHeaderResponse{}, err
 	}
@@ -361,7 +353,7 @@ func (client *ExplicitClient) PostOptionalStringParameter(ctx context.Context, o
 	if err != nil {
 		return ExplicitClientPostOptionalStringParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalStringParameterResponse{}, err
 	}
@@ -397,7 +389,7 @@ func (client *ExplicitClient) PostOptionalStringProperty(ctx context.Context, op
 	if err != nil {
 		return ExplicitClientPostOptionalStringPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostOptionalStringPropertyResponse{}, err
 	}
@@ -433,7 +425,7 @@ func (client *ExplicitClient) PostRequiredArrayHeader(ctx context.Context, heade
 	if err != nil {
 		return ExplicitClientPostRequiredArrayHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredArrayHeaderResponse{}, err
 	}
@@ -467,7 +459,7 @@ func (client *ExplicitClient) PostRequiredArrayParameter(ctx context.Context, bo
 	if err != nil {
 		return ExplicitClientPostRequiredArrayParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredArrayParameterResponse{}, err
 	}
@@ -500,7 +492,7 @@ func (client *ExplicitClient) PostRequiredArrayProperty(ctx context.Context, bod
 	if err != nil {
 		return ExplicitClientPostRequiredArrayPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredArrayPropertyResponse{}, err
 	}
@@ -533,7 +525,7 @@ func (client *ExplicitClient) PostRequiredClassParameter(ctx context.Context, bo
 	if err != nil {
 		return ExplicitClientPostRequiredClassParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredClassParameterResponse{}, err
 	}
@@ -566,7 +558,7 @@ func (client *ExplicitClient) PostRequiredClassProperty(ctx context.Context, bod
 	if err != nil {
 		return ExplicitClientPostRequiredClassPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredClassPropertyResponse{}, err
 	}
@@ -599,7 +591,7 @@ func (client *ExplicitClient) PostRequiredIntegerHeader(ctx context.Context, hea
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerHeaderResponse{}, err
 	}
@@ -633,7 +625,7 @@ func (client *ExplicitClient) PostRequiredIntegerParameter(ctx context.Context, 
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerParameterResponse{}, err
 	}
@@ -666,7 +658,7 @@ func (client *ExplicitClient) PostRequiredIntegerProperty(ctx context.Context, b
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredIntegerPropertyResponse{}, err
 	}
@@ -699,7 +691,7 @@ func (client *ExplicitClient) PostRequiredStringHeader(ctx context.Context, head
 	if err != nil {
 		return ExplicitClientPostRequiredStringHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredStringHeaderResponse{}, err
 	}
@@ -733,7 +725,7 @@ func (client *ExplicitClient) PostRequiredStringParameter(ctx context.Context, b
 	if err != nil {
 		return ExplicitClientPostRequiredStringParameterResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredStringParameterResponse{}, err
 	}
@@ -767,7 +759,7 @@ func (client *ExplicitClient) PostRequiredStringProperty(ctx context.Context, bo
 	if err != nil {
 		return ExplicitClientPostRequiredStringPropertyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPostRequiredStringPropertyResponse{}, err
 	}
@@ -799,7 +791,7 @@ func (client *ExplicitClient) PutOptionalBinaryBody(ctx context.Context, bodyPar
 	if err != nil {
 		return ExplicitClientPutOptionalBinaryBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPutOptionalBinaryBodyResponse{}, err
 	}
@@ -831,7 +823,7 @@ func (client *ExplicitClient) PutRequiredBinaryBody(ctx context.Context, bodyPar
 	if err != nil {
 		return ExplicitClientPutRequiredBinaryBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExplicitClientPutRequiredBinaryBodyResponse{}, err
 	}

--- a/test/autorest/optionalgroup/zz_implicit_client.go
+++ b/test/autorest/optionalgroup/zz_implicit_client.go
@@ -12,6 +12,7 @@ package optionalgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -23,27 +24,12 @@ import (
 )
 
 // ImplicitClient contains the methods for the Implicit group.
-// Don't use this type directly, use NewImplicitClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ImplicitClient struct {
+	internal            *azcore.Client
 	requiredGlobalPath  string
 	requiredGlobalQuery string
 	optionalGlobalQuery *int32
-	pl                  runtime.Pipeline
-}
-
-// NewImplicitClient creates a new instance of ImplicitClient with the specified values.
-//   - requiredGlobalPath - number of items to skip
-//   - requiredGlobalQuery - number of items to skip
-//   - optionalGlobalQuery - number of items to skip
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewImplicitClient(requiredGlobalPath string, requiredGlobalQuery string, optionalGlobalQuery *int32, pl runtime.Pipeline) *ImplicitClient {
-	client := &ImplicitClient{
-		requiredGlobalPath:  requiredGlobalPath,
-		requiredGlobalQuery: requiredGlobalQuery,
-		optionalGlobalQuery: optionalGlobalQuery,
-		pl:                  pl,
-	}
-	return client
 }
 
 // GetOptionalGlobalQuery - Test implicitly optional query parameter
@@ -57,7 +43,7 @@ func (client *ImplicitClient) GetOptionalGlobalQuery(ctx context.Context, option
 	if err != nil {
 		return ImplicitClientGetOptionalGlobalQueryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientGetOptionalGlobalQueryResponse{}, err
 	}
@@ -94,7 +80,7 @@ func (client *ImplicitClient) GetRequiredGlobalPath(ctx context.Context, options
 	if err != nil {
 		return ImplicitClientGetRequiredGlobalPathResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientGetRequiredGlobalPathResponse{}, err
 	}
@@ -130,7 +116,7 @@ func (client *ImplicitClient) GetRequiredGlobalQuery(ctx context.Context, option
 	if err != nil {
 		return ImplicitClientGetRequiredGlobalQueryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientGetRequiredGlobalQueryResponse{}, err
 	}
@@ -165,7 +151,7 @@ func (client *ImplicitClient) GetRequiredPath(ctx context.Context, pathParameter
 	if err != nil {
 		return ImplicitClientGetRequiredPathResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientGetRequiredPathResponse{}, err
 	}
@@ -201,7 +187,7 @@ func (client *ImplicitClient) PutOptionalBinaryBody(ctx context.Context, bodyPar
 	if err != nil {
 		return ImplicitClientPutOptionalBinaryBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientPutOptionalBinaryBodyResponse{}, err
 	}
@@ -233,7 +219,7 @@ func (client *ImplicitClient) PutOptionalBody(ctx context.Context, bodyParameter
 	if err != nil {
 		return ImplicitClientPutOptionalBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientPutOptionalBodyResponse{}, err
 	}
@@ -266,7 +252,7 @@ func (client *ImplicitClient) PutOptionalHeader(ctx context.Context, options *Im
 	if err != nil {
 		return ImplicitClientPutOptionalHeaderResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientPutOptionalHeaderResponse{}, err
 	}
@@ -301,7 +287,7 @@ func (client *ImplicitClient) PutOptionalQuery(ctx context.Context, options *Imp
 	if err != nil {
 		return ImplicitClientPutOptionalQueryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ImplicitClientPutOptionalQueryResponse{}, err
 	}

--- a/test/autorest/paginggroup/zz_paging_client.go
+++ b/test/autorest/paginggroup/zz_paging_client.go
@@ -12,6 +12,7 @@ package paginggroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -21,18 +22,9 @@ import (
 )
 
 // PagingClient contains the methods for the Paging group.
-// Don't use this type directly, use NewPagingClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PagingClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPagingClient creates a new instance of PagingClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPagingClient(pl runtime.Pipeline) *PagingClient {
-	client := &PagingClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // NewDuplicateParamsPager - Define filter as a query param for all calls. However, the returned next link will also include
@@ -57,7 +49,7 @@ func (client *PagingClient) NewDuplicateParamsPager(options *PagingClientDuplica
 			if err != nil {
 				return PagingClientDuplicateParamsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientDuplicateParamsResponse{}, err
 			}
@@ -116,7 +108,7 @@ func (client *PagingClient) NewFirstResponseEmptyPager(options *PagingClientFirs
 			if err != nil {
 				return PagingClientFirstResponseEmptyResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientFirstResponseEmptyResponse{}, err
 			}
@@ -169,7 +161,7 @@ func (client *PagingClient) NewGetMultiplePagesPager(options *PagingClientGetMul
 			if err != nil {
 				return PagingClientGetMultiplePagesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesResponse{}, err
 			}
@@ -231,7 +223,7 @@ func (client *PagingClient) NewGetMultiplePagesFailurePager(options *PagingClien
 			if err != nil {
 				return PagingClientGetMultiplePagesFailureResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesFailureResponse{}, err
 			}
@@ -284,7 +276,7 @@ func (client *PagingClient) NewGetMultiplePagesFailureURIPager(options *PagingCl
 			if err != nil {
 				return PagingClientGetMultiplePagesFailureURIResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesFailureURIResponse{}, err
 			}
@@ -339,7 +331,7 @@ func (client *PagingClient) NewGetMultiplePagesFragmentNextLinkPager(apiVersion 
 			if err != nil {
 				return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesFragmentNextLinkResponse{}, err
 			}
@@ -402,7 +394,7 @@ func (client *PagingClient) NewGetMultiplePagesFragmentWithGroupingNextLinkPager
 			if err != nil {
 				return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 			}
@@ -456,7 +448,7 @@ func (client *PagingClient) BeginGetMultiplePagesLRO(ctx context.Context, option
 			if err != nil {
 				return PagingClientGetMultiplePagesLROResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesLROResponse{}, err
 			}
@@ -471,11 +463,11 @@ func (client *PagingClient) BeginGetMultiplePagesLRO(ctx context.Context, option
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[*runtime.Pager[PagingClientGetMultiplePagesLROResponse]]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[*runtime.Pager[PagingClientGetMultiplePagesLROResponse]]{
 			Response: &pager,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.pl, &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[PagingClientGetMultiplePagesLROResponse]]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[PagingClientGetMultiplePagesLROResponse]]{
 			Response: &pager,
 		})
 	}
@@ -489,7 +481,7 @@ func (client *PagingClient) getMultiplePagesLRO(ctx context.Context, options *Pa
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +542,7 @@ func (client *PagingClient) NewGetMultiplePagesRetryFirstPager(options *PagingCl
 			if err != nil {
 				return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesRetryFirstResponse{}, err
 			}
@@ -604,7 +596,7 @@ func (client *PagingClient) NewGetMultiplePagesRetrySecondPager(options *PagingC
 			if err != nil {
 				return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesRetrySecondResponse{}, err
 			}
@@ -657,7 +649,7 @@ func (client *PagingClient) NewGetMultiplePagesWithOffsetPager(options PagingCli
 			if err != nil {
 				return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetMultiplePagesWithOffsetResponse{}, err
 			}
@@ -720,7 +712,7 @@ func (client *PagingClient) NewGetNoItemNamePagesPager(options *PagingClientGetN
 			if err != nil {
 				return PagingClientGetNoItemNamePagesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetNoItemNamePagesResponse{}, err
 			}
@@ -767,7 +759,7 @@ func (client *PagingClient) NewGetNullNextLinkNamePagesPager(options *PagingClie
 			if err != nil {
 				return PagingClientGetNullNextLinkNamePagesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetNullNextLinkNamePagesResponse{}, err
 			}
@@ -820,7 +812,7 @@ func (client *PagingClient) NewGetODataMultiplePagesPager(options *PagingClientG
 			if err != nil {
 				return PagingClientGetODataMultiplePagesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetODataMultiplePagesResponse{}, err
 			}
@@ -883,7 +875,7 @@ func (client *PagingClient) NewGetPagingModelWithItemNameWithXMSClientNamePager(
 			if err != nil {
 				return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse{}, err
 			}
@@ -936,7 +928,7 @@ func (client *PagingClient) NewGetSinglePagesPager(options *PagingClientGetSingl
 			if err != nil {
 				return PagingClientGetSinglePagesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetSinglePagesResponse{}, err
 			}
@@ -989,7 +981,7 @@ func (client *PagingClient) NewGetSinglePagesFailurePager(options *PagingClientG
 			if err != nil {
 				return PagingClientGetSinglePagesFailureResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetSinglePagesFailureResponse{}, err
 			}
@@ -1044,7 +1036,7 @@ func (client *PagingClient) NewGetWithQueryParamsPager(requiredQueryParameter in
 			if err != nil {
 				return PagingClientGetWithQueryParamsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PagingClientGetWithQueryParamsResponse{}, err
 			}

--- a/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
+++ b/test/autorest/paramgroupinggroup/paramgroupinggroup_test.go
@@ -13,14 +13,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newParameterGroupingClient() *ParameterGroupingClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewParameterGroupingClient(pl)
+func newParameterGroupingClient(t *testing.T) *ParameterGroupingClient {
+	client, err := NewParameterGroupingClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewParameterGroupingClient(options *azcore.ClientOptions) (*ParameterGroupingClient, error) {
+	client, err := azcore.NewClient("paramgroupinggroup.ParameterGroupingClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &ParameterGroupingClient{internal: client}, nil
 }
 
 // PostMultiParamGroups - Post parameters from multiple different parameter groups
 func TestPostMultiParamGroups(t *testing.T) {
-	client := newParameterGroupingClient()
+	client := newParameterGroupingClient(t)
 	result, err := client.PostMultiParamGroups(context.Background(), nil, nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -28,7 +37,7 @@ func TestPostMultiParamGroups(t *testing.T) {
 
 // PostOptional - Post a bunch of optional parameters grouped
 func TestPostOptional(t *testing.T) {
-	client := newParameterGroupingClient()
+	client := newParameterGroupingClient(t)
 	result, err := client.PostOptional(context.Background(), nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -36,7 +45,7 @@ func TestPostOptional(t *testing.T) {
 
 // PostRequired - Post a bunch of required parameters grouped
 func TestPostRequired(t *testing.T) {
-	client := newParameterGroupingClient()
+	client := newParameterGroupingClient(t)
 	result, err := client.PostRequired(context.Background(), ParameterGroupingClientPostRequiredParameters{
 		Body: 1234,
 		Path: "path",
@@ -47,7 +56,7 @@ func TestPostRequired(t *testing.T) {
 
 // PostSharedParameterGroupObject - Post parameters with a shared parameter group object
 func TestPostSharedParameterGroupObject(t *testing.T) {
-	client := newParameterGroupingClient()
+	client := newParameterGroupingClient(t)
 	result, err := client.PostSharedParameterGroupObject(context.Background(), nil, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/paramgroupinggroup/zz_parametergrouping_client.go
+++ b/test/autorest/paramgroupinggroup/zz_parametergrouping_client.go
@@ -12,6 +12,7 @@ package paramgroupinggroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -21,18 +22,9 @@ import (
 )
 
 // ParameterGroupingClient contains the methods for the ParameterGrouping group.
-// Don't use this type directly, use NewParameterGroupingClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ParameterGroupingClient struct {
-	pl runtime.Pipeline
-}
-
-// NewParameterGroupingClient creates a new instance of ParameterGroupingClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewParameterGroupingClient(pl runtime.Pipeline) *ParameterGroupingClient {
-	client := &ParameterGroupingClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // PostMultiParamGroups - Post parameters from multiple different parameter groups
@@ -50,7 +42,7 @@ func (client *ParameterGroupingClient) PostMultiParamGroups(ctx context.Context,
 	if err != nil {
 		return ParameterGroupingClientPostMultiParamGroupsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ParameterGroupingClientPostMultiParamGroupsResponse{}, err
 	}
@@ -98,7 +90,7 @@ func (client *ParameterGroupingClient) PostOptional(ctx context.Context, paramet
 	if err != nil {
 		return ParameterGroupingClientPostOptionalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ParameterGroupingClientPostOptionalResponse{}, err
 	}
@@ -140,7 +132,7 @@ func (client *ParameterGroupingClient) PostRequired(ctx context.Context, paramet
 	if err != nil {
 		return ParameterGroupingClientPostRequiredResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ParameterGroupingClientPostRequiredResponse{}, err
 	}
@@ -186,7 +178,7 @@ func (client *ParameterGroupingClient) PostReservedWords(ctx context.Context, pa
 	if err != nil {
 		return ParameterGroupingClientPostReservedWordsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ParameterGroupingClientPostReservedWordsResponse{}, err
 	}
@@ -228,7 +220,7 @@ func (client *ParameterGroupingClient) PostSharedParameterGroupObject(ctx contex
 	if err != nil {
 		return ParameterGroupingClientPostSharedParameterGroupObjectResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ParameterGroupingClientPostSharedParameterGroupObjectResponse{}, err
 	}

--- a/test/autorest/reportgroup/custom_client.go
+++ b/test/autorest/reportgroup/custom_client.go
@@ -1,0 +1,25 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package reportgroup
+
+import (
+	"generatortests"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewAutoRestReportServiceClient(options *azcore.ClientOptions) (*AutoRestReportServiceClient, error) {
+	cl, err := azcore.NewClient("reportgroup.AutoRestReportServiceClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	client := &AutoRestReportServiceClient{
+		internal: cl,
+	}
+	return client, nil
+}

--- a/test/autorest/reportgroup/zz_autorestreportservice_client.go
+++ b/test/autorest/reportgroup/zz_autorestreportservice_client.go
@@ -11,24 +11,16 @@ package reportgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // AutoRestReportServiceClient contains the methods for the AutoRestReportService group.
-// Don't use this type directly, use NewAutoRestReportServiceClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type AutoRestReportServiceClient struct {
-	pl runtime.Pipeline
-}
-
-// NewAutoRestReportServiceClient creates a new instance of AutoRestReportServiceClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewAutoRestReportServiceClient(pl runtime.Pipeline) *AutoRestReportServiceClient {
-	client := &AutoRestReportServiceClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetOptionalReport - Get optional test coverage report
@@ -42,7 +34,7 @@ func (client *AutoRestReportServiceClient) GetOptionalReport(ctx context.Context
 	if err != nil {
 		return AutoRestReportServiceClientGetOptionalReportResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestReportServiceClientGetOptionalReportResponse{}, err
 	}
@@ -88,7 +80,7 @@ func (client *AutoRestReportServiceClient) GetReport(ctx context.Context, option
 	if err != nil {
 		return AutoRestReportServiceClientGetReportResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestReportServiceClientGetReportResponse{}, err
 	}

--- a/test/autorest/stringgroup/enum_test.go
+++ b/test/autorest/stringgroup/enum_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newEnumClient() *EnumClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewEnumClient(pl)
+func newEnumClient(t *testing.T) *EnumClient {
+	client, err := NewEnumClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewEnumClient(options *azcore.ClientOptions) (*EnumClient, error) {
+	client, err := azcore.NewClient("stringgroup.EnumClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &EnumClient{internal: client}, nil
 }
 
 func TestEnumGetNotExpandable(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.GetNotExpandable(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(ColorsRedColor)); r != "" {
@@ -30,7 +39,7 @@ func TestEnumGetNotExpandable(t *testing.T) {
 }
 
 func TestEnumGetReferenced(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.GetReferenced(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr(ColorsRedColor)); r != "" {
@@ -39,7 +48,7 @@ func TestEnumGetReferenced(t *testing.T) {
 }
 
 func TestEnumGetReferencedConstant(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.GetReferencedConstant(context.Background(), nil)
 	require.NoError(t, err)
 	val := "Sample String"
@@ -49,21 +58,21 @@ func TestEnumGetReferencedConstant(t *testing.T) {
 }
 
 func TestEnumPutNotExpandable(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.PutNotExpandable(context.Background(), ColorsRedColor, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestEnumPutReferenced(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.PutReferenced(context.Background(), ColorsRedColor, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestEnumPutReferencedConstant(t *testing.T) {
-	client := newEnumClient()
+	client := newEnumClient(t)
 	result, err := client.PutReferencedConstant(context.Background(), RefColorConstant{}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/stringgroup/string_test.go
+++ b/test/autorest/stringgroup/string_test.go
@@ -15,13 +15,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newStringClient() *StringClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewStringClient(pl)
+func newStringClient(t *testing.T) *StringClient {
+	client, err := NewStringClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewStringClient(options *azcore.ClientOptions) (*StringClient, error) {
+	client, err := azcore.NewClient("stringgroup.StringClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &StringClient{internal: client}, nil
 }
 
 func TestStringGetMBCS(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetMBCS(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr("啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€")); r != "" {
@@ -30,14 +39,14 @@ func TestStringGetMBCS(t *testing.T) {
 }
 
 func TestStringPutMBCS(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.PutMBCS(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestStringGetBase64Encoded(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetBase64Encoded(context.Background(), nil)
 	require.NoError(t, err)
 	val := []byte("a string that gets encoded with base64")
@@ -47,7 +56,7 @@ func TestStringGetBase64Encoded(t *testing.T) {
 }
 
 func TestStringGetBase64URLEncoded(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetBase64URLEncoded(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, []byte("a string that gets encoded with base64url")); r != "" {
@@ -56,7 +65,7 @@ func TestStringGetBase64URLEncoded(t *testing.T) {
 }
 
 func TestStringGetEmpty(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr("")); r != "" {
@@ -65,21 +74,21 @@ func TestStringGetEmpty(t *testing.T) {
 }
 
 func TestStringGetNotProvided(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetNotProvided(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestStringGetNull(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestStringGetNullBase64URLEncoded(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetNullBase64URLEncoded(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, ([]byte)(nil)); r != "" {
@@ -88,7 +97,7 @@ func TestStringGetNullBase64URLEncoded(t *testing.T) {
 }
 
 func TestStringGetWhitespace(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.GetWhitespace(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.Value, to.Ptr("    Now is the time for all good men to come to the aid of their country    ")); r != "" {
@@ -97,14 +106,14 @@ func TestStringGetWhitespace(t *testing.T) {
 }
 
 func TestStringPutBase64URLEncoded(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.PutBase64URLEncoded(context.Background(), []byte("a string that gets encoded with base64url"), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestStringPutEmpty(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.PutEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -112,14 +121,14 @@ func TestStringPutEmpty(t *testing.T) {
 
 func TestStringPutNull(t *testing.T) {
 	t.Skip("missing x-nullable")
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.PutNull(context.Background(), "", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestStringPutWhitespace(t *testing.T) {
-	client := newStringClient()
+	client := newStringClient(t)
 	result, err := client.PutWhitespace(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/stringgroup/zz_enum_client.go
+++ b/test/autorest/stringgroup/zz_enum_client.go
@@ -11,24 +11,16 @@ package stringgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // EnumClient contains the methods for the Enum group.
-// Don't use this type directly, use NewEnumClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type EnumClient struct {
-	pl runtime.Pipeline
-}
-
-// NewEnumClient creates a new instance of EnumClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewEnumClient(pl runtime.Pipeline) *EnumClient {
-	client := &EnumClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetNotExpandable - Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
@@ -41,7 +33,7 @@ func (client *EnumClient) GetNotExpandable(ctx context.Context, options *EnumCli
 	if err != nil {
 		return EnumClientGetNotExpandableResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientGetNotExpandableResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *EnumClient) GetReferenced(ctx context.Context, options *EnumClient
 	if err != nil {
 		return EnumClientGetReferencedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientGetReferencedResponse{}, err
 	}
@@ -122,7 +114,7 @@ func (client *EnumClient) GetReferencedConstant(ctx context.Context, options *En
 	if err != nil {
 		return EnumClientGetReferencedConstantResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientGetReferencedConstantResponse{}, err
 	}
@@ -163,7 +155,7 @@ func (client *EnumClient) PutNotExpandable(ctx context.Context, stringBody Color
 	if err != nil {
 		return EnumClientPutNotExpandableResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientPutNotExpandableResponse{}, err
 	}
@@ -195,7 +187,7 @@ func (client *EnumClient) PutReferenced(ctx context.Context, enumStringBody Colo
 	if err != nil {
 		return EnumClientPutReferencedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientPutReferencedResponse{}, err
 	}
@@ -228,7 +220,7 @@ func (client *EnumClient) PutReferencedConstant(ctx context.Context, enumStringB
 	if err != nil {
 		return EnumClientPutReferencedConstantResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return EnumClientPutReferencedConstantResponse{}, err
 	}

--- a/test/autorest/stringgroup/zz_string_client.go
+++ b/test/autorest/stringgroup/zz_string_client.go
@@ -11,6 +11,7 @@ package stringgroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
@@ -19,18 +20,9 @@ import (
 )
 
 // StringClient contains the methods for the String group.
-// Don't use this type directly, use NewStringClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type StringClient struct {
-	pl runtime.Pipeline
-}
-
-// NewStringClient creates a new instance of StringClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewStringClient(pl runtime.Pipeline) *StringClient {
-	client := &StringClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetBase64Encoded - Get value that is base64 encoded
@@ -43,7 +35,7 @@ func (client *StringClient) GetBase64Encoded(ctx context.Context, options *Strin
 	if err != nil {
 		return StringClientGetBase64EncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetBase64EncodedResponse{}, err
 	}
@@ -84,7 +76,7 @@ func (client *StringClient) GetBase64URLEncoded(ctx context.Context, options *St
 	if err != nil {
 		return StringClientGetBase64URLEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetBase64URLEncodedResponse{}, err
 	}
@@ -124,7 +116,7 @@ func (client *StringClient) GetEmpty(ctx context.Context, options *StringClientG
 	if err != nil {
 		return StringClientGetEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetEmptyResponse{}, err
 	}
@@ -164,7 +156,7 @@ func (client *StringClient) GetMBCS(ctx context.Context, options *StringClientGe
 	if err != nil {
 		return StringClientGetMBCSResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetMBCSResponse{}, err
 	}
@@ -204,7 +196,7 @@ func (client *StringClient) GetNotProvided(ctx context.Context, options *StringC
 	if err != nil {
 		return StringClientGetNotProvidedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetNotProvidedResponse{}, err
 	}
@@ -244,7 +236,7 @@ func (client *StringClient) GetNull(ctx context.Context, options *StringClientGe
 	if err != nil {
 		return StringClientGetNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetNullResponse{}, err
 	}
@@ -285,7 +277,7 @@ func (client *StringClient) GetNullBase64URLEncoded(ctx context.Context, options
 	if err != nil {
 		return StringClientGetNullBase64URLEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetNullBase64URLEncodedResponse{}, err
 	}
@@ -326,7 +318,7 @@ func (client *StringClient) GetWhitespace(ctx context.Context, options *StringCl
 	if err != nil {
 		return StringClientGetWhitespaceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientGetWhitespaceResponse{}, err
 	}
@@ -368,7 +360,7 @@ func (client *StringClient) PutBase64URLEncoded(ctx context.Context, stringBody 
 	if err != nil {
 		return StringClientPutBase64URLEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientPutBase64URLEncodedResponse{}, err
 	}
@@ -399,7 +391,7 @@ func (client *StringClient) PutEmpty(ctx context.Context, options *StringClientP
 	if err != nil {
 		return StringClientPutEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientPutEmptyResponse{}, err
 	}
@@ -430,7 +422,7 @@ func (client *StringClient) PutMBCS(ctx context.Context, options *StringClientPu
 	if err != nil {
 		return StringClientPutMBCSResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientPutMBCSResponse{}, err
 	}
@@ -462,7 +454,7 @@ func (client *StringClient) PutNull(ctx context.Context, stringBody string, opti
 	if err != nil {
 		return StringClientPutNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientPutNullResponse{}, err
 	}
@@ -495,7 +487,7 @@ func (client *StringClient) PutWhitespace(ctx context.Context, options *StringCl
 	if err != nil {
 		return StringClientPutWhitespaceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return StringClientPutWhitespaceResponse{}, err
 	}

--- a/test/autorest/urlgroup/pathitems_test.go
+++ b/test/autorest/urlgroup/pathitems_test.go
@@ -14,9 +14,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newPathItemsClient(t *testing.T, globalStringPath string, globalStringQuery *string) *PathItemsClient {
+	client, err := NewPathItemsClient(globalStringPath, globalStringQuery, nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPathItemsClient(globalStringPath string, globalStringQuery *string, options *azcore.ClientOptions) (*PathItemsClient, error) {
+	client, err := azcore.NewClient("urlgroup.PathItemsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PathItemsClient{
+		internal:          client,
+		globalStringPath:  globalStringPath,
+		globalStringQuery: globalStringQuery,
+	}, nil
+}
+
 func TestGetAllWithValues(t *testing.T) {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
+	grp := newPathItemsClient(t, "globalStringPath", to.Ptr("globalStringQuery"))
 	result, err := grp.GetAllWithValues(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetAllWithValuesOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
@@ -26,8 +43,7 @@ func TestGetAllWithValues(t *testing.T) {
 }
 
 func TestGetGlobalAndLocalQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	grp := NewPathItemsClient("globalStringPath", nil, pl)
+	grp := newPathItemsClient(t, "globalStringPath", nil)
 	result, err := grp.GetGlobalAndLocalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalAndLocalQueryNullOptions{
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
 	})
@@ -36,8 +52,7 @@ func TestGetGlobalAndLocalQueryNull(t *testing.T) {
 }
 
 func TestGetGlobalQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	grp := NewPathItemsClient("globalStringPath", nil, pl)
+	grp := newPathItemsClient(t, "globalStringPath", nil)
 	result, err := grp.GetGlobalQueryNull(context.Background(), "pathItemStringPath", "localStringPath", &PathItemsClientGetGlobalQueryNullOptions{
 		LocalStringQuery:    to.Ptr("localStringQuery"),
 		PathItemStringQuery: to.Ptr("pathItemStringQuery"),
@@ -47,8 +62,7 @@ func TestGetGlobalQueryNull(t *testing.T) {
 }
 
 func TestGetLocalPathItemQueryNull(t *testing.T) {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	grp := NewPathItemsClient("globalStringPath", to.Ptr("globalStringQuery"), pl)
+	grp := newPathItemsClient(t, "globalStringPath", to.Ptr("globalStringQuery"))
 	result, err := grp.GetLocalPathItemQueryNull(context.Background(), "pathItemStringPath", "localStringPath", nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/urlgroup/paths_test.go
+++ b/test/autorest/urlgroup/paths_test.go
@@ -14,34 +14,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newPathsClient() *PathsClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewPathsClient(pl)
+func newPathsClient(t *testing.T) *PathsClient {
+	client, err := NewPathsClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewPathsClient(options *azcore.ClientOptions) (*PathsClient, error) {
+	client, err := azcore.NewClient("urlgroup.PathsClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &PathsClient{internal: client}, nil
 }
 
 func TestArrayCSVInPath(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.ArrayCSVInPath(context.Background(), []string{"ArrayPath1", "begin!*'();:@ &=+$,/?#[]end", "", ""}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsBase64URL(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.Base64URL(context.Background(), []byte("lorem"), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsByteEmpty(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.ByteEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsByteMultiByte(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.ByteMultiByte(context.Background(), []byte("啊齄丂狛狜隣郎隣兀﨩"), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -49,13 +58,13 @@ func TestPathsByteMultiByte(t *testing.T) {
 
 // TODO: check
 func TestPathsByteNull(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	_, err := client.ByteNull(context.Background(), nil, nil)
 	require.Error(t, err)
 }
 
 func TestPathsDateNull(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	var time time.Time
 	result, err := client.DateNull(context.Background(), time, nil)
 	require.NoError(t, err)
@@ -63,7 +72,7 @@ func TestPathsDateNull(t *testing.T) {
 }
 
 func TestPathsDateTimeNull(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	var time time.Time
 	result, err := client.DateTimeNull(context.Background(), time, nil)
 	require.NoError(t, err)
@@ -71,42 +80,42 @@ func TestPathsDateTimeNull(t *testing.T) {
 }
 
 func TestPathsDateTimeValid(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.DateTimeValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsDateValid(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.DateValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsDoubleDecimalNegative(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.DoubleDecimalNegative(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsDoubleDecimalPositive(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.DoubleDecimalPositive(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsEnumNull(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	var color URIColor
 	_, err := client.EnumNull(context.Background(), color, nil)
 	require.Error(t, err)
 }
 
 func TestPathsEnumValid(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	color := URIColorGreenColor
 	result, err := client.EnumValid(context.Background(), color, nil)
 	require.NoError(t, err)
@@ -114,98 +123,98 @@ func TestPathsEnumValid(t *testing.T) {
 }
 
 func TestPathsFloatScientificNegative(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.FloatScientificNegative(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsFloatScientificPositive(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.FloatScientificPositive(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetBooleanFalse(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetBooleanFalse(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetBooleanTrue(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetBooleanTrue(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetIntNegativeOneMillion(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetIntNegativeOneMillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetIntOneMillion(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetIntOneMillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetNegativeTenBillion(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetNegativeTenBillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsGetTenBillion(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.GetTenBillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsStringEmpty(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.StringEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsStringNull(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	var s string
 	_, err := client.StringNull(context.Background(), s, nil)
 	require.Error(t, err)
 }
 
 func TestPathsStringURLEncoded(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.StringURLEncoded(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsStringURLNonEncoded(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.StringURLNonEncoded(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsStringUnicode(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	result, err := client.StringUnicode(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPathsUnixTimeURL(t *testing.T) {
-	client := newPathsClient()
+	client := newPathsClient(t)
 	d, err := time.Parse("2006-01-02", "2016-04-13")
 	require.NoError(t, err)
 	result, err := client.UnixTimeURL(context.Background(), d, nil)

--- a/test/autorest/urlgroup/queries_test.go
+++ b/test/autorest/urlgroup/queries_test.go
@@ -14,14 +14,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newQueriesClient() *QueriesClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewQueriesClient(pl)
+func newQueriesClient(t *testing.T) *QueriesClient {
+	client, err := NewQueriesClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewQueriesClient(options *azcore.ClientOptions) (*QueriesClient, error) {
+	client, err := azcore.NewClient("urlgroup.QueriesClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &QueriesClient{internal: client}, nil
 }
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
 func TestArrayStringCSVEmpty(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringCSVEmpty(context.Background(), &QueriesClientArrayStringCSVEmptyOptions{
 		ArrayQuery: []string{},
 	})
@@ -31,7 +40,7 @@ func TestArrayStringCSVEmpty(t *testing.T) {
 
 // ArrayStringCSVNull - Get a null array of string using the csv-array format
 func TestArrayStringCSVNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringCSVNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -39,7 +48,7 @@ func TestArrayStringCSVNull(t *testing.T) {
 
 // ArrayStringCSVValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ”] using the csv-array format
 func TestArrayStringCsvValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringCSVValid(context.Background(), &QueriesClientArrayStringCSVValidOptions{
 		ArrayQuery: []string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -49,7 +58,7 @@ func TestArrayStringCsvValid(t *testing.T) {
 
 // ArrayStringPipesValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ”] using the pipes-array format
 func TestArrayStringPipesValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringPipesValid(context.Background(), &QueriesClientArrayStringPipesValidOptions{
 		ArrayQuery: []string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -59,7 +68,7 @@ func TestArrayStringPipesValid(t *testing.T) {
 
 // ArrayStringSsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ”] using the ssv-array format
 func TestArrayStringSsvValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringSsvValid(context.Background(), &QueriesClientArrayStringSsvValidOptions{
 		ArrayQuery: []string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -69,7 +78,7 @@ func TestArrayStringSsvValid(t *testing.T) {
 
 // ArrayStringTsvValid - Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ”] using the tsv-array format
 func TestArrayStringTsvValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringTsvValid(context.Background(), &QueriesClientArrayStringTsvValidOptions{
 		ArrayQuery: []string{"ArrayQuery1", "begin!*'();:@ &=+$,/?#[]end", "", ""},
 	})
@@ -79,7 +88,7 @@ func TestArrayStringTsvValid(t *testing.T) {
 
 // ByteEmpty - Get ” as byte array
 func TestByteEmpty(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ByteEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -87,7 +96,7 @@ func TestByteEmpty(t *testing.T) {
 
 // ByteMultiByte - Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
 func TestByteMultiByte(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ByteMultiByte(context.Background(), &QueriesClientByteMultiByteOptions{
 		ByteQuery: []byte("啊齄丂狛狜隣郎隣兀﨩"),
 	})
@@ -97,7 +106,7 @@ func TestByteMultiByte(t *testing.T) {
 
 // ByteNull - Get null as byte array (no query parameters in uri)
 func TestByteNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ByteNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -105,7 +114,7 @@ func TestByteNull(t *testing.T) {
 
 // DateNull - Get null as date - this should result in no query parameters in uri
 func TestDateNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DateNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -113,7 +122,7 @@ func TestDateNull(t *testing.T) {
 
 // DateTimeNull - Get null as date-time, should result in no query parameters in uri
 func TestDateTimeNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DateTimeNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -121,7 +130,7 @@ func TestDateTimeNull(t *testing.T) {
 
 // DateTimeValid - Get '2012-01-01T01:01:01Z' as date-time
 func TestDateTimeValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DateTimeValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -129,7 +138,7 @@ func TestDateTimeValid(t *testing.T) {
 
 // DateValid - Get '2012-01-01' as date
 func TestDateValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DateValid(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -137,7 +146,7 @@ func TestDateValid(t *testing.T) {
 
 // DoubleDecimalNegative - Get '-9999999.999' numeric value
 func TestDoubleDecimalNegative(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DoubleDecimalNegative(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -145,7 +154,7 @@ func TestDoubleDecimalNegative(t *testing.T) {
 
 // DoubleDecimalPositive - Get '9999999.999' numeric value
 func TestDoubleDecimalPositive(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DoubleDecimalPositive(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -153,7 +162,7 @@ func TestDoubleDecimalPositive(t *testing.T) {
 
 // DoubleNull - Get null numeric value (no query parameter)
 func TestDoubleNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.DoubleNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -161,7 +170,7 @@ func TestDoubleNull(t *testing.T) {
 
 // EnumNull - Get null (no query parameter in url)
 func TestEnumNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.EnumNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -169,7 +178,7 @@ func TestEnumNull(t *testing.T) {
 
 // EnumValid - Get using uri with query parameter 'green color'
 func TestEnumValid(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.EnumValid(context.Background(), &QueriesClientEnumValidOptions{
 		EnumQuery: to.Ptr(URIColorGreenColor),
 	})
@@ -179,7 +188,7 @@ func TestEnumValid(t *testing.T) {
 
 // FloatNull - Get null numeric value (no query parameter)
 func TestFloatNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.FloatNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -187,7 +196,7 @@ func TestFloatNull(t *testing.T) {
 
 // FloatScientificNegative - Get '-1.034E-20' numeric value
 func TestFloatScientificNegative(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.FloatScientificNegative(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -195,7 +204,7 @@ func TestFloatScientificNegative(t *testing.T) {
 
 // FloatScientificPositive - Get '1.034E+20' numeric value
 func TestFloatScientificPositive(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.FloatScientificPositive(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -203,7 +212,7 @@ func TestFloatScientificPositive(t *testing.T) {
 
 // GetBooleanFalse - Get false Boolean value on path
 func TestGetBooleanFalse(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetBooleanFalse(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -211,7 +220,7 @@ func TestGetBooleanFalse(t *testing.T) {
 
 // GetBooleanNull - Get null Boolean value on query (query string should be absent)
 func TestGetBooleanNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetBooleanNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -219,7 +228,7 @@ func TestGetBooleanNull(t *testing.T) {
 
 // GetBooleanTrue - Get true Boolean value on path
 func TestGetBooleanTrue(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetBooleanTrue(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -227,7 +236,7 @@ func TestGetBooleanTrue(t *testing.T) {
 
 // GetIntNegativeOneMillion - Get '-1000000' integer value
 func TestGetIntNegativeOneMillion(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetIntNegativeOneMillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -235,7 +244,7 @@ func TestGetIntNegativeOneMillion(t *testing.T) {
 
 // GetIntNull - Get null integer value (no query parameter)
 func TestGetIntNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetIntNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -243,7 +252,7 @@ func TestGetIntNull(t *testing.T) {
 
 // GetIntOneMillion - Get '1000000' integer value
 func TestGetIntOneMillion(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetIntOneMillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -251,7 +260,7 @@ func TestGetIntOneMillion(t *testing.T) {
 
 // GetLongNull - Get 'null 64 bit integer value (no query param in uri)
 func TestGetLongNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetLongNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -259,7 +268,7 @@ func TestGetLongNull(t *testing.T) {
 
 // GetNegativeTenBillion - Get '-10000000000' 64 bit integer value
 func TestGetNegativeTenBillion(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetNegativeTenBillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -267,7 +276,7 @@ func TestGetNegativeTenBillion(t *testing.T) {
 
 // GetTenBillion - Get '10000000000' 64 bit integer value
 func TestGetTenBillion(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.GetTenBillion(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -275,7 +284,7 @@ func TestGetTenBillion(t *testing.T) {
 
 // StringEmpty - Get ”
 func TestStringEmpty(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.StringEmpty(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -283,7 +292,7 @@ func TestStringEmpty(t *testing.T) {
 
 // StringNull - Get null (no query parameter in url)
 func TestStringNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.StringNull(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -291,7 +300,7 @@ func TestStringNull(t *testing.T) {
 
 // StringURLEncoded - Get 'begin!*'();:@ &=+$,/?#[]end
 func TestStringURLEncoded(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.StringURLEncoded(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
@@ -299,7 +308,7 @@ func TestStringURLEncoded(t *testing.T) {
 
 // StringUnicode - Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
 func TestStringUnicode(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.StringUnicode(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)

--- a/test/autorest/urlgroup/zz_pathitems_client.go
+++ b/test/autorest/urlgroup/zz_pathitems_client.go
@@ -12,6 +12,7 @@ package urlgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,24 +21,11 @@ import (
 )
 
 // PathItemsClient contains the methods for the PathItems group.
-// Don't use this type directly, use NewPathItemsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PathItemsClient struct {
+	internal          *azcore.Client
 	globalStringPath  string
 	globalStringQuery *string
-	pl                runtime.Pipeline
-}
-
-// NewPathItemsClient creates a new instance of PathItemsClient with the specified values.
-//   - globalStringPath - A string value 'globalItemStringPath' that appears in the path
-//   - globalStringQuery - should contain value null
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPathItemsClient(globalStringPath string, globalStringQuery *string, pl runtime.Pipeline) *PathItemsClient {
-	client := &PathItemsClient{
-		globalStringPath:  globalStringPath,
-		globalStringQuery: globalStringQuery,
-		pl:                pl,
-	}
-	return client
 }
 
 // GetAllWithValues - send globalStringPath='globalStringPath', pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
@@ -55,7 +43,7 @@ func (client *PathItemsClient) GetAllWithValues(ctx context.Context, pathItemStr
 	if err != nil {
 		return PathItemsClientGetAllWithValuesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathItemsClientGetAllWithValuesResponse{}, err
 	}
@@ -114,7 +102,7 @@ func (client *PathItemsClient) GetGlobalAndLocalQueryNull(ctx context.Context, p
 	if err != nil {
 		return PathItemsClientGetGlobalAndLocalQueryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathItemsClientGetGlobalAndLocalQueryNullResponse{}, err
 	}
@@ -173,7 +161,7 @@ func (client *PathItemsClient) GetGlobalQueryNull(ctx context.Context, pathItemS
 	if err != nil {
 		return PathItemsClientGetGlobalQueryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathItemsClientGetGlobalQueryNullResponse{}, err
 	}
@@ -232,7 +220,7 @@ func (client *PathItemsClient) GetLocalPathItemQueryNull(ctx context.Context, pa
 	if err != nil {
 		return PathItemsClientGetLocalPathItemQueryNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathItemsClientGetLocalPathItemQueryNullResponse{}, err
 	}

--- a/test/autorest/urlgroup/zz_paths_client.go
+++ b/test/autorest/urlgroup/zz_paths_client.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -22,18 +23,9 @@ import (
 )
 
 // PathsClient contains the methods for the Paths group.
-// Don't use this type directly, use NewPathsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type PathsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewPathsClient creates a new instance of PathsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewPathsClient(pl runtime.Pipeline) *PathsClient {
-	client := &PathsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // ArrayCSVInPath - Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ”] using the csv-array format
@@ -47,7 +39,7 @@ func (client *PathsClient) ArrayCSVInPath(ctx context.Context, arrayPath []strin
 	if err != nil {
 		return PathsClientArrayCSVInPathResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientArrayCSVInPathResponse{}, err
 	}
@@ -80,7 +72,7 @@ func (client *PathsClient) Base64URL(ctx context.Context, base64URLPath []byte, 
 	if err != nil {
 		return PathsClientBase64URLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientBase64URLResponse{}, err
 	}
@@ -112,7 +104,7 @@ func (client *PathsClient) ByteEmpty(ctx context.Context, options *PathsClientBy
 	if err != nil {
 		return PathsClientByteEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientByteEmptyResponse{}, err
 	}
@@ -145,7 +137,7 @@ func (client *PathsClient) ByteMultiByte(ctx context.Context, bytePath []byte, o
 	if err != nil {
 		return PathsClientByteMultiByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientByteMultiByteResponse{}, err
 	}
@@ -178,7 +170,7 @@ func (client *PathsClient) ByteNull(ctx context.Context, bytePath []byte, option
 	if err != nil {
 		return PathsClientByteNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientByteNullResponse{}, err
 	}
@@ -211,7 +203,7 @@ func (client *PathsClient) DateNull(ctx context.Context, datePath time.Time, opt
 	if err != nil {
 		return PathsClientDateNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDateNullResponse{}, err
 	}
@@ -244,7 +236,7 @@ func (client *PathsClient) DateTimeNull(ctx context.Context, dateTimePath time.T
 	if err != nil {
 		return PathsClientDateTimeNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDateTimeNullResponse{}, err
 	}
@@ -276,7 +268,7 @@ func (client *PathsClient) DateTimeValid(ctx context.Context, options *PathsClie
 	if err != nil {
 		return PathsClientDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDateTimeValidResponse{}, err
 	}
@@ -308,7 +300,7 @@ func (client *PathsClient) DateValid(ctx context.Context, options *PathsClientDa
 	if err != nil {
 		return PathsClientDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDateValidResponse{}, err
 	}
@@ -341,7 +333,7 @@ func (client *PathsClient) DoubleDecimalNegative(ctx context.Context, options *P
 	if err != nil {
 		return PathsClientDoubleDecimalNegativeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDoubleDecimalNegativeResponse{}, err
 	}
@@ -374,7 +366,7 @@ func (client *PathsClient) DoubleDecimalPositive(ctx context.Context, options *P
 	if err != nil {
 		return PathsClientDoubleDecimalPositiveResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientDoubleDecimalPositiveResponse{}, err
 	}
@@ -407,7 +399,7 @@ func (client *PathsClient) EnumNull(ctx context.Context, enumPath URIColor, opti
 	if err != nil {
 		return PathsClientEnumNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientEnumNullResponse{}, err
 	}
@@ -443,7 +435,7 @@ func (client *PathsClient) EnumValid(ctx context.Context, enumPath URIColor, opt
 	if err != nil {
 		return PathsClientEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientEnumValidResponse{}, err
 	}
@@ -479,7 +471,7 @@ func (client *PathsClient) FloatScientificNegative(ctx context.Context, options 
 	if err != nil {
 		return PathsClientFloatScientificNegativeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientFloatScientificNegativeResponse{}, err
 	}
@@ -512,7 +504,7 @@ func (client *PathsClient) FloatScientificPositive(ctx context.Context, options 
 	if err != nil {
 		return PathsClientFloatScientificPositiveResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientFloatScientificPositiveResponse{}, err
 	}
@@ -544,7 +536,7 @@ func (client *PathsClient) GetBooleanFalse(ctx context.Context, options *PathsCl
 	if err != nil {
 		return PathsClientGetBooleanFalseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetBooleanFalseResponse{}, err
 	}
@@ -576,7 +568,7 @@ func (client *PathsClient) GetBooleanTrue(ctx context.Context, options *PathsCli
 	if err != nil {
 		return PathsClientGetBooleanTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetBooleanTrueResponse{}, err
 	}
@@ -609,7 +601,7 @@ func (client *PathsClient) GetIntNegativeOneMillion(ctx context.Context, options
 	if err != nil {
 		return PathsClientGetIntNegativeOneMillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetIntNegativeOneMillionResponse{}, err
 	}
@@ -641,7 +633,7 @@ func (client *PathsClient) GetIntOneMillion(ctx context.Context, options *PathsC
 	if err != nil {
 		return PathsClientGetIntOneMillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetIntOneMillionResponse{}, err
 	}
@@ -674,7 +666,7 @@ func (client *PathsClient) GetNegativeTenBillion(ctx context.Context, options *P
 	if err != nil {
 		return PathsClientGetNegativeTenBillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetNegativeTenBillionResponse{}, err
 	}
@@ -706,7 +698,7 @@ func (client *PathsClient) GetTenBillion(ctx context.Context, options *PathsClie
 	if err != nil {
 		return PathsClientGetTenBillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientGetTenBillionResponse{}, err
 	}
@@ -738,7 +730,7 @@ func (client *PathsClient) StringEmpty(ctx context.Context, options *PathsClient
 	if err != nil {
 		return PathsClientStringEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientStringEmptyResponse{}, err
 	}
@@ -771,7 +763,7 @@ func (client *PathsClient) StringNull(ctx context.Context, stringPath string, op
 	if err != nil {
 		return PathsClientStringNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientStringNullResponse{}, err
 	}
@@ -806,7 +798,7 @@ func (client *PathsClient) StringURLEncoded(ctx context.Context, options *PathsC
 	if err != nil {
 		return PathsClientStringURLEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientStringURLEncodedResponse{}, err
 	}
@@ -839,7 +831,7 @@ func (client *PathsClient) StringURLNonEncoded(ctx context.Context, options *Pat
 	if err != nil {
 		return PathsClientStringURLNonEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientStringURLNonEncodedResponse{}, err
 	}
@@ -871,7 +863,7 @@ func (client *PathsClient) StringUnicode(ctx context.Context, options *PathsClie
 	if err != nil {
 		return PathsClientStringUnicodeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientStringUnicodeResponse{}, err
 	}
@@ -904,7 +896,7 @@ func (client *PathsClient) UnixTimeURL(ctx context.Context, unixTimeURLPath time
 	if err != nil {
 		return PathsClientUnixTimeURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PathsClientUnixTimeURLResponse{}, err
 	}

--- a/test/autorest/urlgroup/zz_queries_client.go
+++ b/test/autorest/urlgroup/zz_queries_client.go
@@ -12,6 +12,7 @@ package urlgroup
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -21,18 +22,9 @@ import (
 )
 
 // QueriesClient contains the methods for the Queries group.
-// Don't use this type directly, use NewQueriesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type QueriesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewQueriesClient creates a new instance of QueriesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewQueriesClient(pl runtime.Pipeline) *QueriesClient {
-	client := &QueriesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // ArrayStringCSVEmpty - Get an empty array [] of string using the csv-array format
@@ -46,7 +38,7 @@ func (client *QueriesClient) ArrayStringCSVEmpty(ctx context.Context, options *Q
 	if err != nil {
 		return QueriesClientArrayStringCSVEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringCSVEmptyResponse{}, err
 	}
@@ -83,7 +75,7 @@ func (client *QueriesClient) ArrayStringCSVNull(ctx context.Context, options *Qu
 	if err != nil {
 		return QueriesClientArrayStringCSVNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringCSVNullResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *QueriesClient) ArrayStringCSVValid(ctx context.Context, options *Q
 	if err != nil {
 		return QueriesClientArrayStringCSVValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringCSVValidResponse{}, err
 	}
@@ -159,7 +151,7 @@ func (client *QueriesClient) ArrayStringNoCollectionFormatEmpty(ctx context.Cont
 	if err != nil {
 		return QueriesClientArrayStringNoCollectionFormatEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringNoCollectionFormatEmptyResponse{}, err
 	}
@@ -197,7 +189,7 @@ func (client *QueriesClient) ArrayStringPipesValid(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientArrayStringPipesValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringPipesValidResponse{}, err
 	}
@@ -235,7 +227,7 @@ func (client *QueriesClient) ArrayStringSsvValid(ctx context.Context, options *Q
 	if err != nil {
 		return QueriesClientArrayStringSsvValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringSsvValidResponse{}, err
 	}
@@ -273,7 +265,7 @@ func (client *QueriesClient) ArrayStringTsvValid(ctx context.Context, options *Q
 	if err != nil {
 		return QueriesClientArrayStringTsvValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringTsvValidResponse{}, err
 	}
@@ -309,7 +301,7 @@ func (client *QueriesClient) ByteEmpty(ctx context.Context, options *QueriesClie
 	if err != nil {
 		return QueriesClientByteEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientByteEmptyResponse{}, err
 	}
@@ -343,7 +335,7 @@ func (client *QueriesClient) ByteMultiByte(ctx context.Context, options *Queries
 	if err != nil {
 		return QueriesClientByteMultiByteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientByteMultiByteResponse{}, err
 	}
@@ -379,7 +371,7 @@ func (client *QueriesClient) ByteNull(ctx context.Context, options *QueriesClien
 	if err != nil {
 		return QueriesClientByteNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientByteNullResponse{}, err
 	}
@@ -415,7 +407,7 @@ func (client *QueriesClient) DateNull(ctx context.Context, options *QueriesClien
 	if err != nil {
 		return QueriesClientDateNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDateNullResponse{}, err
 	}
@@ -451,7 +443,7 @@ func (client *QueriesClient) DateTimeNull(ctx context.Context, options *QueriesC
 	if err != nil {
 		return QueriesClientDateTimeNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDateTimeNullResponse{}, err
 	}
@@ -487,7 +479,7 @@ func (client *QueriesClient) DateTimeValid(ctx context.Context, options *Queries
 	if err != nil {
 		return QueriesClientDateTimeValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDateTimeValidResponse{}, err
 	}
@@ -521,7 +513,7 @@ func (client *QueriesClient) DateValid(ctx context.Context, options *QueriesClie
 	if err != nil {
 		return QueriesClientDateValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDateValidResponse{}, err
 	}
@@ -556,7 +548,7 @@ func (client *QueriesClient) DoubleDecimalNegative(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientDoubleDecimalNegativeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDoubleDecimalNegativeResponse{}, err
 	}
@@ -591,7 +583,7 @@ func (client *QueriesClient) DoubleDecimalPositive(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientDoubleDecimalPositiveResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDoubleDecimalPositiveResponse{}, err
 	}
@@ -625,7 +617,7 @@ func (client *QueriesClient) DoubleNull(ctx context.Context, options *QueriesCli
 	if err != nil {
 		return QueriesClientDoubleNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientDoubleNullResponse{}, err
 	}
@@ -661,7 +653,7 @@ func (client *QueriesClient) EnumNull(ctx context.Context, options *QueriesClien
 	if err != nil {
 		return QueriesClientEnumNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientEnumNullResponse{}, err
 	}
@@ -697,7 +689,7 @@ func (client *QueriesClient) EnumValid(ctx context.Context, options *QueriesClie
 	if err != nil {
 		return QueriesClientEnumValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientEnumValidResponse{}, err
 	}
@@ -733,7 +725,7 @@ func (client *QueriesClient) FloatNull(ctx context.Context, options *QueriesClie
 	if err != nil {
 		return QueriesClientFloatNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientFloatNullResponse{}, err
 	}
@@ -770,7 +762,7 @@ func (client *QueriesClient) FloatScientificNegative(ctx context.Context, option
 	if err != nil {
 		return QueriesClientFloatScientificNegativeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientFloatScientificNegativeResponse{}, err
 	}
@@ -805,7 +797,7 @@ func (client *QueriesClient) FloatScientificPositive(ctx context.Context, option
 	if err != nil {
 		return QueriesClientFloatScientificPositiveResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientFloatScientificPositiveResponse{}, err
 	}
@@ -839,7 +831,7 @@ func (client *QueriesClient) GetBooleanFalse(ctx context.Context, options *Queri
 	if err != nil {
 		return QueriesClientGetBooleanFalseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetBooleanFalseResponse{}, err
 	}
@@ -873,7 +865,7 @@ func (client *QueriesClient) GetBooleanNull(ctx context.Context, options *Querie
 	if err != nil {
 		return QueriesClientGetBooleanNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetBooleanNullResponse{}, err
 	}
@@ -909,7 +901,7 @@ func (client *QueriesClient) GetBooleanTrue(ctx context.Context, options *Querie
 	if err != nil {
 		return QueriesClientGetBooleanTrueResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetBooleanTrueResponse{}, err
 	}
@@ -944,7 +936,7 @@ func (client *QueriesClient) GetIntNegativeOneMillion(ctx context.Context, optio
 	if err != nil {
 		return QueriesClientGetIntNegativeOneMillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetIntNegativeOneMillionResponse{}, err
 	}
@@ -978,7 +970,7 @@ func (client *QueriesClient) GetIntNull(ctx context.Context, options *QueriesCli
 	if err != nil {
 		return QueriesClientGetIntNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetIntNullResponse{}, err
 	}
@@ -1015,7 +1007,7 @@ func (client *QueriesClient) GetIntOneMillion(ctx context.Context, options *Quer
 	if err != nil {
 		return QueriesClientGetIntOneMillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetIntOneMillionResponse{}, err
 	}
@@ -1049,7 +1041,7 @@ func (client *QueriesClient) GetLongNull(ctx context.Context, options *QueriesCl
 	if err != nil {
 		return QueriesClientGetLongNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetLongNullResponse{}, err
 	}
@@ -1086,7 +1078,7 @@ func (client *QueriesClient) GetNegativeTenBillion(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientGetNegativeTenBillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetNegativeTenBillionResponse{}, err
 	}
@@ -1120,7 +1112,7 @@ func (client *QueriesClient) GetTenBillion(ctx context.Context, options *Queries
 	if err != nil {
 		return QueriesClientGetTenBillionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientGetTenBillionResponse{}, err
 	}
@@ -1154,7 +1146,7 @@ func (client *QueriesClient) StringEmpty(ctx context.Context, options *QueriesCl
 	if err != nil {
 		return QueriesClientStringEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientStringEmptyResponse{}, err
 	}
@@ -1188,7 +1180,7 @@ func (client *QueriesClient) StringNull(ctx context.Context, options *QueriesCli
 	if err != nil {
 		return QueriesClientStringNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientStringNullResponse{}, err
 	}
@@ -1225,7 +1217,7 @@ func (client *QueriesClient) StringURLEncoded(ctx context.Context, options *Quer
 	if err != nil {
 		return QueriesClientStringURLEncodedResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientStringURLEncodedResponse{}, err
 	}
@@ -1259,7 +1251,7 @@ func (client *QueriesClient) StringUnicode(ctx context.Context, options *Queries
 	if err != nil {
 		return QueriesClientStringUnicodeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientStringUnicodeResponse{}, err
 	}

--- a/test/autorest/urlmultigroup/urlmultigroup_test.go
+++ b/test/autorest/urlmultigroup/urlmultigroup_test.go
@@ -14,13 +14,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newQueriesClient() *QueriesClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewQueriesClient(pl)
+func newQueriesClient(t *testing.T) *QueriesClient {
+	client, err := NewQueriesClient(nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewQueriesClient(options *azcore.ClientOptions) (*QueriesClient, error) {
+	client, err := azcore.NewClient("urlmultigroup.QueriesClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &QueriesClient{internal: client}, nil
 }
 
 func TestURLMultiArrayStringMultiEmpty(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringMultiEmpty(context.Background(), &QueriesClientArrayStringMultiEmptyOptions{
 		ArrayQuery: []string{},
 	})
@@ -29,7 +38,7 @@ func TestURLMultiArrayStringMultiEmpty(t *testing.T) {
 }
 
 func TestURLMultiArrayStringMultiNull(t *testing.T) {
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringMultiNull(context.Background(), &QueriesClientArrayStringMultiNullOptions{
 		ArrayQuery: nil,
 	})
@@ -39,7 +48,7 @@ func TestURLMultiArrayStringMultiNull(t *testing.T) {
 
 func TestURLMultiArrayStringMultiValid(t *testing.T) {
 	t.Skip("Cannot set nil for string value in string slice")
-	client := newQueriesClient()
+	client := newQueriesClient(t)
 	result, err := client.ArrayStringMultiValid(context.Background(), &QueriesClientArrayStringMultiValidOptions{
 		ArrayQuery: []string{
 			"ArrayQuery1",

--- a/test/autorest/urlmultigroup/zz_queries_client.go
+++ b/test/autorest/urlmultigroup/zz_queries_client.go
@@ -11,24 +11,16 @@ package urlmultigroup
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // QueriesClient contains the methods for the Queries group.
-// Don't use this type directly, use NewQueriesClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type QueriesClient struct {
-	pl runtime.Pipeline
-}
-
-// NewQueriesClient creates a new instance of QueriesClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewQueriesClient(pl runtime.Pipeline) *QueriesClient {
-	client := &QueriesClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // ArrayStringMultiEmpty - Get an empty array [] of string using the multi-array format
@@ -42,7 +34,7 @@ func (client *QueriesClient) ArrayStringMultiEmpty(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientArrayStringMultiEmptyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringMultiEmptyResponse{}, err
 	}
@@ -81,7 +73,7 @@ func (client *QueriesClient) ArrayStringMultiNull(ctx context.Context, options *
 	if err != nil {
 		return QueriesClientArrayStringMultiNullResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringMultiNullResponse{}, err
 	}
@@ -121,7 +113,7 @@ func (client *QueriesClient) ArrayStringMultiValid(ctx context.Context, options 
 	if err != nil {
 		return QueriesClientArrayStringMultiValidResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return QueriesClientArrayStringMultiValidResponse{}, err
 	}

--- a/test/autorest/validationgroup/validationgroup_test.go
+++ b/test/autorest/validationgroup/validationgroup_test.go
@@ -14,20 +14,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newAutoRestValidationTestClient() *AutoRestValidationTestClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{})
-	return NewAutoRestValidationTestClient("", pl)
+func newAutoRestValidationTestClient(t *testing.T) *AutoRestValidationTestClient {
+	client, err := NewAutoRestValidationTestClient("", nil)
+	require.NoError(t, err)
+	return client
+}
+
+func NewAutoRestValidationTestClient(subscriptionID string, options *azcore.ClientOptions) (*AutoRestValidationTestClient, error) {
+	client, err := azcore.NewClient("validationgroup.AutoRestValidationTestClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &AutoRestValidationTestClient{
+		internal:       client,
+		subscriptionID: subscriptionID,
+	}, nil
 }
 
 func TestValidationGetWithConstantInPath(t *testing.T) {
-	client := newAutoRestValidationTestClient()
+	client := newAutoRestValidationTestClient(t)
 	result, err := client.GetWithConstantInPath(context.Background(), nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestValidationPostWithConstantInBody(t *testing.T) {
-	client := newAutoRestValidationTestClient()
+	client := newAutoRestValidationTestClient(t)
 	product := Product{
 		Child:      &ChildProduct{},
 		ConstChild: &ConstantProduct{},
@@ -50,7 +62,7 @@ func TestValidationPostWithConstantInBody(t *testing.T) {
 
 func TestValidationValidationOfBody(t *testing.T) {
 	t.Skip("need to confirm if this test will remain in the testserver and what values it's expecting")
-	client := newAutoRestValidationTestClient()
+	client := newAutoRestValidationTestClient(t)
 	result, err := client.ValidationOfBody(context.Background(), "123", 150, Product{
 		DisplayNames: []*string{
 			to.Ptr("displayname1"),

--- a/test/autorest/validationgroup/zz_autorestvalidationtest_client.go
+++ b/test/autorest/validationgroup/zz_autorestvalidationtest_client.go
@@ -12,6 +12,7 @@ package validationgroup
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -21,21 +22,10 @@ import (
 )
 
 // AutoRestValidationTestClient contains the methods for the AutoRestValidationTest group.
-// Don't use this type directly, use NewAutoRestValidationTestClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type AutoRestValidationTestClient struct {
+	internal       *azcore.Client
 	subscriptionID string
-	pl             runtime.Pipeline
-}
-
-// NewAutoRestValidationTestClient creates a new instance of AutoRestValidationTestClient with the specified values.
-//   - subscriptionID - Subscription ID.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewAutoRestValidationTestClient(subscriptionID string, pl runtime.Pipeline) *AutoRestValidationTestClient {
-	client := &AutoRestValidationTestClient{
-		subscriptionID: subscriptionID,
-		pl:             pl,
-	}
-	return client
 }
 
 // GetWithConstantInPath -
@@ -49,7 +39,7 @@ func (client *AutoRestValidationTestClient) GetWithConstantInPath(ctx context.Co
 	if err != nil {
 		return AutoRestValidationTestClientGetWithConstantInPathResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestValidationTestClientGetWithConstantInPathResponse{}, err
 	}
@@ -81,7 +71,7 @@ func (client *AutoRestValidationTestClient) PostWithConstantInBody(ctx context.C
 	if err != nil {
 		return AutoRestValidationTestClientPostWithConstantInBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestValidationTestClientPostWithConstantInBodyResponse{}, err
 	}
@@ -128,7 +118,7 @@ func (client *AutoRestValidationTestClient) ValidationOfBody(ctx context.Context
 	if err != nil {
 		return AutoRestValidationTestClientValidationOfBodyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestValidationTestClientValidationOfBodyResponse{}, err
 	}
@@ -183,7 +173,7 @@ func (client *AutoRestValidationTestClient) ValidationOfMethodParameters(ctx con
 	if err != nil {
 		return AutoRestValidationTestClientValidationOfMethodParametersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AutoRestValidationTestClientValidationOfMethodParametersResponse{}, err
 	}

--- a/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/test/autorest/xmlgroup/xmlgroup_test.go
@@ -25,17 +25,27 @@ func toTimePtr(layout string, value string) *time.Time {
 	return &t
 }
 
-func newXMLClient() *XMLClient {
-	pl := runtime.NewPipeline(generatortests.ModuleName, generatortests.ModuleVersion, runtime.PipelineOptions{}, &azcore.ClientOptions{
+func newXMLClient(t *testing.T) *XMLClient {
+	options := azcore.ClientOptions{
 		Logging: policy.LogOptions{
 			IncludeBody: true,
 		},
-	})
-	return NewXMLClient(pl)
+	}
+	client, err := NewXMLClient(&options)
+	require.NoError(t, err)
+	return client
+}
+
+func NewXMLClient(options *azcore.ClientOptions) (*XMLClient, error) {
+	client, err := azcore.NewClient("xmlgroup.XMLClient", generatortests.ModuleVersion, runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &XMLClient{internal: client}, nil
 }
 
 func TestGetACLs(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetACLs(context.Background(), nil)
 	require.NoError(t, err)
 	expected := []*SignedIdentifier{
@@ -54,7 +64,7 @@ func TestGetACLs(t *testing.T) {
 }
 
 func TestGetBytes(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetBytes(context.Background(), nil)
 	require.NoError(t, err)
 	if string(result.Bytes) != "Hello world" {
@@ -63,7 +73,7 @@ func TestGetBytes(t *testing.T) {
 }
 
 func TestGetComplexTypeRefNoMeta(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetComplexTypeRefNoMeta(context.Background(), nil)
 	require.NoError(t, err)
 	expected := RootWithRefAndNoMeta{
@@ -78,7 +88,7 @@ func TestGetComplexTypeRefNoMeta(t *testing.T) {
 }
 
 func TestGetComplexTypeRefWithMeta(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetComplexTypeRefWithMeta(context.Background(), nil)
 	require.NoError(t, err)
 	expected := RootWithRefAndMeta{
@@ -93,7 +103,7 @@ func TestGetComplexTypeRefWithMeta(t *testing.T) {
 }
 
 func TestGetEmptyChildElement(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetEmptyChildElement(context.Background(), nil)
 	require.NoError(t, err)
 	expected := Banana{
@@ -107,7 +117,7 @@ func TestGetEmptyChildElement(t *testing.T) {
 }
 
 func TestGetEmptyList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetEmptyList(context.Background(), nil)
 	require.NoError(t, err)
 	expected := Slideshow{}
@@ -117,7 +127,7 @@ func TestGetEmptyList(t *testing.T) {
 }
 
 func TestGetEmptyRootList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetEmptyRootList(context.Background(), nil)
 	require.NoError(t, err)
 	if result.Bananas != nil {
@@ -126,7 +136,7 @@ func TestGetEmptyRootList(t *testing.T) {
 }
 
 func TestGetEmptyWrappedLists(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetEmptyWrappedLists(context.Background(), nil)
 	require.NoError(t, err)
 	expected := AppleBarrel{}
@@ -136,7 +146,7 @@ func TestGetEmptyWrappedLists(t *testing.T) {
 }
 
 func TestGetHeaders(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetHeaders(context.Background(), nil)
 	require.NoError(t, err)
 	if r := cmp.Diff(result.CustomHeader, to.Ptr("custom-value")); r != "" {
@@ -145,7 +155,7 @@ func TestGetHeaders(t *testing.T) {
 }
 
 func TestGetRootList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetRootList(context.Background(), nil)
 	require.NoError(t, err)
 	expected := []*Banana{
@@ -166,7 +176,7 @@ func TestGetRootList(t *testing.T) {
 }
 
 func TestGetRootListSingleItem(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetRootListSingleItem(context.Background(), nil)
 	require.NoError(t, err)
 	expected := []*Banana{
@@ -182,7 +192,7 @@ func TestGetRootListSingleItem(t *testing.T) {
 }
 
 func TestGetServiceProperties(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetServiceProperties(context.Background(), nil)
 	require.NoError(t, err)
 	expected := StorageServiceProperties{
@@ -221,7 +231,7 @@ func TestGetServiceProperties(t *testing.T) {
 }
 
 func TestGetSimple(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetSimple(context.Background(), nil)
 	require.NoError(t, err)
 	expected := Slideshow{
@@ -246,7 +256,7 @@ func TestGetSimple(t *testing.T) {
 }
 
 func TestGetWrappedLists(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetWrappedLists(context.Background(), nil)
 	require.NoError(t, err)
 	expected := AppleBarrel{
@@ -260,7 +270,7 @@ func TestGetWrappedLists(t *testing.T) {
 
 func TestGetXMsText(t *testing.T) {
 	t.Skip("support NYI")
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.GetXMsText(context.Background(), nil)
 	require.NoError(t, err)
 	expected := ObjectWithXMsTextProperty{
@@ -273,7 +283,7 @@ func TestGetXMsText(t *testing.T) {
 }
 
 func TestJSONInput(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.JSONInput(context.Background(), JSONInput{
 		ID: to.Ptr[int32](42),
 	}, nil)
@@ -282,7 +292,7 @@ func TestJSONInput(t *testing.T) {
 }
 
 func TestJSONOutput(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.JSONOutput(context.Background(), nil)
 	require.NoError(t, err)
 	expected := JSONOutput{
@@ -294,7 +304,7 @@ func TestJSONOutput(t *testing.T) {
 }
 
 func TestListBlobs(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.ListBlobs(context.Background(), nil)
 	require.NoError(t, err)
 	blob1LM, err := time.Parse(time.RFC1123, "Wed, 09 Sep 2009 09:20:02 GMT")
@@ -417,7 +427,7 @@ func TestListBlobs(t *testing.T) {
 }
 
 func TestListContainers(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.ListContainers(context.Background(), nil)
 	require.NoError(t, err)
 	expected := ListContainersResponse{
@@ -455,7 +465,7 @@ func TestListContainers(t *testing.T) {
 }
 
 func TestPutACLs(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutACLs(context.Background(), []*SignedIdentifier{
 		{
 			ID: to.Ptr("MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="),
@@ -471,7 +481,7 @@ func TestPutACLs(t *testing.T) {
 }
 
 func TestPutBinary(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	_, err := client.PutBinary(context.Background(), ModelWithByteProperty{
 		Bytes: []byte("Hello world"),
 	}, nil)
@@ -479,7 +489,7 @@ func TestPutBinary(t *testing.T) {
 }
 
 func TestPutComplexTypeRefNoMeta(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutComplexTypeRefNoMeta(context.Background(), RootWithRefAndNoMeta{
 		RefToModel: &ComplexTypeNoMeta{
 			ID: to.Ptr("myid"),
@@ -491,7 +501,7 @@ func TestPutComplexTypeRefNoMeta(t *testing.T) {
 }
 
 func TestPutComplexTypeRefWithMeta(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutComplexTypeRefWithMeta(context.Background(), RootWithRefAndMeta{
 		RefToModel: &ComplexTypeWithMeta{
 			ID: to.Ptr("myid"),
@@ -503,7 +513,7 @@ func TestPutComplexTypeRefWithMeta(t *testing.T) {
 }
 
 func TestPutEmptyChildElement(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutEmptyChildElement(context.Background(), Banana{
 		Name:       to.Ptr("Unknown Banana"),
 		Expiration: toTimePtr(time.RFC3339Nano, "2012-02-24T00:53:52.789Z"),
@@ -514,7 +524,7 @@ func TestPutEmptyChildElement(t *testing.T) {
 }
 
 func TestPutEmptyList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutEmptyList(context.Background(), Slideshow{
 		Slides: []*Slide{},
 	}, nil)
@@ -523,14 +533,14 @@ func TestPutEmptyList(t *testing.T) {
 }
 
 func TestPutEmptyRootList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutEmptyRootList(context.Background(), []*Banana{}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
 }
 
 func TestPutEmptyWrappedLists(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutEmptyWrappedLists(context.Background(), AppleBarrel{
 		BadApples:  []*string{},
 		GoodApples: []*string{},
@@ -540,7 +550,7 @@ func TestPutEmptyWrappedLists(t *testing.T) {
 }
 
 func TestPutRootList(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutRootList(context.Background(), []*Banana{
 		{
 			Name:       to.Ptr("Cavendish"),
@@ -558,7 +568,7 @@ func TestPutRootList(t *testing.T) {
 }
 
 func TestPutRootListSingleItem(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutRootListSingleItem(context.Background(), []*Banana{
 		{
 			Name:       to.Ptr("Cavendish"),
@@ -571,7 +581,7 @@ func TestPutRootListSingleItem(t *testing.T) {
 }
 
 func TestPutServiceProperties(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutServiceProperties(context.Background(), StorageServiceProperties{
 		HourMetrics: &Metrics{
 			Version:     to.Ptr("1.0"),
@@ -607,7 +617,7 @@ func TestPutServiceProperties(t *testing.T) {
 }
 
 func TestPutSimple(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutSimple(context.Background(), Slideshow{
 		Author: to.Ptr("Yours Truly"),
 		Date:   to.Ptr("Date of publication"),
@@ -629,7 +639,7 @@ func TestPutSimple(t *testing.T) {
 }
 
 func TestPutWrappedLists(t *testing.T) {
-	client := newXMLClient()
+	client := newXMLClient(t)
 	result, err := client.PutWrappedLists(context.Background(), AppleBarrel{
 		BadApples:  to.SliceOfPtrs("Red Delicious"),
 		GoodApples: to.SliceOfPtrs("Fuji", "Gala"),

--- a/test/autorest/xmlgroup/zz_xml_client.go
+++ b/test/autorest/xmlgroup/zz_xml_client.go
@@ -12,24 +12,16 @@ package xmlgroup
 import (
 	"context"
 	"encoding/xml"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
 // XMLClient contains the methods for the XML group.
-// Don't use this type directly, use NewXMLClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type XMLClient struct {
-	pl runtime.Pipeline
-}
-
-// NewXMLClient creates a new instance of XMLClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewXMLClient(pl runtime.Pipeline) *XMLClient {
-	client := &XMLClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // GetACLs - Gets storage ACLs for a container.
@@ -42,7 +34,7 @@ func (client *XMLClient) GetACLs(ctx context.Context, options *XMLClientGetACLsO
 	if err != nil {
 		return XMLClientGetACLsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetACLsResponse{}, err
 	}
@@ -86,7 +78,7 @@ func (client *XMLClient) GetBytes(ctx context.Context, options *XMLClientGetByte
 	if err != nil {
 		return XMLClientGetBytesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetBytesResponse{}, err
 	}
@@ -127,7 +119,7 @@ func (client *XMLClient) GetComplexTypeRefNoMeta(ctx context.Context, options *X
 	if err != nil {
 		return XMLClientGetComplexTypeRefNoMetaResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetComplexTypeRefNoMetaResponse{}, err
 	}
@@ -168,7 +160,7 @@ func (client *XMLClient) GetComplexTypeRefWithMeta(ctx context.Context, options 
 	if err != nil {
 		return XMLClientGetComplexTypeRefWithMetaResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetComplexTypeRefWithMetaResponse{}, err
 	}
@@ -209,7 +201,7 @@ func (client *XMLClient) GetEmptyChildElement(ctx context.Context, options *XMLC
 	if err != nil {
 		return XMLClientGetEmptyChildElementResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetEmptyChildElementResponse{}, err
 	}
@@ -249,7 +241,7 @@ func (client *XMLClient) GetEmptyList(ctx context.Context, options *XMLClientGet
 	if err != nil {
 		return XMLClientGetEmptyListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetEmptyListResponse{}, err
 	}
@@ -289,7 +281,7 @@ func (client *XMLClient) GetEmptyRootList(ctx context.Context, options *XMLClien
 	if err != nil {
 		return XMLClientGetEmptyRootListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetEmptyRootListResponse{}, err
 	}
@@ -330,7 +322,7 @@ func (client *XMLClient) GetEmptyWrappedLists(ctx context.Context, options *XMLC
 	if err != nil {
 		return XMLClientGetEmptyWrappedListsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetEmptyWrappedListsResponse{}, err
 	}
@@ -370,7 +362,7 @@ func (client *XMLClient) GetHeaders(ctx context.Context, options *XMLClientGetHe
 	if err != nil {
 		return XMLClientGetHeadersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetHeadersResponse{}, err
 	}
@@ -409,7 +401,7 @@ func (client *XMLClient) GetRootList(ctx context.Context, options *XMLClientGetR
 	if err != nil {
 		return XMLClientGetRootListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetRootListResponse{}, err
 	}
@@ -450,7 +442,7 @@ func (client *XMLClient) GetRootListSingleItem(ctx context.Context, options *XML
 	if err != nil {
 		return XMLClientGetRootListSingleItemResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetRootListSingleItemResponse{}, err
 	}
@@ -491,7 +483,7 @@ func (client *XMLClient) GetServiceProperties(ctx context.Context, options *XMLC
 	if err != nil {
 		return XMLClientGetServicePropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetServicePropertiesResponse{}, err
 	}
@@ -535,7 +527,7 @@ func (client *XMLClient) GetSimple(ctx context.Context, options *XMLClientGetSim
 	if err != nil {
 		return XMLClientGetSimpleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetSimpleResponse{}, err
 	}
@@ -575,7 +567,7 @@ func (client *XMLClient) GetURI(ctx context.Context, options *XMLClientGetURIOpt
 	if err != nil {
 		return XMLClientGetURIResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetURIResponse{}, err
 	}
@@ -615,7 +607,7 @@ func (client *XMLClient) GetWrappedLists(ctx context.Context, options *XMLClient
 	if err != nil {
 		return XMLClientGetWrappedListsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetWrappedListsResponse{}, err
 	}
@@ -656,7 +648,7 @@ func (client *XMLClient) GetXMsText(ctx context.Context, options *XMLClientGetXM
 	if err != nil {
 		return XMLClientGetXMsTextResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientGetXMsTextResponse{}, err
 	}
@@ -696,7 +688,7 @@ func (client *XMLClient) JSONInput(ctx context.Context, properties JSONInput, op
 	if err != nil {
 		return XMLClientJSONInputResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientJSONInputResponse{}, err
 	}
@@ -726,7 +718,7 @@ func (client *XMLClient) JSONOutput(ctx context.Context, options *XMLClientJSONO
 	if err != nil {
 		return XMLClientJSONOutputResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientJSONOutputResponse{}, err
 	}
@@ -766,7 +758,7 @@ func (client *XMLClient) ListBlobs(ctx context.Context, options *XMLClientListBl
 	if err != nil {
 		return XMLClientListBlobsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientListBlobsResponse{}, err
 	}
@@ -810,7 +802,7 @@ func (client *XMLClient) ListContainers(ctx context.Context, options *XMLClientL
 	if err != nil {
 		return XMLClientListContainersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientListContainersResponse{}, err
 	}
@@ -853,7 +845,7 @@ func (client *XMLClient) PutACLs(ctx context.Context, properties []*SignedIdenti
 	if err != nil {
 		return XMLClientPutACLsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutACLsResponse{}, err
 	}
@@ -891,7 +883,7 @@ func (client *XMLClient) PutBinary(ctx context.Context, slideshow ModelWithByteP
 	if err != nil {
 		return XMLClientPutBinaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutBinaryResponse{}, err
 	}
@@ -923,7 +915,7 @@ func (client *XMLClient) PutComplexTypeRefNoMeta(ctx context.Context, model Root
 	if err != nil {
 		return XMLClientPutComplexTypeRefNoMetaResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutComplexTypeRefNoMetaResponse{}, err
 	}
@@ -954,7 +946,7 @@ func (client *XMLClient) PutComplexTypeRefWithMeta(ctx context.Context, model Ro
 	if err != nil {
 		return XMLClientPutComplexTypeRefWithMetaResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutComplexTypeRefWithMetaResponse{}, err
 	}
@@ -985,7 +977,7 @@ func (client *XMLClient) PutEmptyChildElement(ctx context.Context, banana Banana
 	if err != nil {
 		return XMLClientPutEmptyChildElementResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutEmptyChildElementResponse{}, err
 	}
@@ -1015,7 +1007,7 @@ func (client *XMLClient) PutEmptyList(ctx context.Context, slideshow Slideshow, 
 	if err != nil {
 		return XMLClientPutEmptyListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutEmptyListResponse{}, err
 	}
@@ -1045,7 +1037,7 @@ func (client *XMLClient) PutEmptyRootList(ctx context.Context, bananas []*Banana
 	if err != nil {
 		return XMLClientPutEmptyRootListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutEmptyRootListResponse{}, err
 	}
@@ -1080,7 +1072,7 @@ func (client *XMLClient) PutEmptyWrappedLists(ctx context.Context, appleBarrel A
 	if err != nil {
 		return XMLClientPutEmptyWrappedListsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutEmptyWrappedListsResponse{}, err
 	}
@@ -1110,7 +1102,7 @@ func (client *XMLClient) PutRootList(ctx context.Context, bananas []*Banana, opt
 	if err != nil {
 		return XMLClientPutRootListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutRootListResponse{}, err
 	}
@@ -1145,7 +1137,7 @@ func (client *XMLClient) PutRootListSingleItem(ctx context.Context, bananas []*B
 	if err != nil {
 		return XMLClientPutRootListSingleItemResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutRootListSingleItemResponse{}, err
 	}
@@ -1180,7 +1172,7 @@ func (client *XMLClient) PutServiceProperties(ctx context.Context, properties St
 	if err != nil {
 		return XMLClientPutServicePropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutServicePropertiesResponse{}, err
 	}
@@ -1214,7 +1206,7 @@ func (client *XMLClient) PutSimple(ctx context.Context, slideshow Slideshow, opt
 	if err != nil {
 		return XMLClientPutSimpleResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutSimpleResponse{}, err
 	}
@@ -1245,7 +1237,7 @@ func (client *XMLClient) PutURI(ctx context.Context, model ModelWithURLProperty,
 	if err != nil {
 		return XMLClientPutURIResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutURIResponse{}, err
 	}
@@ -1276,7 +1268,7 @@ func (client *XMLClient) PutWrappedLists(ctx context.Context, wrappedLists Apple
 	if err != nil {
 		return XMLClientPutWrappedListsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return XMLClientPutWrappedListsResponse{}, err
 	}

--- a/test/compute/2019-12-01/armcompute/go.mod
+++ b/test/compute/2019-12-01/armcompute/go.mod
@@ -2,10 +2,10 @@ module armcompute
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/compute/2019-12-01/armcompute/go.sum
+++ b/test/compute/2019-12-01/armcompute/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/compute/2019-12-01/armcompute/zz_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_availabilitysets_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailabilitySetsClient contains the methods for the AvailabilitySets group.
 // Don't use this type directly, use NewAvailabilitySetsClient() instead.
 type AvailabilitySetsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailabilitySetsClient creates a new instance of AvailabilitySetsClient with the specified values.
@@ -37,21 +34,13 @@ type AvailabilitySetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailabilitySetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailabilitySetsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.AvailabilitySetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailabilitySetsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *AvailabilitySetsClient) CreateOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return AvailabilitySetsClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AvailabilitySetsClientCreateOrUpdateResponse{}, err
 	}
@@ -95,7 +84,7 @@ func (client *AvailabilitySetsClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +116,7 @@ func (client *AvailabilitySetsClient) Delete(ctx context.Context, resourceGroupN
 	if err != nil {
 		return AvailabilitySetsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AvailabilitySetsClientDeleteResponse{}, err
 	}
@@ -152,7 +141,7 @@ func (client *AvailabilitySetsClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +163,7 @@ func (client *AvailabilitySetsClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return AvailabilitySetsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AvailabilitySetsClientGetResponse{}, err
 	}
@@ -199,7 +188,7 @@ func (client *AvailabilitySetsClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +230,7 @@ func (client *AvailabilitySetsClient) NewListPager(resourceGroupName string, opt
 			if err != nil {
 				return AvailabilitySetsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailabilitySetsClientListResponse{}, err
 			}
@@ -264,7 +253,7 @@ func (client *AvailabilitySetsClient) listCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -302,7 +291,7 @@ func (client *AvailabilitySetsClient) NewListAvailableSizesPager(resourceGroupNa
 			if err != nil {
 				return AvailabilitySetsClientListAvailableSizesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailabilitySetsClientListAvailableSizesResponse{}, err
 			}
@@ -329,7 +318,7 @@ func (client *AvailabilitySetsClient) listAvailableSizesCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +359,7 @@ func (client *AvailabilitySetsClient) NewListBySubscriptionPager(options *Availa
 			if err != nil {
 				return AvailabilitySetsClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailabilitySetsClientListBySubscriptionResponse{}, err
 			}
@@ -389,7 +378,7 @@ func (client *AvailabilitySetsClient) listBySubscriptionCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +414,7 @@ func (client *AvailabilitySetsClient) Update(ctx context.Context, resourceGroupN
 	if err != nil {
 		return AvailabilitySetsClientUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AvailabilitySetsClientUpdateResponse{}, err
 	}
@@ -450,7 +439,7 @@ func (client *AvailabilitySetsClient) updateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_dedicatedhostgroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DedicatedHostGroupsClient contains the methods for the DedicatedHostGroups group.
 // Don't use this type directly, use NewDedicatedHostGroupsClient() instead.
 type DedicatedHostGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDedicatedHostGroupsClient creates a new instance of DedicatedHostGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type DedicatedHostGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDedicatedHostGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.DedicatedHostGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DedicatedHostGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,7 +60,7 @@ func (client *DedicatedHostGroupsClient) CreateOrUpdate(ctx context.Context, res
 	if err != nil {
 		return DedicatedHostGroupsClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DedicatedHostGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -96,7 +85,7 @@ func (client *DedicatedHostGroupsClient) createOrUpdateCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -129,7 +118,7 @@ func (client *DedicatedHostGroupsClient) Delete(ctx context.Context, resourceGro
 	if err != nil {
 		return DedicatedHostGroupsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DedicatedHostGroupsClientDeleteResponse{}, err
 	}
@@ -154,7 +143,7 @@ func (client *DedicatedHostGroupsClient) deleteCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +165,7 @@ func (client *DedicatedHostGroupsClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return DedicatedHostGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DedicatedHostGroupsClientGetResponse{}, err
 	}
@@ -201,7 +190,7 @@ func (client *DedicatedHostGroupsClient) getCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -244,7 +233,7 @@ func (client *DedicatedHostGroupsClient) NewListByResourceGroupPager(resourceGro
 			if err != nil {
 				return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DedicatedHostGroupsClientListByResourceGroupResponse{}, err
 			}
@@ -267,7 +256,7 @@ func (client *DedicatedHostGroupsClient) listByResourceGroupCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +298,7 @@ func (client *DedicatedHostGroupsClient) NewListBySubscriptionPager(options *Ded
 			if err != nil {
 				return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DedicatedHostGroupsClientListBySubscriptionResponse{}, err
 			}
@@ -328,7 +317,7 @@ func (client *DedicatedHostGroupsClient) listBySubscriptionCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +351,7 @@ func (client *DedicatedHostGroupsClient) Update(ctx context.Context, resourceGro
 	if err != nil {
 		return DedicatedHostGroupsClientUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DedicatedHostGroupsClientUpdateResponse{}, err
 	}
@@ -387,7 +376,7 @@ func (client *DedicatedHostGroupsClient) updateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_operations_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,28 +21,19 @@ import (
 // OperationsClient contains the methods for the Operations group.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -63,7 +52,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
@@ -78,7 +67,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 // listCreateRequest creates the List request.
 func (client *OperationsClient) listCreateRequest(ctx context.Context, options *OperationsClientListOptions) (*policy.Request, error) {
 	urlPath := "/providers/Microsoft.Compute/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_proximityplacementgroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ProximityPlacementGroupsClient contains the methods for the ProximityPlacementGroups group.
 // Don't use this type directly, use NewProximityPlacementGroupsClient() instead.
 type ProximityPlacementGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewProximityPlacementGroupsClient creates a new instance of ProximityPlacementGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type ProximityPlacementGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProximityPlacementGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProximityPlacementGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.ProximityPlacementGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ProximityPlacementGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *ProximityPlacementGroupsClient) CreateOrUpdate(ctx context.Context
 	if err != nil {
 		return ProximityPlacementGroupsClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProximityPlacementGroupsClientCreateOrUpdateResponse{}, err
 	}
@@ -95,7 +84,7 @@ func (client *ProximityPlacementGroupsClient) createOrUpdateCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +117,7 @@ func (client *ProximityPlacementGroupsClient) Delete(ctx context.Context, resour
 	if err != nil {
 		return ProximityPlacementGroupsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProximityPlacementGroupsClientDeleteResponse{}, err
 	}
@@ -153,7 +142,7 @@ func (client *ProximityPlacementGroupsClient) deleteCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +165,7 @@ func (client *ProximityPlacementGroupsClient) Get(ctx context.Context, resourceG
 	if err != nil {
 		return ProximityPlacementGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProximityPlacementGroupsClientGetResponse{}, err
 	}
@@ -201,7 +190,7 @@ func (client *ProximityPlacementGroupsClient) getCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +235,7 @@ func (client *ProximityPlacementGroupsClient) NewListByResourceGroupPager(resour
 			if err != nil {
 				return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ProximityPlacementGroupsClientListByResourceGroupResponse{}, err
 			}
@@ -269,7 +258,7 @@ func (client *ProximityPlacementGroupsClient) listByResourceGroupCreateRequest(c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +299,7 @@ func (client *ProximityPlacementGroupsClient) NewListBySubscriptionPager(options
 			if err != nil {
 				return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ProximityPlacementGroupsClientListBySubscriptionResponse{}, err
 			}
@@ -329,7 +318,7 @@ func (client *ProximityPlacementGroupsClient) listBySubscriptionCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +352,7 @@ func (client *ProximityPlacementGroupsClient) Update(ctx context.Context, resour
 	if err != nil {
 		return ProximityPlacementGroupsClientUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProximityPlacementGroupsClientUpdateResponse{}, err
 	}
@@ -388,7 +377,7 @@ func (client *ProximityPlacementGroupsClient) updateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_resourceskus_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ResourceSKUsClient contains the methods for the ResourceSKUs group.
 // Don't use this type directly, use NewResourceSKUsClient() instead.
 type ResourceSKUsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewResourceSKUsClient creates a new instance of ResourceSKUsClient with the specified values.
@@ -37,21 +34,13 @@ type ResourceSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceSKUsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.ResourceSKUsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ResourceSKUsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -76,7 +65,7 @@ func (client *ResourceSKUsClient) NewListPager(options *ResourceSKUsClientListOp
 			if err != nil {
 				return ResourceSKUsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ResourceSKUsClientListResponse{}, err
 			}
@@ -95,7 +84,7 @@ func (client *ResourceSKUsClient) listCreateRequest(ctx context.Context, options
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_usage_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // UsageClient contains the methods for the Usage group.
 // Don't use this type directly, use NewUsageClient() instead.
 type UsageClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewUsageClient creates a new instance of UsageClient with the specified values.
@@ -37,21 +34,13 @@ type UsageClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.UsageClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &UsageClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *UsageClient) NewListPager(location string, options *UsageClientLis
 			if err != nil {
 				return UsageClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return UsageClientListResponse{}, err
 			}
@@ -101,7 +90,7 @@ func (client *UsageClient) listCreateRequest(ctx context.Context, location strin
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineextensionimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineextensionimages_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -27,9 +25,8 @@ import (
 // VirtualMachineExtensionImagesClient contains the methods for the VirtualMachineExtensionImages group.
 // Don't use this type directly, use NewVirtualMachineExtensionImagesClient() instead.
 type VirtualMachineExtensionImagesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualMachineExtensionImagesClient creates a new instance of VirtualMachineExtensionImagesClient with the specified values.
@@ -38,21 +35,13 @@ type VirtualMachineExtensionImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineExtensionImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionImagesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.VirtualMachineExtensionImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualMachineExtensionImagesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *VirtualMachineExtensionImagesClient) Get(ctx context.Context, loca
 	if err != nil {
 		return VirtualMachineExtensionImagesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineExtensionImagesClientGetResponse{}, err
 	}
@@ -102,7 +91,7 @@ func (client *VirtualMachineExtensionImagesClient) getCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +123,7 @@ func (client *VirtualMachineExtensionImagesClient) ListTypes(ctx context.Context
 	if err != nil {
 		return VirtualMachineExtensionImagesClientListTypesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineExtensionImagesClientListTypesResponse{}, err
 	}
@@ -159,7 +148,7 @@ func (client *VirtualMachineExtensionImagesClient) listTypesCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +180,7 @@ func (client *VirtualMachineExtensionImagesClient) ListVersions(ctx context.Cont
 	if err != nil {
 		return VirtualMachineExtensionImagesClientListVersionsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineExtensionImagesClientListVersionsResponse{}, err
 	}
@@ -220,7 +209,7 @@ func (client *VirtualMachineExtensionImagesClient) listVersionsCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineimages_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -27,9 +25,8 @@ import (
 // VirtualMachineImagesClient contains the methods for the VirtualMachineImages group.
 // Don't use this type directly, use NewVirtualMachineImagesClient() instead.
 type VirtualMachineImagesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualMachineImagesClient creates a new instance of VirtualMachineImagesClient with the specified values.
@@ -38,21 +35,13 @@ type VirtualMachineImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.VirtualMachineImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualMachineImagesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -73,7 +62,7 @@ func (client *VirtualMachineImagesClient) Get(ctx context.Context, location stri
 	if err != nil {
 		return VirtualMachineImagesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineImagesClientGetResponse{}, err
 	}
@@ -110,7 +99,7 @@ func (client *VirtualMachineImagesClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +134,7 @@ func (client *VirtualMachineImagesClient) List(ctx context.Context, location str
 	if err != nil {
 		return VirtualMachineImagesClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineImagesClientListResponse{}, err
 	}
@@ -178,7 +167,7 @@ func (client *VirtualMachineImagesClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +209,7 @@ func (client *VirtualMachineImagesClient) ListOffers(ctx context.Context, locati
 	if err != nil {
 		return VirtualMachineImagesClientListOffersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineImagesClientListOffersResponse{}, err
 	}
@@ -245,7 +234,7 @@ func (client *VirtualMachineImagesClient) listOffersCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +266,7 @@ func (client *VirtualMachineImagesClient) ListPublishers(ctx context.Context, lo
 	if err != nil {
 		return VirtualMachineImagesClientListPublishersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineImagesClientListPublishersResponse{}, err
 	}
@@ -298,7 +287,7 @@ func (client *VirtualMachineImagesClient) listPublishersCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +321,7 @@ func (client *VirtualMachineImagesClient) ListSKUs(ctx context.Context, location
 	if err != nil {
 		return VirtualMachineImagesClientListSKUsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineImagesClientListSKUsResponse{}, err
 	}
@@ -361,7 +350,7 @@ func (client *VirtualMachineImagesClient) listSKUsCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineruncommands_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualMachineRunCommandsClient contains the methods for the VirtualMachineRunCommands group.
 // Don't use this type directly, use NewVirtualMachineRunCommandsClient() instead.
 type VirtualMachineRunCommandsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualMachineRunCommandsClient creates a new instance of VirtualMachineRunCommandsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualMachineRunCommandsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineRunCommandsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.VirtualMachineRunCommandsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualMachineRunCommandsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *VirtualMachineRunCommandsClient) Get(ctx context.Context, location
 	if err != nil {
 		return VirtualMachineRunCommandsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineRunCommandsClientGetResponse{}, err
 	}
@@ -94,7 +83,7 @@ func (client *VirtualMachineRunCommandsClient) getCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +125,7 @@ func (client *VirtualMachineRunCommandsClient) NewListPager(location string, opt
 			if err != nil {
 				return VirtualMachineRunCommandsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualMachineRunCommandsClientListResponse{}, err
 			}
@@ -159,7 +148,7 @@ func (client *VirtualMachineRunCommandsClient) listCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualMachineScaleSetRollingUpgradesClient contains the methods for the VirtualMachineScaleSetRollingUpgrades group.
 // Don't use this type directly, use NewVirtualMachineScaleSetRollingUpgradesClient() instead.
 type VirtualMachineScaleSetRollingUpgradesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualMachineScaleSetRollingUpgradesClient creates a new instance of VirtualMachineScaleSetRollingUpgradesClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualMachineScaleSetRollingUpgradesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetRollingUpgradesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetRollingUpgradesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetRollingUpgradesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualMachineScaleSetRollingUpgradesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,9 +59,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginCancel(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientCancelResponse](resp, client.pl, nil)
+		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientCancelResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientCancelResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientCancelResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -85,7 +74,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) cancel(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +99,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) cancelCreateRequest(c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +122,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) GetLatest(ctx context
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualMachineScaleSetRollingUpgradesClientGetLatestResponse{}, err
 	}
@@ -158,7 +147,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) getLatestCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -194,9 +183,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartExtensionUp
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse](resp, client.pl, nil)
+		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -211,7 +200,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) startExtensionUpgrade
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +225,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) startExtensionUpgrade
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,9 +251,9 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) BeginStartOSUpgrade(c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse](resp, client.pl, nil)
+		return runtime.NewPoller[VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -279,7 +268,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) startOSUpgrade(ctx co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +293,7 @@ func (client *VirtualMachineScaleSetRollingUpgradesClient) startOSUpgradeCreateR
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinesizes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualMachineSizesClient contains the methods for the VirtualMachineSizes group.
 // Don't use this type directly, use NewVirtualMachineSizesClient() instead.
 type VirtualMachineSizesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualMachineSizesClient creates a new instance of VirtualMachineSizesClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualMachineSizesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armcompute.VirtualMachineSizesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualMachineSizesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,7 +61,7 @@ func (client *VirtualMachineSizesClient) NewListPager(location string, options *
 			if err != nil {
 				return VirtualMachineSizesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualMachineSizesClientListResponse{}, err
 			}
@@ -95,7 +84,7 @@ func (client *VirtualMachineSizesClient) listCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/go.mod
+++ b/test/consumption/2019-10-01/armconsumption/go.mod
@@ -2,10 +2,10 @@ module armconsumption
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/consumption/2019-10-01/armconsumption/go.sum
+++ b/test/consumption/2019-10-01/armconsumption/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/consumption/2019-10-01/armconsumption/zz_budgets_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_budgets_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,28 +24,19 @@ import (
 // BudgetsClient contains the methods for the Budgets group.
 // Don't use this type directly, use NewBudgetsClient() instead.
 type BudgetsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewBudgetsClient creates a new instance of BudgetsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBudgetsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BudgetsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.BudgetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &BudgetsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -75,7 +64,7 @@ func (client *BudgetsClient) CreateOrUpdate(ctx context.Context, scope string, b
 	if err != nil {
 		return BudgetsClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BudgetsClientCreateOrUpdateResponse{}, err
 	}
@@ -93,7 +82,7 @@ func (client *BudgetsClient) createOrUpdateCreateRequest(ctx context.Context, sc
 		return nil, errors.New("parameter budgetName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{budgetName}", url.PathEscape(budgetName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +122,7 @@ func (client *BudgetsClient) Delete(ctx context.Context, scope string, budgetNam
 	if err != nil {
 		return BudgetsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BudgetsClientDeleteResponse{}, err
 	}
@@ -151,7 +140,7 @@ func (client *BudgetsClient) deleteCreateRequest(ctx context.Context, scope stri
 		return nil, errors.New("parameter budgetName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{budgetName}", url.PathEscape(budgetName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +171,7 @@ func (client *BudgetsClient) Get(ctx context.Context, scope string, budgetName s
 	if err != nil {
 		return BudgetsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BudgetsClientGetResponse{}, err
 	}
@@ -200,7 +189,7 @@ func (client *BudgetsClient) getCreateRequest(ctx context.Context, scope string,
 		return nil, errors.New("parameter budgetName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{budgetName}", url.PathEscape(budgetName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +238,7 @@ func (client *BudgetsClient) NewListPager(scope string, options *BudgetsClientLi
 			if err != nil {
 				return BudgetsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return BudgetsClientListResponse{}, err
 			}
@@ -265,7 +254,7 @@ func (client *BudgetsClient) NewListPager(scope string, options *BudgetsClientLi
 func (client *BudgetsClient) listCreateRequest(ctx context.Context, scope string, options *BudgetsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/budgets"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_charges_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_charges_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // ChargesClient contains the methods for the Charges group.
 // Don't use this type directly, use NewChargesClient() instead.
 type ChargesClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewChargesClient creates a new instance of ChargesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewChargesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ChargesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ChargesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ChargesClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -73,7 +62,7 @@ func (client *ChargesClient) List(ctx context.Context, scope string, options *Ch
 	if err != nil {
 		return ChargesClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ChargesClientListResponse{}, err
 	}
@@ -87,7 +76,7 @@ func (client *ChargesClient) List(ctx context.Context, scope string, options *Ch
 func (client *ChargesClient) listCreateRequest(ctx context.Context, scope string, options *ChargesClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/charges"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_credits_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_credits_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // CreditsClient contains the methods for the Credits group.
 // Don't use this type directly, use NewCreditsClient() instead.
 type CreditsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewCreditsClient creates a new instance of CreditsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCreditsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*CreditsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.CreditsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &CreditsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -63,7 +52,7 @@ func (client *CreditsClient) Get(ctx context.Context, scope string, options *Cre
 	if err != nil {
 		return CreditsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return CreditsClientGetResponse{}, err
 	}
@@ -77,7 +66,7 @@ func (client *CreditsClient) Get(ctx context.Context, scope string, options *Cre
 func (client *CreditsClient) getCreateRequest(ctx context.Context, scope string, options *CreditsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/credits/balanceSummary"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_events_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_events_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // EventsClient contains the methods for the Events group.
 // Don't use this type directly, use NewEventsClient() instead.
 type EventsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewEventsClient creates a new instance of EventsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewEventsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*EventsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.EventsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &EventsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -75,7 +64,7 @@ func (client *EventsClient) NewListPager(startDate string, endDate string, scope
 			if err != nil {
 				return EventsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return EventsClientListResponse{}, err
 			}
@@ -91,7 +80,7 @@ func (client *EventsClient) NewListPager(startDate string, endDate string, scope
 func (client *EventsClient) listCreateRequest(ctx context.Context, startDate string, endDate string, scope string, options *EventsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/events"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_lots_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_lots_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // LotsClient contains the methods for the Lots group.
 // Don't use this type directly, use NewLotsClient() instead.
 type LotsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewLotsClient creates a new instance of LotsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLotsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*LotsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.LotsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LotsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -73,7 +62,7 @@ func (client *LotsClient) NewListPager(scope string, options *LotsClientListOpti
 			if err != nil {
 				return LotsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LotsClientListResponse{}, err
 			}
@@ -89,7 +78,7 @@ func (client *LotsClient) NewListPager(scope string, options *LotsClientListOpti
 func (client *LotsClient) listCreateRequest(ctx context.Context, scope string, options *LotsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/lots"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_operations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_operations_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,28 +21,19 @@ import (
 // OperationsClient contains the methods for the Operations group.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
@@ -84,7 +73,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 // listCreateRequest creates the List request.
 func (client *OperationsClient) listCreateRequest(ctx context.Context, options *OperationsClientListOptions) (*policy.Request, error) {
 	urlPath := "/providers/Microsoft.Consumption/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendationdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendationdetails_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // ReservationRecommendationDetailsClient contains the methods for the ReservationRecommendationDetails group.
 // Don't use this type directly, use NewReservationRecommendationDetailsClient() instead.
 type ReservationRecommendationDetailsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewReservationRecommendationDetailsClient creates a new instance of ReservationRecommendationDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationDetailsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ReservationRecommendationDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ReservationRecommendationDetailsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -73,7 +62,7 @@ func (client *ReservationRecommendationDetailsClient) Get(ctx context.Context, b
 	if err != nil {
 		return ReservationRecommendationDetailsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ReservationRecommendationDetailsClientGetResponse{}, err
 	}
@@ -87,7 +76,7 @@ func (client *ReservationRecommendationDetailsClient) Get(ctx context.Context, b
 func (client *ReservationRecommendationDetailsClient) getCreateRequest(ctx context.Context, billingScope string, scope Scope, region string, term Term, lookBackPeriod LookBackPeriod, product string, options *ReservationRecommendationDetailsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/{billingScope}/providers/Microsoft.Consumption/reservationRecommendationDetails"
 	urlPath = strings.ReplaceAll(urlPath, "{billingScope}", billingScope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendations_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -24,28 +22,19 @@ import (
 // ReservationRecommendationsClient contains the methods for the ReservationRecommendations group.
 // Don't use this type directly, use NewReservationRecommendationsClient() instead.
 type ReservationRecommendationsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewReservationRecommendationsClient creates a new instance of ReservationRecommendationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ReservationRecommendationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ReservationRecommendationsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *ReservationRecommendationsClient) NewListPager(scope string, optio
 			if err != nil {
 				return ReservationRecommendationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationRecommendationsClientListResponse{}, err
 			}
@@ -93,7 +82,7 @@ func (client *ReservationRecommendationsClient) NewListPager(scope string, optio
 func (client *ReservationRecommendationsClient) listCreateRequest(ctx context.Context, scope string, options *ReservationRecommendationsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/reservationRecommendations"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationsdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationsdetails_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,28 +24,19 @@ import (
 // ReservationsDetailsClient contains the methods for the ReservationsDetails group.
 // Don't use this type directly, use NewReservationsDetailsClient() instead.
 type ReservationsDetailsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewReservationsDetailsClient creates a new instance of ReservationsDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsDetailsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ReservationsDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ReservationsDetailsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *ReservationsDetailsClient) NewListPager(scope string, options *Res
 			if err != nil {
 				return ReservationsDetailsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsDetailsClientListResponse{}, err
 			}
@@ -93,7 +82,7 @@ func (client *ReservationsDetailsClient) NewListPager(scope string, options *Res
 func (client *ReservationsDetailsClient) listCreateRequest(ctx context.Context, scope string, options *ReservationsDetailsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/reservationDetails"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +141,7 @@ func (client *ReservationsDetailsClient) NewListByReservationOrderPager(reservat
 			if err != nil {
 				return ReservationsDetailsClientListByReservationOrderResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsDetailsClientListByReservationOrderResponse{}, err
 			}
@@ -171,7 +160,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderCreateRequest(ctx
 		return nil, errors.New("parameter reservationOrderID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{reservationOrderId}", url.PathEscape(reservationOrderID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +206,7 @@ func (client *ReservationsDetailsClient) NewListByReservationOrderAndReservation
 			if err != nil {
 				return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsDetailsClientListByReservationOrderAndReservationResponse{}, err
 			}
@@ -240,7 +229,7 @@ func (client *ReservationsDetailsClient) listByReservationOrderAndReservationCre
 		return nil, errors.New("parameter reservationID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{reservationId}", url.PathEscape(reservationID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationssummaries_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationssummaries_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,28 +24,19 @@ import (
 // ReservationsSummariesClient contains the methods for the ReservationsSummaries group.
 // Don't use this type directly, use NewReservationsSummariesClient() instead.
 type ReservationsSummariesClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewReservationsSummariesClient creates a new instance of ReservationsSummariesClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsSummariesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsSummariesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ReservationsSummariesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ReservationsSummariesClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *ReservationsSummariesClient) NewListPager(scope string, grain Data
 			if err != nil {
 				return ReservationsSummariesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsSummariesClientListResponse{}, err
 			}
@@ -94,7 +83,7 @@ func (client *ReservationsSummariesClient) NewListPager(scope string, grain Data
 func (client *ReservationsSummariesClient) listCreateRequest(ctx context.Context, scope string, grain Datagrain, options *ReservationsSummariesClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/reservationSummaries"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +142,7 @@ func (client *ReservationsSummariesClient) NewListByReservationOrderPager(reserv
 			if err != nil {
 				return ReservationsSummariesClientListByReservationOrderResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsSummariesClientListByReservationOrderResponse{}, err
 			}
@@ -172,7 +161,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderCreateRequest(c
 		return nil, errors.New("parameter reservationOrderID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{reservationOrderId}", url.PathEscape(reservationOrderID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +209,7 @@ func (client *ReservationsSummariesClient) NewListByReservationOrderAndReservati
 			if err != nil {
 				return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationsSummariesClientListByReservationOrderAndReservationResponse{}, err
 			}
@@ -243,7 +232,7 @@ func (client *ReservationsSummariesClient) listByReservationOrderAndReservationC
 		return nil, errors.New("parameter reservationID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{reservationId}", url.PathEscape(reservationID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationtransactions_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationtransactions_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,28 +24,19 @@ import (
 // ReservationTransactionsClient contains the methods for the ReservationTransactions group.
 // Don't use this type directly, use NewReservationTransactionsClient() instead.
 type ReservationTransactionsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewReservationTransactionsClient creates a new instance of ReservationTransactionsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationTransactionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationTransactionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.ReservationTransactionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ReservationTransactionsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -74,7 +63,7 @@ func (client *ReservationTransactionsClient) NewListPager(billingAccountID strin
 			if err != nil {
 				return ReservationTransactionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationTransactionsClientListResponse{}, err
 			}
@@ -93,7 +82,7 @@ func (client *ReservationTransactionsClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter billingAccountID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{billingAccountId}", url.PathEscape(billingAccountID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +128,7 @@ func (client *ReservationTransactionsClient) NewListByBillingProfilePager(billin
 			if err != nil {
 				return ReservationTransactionsClientListByBillingProfileResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ReservationTransactionsClientListByBillingProfileResponse{}, err
 			}
@@ -162,7 +151,7 @@ func (client *ReservationTransactionsClient) listByBillingProfileCreateRequest(c
 		return nil, errors.New("parameter billingProfileID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{billingProfileId}", url.PathEscape(billingProfileID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_usagedetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_usagedetails_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -25,28 +23,19 @@ import (
 // UsageDetailsClient contains the methods for the UsageDetails group.
 // Don't use this type directly, use NewUsageDetailsClient() instead.
 type UsageDetailsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewUsageDetailsClient creates a new instance of UsageDetailsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageDetailsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armconsumption.UsageDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &UsageDetailsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -88,7 +77,7 @@ func (client *UsageDetailsClient) NewListPager(scope string, options *UsageDetai
 			if err != nil {
 				return UsageDetailsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return UsageDetailsClientListResponse{}, err
 			}
@@ -104,7 +93,7 @@ func (client *UsageDetailsClient) NewListPager(scope string, options *UsageDetai
 func (client *UsageDetailsClient) listCreateRequest(ctx context.Context, scope string, options *UsageDetailsClientListOptions) (*policy.Request, error) {
 	urlPath := "/{scope}/providers/Microsoft.Consumption/usageDetails"
 	urlPath = strings.ReplaceAll(urlPath, "{scope}", scope)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/go.mod
+++ b/test/databoxedge/2021-02-01/armdataboxedge/go.mod
@@ -2,10 +2,10 @@ module armdataboxedge
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/databoxedge/2021-02-01/armdataboxedge/go.sum
+++ b/test/databoxedge/2021-02-01/armdataboxedge/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_availableskus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_availableskus_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailableSKUsClient contains the methods for the AvailableSKUs group.
 // Don't use this type directly, use NewAvailableSKUsClient() instead.
 type AvailableSKUsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailableSKUsClient creates a new instance of AvailableSKUsClient with the specified values.
@@ -36,21 +33,13 @@ type AvailableSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableSKUsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.AvailableSKUsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailableSKUsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -75,7 +64,7 @@ func (client *AvailableSKUsClient) NewListPager(options *AvailableSKUsClientList
 			if err != nil {
 				return AvailableSKUsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableSKUsClientListResponse{}, err
 			}
@@ -94,7 +83,7 @@ func (client *AvailableSKUsClient) listCreateRequest(ctx context.Context, option
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_devices_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DevicesClient contains the methods for the Devices group.
 // Don't use this type directly, use NewDevicesClient() instead.
 type DevicesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDevicesClient creates a new instance of DevicesClient with the specified values.
@@ -36,21 +33,13 @@ type DevicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDevicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DevicesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.DevicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DevicesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -68,7 +57,7 @@ func (client *DevicesClient) CreateOrUpdate(ctx context.Context, deviceName stri
 	if err != nil {
 		return DevicesClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientCreateOrUpdateResponse{}, err
 	}
@@ -90,7 +79,7 @@ func (client *DevicesClient) createOrUpdateCreateRequest(ctx context.Context, de
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -125,9 +114,9 @@ func (client *DevicesClient) BeginCreateOrUpdateSecuritySettings(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DevicesClientCreateOrUpdateSecuritySettingsResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DevicesClientCreateOrUpdateSecuritySettingsResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DevicesClientCreateOrUpdateSecuritySettingsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DevicesClientCreateOrUpdateSecuritySettingsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -140,7 +129,7 @@ func (client *DevicesClient) createOrUpdateSecuritySettings(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +151,7 @@ func (client *DevicesClient) createOrUpdateSecuritySettingsCreateRequest(ctx con
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -186,9 +175,9 @@ func (client *DevicesClient) BeginDelete(ctx context.Context, deviceName string,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DevicesClientDeleteResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DevicesClientDeleteResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DevicesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DevicesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -201,7 +190,7 @@ func (client *DevicesClient) deleteOperation(ctx context.Context, deviceName str
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -223,7 +212,7 @@ func (client *DevicesClient) deleteCreateRequest(ctx context.Context, deviceName
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -248,9 +237,9 @@ func (client *DevicesClient) BeginDownloadUpdates(ctx context.Context, deviceNam
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DevicesClientDownloadUpdatesResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DevicesClientDownloadUpdatesResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DevicesClientDownloadUpdatesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DevicesClientDownloadUpdatesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -263,7 +252,7 @@ func (client *DevicesClient) downloadUpdates(ctx context.Context, deviceName str
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +274,7 @@ func (client *DevicesClient) downloadUpdatesCreateRequest(ctx context.Context, d
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +298,7 @@ func (client *DevicesClient) GenerateCertificate(ctx context.Context, deviceName
 	if err != nil {
 		return DevicesClientGenerateCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientGenerateCertificateResponse{}, err
 	}
@@ -331,7 +320,7 @@ func (client *DevicesClient) generateCertificateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +352,7 @@ func (client *DevicesClient) Get(ctx context.Context, deviceName string, resourc
 	if err != nil {
 		return DevicesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientGetResponse{}, err
 	}
@@ -385,7 +374,7 @@ func (client *DevicesClient) getCreateRequest(ctx context.Context, deviceName st
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +407,7 @@ func (client *DevicesClient) GetExtendedInformation(ctx context.Context, deviceN
 	if err != nil {
 		return DevicesClientGetExtendedInformationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientGetExtendedInformationResponse{}, err
 	}
@@ -440,7 +429,7 @@ func (client *DevicesClient) getExtendedInformationCreateRequest(ctx context.Con
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +462,7 @@ func (client *DevicesClient) GetNetworkSettings(ctx context.Context, deviceName 
 	if err != nil {
 		return DevicesClientGetNetworkSettingsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientGetNetworkSettingsResponse{}, err
 	}
@@ -495,7 +484,7 @@ func (client *DevicesClient) getNetworkSettingsCreateRequest(ctx context.Context
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +518,7 @@ func (client *DevicesClient) GetUpdateSummary(ctx context.Context, deviceName st
 	if err != nil {
 		return DevicesClientGetUpdateSummaryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientGetUpdateSummaryResponse{}, err
 	}
@@ -551,7 +540,7 @@ func (client *DevicesClient) getUpdateSummaryCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -585,9 +574,9 @@ func (client *DevicesClient) BeginInstallUpdates(ctx context.Context, deviceName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DevicesClientInstallUpdatesResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DevicesClientInstallUpdatesResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DevicesClientInstallUpdatesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DevicesClientInstallUpdatesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -600,7 +589,7 @@ func (client *DevicesClient) installUpdates(ctx context.Context, deviceName stri
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -622,7 +611,7 @@ func (client *DevicesClient) installUpdatesCreateRequest(ctx context.Context, de
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +644,7 @@ func (client *DevicesClient) NewListByResourceGroupPager(resourceGroupName strin
 			if err != nil {
 				return DevicesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DevicesClientListByResourceGroupResponse{}, err
 			}
@@ -678,7 +667,7 @@ func (client *DevicesClient) listByResourceGroupCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -722,7 +711,7 @@ func (client *DevicesClient) NewListBySubscriptionPager(options *DevicesClientLi
 			if err != nil {
 				return DevicesClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DevicesClientListBySubscriptionResponse{}, err
 			}
@@ -741,7 +730,7 @@ func (client *DevicesClient) listBySubscriptionCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -778,9 +767,9 @@ func (client *DevicesClient) BeginScanForUpdates(ctx context.Context, deviceName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DevicesClientScanForUpdatesResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DevicesClientScanForUpdatesResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DevicesClientScanForUpdatesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DevicesClientScanForUpdatesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -793,7 +782,7 @@ func (client *DevicesClient) scanForUpdates(ctx context.Context, deviceName stri
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +804,7 @@ func (client *DevicesClient) scanForUpdatesCreateRequest(ctx context.Context, de
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -839,7 +828,7 @@ func (client *DevicesClient) Update(ctx context.Context, deviceName string, reso
 	if err != nil {
 		return DevicesClientUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientUpdateResponse{}, err
 	}
@@ -861,7 +850,7 @@ func (client *DevicesClient) updateCreateRequest(ctx context.Context, deviceName
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -895,7 +884,7 @@ func (client *DevicesClient) UpdateExtendedInformation(ctx context.Context, devi
 	if err != nil {
 		return DevicesClientUpdateExtendedInformationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientUpdateExtendedInformationResponse{}, err
 	}
@@ -917,7 +906,7 @@ func (client *DevicesClient) updateExtendedInformationCreateRequest(ctx context.
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -951,7 +940,7 @@ func (client *DevicesClient) UploadCertificate(ctx context.Context, deviceName s
 	if err != nil {
 		return DevicesClientUploadCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DevicesClientUploadCertificateResponse{}, err
 	}
@@ -973,7 +962,7 @@ func (client *DevicesClient) uploadCertificateCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_diagnosticsettings_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DiagnosticSettingsClient contains the methods for the DiagnosticSettings group.
 // Don't use this type directly, use NewDiagnosticSettingsClient() instead.
 type DiagnosticSettingsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDiagnosticSettingsClient creates a new instance of DiagnosticSettingsClient with the specified values.
@@ -36,21 +33,13 @@ type DiagnosticSettingsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiagnosticSettingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiagnosticSettingsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.DiagnosticSettingsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DiagnosticSettingsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *DiagnosticSettingsClient) GetDiagnosticProactiveLogCollectionSetti
 	if err != nil {
 		return DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DiagnosticSettingsClientGetDiagnosticProactiveLogCollectionSettingsResponse{}, err
 	}
@@ -91,7 +80,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticProactiveLogCollectionSetti
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +114,7 @@ func (client *DiagnosticSettingsClient) GetDiagnosticRemoteSupportSettings(ctx c
 	if err != nil {
 		return DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsResponse{}, err
 	}
@@ -147,7 +136,7 @@ func (client *DiagnosticSettingsClient) getDiagnosticRemoteSupportSettingsCreate
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -183,9 +172,9 @@ func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticProactiveLogCollect
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DiagnosticSettingsClientUpdateDiagnosticProactiveLogCollectionSettingsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -199,7 +188,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticProactiveLogCollectionSe
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -221,7 +210,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticProactiveLogCollectionSe
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -248,9 +237,9 @@ func (client *DiagnosticSettingsClient) BeginUpdateDiagnosticRemoteSupportSettin
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DiagnosticSettingsClientUpdateDiagnosticRemoteSupportSettingsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -264,7 +253,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticRemoteSupportSettings(ct
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +275,7 @@ func (client *DiagnosticSettingsClient) updateDiagnosticRemoteSupportSettingsCre
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_jobs_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_jobs_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // JobsClient contains the methods for the Jobs group.
 // Don't use this type directly, use NewJobsClient() instead.
 type JobsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewJobsClient creates a new instance of JobsClient with the specified values.
@@ -36,21 +33,13 @@ type JobsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.JobsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &JobsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -68,7 +57,7 @@ func (client *JobsClient) Get(ctx context.Context, deviceName string, name strin
 	if err != nil {
 		return JobsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return JobsClientGetResponse{}, err
 	}
@@ -94,7 +83,7 @@ func (client *JobsClient) getCreateRequest(ctx context.Context, deviceName strin
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_nodes_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_nodes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // NodesClient contains the methods for the Nodes group.
 // Don't use this type directly, use NewNodesClient() instead.
 type NodesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewNodesClient creates a new instance of NodesClient with the specified values.
@@ -36,21 +33,13 @@ type NodesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNodesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NodesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.NodesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &NodesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *NodesClient) NewListByDataBoxEdgeDevicePager(deviceName string, re
 			if err != nil {
 				return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return NodesClientListByDataBoxEdgeDeviceResponse{}, err
 			}
@@ -102,7 +91,7 @@ func (client *NodesClient) listByDataBoxEdgeDeviceCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_operations_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_operations_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,28 +21,19 @@ import (
 // OperationsClient contains the methods for the Operations group.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
@@ -84,7 +73,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 // listCreateRequest creates the List request.
 func (client *OperationsClient) listCreateRequest(ctx context.Context, options *OperationsClientListOptions) (*policy.Request, error) {
 	urlPath := "/providers/Microsoft.DataBoxEdge/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_operationsstatus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_operationsstatus_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // OperationsStatusClient contains the methods for the OperationsStatus group.
 // Don't use this type directly, use NewOperationsStatusClient() instead.
 type OperationsStatusClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewOperationsStatusClient creates a new instance of OperationsStatusClient with the specified values.
@@ -36,21 +33,13 @@ type OperationsStatusClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsStatusClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armdataboxedge.OperationsStatusClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsStatusClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -68,7 +57,7 @@ func (client *OperationsStatusClient) Get(ctx context.Context, deviceName string
 	if err != nil {
 		return OperationsStatusClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return OperationsStatusClientGetResponse{}, err
 	}
@@ -94,7 +83,7 @@ func (client *OperationsStatusClient) getCreateRequest(ctx context.Context, devi
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/keyvault/7.2/azkeyvault/go.mod
+++ b/test/keyvault/7.2/azkeyvault/go.mod
@@ -2,10 +2,10 @@ module azkeyvault
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/keyvault/7.2/azkeyvault/go.sum
+++ b/test/keyvault/7.2/azkeyvault/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/keyvault/7.2/azkeyvault/zz_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_client.go
@@ -12,6 +12,7 @@ package azkeyvault
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -21,18 +22,9 @@ import (
 )
 
 // Client contains the methods for the KeyVaultClient group.
-// Don't use this type directly, use NewClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type Client struct {
-	pl runtime.Pipeline
-}
-
-// NewClient creates a new instance of Client with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewClient(pl runtime.Pipeline) *Client {
-	client := &Client{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BackupCertificate - Requests that a backup of the specified certificate be downloaded to the client. All versions of the
@@ -48,7 +40,7 @@ func (client *Client) BackupCertificate(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientBackupCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientBackupCertificateResponse{}, err
 	}
@@ -108,7 +100,7 @@ func (client *Client) BackupKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientBackupKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientBackupKeyResponse{}, err
 	}
@@ -160,7 +152,7 @@ func (client *Client) BackupSecret(ctx context.Context, vaultBaseURL string, sec
 	if err != nil {
 		return ClientBackupSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientBackupSecretResponse{}, err
 	}
@@ -212,7 +204,7 @@ func (client *Client) BackupStorageAccount(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientBackupStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientBackupStorageAccountResponse{}, err
 	}
@@ -265,7 +257,7 @@ func (client *Client) CreateCertificate(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientCreateCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCreateCertificateResponse{}, err
 	}
@@ -319,7 +311,7 @@ func (client *Client) CreateKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientCreateKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCreateKeyResponse{}, err
 	}
@@ -376,7 +368,7 @@ func (client *Client) Decrypt(ctx context.Context, vaultBaseURL string, keyName 
 	if err != nil {
 		return ClientDecryptResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDecryptResponse{}, err
 	}
@@ -433,7 +425,7 @@ func (client *Client) DeleteCertificate(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientDeleteCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteCertificateResponse{}, err
 	}
@@ -485,7 +477,7 @@ func (client *Client) DeleteCertificateContacts(ctx context.Context, vaultBaseUR
 	if err != nil {
 		return ClientDeleteCertificateContactsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteCertificateContactsResponse{}, err
 	}
@@ -534,7 +526,7 @@ func (client *Client) DeleteCertificateIssuer(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientDeleteCertificateIssuerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteCertificateIssuerResponse{}, err
 	}
@@ -587,7 +579,7 @@ func (client *Client) DeleteCertificateOperation(ctx context.Context, vaultBaseU
 	if err != nil {
 		return ClientDeleteCertificateOperationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteCertificateOperationResponse{}, err
 	}
@@ -640,7 +632,7 @@ func (client *Client) DeleteKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientDeleteKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteKeyResponse{}, err
 	}
@@ -693,7 +685,7 @@ func (client *Client) DeleteSasDefinition(ctx context.Context, vaultBaseURL stri
 	if err != nil {
 		return ClientDeleteSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteSasDefinitionResponse{}, err
 	}
@@ -749,7 +741,7 @@ func (client *Client) DeleteSecret(ctx context.Context, vaultBaseURL string, sec
 	if err != nil {
 		return ClientDeleteSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteSecretResponse{}, err
 	}
@@ -800,7 +792,7 @@ func (client *Client) DeleteStorageAccount(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientDeleteStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteStorageAccountResponse{}, err
 	}
@@ -859,7 +851,7 @@ func (client *Client) Encrypt(ctx context.Context, vaultBaseURL string, keyName 
 	if err != nil {
 		return ClientEncryptResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientEncryptResponse{}, err
 	}
@@ -914,11 +906,11 @@ func (client *Client) BeginFullBackup(ctx context.Context, vaultBaseURL string, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ClientFullBackupResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ClientFullBackupResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ClientFullBackupResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ClientFullBackupResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -931,7 +923,7 @@ func (client *Client) fullBackup(ctx context.Context, vaultBaseURL string, optio
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -972,7 +964,7 @@ func (client *Client) FullBackupStatus(ctx context.Context, vaultBaseURL string,
 	if err != nil {
 		return ClientFullBackupStatusResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientFullBackupStatusResponse{}, err
 	}
@@ -1026,11 +1018,11 @@ func (client *Client) BeginFullRestoreOperation(ctx context.Context, vaultBaseUR
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ClientFullRestoreOperationResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ClientFullRestoreOperationResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ClientFullRestoreOperationResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ClientFullRestoreOperationResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1044,7 +1036,7 @@ func (client *Client) fullRestoreOperation(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1084,7 +1076,7 @@ func (client *Client) GetCertificate(ctx context.Context, vaultBaseURL string, c
 	if err != nil {
 		return ClientGetCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetCertificateResponse{}, err
 	}
@@ -1139,7 +1131,7 @@ func (client *Client) GetCertificateContacts(ctx context.Context, vaultBaseURL s
 	if err != nil {
 		return ClientGetCertificateContactsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetCertificateContactsResponse{}, err
 	}
@@ -1187,7 +1179,7 @@ func (client *Client) GetCertificateIssuer(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientGetCertificateIssuerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetCertificateIssuerResponse{}, err
 	}
@@ -1249,7 +1241,7 @@ func (client *Client) NewGetCertificateIssuersPager(vaultBaseURL string, options
 			if err != nil {
 				return ClientGetCertificateIssuersResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetCertificateIssuersResponse{}, err
 			}
@@ -1303,7 +1295,7 @@ func (client *Client) GetCertificateOperation(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientGetCertificateOperationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetCertificateOperationResponse{}, err
 	}
@@ -1355,7 +1347,7 @@ func (client *Client) GetCertificatePolicy(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientGetCertificatePolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetCertificatePolicyResponse{}, err
 	}
@@ -1418,7 +1410,7 @@ func (client *Client) NewGetCertificateVersionsPager(vaultBaseURL string, certif
 			if err != nil {
 				return ClientGetCertificateVersionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetCertificateVersionsResponse{}, err
 			}
@@ -1484,7 +1476,7 @@ func (client *Client) NewGetCertificatesPager(vaultBaseURL string, options *Clie
 			if err != nil {
 				return ClientGetCertificatesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetCertificatesResponse{}, err
 			}
@@ -1541,7 +1533,7 @@ func (client *Client) GetDeletedCertificate(ctx context.Context, vaultBaseURL st
 	if err != nil {
 		return ClientGetDeletedCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetDeletedCertificateResponse{}, err
 	}
@@ -1605,7 +1597,7 @@ func (client *Client) NewGetDeletedCertificatesPager(vaultBaseURL string, option
 			if err != nil {
 				return ClientGetDeletedCertificatesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetDeletedCertificatesResponse{}, err
 			}
@@ -1662,7 +1654,7 @@ func (client *Client) GetDeletedKey(ctx context.Context, vaultBaseURL string, ke
 	if err != nil {
 		return ClientGetDeletedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetDeletedKeyResponse{}, err
 	}
@@ -1726,7 +1718,7 @@ func (client *Client) NewGetDeletedKeysPager(vaultBaseURL string, options *Clien
 			if err != nil {
 				return ClientGetDeletedKeysResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetDeletedKeysResponse{}, err
 			}
@@ -1781,7 +1773,7 @@ func (client *Client) GetDeletedSasDefinition(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientGetDeletedSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetDeletedSasDefinitionResponse{}, err
 	}
@@ -1848,7 +1840,7 @@ func (client *Client) NewGetDeletedSasDefinitionsPager(vaultBaseURL string, stor
 			if err != nil {
 				return ClientGetDeletedSasDefinitionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetDeletedSasDefinitionsResponse{}, err
 			}
@@ -1905,7 +1897,7 @@ func (client *Client) GetDeletedSecret(ctx context.Context, vaultBaseURL string,
 	if err != nil {
 		return ClientGetDeletedSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetDeletedSecretResponse{}, err
 	}
@@ -1966,7 +1958,7 @@ func (client *Client) NewGetDeletedSecretsPager(vaultBaseURL string, options *Cl
 			if err != nil {
 				return ClientGetDeletedSecretsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetDeletedSecretsResponse{}, err
 			}
@@ -2020,7 +2012,7 @@ func (client *Client) GetDeletedStorageAccount(ctx context.Context, vaultBaseURL
 	if err != nil {
 		return ClientGetDeletedStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetDeletedStorageAccountResponse{}, err
 	}
@@ -2082,7 +2074,7 @@ func (client *Client) NewGetDeletedStorageAccountsPager(vaultBaseURL string, opt
 			if err != nil {
 				return ClientGetDeletedStorageAccountsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetDeletedStorageAccountsResponse{}, err
 			}
@@ -2137,7 +2129,7 @@ func (client *Client) GetKey(ctx context.Context, vaultBaseURL string, keyName s
 	if err != nil {
 		return ClientGetKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetKeyResponse{}, err
 	}
@@ -2203,7 +2195,7 @@ func (client *Client) NewGetKeyVersionsPager(vaultBaseURL string, keyName string
 			if err != nil {
 				return ClientGetKeyVersionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetKeyVersionsResponse{}, err
 			}
@@ -2271,7 +2263,7 @@ func (client *Client) NewGetKeysPager(vaultBaseURL string, options *ClientGetKey
 			if err != nil {
 				return ClientGetKeysResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetKeysResponse{}, err
 			}
@@ -2325,7 +2317,7 @@ func (client *Client) GetSasDefinition(ctx context.Context, vaultBaseURL string,
 	if err != nil {
 		return ClientGetSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetSasDefinitionResponse{}, err
 	}
@@ -2391,7 +2383,7 @@ func (client *Client) NewGetSasDefinitionsPager(vaultBaseURL string, storageAcco
 			if err != nil {
 				return ClientGetSasDefinitionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetSasDefinitionsResponse{}, err
 			}
@@ -2450,7 +2442,7 @@ func (client *Client) GetSecret(ctx context.Context, vaultBaseURL string, secret
 	if err != nil {
 		return ClientGetSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetSecretResponse{}, err
 	}
@@ -2516,7 +2508,7 @@ func (client *Client) NewGetSecretVersionsPager(vaultBaseURL string, secretName 
 			if err != nil {
 				return ClientGetSecretVersionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetSecretVersionsResponse{}, err
 			}
@@ -2583,7 +2575,7 @@ func (client *Client) NewGetSecretsPager(vaultBaseURL string, options *ClientGet
 			if err != nil {
 				return ClientGetSecretsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetSecretsResponse{}, err
 			}
@@ -2635,7 +2627,7 @@ func (client *Client) GetStorageAccount(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientGetStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetStorageAccountResponse{}, err
 	}
@@ -2696,7 +2688,7 @@ func (client *Client) NewGetStorageAccountsPager(vaultBaseURL string, options *C
 			if err != nil {
 				return ClientGetStorageAccountsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientGetStorageAccountsResponse{}, err
 			}
@@ -2751,7 +2743,7 @@ func (client *Client) ImportCertificate(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientImportCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientImportCertificateResponse{}, err
 	}
@@ -2805,7 +2797,7 @@ func (client *Client) ImportKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientImportKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientImportKeyResponse{}, err
 	}
@@ -2859,7 +2851,7 @@ func (client *Client) MergeCertificate(ctx context.Context, vaultBaseURL string,
 	if err != nil {
 		return ClientMergeCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientMergeCertificateResponse{}, err
 	}
@@ -2913,7 +2905,7 @@ func (client *Client) PurgeDeletedCertificate(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientPurgeDeletedCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientPurgeDeletedCertificateResponse{}, err
 	}
@@ -2957,7 +2949,7 @@ func (client *Client) PurgeDeletedKey(ctx context.Context, vaultBaseURL string, 
 	if err != nil {
 		return ClientPurgeDeletedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientPurgeDeletedKeyResponse{}, err
 	}
@@ -3001,7 +2993,7 @@ func (client *Client) PurgeDeletedSecret(ctx context.Context, vaultBaseURL strin
 	if err != nil {
 		return ClientPurgeDeletedSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientPurgeDeletedSecretResponse{}, err
 	}
@@ -3046,7 +3038,7 @@ func (client *Client) PurgeDeletedStorageAccount(ctx context.Context, vaultBaseU
 	if err != nil {
 		return ClientPurgeDeletedStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientPurgeDeletedStorageAccountResponse{}, err
 	}
@@ -3091,7 +3083,7 @@ func (client *Client) RecoverDeletedCertificate(ctx context.Context, vaultBaseUR
 	if err != nil {
 		return ClientRecoverDeletedCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRecoverDeletedCertificateResponse{}, err
 	}
@@ -3145,7 +3137,7 @@ func (client *Client) RecoverDeletedKey(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientRecoverDeletedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRecoverDeletedKeyResponse{}, err
 	}
@@ -3199,7 +3191,7 @@ func (client *Client) RecoverDeletedSasDefinition(ctx context.Context, vaultBase
 	if err != nil {
 		return ClientRecoverDeletedSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRecoverDeletedSasDefinitionResponse{}, err
 	}
@@ -3255,7 +3247,7 @@ func (client *Client) RecoverDeletedSecret(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientRecoverDeletedSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRecoverDeletedSecretResponse{}, err
 	}
@@ -3308,7 +3300,7 @@ func (client *Client) RecoverDeletedStorageAccount(ctx context.Context, vaultBas
 	if err != nil {
 		return ClientRecoverDeletedStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRecoverDeletedStorageAccountResponse{}, err
 	}
@@ -3362,7 +3354,7 @@ func (client *Client) RegenerateStorageAccountKey(ctx context.Context, vaultBase
 	if err != nil {
 		return ClientRegenerateStorageAccountKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRegenerateStorageAccountKeyResponse{}, err
 	}
@@ -3414,7 +3406,7 @@ func (client *Client) RestoreCertificate(ctx context.Context, vaultBaseURL strin
 	if err != nil {
 		return ClientRestoreCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRestoreCertificateResponse{}, err
 	}
@@ -3469,7 +3461,7 @@ func (client *Client) RestoreKey(ctx context.Context, vaultBaseURL string, param
 	if err != nil {
 		return ClientRestoreKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRestoreKeyResponse{}, err
 	}
@@ -3517,7 +3509,7 @@ func (client *Client) RestoreSecret(ctx context.Context, vaultBaseURL string, pa
 	if err != nil {
 		return ClientRestoreSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRestoreSecretResponse{}, err
 	}
@@ -3564,7 +3556,7 @@ func (client *Client) RestoreStatus(ctx context.Context, vaultBaseURL string, jo
 	if err != nil {
 		return ClientRestoreStatusResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRestoreStatusResponse{}, err
 	}
@@ -3615,7 +3607,7 @@ func (client *Client) RestoreStorageAccount(ctx context.Context, vaultBaseURL st
 	if err != nil {
 		return ClientRestoreStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRestoreStorageAccountResponse{}, err
 	}
@@ -3666,11 +3658,11 @@ func (client *Client) BeginSelectiveKeyRestoreOperation(ctx context.Context, vau
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ClientSelectiveKeyRestoreOperationResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ClientSelectiveKeyRestoreOperationResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ClientSelectiveKeyRestoreOperationResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ClientSelectiveKeyRestoreOperationResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -3684,7 +3676,7 @@ func (client *Client) selectiveKeyRestoreOperation(ctx context.Context, vaultBas
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -3727,7 +3719,7 @@ func (client *Client) SetCertificateContacts(ctx context.Context, vaultBaseURL s
 	if err != nil {
 		return ClientSetCertificateContactsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetCertificateContactsResponse{}, err
 	}
@@ -3776,7 +3768,7 @@ func (client *Client) SetCertificateIssuer(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientSetCertificateIssuerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetCertificateIssuerResponse{}, err
 	}
@@ -3830,7 +3822,7 @@ func (client *Client) SetSasDefinition(ctx context.Context, vaultBaseURL string,
 	if err != nil {
 		return ClientSetSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetSasDefinitionResponse{}, err
 	}
@@ -3887,7 +3879,7 @@ func (client *Client) SetSecret(ctx context.Context, vaultBaseURL string, secret
 	if err != nil {
 		return ClientSetSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetSecretResponse{}, err
 	}
@@ -3939,7 +3931,7 @@ func (client *Client) SetStorageAccount(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientSetStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetStorageAccountResponse{}, err
 	}
@@ -3993,7 +3985,7 @@ func (client *Client) Sign(ctx context.Context, vaultBaseURL string, keyName str
 	if err != nil {
 		return ClientSignResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSignResponse{}, err
 	}
@@ -4053,7 +4045,7 @@ func (client *Client) UnwrapKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientUnwrapKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUnwrapKeyResponse{}, err
 	}
@@ -4112,7 +4104,7 @@ func (client *Client) UpdateCertificate(ctx context.Context, vaultBaseURL string
 	if err != nil {
 		return ClientUpdateCertificateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateCertificateResponse{}, err
 	}
@@ -4170,7 +4162,7 @@ func (client *Client) UpdateCertificateIssuer(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientUpdateCertificateIssuerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateCertificateIssuerResponse{}, err
 	}
@@ -4224,7 +4216,7 @@ func (client *Client) UpdateCertificateOperation(ctx context.Context, vaultBaseU
 	if err != nil {
 		return ClientUpdateCertificateOperationResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateCertificateOperationResponse{}, err
 	}
@@ -4278,7 +4270,7 @@ func (client *Client) UpdateCertificatePolicy(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return ClientUpdateCertificatePolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateCertificatePolicyResponse{}, err
 	}
@@ -4332,7 +4324,7 @@ func (client *Client) UpdateKey(ctx context.Context, vaultBaseURL string, keyNam
 	if err != nil {
 		return ClientUpdateKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateKeyResponse{}, err
 	}
@@ -4390,7 +4382,7 @@ func (client *Client) UpdateSasDefinition(ctx context.Context, vaultBaseURL stri
 	if err != nil {
 		return ClientUpdateSasDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateSasDefinitionResponse{}, err
 	}
@@ -4449,7 +4441,7 @@ func (client *Client) UpdateSecret(ctx context.Context, vaultBaseURL string, sec
 	if err != nil {
 		return ClientUpdateSecretResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateSecretResponse{}, err
 	}
@@ -4506,7 +4498,7 @@ func (client *Client) UpdateStorageAccount(ctx context.Context, vaultBaseURL str
 	if err != nil {
 		return ClientUpdateStorageAccountResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateStorageAccountResponse{}, err
 	}
@@ -4563,7 +4555,7 @@ func (client *Client) Verify(ctx context.Context, vaultBaseURL string, keyName s
 	if err != nil {
 		return ClientVerifyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientVerifyResponse{}, err
 	}
@@ -4625,7 +4617,7 @@ func (client *Client) WrapKey(ctx context.Context, vaultBaseURL string, keyName 
 	if err != nil {
 		return ClientWrapKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientWrapKeyResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_hsmsecuritydomain_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_hsmsecuritydomain_client.go
@@ -11,6 +11,7 @@ package azkeyvault
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,18 +19,9 @@ import (
 )
 
 // HSMSecurityDomainClient contains the methods for the HSMSecurityDomain group.
-// Don't use this type directly, use NewHSMSecurityDomainClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type HSMSecurityDomainClient struct {
-	pl runtime.Pipeline
-}
-
-// NewHSMSecurityDomainClient creates a new instance of HSMSecurityDomainClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewHSMSecurityDomainClient(pl runtime.Pipeline) *HSMSecurityDomainClient {
-	client := &HSMSecurityDomainClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // BeginDownload - Retrieves the Security Domain from the managed HSM. Calling this endpoint can be used to activate a provisioned
@@ -48,11 +40,11 @@ func (client *HSMSecurityDomainClient) BeginDownload(ctx context.Context, vaultB
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[HSMSecurityDomainClientDownloadResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[HSMSecurityDomainClientDownloadResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[HSMSecurityDomainClientDownloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[HSMSecurityDomainClientDownloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -66,7 +58,7 @@ func (client *HSMSecurityDomainClient) download(ctx context.Context, vaultBaseUR
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +96,7 @@ func (client *HSMSecurityDomainClient) DownloadPending(ctx context.Context, vaul
 	if err != nil {
 		return HSMSecurityDomainClientDownloadPendingResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HSMSecurityDomainClientDownloadPendingResponse{}, err
 	}
@@ -148,7 +140,7 @@ func (client *HSMSecurityDomainClient) TransferKey(ctx context.Context, vaultBas
 	if err != nil {
 		return HSMSecurityDomainClientTransferKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HSMSecurityDomainClientTransferKeyResponse{}, err
 	}
@@ -197,11 +189,11 @@ func (client *HSMSecurityDomainClient) BeginUpload(ctx context.Context, vaultBas
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[HSMSecurityDomainClientUploadResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[HSMSecurityDomainClientUploadResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[HSMSecurityDomainClientUploadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[HSMSecurityDomainClientUploadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -214,7 +206,7 @@ func (client *HSMSecurityDomainClient) upload(ctx context.Context, vaultBaseURL 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +241,7 @@ func (client *HSMSecurityDomainClient) UploadPending(ctx context.Context, vaultB
 	if err != nil {
 		return HSMSecurityDomainClientUploadPendingResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HSMSecurityDomainClientUploadPendingResponse{}, err
 	}

--- a/test/keyvault/7.2/azkeyvault/zz_roleassignments_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_roleassignments_client.go
@@ -12,6 +12,7 @@ package azkeyvault
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // RoleAssignmentsClient contains the methods for the RoleAssignments group.
-// Don't use this type directly, use NewRoleAssignmentsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type RoleAssignmentsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewRoleAssignmentsClient creates a new instance of RoleAssignmentsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewRoleAssignmentsClient(pl runtime.Pipeline) *RoleAssignmentsClient {
-	client := &RoleAssignmentsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // Create - Creates a role assignment.
@@ -48,7 +40,7 @@ func (client *RoleAssignmentsClient) Create(ctx context.Context, vaultBaseURL st
 	if err != nil {
 		return RoleAssignmentsClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleAssignmentsClientCreateResponse{}, err
 	}
@@ -101,7 +93,7 @@ func (client *RoleAssignmentsClient) Delete(ctx context.Context, vaultBaseURL st
 	if err != nil {
 		return RoleAssignmentsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleAssignmentsClientDeleteResponse{}, err
 	}
@@ -154,7 +146,7 @@ func (client *RoleAssignmentsClient) Get(ctx context.Context, vaultBaseURL strin
 	if err != nil {
 		return RoleAssignmentsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleAssignmentsClientGetResponse{}, err
 	}
@@ -217,7 +209,7 @@ func (client *RoleAssignmentsClient) NewListForScopePager(vaultBaseURL string, s
 			if err != nil {
 				return RoleAssignmentsClientListForScopeResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RoleAssignmentsClientListForScopeResponse{}, err
 			}

--- a/test/keyvault/7.2/azkeyvault/zz_roledefinitions_client.go
+++ b/test/keyvault/7.2/azkeyvault/zz_roledefinitions_client.go
@@ -12,6 +12,7 @@ package azkeyvault
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,18 +21,9 @@ import (
 )
 
 // RoleDefinitionsClient contains the methods for the RoleDefinitions group.
-// Don't use this type directly, use NewRoleDefinitionsClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type RoleDefinitionsClient struct {
-	pl runtime.Pipeline
-}
-
-// NewRoleDefinitionsClient creates a new instance of RoleDefinitionsClient with the specified values.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewRoleDefinitionsClient(pl runtime.Pipeline) *RoleDefinitionsClient {
-	client := &RoleDefinitionsClient{
-		pl: pl,
-	}
-	return client
+	internal *azcore.Client
 }
 
 // CreateOrUpdate - Creates or updates a custom role definition.
@@ -49,7 +41,7 @@ func (client *RoleDefinitionsClient) CreateOrUpdate(ctx context.Context, vaultBa
 	if err != nil {
 		return RoleDefinitionsClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleDefinitionsClientCreateOrUpdateResponse{}, err
 	}
@@ -102,7 +94,7 @@ func (client *RoleDefinitionsClient) Delete(ctx context.Context, vaultBaseURL st
 	if err != nil {
 		return RoleDefinitionsClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleDefinitionsClientDeleteResponse{}, err
 	}
@@ -155,7 +147,7 @@ func (client *RoleDefinitionsClient) Get(ctx context.Context, vaultBaseURL strin
 	if err != nil {
 		return RoleDefinitionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoleDefinitionsClientGetResponse{}, err
 	}
@@ -218,7 +210,7 @@ func (client *RoleDefinitionsClient) NewListPager(vaultBaseURL string, scope str
 			if err != nil {
 				return RoleDefinitionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RoleDefinitionsClientListResponse{}, err
 			}

--- a/test/maps/azalias/go.mod
+++ b/test/maps/azalias/go.mod
@@ -3,12 +3,12 @@ module azalias
 go 1.18
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 	github.com/stretchr/testify v1.7.0
 )
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect

--- a/test/maps/azalias/go.sum
+++ b/test/maps/azalias/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/test/maps/azalias/zz_client.go
+++ b/test/maps/azalias/zz_client.go
@@ -12,45 +12,20 @@ package azalias
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"strconv"
-	"strings"
 )
 
-type client struct {
+// Client contains the methods for the Alias group.
+// Don't use this type directly, use a constructor function instead.
+type Client struct {
+	internal      *azcore.Client
 	endpoint      string
 	clientVersion string
 	clientIndex   int32
-	pl            runtime.Pipeline
-}
-
-// newClient creates a new instance of client with the specified values.
-//   - geography - This parameter specifies where the Azure Maps Creator resource is located. Valid values are us and eu.
-//   - clientVersion - Version number of Azure Maps API.
-//   - clientIndex - Index number of Azure Maps API.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newClient(geography *Geography, clientVersion *string, clientIndex *int32, pl runtime.Pipeline) *client {
-	hostURL := "https://{geography}.atlas.microsoft.com"
-	if geography == nil {
-		defaultValue := GeographyUs
-		geography = &defaultValue
-	}
-	hostURL = strings.ReplaceAll(hostURL, "{geography}", string(*geography))
-	client := &client{
-		clientVersion: "2.0",
-		clientIndex:   int32(567),
-		endpoint:      hostURL,
-		pl:            pl,
-	}
-	if clientVersion != nil {
-		client.clientVersion = *clientVersion
-	}
-	if clientIndex != nil {
-		client.clientIndex = *clientIndex
-	}
-	return client
 }
 
 // Create - Applies to: see pricing tiers [https://aka.ms/AzureMapsPricingTier].
@@ -70,13 +45,13 @@ func newClient(geography *Geography, clientVersion *string, clientIndex *int32, 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2.0
-//   - options - ClientCreateOptions contains the optional parameters for the client.Create method.
-func (client *client) Create(ctx context.Context, options *ClientCreateOptions) (ClientCreateResponse, error) {
+//   - options - ClientCreateOptions contains the optional parameters for the Client.Create method.
+func (client *Client) Create(ctx context.Context, options *ClientCreateOptions) (ClientCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, options)
 	if err != nil {
 		return ClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCreateResponse{}, err
 	}
@@ -87,7 +62,7 @@ func (client *client) Create(ctx context.Context, options *ClientCreateOptions) 
 }
 
 // createCreateRequest creates the Create request.
-func (client *client) createCreateRequest(ctx context.Context, options *ClientCreateOptions) (*policy.Request, error) {
+func (client *Client) createCreateRequest(ctx context.Context, options *ClientCreateOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -117,7 +92,7 @@ func (client *client) createCreateRequest(ctx context.Context, options *ClientCr
 }
 
 // createHandleResponse handles the Create response.
-func (client *client) createHandleResponse(resp *http.Response) (ClientCreateResponse, error) {
+func (client *Client) createHandleResponse(resp *http.Response) (ClientCreateResponse, error) {
 	result := ClientCreateResponse{}
 	if val := resp.Header.Get("Access-Control-Expose-Headers"); val != "" {
 		result.AccessControlExposeHeaders = &val
@@ -132,13 +107,13 @@ func (client *client) createHandleResponse(resp *http.Response) (ClientCreateRes
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2.0
-//   - options - ClientGetScriptOptions contains the optional parameters for the client.GetScript method.
-func (client *client) GetScript(ctx context.Context, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (ClientGetScriptResponse, error) {
+//   - options - ClientGetScriptOptions contains the optional parameters for the Client.GetScript method.
+func (client *Client) GetScript(ctx context.Context, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (ClientGetScriptResponse, error) {
 	req, err := client.getScriptCreateRequest(ctx, props, options)
 	if err != nil {
 		return ClientGetScriptResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetScriptResponse{}, err
 	}
@@ -149,7 +124,7 @@ func (client *client) GetScript(ctx context.Context, props GeoJSONObjectNamedCol
 }
 
 // getScriptCreateRequest creates the GetScript request.
-func (client *client) getScriptCreateRequest(ctx context.Context, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (*policy.Request, error) {
+func (client *Client) getScriptCreateRequest(ctx context.Context, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (*policy.Request, error) {
 	urlPath := "/scripts"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -160,7 +135,7 @@ func (client *client) getScriptCreateRequest(ctx context.Context, props GeoJSONO
 }
 
 // getScriptHandleResponse handles the GetScript response.
-func (client *client) getScriptHandleResponse(resp *http.Response) (ClientGetScriptResponse, error) {
+func (client *Client) getScriptHandleResponse(resp *http.Response) (ClientGetScriptResponse, error) {
 	result := ClientGetScriptResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
@@ -191,8 +166,8 @@ func (client *client) getScriptHandleResponse(resp *http.Response) (ClientGetScr
 // "2020-02-18T19:53:33.123Z" } ] }
 //
 // Generated from API version 2.0
-//   - options - ClientListOptions contains the optional parameters for the client.NewListPager method.
-func (client *client) NewListPager(options *ClientListOptions) *runtime.Pager[ClientListResponse] {
+//   - options - ClientListOptions contains the optional parameters for the Client.NewListPager method.
+func (client *Client) NewListPager(options *ClientListOptions) *runtime.Pager[ClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ClientListResponse]{
 		More: func(page ClientListResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -208,7 +183,7 @@ func (client *client) NewListPager(options *ClientListOptions) *runtime.Pager[Cl
 			if err != nil {
 				return ClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ClientListResponse{}, err
 			}
@@ -221,7 +196,7 @@ func (client *client) NewListPager(options *ClientListOptions) *runtime.Pager[Cl
 }
 
 // listCreateRequest creates the List request.
-func (client *client) listCreateRequest(ctx context.Context, options *ClientListOptions) (*policy.Request, error) {
+func (client *Client) listCreateRequest(ctx context.Context, options *ClientListOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -240,7 +215,7 @@ func (client *client) listCreateRequest(ctx context.Context, options *ClientList
 }
 
 // listHandleResponse handles the List response.
-func (client *client) listHandleResponse(resp *http.Response) (ClientListResponse, error) {
+func (client *Client) listHandleResponse(resp *http.Response) (ClientListResponse, error) {
 	result := ClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
 		return ClientListResponse{}, err
@@ -252,13 +227,13 @@ func (client *client) listHandleResponse(resp *http.Response) (ClientListRespons
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2.0
-//   - options - ClientPolicyAssignmentOptions contains the optional parameters for the client.PolicyAssignment method.
-func (client *client) PolicyAssignment(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (ClientPolicyAssignmentResponse, error) {
+//   - options - ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
+func (client *Client) PolicyAssignment(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (ClientPolicyAssignmentResponse, error) {
 	req, err := client.policyAssignmentCreateRequest(ctx, props, options)
 	if err != nil {
 		return ClientPolicyAssignmentResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientPolicyAssignmentResponse{}, err
 	}
@@ -269,7 +244,7 @@ func (client *client) PolicyAssignment(ctx context.Context, props ScheduleCreate
 }
 
 // policyAssignmentCreateRequest creates the PolicyAssignment request.
-func (client *client) policyAssignmentCreateRequest(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (*policy.Request, error) {
+func (client *Client) policyAssignmentCreateRequest(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (*policy.Request, error) {
 	urlPath := "/policy"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -280,7 +255,7 @@ func (client *client) policyAssignmentCreateRequest(ctx context.Context, props S
 }
 
 // policyAssignmentHandleResponse handles the PolicyAssignment response.
-func (client *client) policyAssignmentHandleResponse(resp *http.Response) (ClientPolicyAssignmentResponse, error) {
+func (client *Client) policyAssignmentHandleResponse(resp *http.Response) (ClientPolicyAssignmentResponse, error) {
 	result := ClientPolicyAssignmentResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PolicyAssignmentProperties); err != nil {
 		return ClientPolicyAssignmentResponse{}, err

--- a/test/maps/azalias/zz_models.go
+++ b/test/maps/azalias/zz_models.go
@@ -26,7 +26,7 @@ type AliasesCreateResponse struct {
 	LastUpdatedTimestamp *string `json:"lastUpdatedTimestamp,omitempty" azure:"ro"`
 }
 
-// ClientCreateOptions contains the optional parameters for the client.Create method.
+// ClientCreateOptions contains the optional parameters for the Client.Create method.
 type ClientCreateOptions struct {
 	GroupBy []SomethingCount
 	// The unique id that references the assigned data item to be aliased.
@@ -35,17 +35,17 @@ type ClientCreateOptions struct {
 	CreatorID *int32
 }
 
-// ClientGetScriptOptions contains the optional parameters for the client.GetScript method.
+// ClientGetScriptOptions contains the optional parameters for the Client.GetScript method.
 type ClientGetScriptOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ClientListOptions contains the optional parameters for the client.NewListPager method.
+// ClientListOptions contains the optional parameters for the Client.NewListPager method.
 type ClientListOptions struct {
 	GroupBy []LogMetricsGroupBy
 }
 
-// ClientPolicyAssignmentOptions contains the optional parameters for the client.PolicyAssignment method.
+// ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
 type ClientPolicyAssignmentOptions struct {
 	// placeholder for future optional parameters
 }

--- a/test/maps/azalias/zz_response_types.go
+++ b/test/maps/azalias/zz_response_types.go
@@ -9,24 +9,24 @@
 
 package azalias
 
-// ClientCreateResponse contains the response from method client.Create.
+// ClientCreateResponse contains the response from method Client.Create.
 type ClientCreateResponse struct {
 	AliasesCreateResponse
 	// AccessControlExposeHeaders contains the information returned from the Access-Control-Expose-Headers header response.
 	AccessControlExposeHeaders *string
 }
 
-// ClientGetScriptResponse contains the response from method client.GetScript.
+// ClientGetScriptResponse contains the response from method Client.GetScript.
 type ClientGetScriptResponse struct {
 	Value *string
 }
 
-// ClientListResponse contains the response from method client.NewListPager.
+// ClientListResponse contains the response from method Client.NewListPager.
 type ClientListResponse struct {
 	ListResponse
 }
 
-// ClientPolicyAssignmentResponse contains the response from method client.PolicyAssignment.
+// ClientPolicyAssignmentResponse contains the response from method Client.PolicyAssignment.
 type ClientPolicyAssignmentResponse struct {
 	PolicyAssignmentProperties
 }

--- a/test/network/2020-03-01/armnetwork/go.mod
+++ b/test/network/2020-03-01/armnetwork/go.mod
@@ -2,10 +2,10 @@ module armnetwork
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/network/2020-03-01/armnetwork/go.sum
+++ b/test/network/2020-03-01/armnetwork/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/network/2020-03-01/armnetwork/zz_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_applicationgateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ApplicationGatewaysClient contains the methods for the ApplicationGateways group.
 // Don't use this type directly, use NewApplicationGatewaysClient() instead.
 type ApplicationGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewApplicationGatewaysClient creates a new instance of ApplicationGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type ApplicationGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ApplicationGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ApplicationGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,11 +59,11 @@ func (client *ApplicationGatewaysClient) BeginBackendHealth(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientBackendHealthResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientBackendHealthResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientBackendHealthResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientBackendHealthResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -87,7 +76,7 @@ func (client *ApplicationGatewaysClient) backendHealth(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +101,7 @@ func (client *ApplicationGatewaysClient) backendHealthCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,11 +131,11 @@ func (client *ApplicationGatewaysClient) BeginBackendHealthOnDemand(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientBackendHealthOnDemandResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientBackendHealthOnDemandResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientBackendHealthOnDemandResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientBackendHealthOnDemandResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -160,7 +149,7 @@ func (client *ApplicationGatewaysClient) backendHealthOnDemand(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +174,7 @@ func (client *ApplicationGatewaysClient) backendHealthOnDemandCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,11 +203,11 @@ func (client *ApplicationGatewaysClient) BeginCreateOrUpdate(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -231,7 +220,7 @@ func (client *ApplicationGatewaysClient) createOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +245,7 @@ func (client *ApplicationGatewaysClient) createOrUpdateCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -281,11 +270,11 @@ func (client *ApplicationGatewaysClient) BeginDelete(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -298,7 +287,7 @@ func (client *ApplicationGatewaysClient) deleteOperation(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +312,7 @@ func (client *ApplicationGatewaysClient) deleteCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +335,7 @@ func (client *ApplicationGatewaysClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return ApplicationGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientGetResponse{}, err
 	}
@@ -371,7 +360,7 @@ func (client *ApplicationGatewaysClient) getCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -403,7 +392,7 @@ func (client *ApplicationGatewaysClient) GetSSLPredefinedPolicy(ctx context.Cont
 	if err != nil {
 		return ApplicationGatewaysClientGetSSLPredefinedPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientGetSSLPredefinedPolicyResponse{}, err
 	}
@@ -424,7 +413,7 @@ func (client *ApplicationGatewaysClient) getSSLPredefinedPolicyCreateRequest(ctx
 		return nil, errors.New("parameter predefinedPolicyName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{predefinedPolicyName}", url.PathEscape(predefinedPolicyName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -466,7 +455,7 @@ func (client *ApplicationGatewaysClient) NewListPager(resourceGroupName string, 
 			if err != nil {
 				return ApplicationGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ApplicationGatewaysClientListResponse{}, err
 			}
@@ -489,7 +478,7 @@ func (client *ApplicationGatewaysClient) listCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +519,7 @@ func (client *ApplicationGatewaysClient) NewListAllPager(options *ApplicationGat
 			if err != nil {
 				return ApplicationGatewaysClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ApplicationGatewaysClientListAllResponse{}, err
 			}
@@ -549,7 +538,7 @@ func (client *ApplicationGatewaysClient) listAllCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -580,7 +569,7 @@ func (client *ApplicationGatewaysClient) ListAvailableRequestHeaders(ctx context
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableRequestHeadersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableRequestHeadersResponse{}, err
 	}
@@ -597,7 +586,7 @@ func (client *ApplicationGatewaysClient) listAvailableRequestHeadersCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +617,7 @@ func (client *ApplicationGatewaysClient) ListAvailableResponseHeaders(ctx contex
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableResponseHeadersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableResponseHeadersResponse{}, err
 	}
@@ -645,7 +634,7 @@ func (client *ApplicationGatewaysClient) listAvailableResponseHeadersCreateReque
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +665,7 @@ func (client *ApplicationGatewaysClient) ListAvailableSSLOptions(ctx context.Con
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableSSLOptionsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableSSLOptionsResponse{}, err
 	}
@@ -693,7 +682,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLOptionsCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -734,7 +723,7 @@ func (client *ApplicationGatewaysClient) NewListAvailableSSLPredefinedPoliciesPa
 			if err != nil {
 				return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse{}, err
 			}
@@ -753,7 +742,7 @@ func (client *ApplicationGatewaysClient) listAvailableSSLPredefinedPoliciesCreat
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -784,7 +773,7 @@ func (client *ApplicationGatewaysClient) ListAvailableServerVariables(ctx contex
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableServerVariablesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableServerVariablesResponse{}, err
 	}
@@ -801,7 +790,7 @@ func (client *ApplicationGatewaysClient) listAvailableServerVariablesCreateReque
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -832,7 +821,7 @@ func (client *ApplicationGatewaysClient) ListAvailableWafRuleSets(ctx context.Co
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableWafRuleSetsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientListAvailableWafRuleSetsResponse{}, err
 	}
@@ -849,7 +838,7 @@ func (client *ApplicationGatewaysClient) listAvailableWafRuleSetsCreateRequest(c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -883,11 +872,11 @@ func (client *ApplicationGatewaysClient) BeginStart(ctx context.Context, resourc
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientStartResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientStartResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientStartResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientStartResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -900,7 +889,7 @@ func (client *ApplicationGatewaysClient) start(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -925,7 +914,7 @@ func (client *ApplicationGatewaysClient) startCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -950,11 +939,11 @@ func (client *ApplicationGatewaysClient) BeginStop(ctx context.Context, resource
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationGatewaysClientStopResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationGatewaysClientStopResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientStopResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationGatewaysClientStopResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -967,7 +956,7 @@ func (client *ApplicationGatewaysClient) stop(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -992,7 +981,7 @@ func (client *ApplicationGatewaysClient) stopCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1017,7 +1006,7 @@ func (client *ApplicationGatewaysClient) UpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return ApplicationGatewaysClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationGatewaysClientUpdateTagsResponse{}, err
 	}
@@ -1042,7 +1031,7 @@ func (client *ApplicationGatewaysClient) updateTagsCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_applicationsecuritygroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ApplicationSecurityGroupsClient contains the methods for the ApplicationSecurityGroups group.
 // Don't use this type directly, use NewApplicationSecurityGroupsClient() instead.
 type ApplicationSecurityGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewApplicationSecurityGroupsClient creates a new instance of ApplicationSecurityGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type ApplicationSecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationSecurityGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ApplicationSecurityGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ApplicationSecurityGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ApplicationSecurityGroupsClient) BeginCreateOrUpdate(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationSecurityGroupsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationSecurityGroupsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationSecurityGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationSecurityGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ApplicationSecurityGroupsClient) createOrUpdate(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ApplicationSecurityGroupsClient) createOrUpdateCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *ApplicationSecurityGroupsClient) BeginDelete(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ApplicationSecurityGroupsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApplicationSecurityGroupsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ApplicationSecurityGroupsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ApplicationSecurityGroupsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *ApplicationSecurityGroupsClient) deleteOperation(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *ApplicationSecurityGroupsClient) deleteCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *ApplicationSecurityGroupsClient) Get(ctx context.Context, resource
 	if err != nil {
 		return ApplicationSecurityGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationSecurityGroupsClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *ApplicationSecurityGroupsClient) getCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *ApplicationSecurityGroupsClient) NewListPager(resourceGroupName st
 			if err != nil {
 				return ApplicationSecurityGroupsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ApplicationSecurityGroupsClientListResponse{}, err
 			}
@@ -294,7 +283,7 @@ func (client *ApplicationSecurityGroupsClient) listCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +324,7 @@ func (client *ApplicationSecurityGroupsClient) NewListAllPager(options *Applicat
 			if err != nil {
 				return ApplicationSecurityGroupsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ApplicationSecurityGroupsClientListAllResponse{}, err
 			}
@@ -354,7 +343,7 @@ func (client *ApplicationSecurityGroupsClient) listAllCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +377,7 @@ func (client *ApplicationSecurityGroupsClient) UpdateTags(ctx context.Context, r
 	if err != nil {
 		return ApplicationSecurityGroupsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ApplicationSecurityGroupsClientUpdateTagsResponse{}, err
 	}
@@ -413,7 +402,7 @@ func (client *ApplicationSecurityGroupsClient) updateTagsCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availabledelegations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailableDelegationsClient contains the methods for the AvailableDelegations group.
 // Don't use this type directly, use NewAvailableDelegationsClient() instead.
 type AvailableDelegationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailableDelegationsClient creates a new instance of AvailableDelegationsClient with the specified values.
@@ -37,21 +34,13 @@ type AvailableDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableDelegationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AvailableDelegationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailableDelegationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *AvailableDelegationsClient) NewListPager(location string, options 
 			if err != nil {
 				return AvailableDelegationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableDelegationsClientListResponse{}, err
 			}
@@ -101,7 +90,7 @@ func (client *AvailableDelegationsClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableendpointservices_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailableEndpointServicesClient contains the methods for the AvailableEndpointServices group.
 // Don't use this type directly, use NewAvailableEndpointServicesClient() instead.
 type AvailableEndpointServicesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailableEndpointServicesClient creates a new instance of AvailableEndpointServicesClient with the specified values.
@@ -37,21 +34,13 @@ type AvailableEndpointServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableEndpointServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableEndpointServicesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AvailableEndpointServicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailableEndpointServicesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *AvailableEndpointServicesClient) NewListPager(location string, opt
 			if err != nil {
 				return AvailableEndpointServicesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableEndpointServicesClientListResponse{}, err
 			}
@@ -101,7 +90,7 @@ func (client *AvailableEndpointServicesClient) listCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableprivateendpointtypes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailablePrivateEndpointTypesClient contains the methods for the AvailablePrivateEndpointTypes group.
 // Don't use this type directly, use NewAvailablePrivateEndpointTypesClient() instead.
 type AvailablePrivateEndpointTypesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailablePrivateEndpointTypesClient creates a new instance of AvailablePrivateEndpointTypesClient with the specified values.
@@ -37,21 +34,13 @@ type AvailablePrivateEndpointTypesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailablePrivateEndpointTypesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailablePrivateEndpointTypesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AvailablePrivateEndpointTypesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailablePrivateEndpointTypesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -79,7 +68,7 @@ func (client *AvailablePrivateEndpointTypesClient) NewListPager(location string,
 			if err != nil {
 				return AvailablePrivateEndpointTypesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailablePrivateEndpointTypesClientListResponse{}, err
 			}
@@ -102,7 +91,7 @@ func (client *AvailablePrivateEndpointTypesClient) listCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +135,7 @@ func (client *AvailablePrivateEndpointTypesClient) NewListByResourceGroupPager(l
 			if err != nil {
 				return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailablePrivateEndpointTypesClientListByResourceGroupResponse{}, err
 			}
@@ -173,7 +162,7 @@ func (client *AvailablePrivateEndpointTypesClient) listByResourceGroupCreateRequ
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableresourcegroupdelegations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailableResourceGroupDelegationsClient contains the methods for the AvailableResourceGroupDelegations group.
 // Don't use this type directly, use NewAvailableResourceGroupDelegationsClient() instead.
 type AvailableResourceGroupDelegationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailableResourceGroupDelegationsClient creates a new instance of AvailableResourceGroupDelegationsClient with the specified values.
@@ -37,21 +34,13 @@ type AvailableResourceGroupDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableResourceGroupDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableResourceGroupDelegationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AvailableResourceGroupDelegationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailableResourceGroupDelegationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -79,7 +68,7 @@ func (client *AvailableResourceGroupDelegationsClient) NewListPager(location str
 			if err != nil {
 				return AvailableResourceGroupDelegationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableResourceGroupDelegationsClientListResponse{}, err
 			}
@@ -106,7 +95,7 @@ func (client *AvailableResourceGroupDelegationsClient) listCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableservicealiases_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AvailableServiceAliasesClient contains the methods for the AvailableServiceAliases group.
 // Don't use this type directly, use NewAvailableServiceAliasesClient() instead.
 type AvailableServiceAliasesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAvailableServiceAliasesClient creates a new instance of AvailableServiceAliasesClient with the specified values.
@@ -37,21 +34,13 @@ type AvailableServiceAliasesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableServiceAliasesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableServiceAliasesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AvailableServiceAliasesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AvailableServiceAliasesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -78,7 +67,7 @@ func (client *AvailableServiceAliasesClient) NewListPager(location string, optio
 			if err != nil {
 				return AvailableServiceAliasesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableServiceAliasesClientListResponse{}, err
 			}
@@ -101,7 +90,7 @@ func (client *AvailableServiceAliasesClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +133,7 @@ func (client *AvailableServiceAliasesClient) NewListByResourceGroupPager(resourc
 			if err != nil {
 				return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AvailableServiceAliasesClientListByResourceGroupResponse{}, err
 			}
@@ -171,7 +160,7 @@ func (client *AvailableServiceAliasesClient) listByResourceGroupCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_azurefirewallfqdntags_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AzureFirewallFqdnTagsClient contains the methods for the AzureFirewallFqdnTags group.
 // Don't use this type directly, use NewAzureFirewallFqdnTagsClient() instead.
 type AzureFirewallFqdnTagsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAzureFirewallFqdnTagsClient creates a new instance of AzureFirewallFqdnTagsClient with the specified values.
@@ -37,21 +34,13 @@ type AzureFirewallFqdnTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallFqdnTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallFqdnTagsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AzureFirewallFqdnTagsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AzureFirewallFqdnTagsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *AzureFirewallFqdnTagsClient) NewListAllPager(options *AzureFirewal
 			if err != nil {
 				return AzureFirewallFqdnTagsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AzureFirewallFqdnTagsClientListAllResponse{}, err
 			}
@@ -96,7 +85,7 @@ func (client *AzureFirewallFqdnTagsClient) listAllCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_azurefirewalls_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // AzureFirewallsClient contains the methods for the AzureFirewalls group.
 // Don't use this type directly, use NewAzureFirewallsClient() instead.
 type AzureFirewallsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewAzureFirewallsClient creates a new instance of AzureFirewallsClient with the specified values.
@@ -37,21 +34,13 @@ type AzureFirewallsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.AzureFirewallsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &AzureFirewallsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *AzureFirewallsClient) BeginCreateOrUpdate(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[AzureFirewallsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[AzureFirewallsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[AzureFirewallsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[AzureFirewallsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *AzureFirewallsClient) createOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *AzureFirewallsClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *AzureFirewallsClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[AzureFirewallsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[AzureFirewallsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[AzureFirewallsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[AzureFirewallsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *AzureFirewallsClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *AzureFirewallsClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *AzureFirewallsClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return AzureFirewallsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AzureFirewallsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *AzureFirewallsClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +258,7 @@ func (client *AzureFirewallsClient) NewListPager(resourceGroupName string, optio
 			if err != nil {
 				return AzureFirewallsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AzureFirewallsClientListResponse{}, err
 			}
@@ -292,7 +281,7 @@ func (client *AzureFirewallsClient) listCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +322,7 @@ func (client *AzureFirewallsClient) NewListAllPager(options *AzureFirewallsClien
 			if err != nil {
 				return AzureFirewallsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return AzureFirewallsClientListAllResponse{}, err
 			}
@@ -352,7 +341,7 @@ func (client *AzureFirewallsClient) listAllCreateRequest(ctx context.Context, op
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,11 +376,11 @@ func (client *AzureFirewallsClient) BeginUpdateTags(ctx context.Context, resourc
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[AzureFirewallsClientUpdateTagsResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[AzureFirewallsClientUpdateTagsResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[AzureFirewallsClientUpdateTagsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[AzureFirewallsClientUpdateTagsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -404,7 +393,7 @@ func (client *AzureFirewallsClient) updateTags(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +418,7 @@ func (client *AzureFirewallsClient) updateTagsCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_bastionhosts_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // BastionHostsClient contains the methods for the BastionHosts group.
 // Don't use this type directly, use NewBastionHostsClient() instead.
 type BastionHostsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewBastionHostsClient creates a new instance of BastionHostsClient with the specified values.
@@ -37,21 +34,13 @@ type BastionHostsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBastionHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BastionHostsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.BastionHostsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &BastionHostsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *BastionHostsClient) BeginCreateOrUpdate(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[BastionHostsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[BastionHostsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[BastionHostsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[BastionHostsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *BastionHostsClient) createOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *BastionHostsClient) createOrUpdateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *BastionHostsClient) BeginDelete(ctx context.Context, resourceGroup
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[BastionHostsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[BastionHostsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[BastionHostsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[BastionHostsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *BastionHostsClient) deleteOperation(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *BastionHostsClient) deleteCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *BastionHostsClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return BastionHostsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BastionHostsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *BastionHostsClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +257,7 @@ func (client *BastionHostsClient) NewListPager(options *BastionHostsClientListOp
 			if err != nil {
 				return BastionHostsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return BastionHostsClientListResponse{}, err
 			}
@@ -287,7 +276,7 @@ func (client *BastionHostsClient) listCreateRequest(ctx context.Context, options
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +318,7 @@ func (client *BastionHostsClient) NewListByResourceGroupPager(resourceGroupName 
 			if err != nil {
 				return BastionHostsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return BastionHostsClientListByResourceGroupResponse{}, err
 			}
@@ -352,7 +341,7 @@ func (client *BastionHostsClient) listByResourceGroupCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_bgpservicecommunities_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // BgpServiceCommunitiesClient contains the methods for the BgpServiceCommunities group.
 // Don't use this type directly, use NewBgpServiceCommunitiesClient() instead.
 type BgpServiceCommunitiesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewBgpServiceCommunitiesClient creates a new instance of BgpServiceCommunitiesClient with the specified values.
@@ -37,21 +34,13 @@ type BgpServiceCommunitiesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBgpServiceCommunitiesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BgpServiceCommunitiesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.BgpServiceCommunitiesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &BgpServiceCommunitiesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *BgpServiceCommunitiesClient) NewListPager(options *BgpServiceCommu
 			if err != nil {
 				return BgpServiceCommunitiesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return BgpServiceCommunitiesClientListResponse{}, err
 			}
@@ -96,7 +85,7 @@ func (client *BgpServiceCommunitiesClient) listCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ddoscustompolicies_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DdosCustomPoliciesClient contains the methods for the DdosCustomPolicies group.
 // Don't use this type directly, use NewDdosCustomPoliciesClient() instead.
 type DdosCustomPoliciesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDdosCustomPoliciesClient creates a new instance of DdosCustomPoliciesClient with the specified values.
@@ -37,21 +34,13 @@ type DdosCustomPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosCustomPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosCustomPoliciesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.DdosCustomPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DdosCustomPoliciesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *DdosCustomPoliciesClient) BeginCreateOrUpdate(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[DdosCustomPoliciesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[DdosCustomPoliciesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[DdosCustomPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DdosCustomPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *DdosCustomPoliciesClient) createOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *DdosCustomPoliciesClient) createOrUpdateCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *DdosCustomPoliciesClient) BeginDelete(ctx context.Context, resourc
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[DdosCustomPoliciesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[DdosCustomPoliciesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[DdosCustomPoliciesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DdosCustomPoliciesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *DdosCustomPoliciesClient) deleteOperation(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *DdosCustomPoliciesClient) deleteCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *DdosCustomPoliciesClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return DdosCustomPoliciesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DdosCustomPoliciesClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *DdosCustomPoliciesClient) getCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +251,7 @@ func (client *DdosCustomPoliciesClient) UpdateTags(ctx context.Context, resource
 	if err != nil {
 		return DdosCustomPoliciesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DdosCustomPoliciesClientUpdateTagsResponse{}, err
 	}
@@ -287,7 +276,7 @@ func (client *DdosCustomPoliciesClient) updateTagsCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ddosprotectionplans_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DdosProtectionPlansClient contains the methods for the DdosProtectionPlans group.
 // Don't use this type directly, use NewDdosProtectionPlansClient() instead.
 type DdosProtectionPlansClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDdosProtectionPlansClient creates a new instance of DdosProtectionPlansClient with the specified values.
@@ -37,21 +34,13 @@ type DdosProtectionPlansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosProtectionPlansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosProtectionPlansClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.DdosProtectionPlansClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DdosProtectionPlansClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *DdosProtectionPlansClient) BeginCreateOrUpdate(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[DdosProtectionPlansClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[DdosProtectionPlansClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[DdosProtectionPlansClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DdosProtectionPlansClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *DdosProtectionPlansClient) createOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *DdosProtectionPlansClient) createOrUpdateCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *DdosProtectionPlansClient) BeginDelete(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[DdosProtectionPlansClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[DdosProtectionPlansClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[DdosProtectionPlansClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DdosProtectionPlansClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *DdosProtectionPlansClient) deleteOperation(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *DdosProtectionPlansClient) deleteCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *DdosProtectionPlansClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return DdosProtectionPlansClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DdosProtectionPlansClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *DdosProtectionPlansClient) getCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +258,7 @@ func (client *DdosProtectionPlansClient) NewListPager(options *DdosProtectionPla
 			if err != nil {
 				return DdosProtectionPlansClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DdosProtectionPlansClientListResponse{}, err
 			}
@@ -288,7 +277,7 @@ func (client *DdosProtectionPlansClient) listCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +319,7 @@ func (client *DdosProtectionPlansClient) NewListByResourceGroupPager(resourceGro
 			if err != nil {
 				return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DdosProtectionPlansClientListByResourceGroupResponse{}, err
 			}
@@ -353,7 +342,7 @@ func (client *DdosProtectionPlansClient) listByResourceGroupCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +376,7 @@ func (client *DdosProtectionPlansClient) UpdateTags(ctx context.Context, resourc
 	if err != nil {
 		return DdosProtectionPlansClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DdosProtectionPlansClientUpdateTagsResponse{}, err
 	}
@@ -412,7 +401,7 @@ func (client *DdosProtectionPlansClient) updateTagsCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_defaultsecurityrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // DefaultSecurityRulesClient contains the methods for the DefaultSecurityRules group.
 // Don't use this type directly, use NewDefaultSecurityRulesClient() instead.
 type DefaultSecurityRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewDefaultSecurityRulesClient creates a new instance of DefaultSecurityRulesClient with the specified values.
@@ -37,21 +34,13 @@ type DefaultSecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDefaultSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DefaultSecurityRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.DefaultSecurityRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &DefaultSecurityRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *DefaultSecurityRulesClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return DefaultSecurityRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DefaultSecurityRulesClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *DefaultSecurityRulesClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *DefaultSecurityRulesClient) NewListPager(resourceGroupName string,
 			if err != nil {
 				return DefaultSecurityRulesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DefaultSecurityRulesClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *DefaultSecurityRulesClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitauthorizations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCircuitAuthorizationsClient contains the methods for the ExpressRouteCircuitAuthorizations group.
 // Don't use this type directly, use NewExpressRouteCircuitAuthorizationsClient() instead.
 type ExpressRouteCircuitAuthorizationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCircuitAuthorizationsClient creates a new instance of ExpressRouteCircuitAuthorizationsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCircuitAuthorizationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitAuthorizationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitAuthorizationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCircuitAuthorizationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginCreateOrUpdate(ctx c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdate(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) createOrUpdateCreateReque
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *ExpressRouteCircuitAuthorizationsClient) BeginDelete(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitAuthorizationsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitAuthorizationsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitAuthorizationsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitAuthorizationsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) deleteOperation(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) deleteCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) Get(ctx context.Context, 
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitAuthorizationsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) getCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) NewListPager(resourceGrou
 			if err != nil {
 				return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCircuitAuthorizationsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *ExpressRouteCircuitAuthorizationsClient) listCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCircuitConnectionsClient contains the methods for the ExpressRouteCircuitConnections group.
 // Don't use this type directly, use NewExpressRouteCircuitConnectionsClient() instead.
 type ExpressRouteCircuitConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCircuitConnectionsClient creates a new instance of ExpressRouteCircuitConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCircuitConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -74,11 +63,11 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginCreateOrUpdate(ctx cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -91,7 +80,7 @@ func (client *ExpressRouteCircuitConnectionsClient) createOrUpdate(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +113,7 @@ func (client *ExpressRouteCircuitConnectionsClient) createOrUpdateCreateRequest(
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -151,11 +140,11 @@ func (client *ExpressRouteCircuitConnectionsClient) BeginDelete(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitConnectionsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitConnectionsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitConnectionsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitConnectionsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -168,7 +157,7 @@ func (client *ExpressRouteCircuitConnectionsClient) deleteOperation(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +190,7 @@ func (client *ExpressRouteCircuitConnectionsClient) deleteCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +216,7 @@ func (client *ExpressRouteCircuitConnectionsClient) Get(ctx context.Context, res
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
@@ -260,7 +249,7 @@ func (client *ExpressRouteCircuitConnectionsClient) getCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +293,7 @@ func (client *ExpressRouteCircuitConnectionsClient) NewListPager(resourceGroupNa
 			if err != nil {
 				return ExpressRouteCircuitConnectionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCircuitConnectionsClientListResponse{}, err
 			}
@@ -335,7 +324,7 @@ func (client *ExpressRouteCircuitConnectionsClient) listCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitpeerings_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCircuitPeeringsClient contains the methods for the ExpressRouteCircuitPeerings group.
 // Don't use this type directly, use NewExpressRouteCircuitPeeringsClient() instead.
 type ExpressRouteCircuitPeeringsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCircuitPeeringsClient creates a new instance of ExpressRouteCircuitPeeringsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCircuitPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitPeeringsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCircuitPeeringsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginCreateOrUpdate(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *ExpressRouteCircuitPeeringsClient) createOrUpdate(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *ExpressRouteCircuitPeeringsClient) createOrUpdateCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *ExpressRouteCircuitPeeringsClient) BeginDelete(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitPeeringsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitPeeringsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitPeeringsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitPeeringsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *ExpressRouteCircuitPeeringsClient) deleteOperation(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *ExpressRouteCircuitPeeringsClient) deleteCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *ExpressRouteCircuitPeeringsClient) Get(ctx context.Context, resour
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitPeeringsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *ExpressRouteCircuitPeeringsClient) getCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *ExpressRouteCircuitPeeringsClient) NewListPager(resourceGroupName 
 			if err != nil {
 				return ExpressRouteCircuitPeeringsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCircuitPeeringsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *ExpressRouteCircuitPeeringsClient) listCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuits_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCircuitsClient contains the methods for the ExpressRouteCircuits group.
 // Don't use this type directly, use NewExpressRouteCircuitsClient() instead.
 type ExpressRouteCircuitsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCircuitsClient creates a new instance of ExpressRouteCircuitsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCircuitsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCircuitsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ExpressRouteCircuitsClient) BeginCreateOrUpdate(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ExpressRouteCircuitsClient) createOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ExpressRouteCircuitsClient) createOrUpdateCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *ExpressRouteCircuitsClient) BeginDelete(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *ExpressRouteCircuitsClient) deleteOperation(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *ExpressRouteCircuitsClient) deleteCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *ExpressRouteCircuitsClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return ExpressRouteCircuitsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitsClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *ExpressRouteCircuitsClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +252,7 @@ func (client *ExpressRouteCircuitsClient) GetPeeringStats(ctx context.Context, r
 	if err != nil {
 		return ExpressRouteCircuitsClientGetPeeringStatsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitsClientGetPeeringStatsResponse{}, err
 	}
@@ -292,7 +281,7 @@ func (client *ExpressRouteCircuitsClient) getPeeringStatsCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +314,7 @@ func (client *ExpressRouteCircuitsClient) GetStats(ctx context.Context, resource
 	if err != nil {
 		return ExpressRouteCircuitsClientGetStatsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitsClientGetStatsResponse{}, err
 	}
@@ -350,7 +339,7 @@ func (client *ExpressRouteCircuitsClient) getStatsCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +381,7 @@ func (client *ExpressRouteCircuitsClient) NewListPager(resourceGroupName string,
 			if err != nil {
 				return ExpressRouteCircuitsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCircuitsClientListResponse{}, err
 			}
@@ -415,7 +404,7 @@ func (client *ExpressRouteCircuitsClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +445,7 @@ func (client *ExpressRouteCircuitsClient) NewListAllPager(options *ExpressRouteC
 			if err != nil {
 				return ExpressRouteCircuitsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCircuitsClientListAllResponse{}, err
 			}
@@ -475,7 +464,7 @@ func (client *ExpressRouteCircuitsClient) listAllCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -511,11 +500,11 @@ func (client *ExpressRouteCircuitsClient) BeginListArpTable(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitsClientListArpTableResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitsClientListArpTableResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListArpTableResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListArpTableResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -528,7 +517,7 @@ func (client *ExpressRouteCircuitsClient) listArpTable(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -561,7 +550,7 @@ func (client *ExpressRouteCircuitsClient) listArpTableCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -589,11 +578,11 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTable(ctx context.Conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitsClientListRoutesTableResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitsClientListRoutesTableResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListRoutesTableResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListRoutesTableResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -606,7 +595,7 @@ func (client *ExpressRouteCircuitsClient) listRoutesTable(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -639,7 +628,7 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -667,11 +656,11 @@ func (client *ExpressRouteCircuitsClient) BeginListRoutesTableSummary(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCircuitsClientListRoutesTableSummaryResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCircuitsClientListRoutesTableSummaryResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListRoutesTableSummaryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCircuitsClientListRoutesTableSummaryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -685,7 +674,7 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableSummary(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -718,7 +707,7 @@ func (client *ExpressRouteCircuitsClient) listRoutesTableSummaryCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -743,7 +732,7 @@ func (client *ExpressRouteCircuitsClient) UpdateTags(ctx context.Context, resour
 	if err != nil {
 		return ExpressRouteCircuitsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCircuitsClientUpdateTagsResponse{}, err
 	}
@@ -768,7 +757,7 @@ func (client *ExpressRouteCircuitsClient) updateTagsCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteConnectionsClient contains the methods for the ExpressRouteConnections group.
 // Don't use this type directly, use NewExpressRouteConnectionsClient() instead.
 type ExpressRouteConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteConnectionsClient creates a new instance of ExpressRouteConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *ExpressRouteConnectionsClient) BeginCreateOrUpdate(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteConnectionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteConnectionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *ExpressRouteConnectionsClient) createOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *ExpressRouteConnectionsClient) createOrUpdateCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *ExpressRouteConnectionsClient) BeginDelete(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteConnectionsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteConnectionsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteConnectionsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteConnectionsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *ExpressRouteConnectionsClient) deleteOperation(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *ExpressRouteConnectionsClient) deleteCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *ExpressRouteConnectionsClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return ExpressRouteConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteConnectionsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *ExpressRouteConnectionsClient) getCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +266,7 @@ func (client *ExpressRouteConnectionsClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return ExpressRouteConnectionsClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteConnectionsClientListResponse{}, err
 	}
@@ -302,7 +291,7 @@ func (client *ExpressRouteConnectionsClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCrossConnectionPeeringsClient contains the methods for the ExpressRouteCrossConnectionPeerings group.
 // Don't use this type directly, use NewExpressRouteCrossConnectionPeeringsClient() instead.
 type ExpressRouteCrossConnectionPeeringsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCrossConnectionPeeringsClient creates a new instance of ExpressRouteCrossConnectionPeeringsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCrossConnectionPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionPeeringsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCrossConnectionPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCrossConnectionPeeringsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginCreateOrUpdate(ctx
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdate(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) createOrUpdateCreateReq
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) BeginDelete(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionPeeringsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionPeeringsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionPeeringsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionPeeringsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) deleteOperation(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) deleteCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) Get(ctx context.Context
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCrossConnectionPeeringsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) getCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) NewListPager(resourceGr
 			if err != nil {
 				return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCrossConnectionPeeringsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *ExpressRouteCrossConnectionPeeringsClient) listCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteCrossConnectionsClient contains the methods for the ExpressRouteCrossConnections group.
 // Don't use this type directly, use NewExpressRouteCrossConnectionsClient() instead.
 type ExpressRouteCrossConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteCrossConnectionsClient creates a new instance of ExpressRouteCrossConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteCrossConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteCrossConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteCrossConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ExpressRouteCrossConnectionsClient) BeginCreateOrUpdate(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ExpressRouteCrossConnectionsClient) createOrUpdate(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ExpressRouteCrossConnectionsClient) createOrUpdateCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +126,7 @@ func (client *ExpressRouteCrossConnectionsClient) Get(ctx context.Context, resou
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientGetResponse{}, err
 	}
@@ -162,7 +151,7 @@ func (client *ExpressRouteCrossConnectionsClient) getCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *ExpressRouteCrossConnectionsClient) NewListPager(options *ExpressR
 			if err != nil {
 				return ExpressRouteCrossConnectionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCrossConnectionsClientListResponse{}, err
 			}
@@ -222,7 +211,7 @@ func (client *ExpressRouteCrossConnectionsClient) listCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -259,11 +248,11 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListArpTable(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListArpTableResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListArpTableResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListArpTableResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListArpTableResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -277,7 +266,7 @@ func (client *ExpressRouteCrossConnectionsClient) listArpTable(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +299,7 @@ func (client *ExpressRouteCrossConnectionsClient) listArpTableCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +332,7 @@ func (client *ExpressRouteCrossConnectionsClient) NewListByResourceGroupPager(re
 			if err != nil {
 				return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteCrossConnectionsClientListByResourceGroupResponse{}, err
 			}
@@ -366,7 +355,7 @@ func (client *ExpressRouteCrossConnectionsClient) listByResourceGroupCreateReque
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -403,11 +392,11 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTable(ctx conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListRoutesTableResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListRoutesTableResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListRoutesTableResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListRoutesTableResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -421,7 +410,7 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTable(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -454,7 +443,7 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableCreateRequest(c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -482,11 +471,11 @@ func (client *ExpressRouteCrossConnectionsClient) BeginListRoutesTableSummary(ct
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -500,7 +489,7 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableSummary(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -533,7 +522,7 @@ func (client *ExpressRouteCrossConnectionsClient) listRoutesTableSummaryCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +547,7 @@ func (client *ExpressRouteCrossConnectionsClient) UpdateTags(ctx context.Context
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteCrossConnectionsClientUpdateTagsResponse{}, err
 	}
@@ -583,7 +572,7 @@ func (client *ExpressRouteCrossConnectionsClient) updateTagsCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutegateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteGatewaysClient contains the methods for the ExpressRouteGateways group.
 // Don't use this type directly, use NewExpressRouteGatewaysClient() instead.
 type ExpressRouteGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteGatewaysClient creates a new instance of ExpressRouteGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ExpressRouteGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ExpressRouteGatewaysClient) createOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ExpressRouteGatewaysClient) createOrUpdateCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -139,11 +128,11 @@ func (client *ExpressRouteGatewaysClient) BeginDelete(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRouteGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRouteGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRouteGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRouteGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -157,7 +146,7 @@ func (client *ExpressRouteGatewaysClient) deleteOperation(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +171,7 @@ func (client *ExpressRouteGatewaysClient) deleteCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +195,7 @@ func (client *ExpressRouteGatewaysClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return ExpressRouteGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteGatewaysClientGetResponse{}, err
 	}
@@ -231,7 +220,7 @@ func (client *ExpressRouteGatewaysClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +252,7 @@ func (client *ExpressRouteGatewaysClient) ListByResourceGroup(ctx context.Contex
 	if err != nil {
 		return ExpressRouteGatewaysClientListByResourceGroupResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteGatewaysClientListByResourceGroupResponse{}, err
 	}
@@ -284,7 +273,7 @@ func (client *ExpressRouteGatewaysClient) listByResourceGroupCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +304,7 @@ func (client *ExpressRouteGatewaysClient) ListBySubscription(ctx context.Context
 	if err != nil {
 		return ExpressRouteGatewaysClientListBySubscriptionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteGatewaysClientListBySubscriptionResponse{}, err
 	}
@@ -332,7 +321,7 @@ func (client *ExpressRouteGatewaysClient) listBySubscriptionCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutelinks_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteLinksClient contains the methods for the ExpressRouteLinks group.
 // Don't use this type directly, use NewExpressRouteLinksClient() instead.
 type ExpressRouteLinksClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteLinksClient creates a new instance of ExpressRouteLinksClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteLinksClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteLinksClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *ExpressRouteLinksClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return ExpressRouteLinksClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRouteLinksClientGetResponse{}, err
 	}
@@ -98,7 +87,7 @@ func (client *ExpressRouteLinksClient) getCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter linkName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{linkName}", url.PathEscape(linkName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +130,7 @@ func (client *ExpressRouteLinksClient) NewListPager(resourceGroupName string, ex
 			if err != nil {
 				return ExpressRouteLinksClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteLinksClientListResponse{}, err
 			}
@@ -168,7 +157,7 @@ func (client *ExpressRouteLinksClient) listCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter expressRoutePortName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteports_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRoutePortsClient contains the methods for the ExpressRoutePorts group.
 // Don't use this type directly, use NewExpressRoutePortsClient() instead.
 type ExpressRoutePortsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRoutePortsClient creates a new instance of ExpressRoutePortsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRoutePortsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRoutePortsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRoutePortsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ExpressRoutePortsClient) BeginCreateOrUpdate(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRoutePortsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRoutePortsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRoutePortsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRoutePortsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ExpressRoutePortsClient) createOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ExpressRoutePortsClient) createOrUpdateCreateRequest(ctx context.C
 		return nil, errors.New("parameter expressRoutePortName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *ExpressRoutePortsClient) BeginDelete(ctx context.Context, resource
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ExpressRoutePortsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ExpressRoutePortsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ExpressRoutePortsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ExpressRoutePortsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *ExpressRoutePortsClient) deleteOperation(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *ExpressRoutePortsClient) deleteCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter expressRoutePortName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *ExpressRoutePortsClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return ExpressRoutePortsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRoutePortsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *ExpressRoutePortsClient) getCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter expressRoutePortName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +258,7 @@ func (client *ExpressRoutePortsClient) NewListPager(options *ExpressRoutePortsCl
 			if err != nil {
 				return ExpressRoutePortsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRoutePortsClientListResponse{}, err
 			}
@@ -288,7 +277,7 @@ func (client *ExpressRoutePortsClient) listCreateRequest(ctx context.Context, op
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +319,7 @@ func (client *ExpressRoutePortsClient) NewListByResourceGroupPager(resourceGroup
 			if err != nil {
 				return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRoutePortsClientListByResourceGroupResponse{}, err
 			}
@@ -353,7 +342,7 @@ func (client *ExpressRoutePortsClient) listByResourceGroupCreateRequest(ctx cont
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +376,7 @@ func (client *ExpressRoutePortsClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return ExpressRoutePortsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRoutePortsClientUpdateTagsResponse{}, err
 	}
@@ -412,7 +401,7 @@ func (client *ExpressRoutePortsClient) updateTagsCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter expressRoutePortName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{expressRoutePortName}", url.PathEscape(expressRoutePortName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteportslocations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRoutePortsLocationsClient contains the methods for the ExpressRoutePortsLocations group.
 // Don't use this type directly, use NewExpressRoutePortsLocationsClient() instead.
 type ExpressRoutePortsLocationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRoutePortsLocationsClient creates a new instance of ExpressRoutePortsLocationsClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRoutePortsLocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsLocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsLocationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRoutePortsLocationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRoutePortsLocationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *ExpressRoutePortsLocationsClient) Get(ctx context.Context, locatio
 	if err != nil {
 		return ExpressRoutePortsLocationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ExpressRoutePortsLocationsClientGetResponse{}, err
 	}
@@ -90,7 +79,7 @@ func (client *ExpressRoutePortsLocationsClient) getCreateRequest(ctx context.Con
 		return nil, errors.New("parameter locationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{locationName}", url.PathEscape(locationName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +121,7 @@ func (client *ExpressRoutePortsLocationsClient) NewListPager(options *ExpressRou
 			if err != nil {
 				return ExpressRoutePortsLocationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRoutePortsLocationsClientListResponse{}, err
 			}
@@ -151,7 +140,7 @@ func (client *ExpressRoutePortsLocationsClient) listCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteserviceproviders_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ExpressRouteServiceProvidersClient contains the methods for the ExpressRouteServiceProviders group.
 // Don't use this type directly, use NewExpressRouteServiceProvidersClient() instead.
 type ExpressRouteServiceProvidersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewExpressRouteServiceProvidersClient creates a new instance of ExpressRouteServiceProvidersClient with the specified values.
@@ -37,21 +34,13 @@ type ExpressRouteServiceProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteServiceProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteServiceProvidersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ExpressRouteServiceProvidersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ExpressRouteServiceProvidersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *ExpressRouteServiceProvidersClient) NewListPager(options *ExpressR
 			if err != nil {
 				return ExpressRouteServiceProvidersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ExpressRouteServiceProvidersClientListResponse{}, err
 			}
@@ -96,7 +85,7 @@ func (client *ExpressRouteServiceProvidersClient) listCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_firewallpolicies_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // FirewallPoliciesClient contains the methods for the FirewallPolicies group.
 // Don't use this type directly, use NewFirewallPoliciesClient() instead.
 type FirewallPoliciesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewFirewallPoliciesClient creates a new instance of FirewallPoliciesClient with the specified values.
@@ -37,21 +34,13 @@ type FirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPoliciesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.FirewallPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &FirewallPoliciesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *FirewallPoliciesClient) BeginCreateOrUpdate(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[FirewallPoliciesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[FirewallPoliciesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[FirewallPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[FirewallPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *FirewallPoliciesClient) createOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *FirewallPoliciesClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *FirewallPoliciesClient) BeginDelete(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[FirewallPoliciesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[FirewallPoliciesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[FirewallPoliciesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[FirewallPoliciesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *FirewallPoliciesClient) deleteOperation(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *FirewallPoliciesClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *FirewallPoliciesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return FirewallPoliciesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FirewallPoliciesClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *FirewallPoliciesClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +262,7 @@ func (client *FirewallPoliciesClient) NewListPager(resourceGroupName string, opt
 			if err != nil {
 				return FirewallPoliciesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return FirewallPoliciesClientListResponse{}, err
 			}
@@ -296,7 +285,7 @@ func (client *FirewallPoliciesClient) listCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +326,7 @@ func (client *FirewallPoliciesClient) NewListAllPager(options *FirewallPoliciesC
 			if err != nil {
 				return FirewallPoliciesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return FirewallPoliciesClientListAllResponse{}, err
 			}
@@ -356,7 +345,7 @@ func (client *FirewallPoliciesClient) listAllCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_flowlogs_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // FlowLogsClient contains the methods for the FlowLogs group.
 // Don't use this type directly, use NewFlowLogsClient() instead.
 type FlowLogsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewFlowLogsClient creates a new instance of FlowLogsClient with the specified values.
@@ -37,21 +34,13 @@ type FlowLogsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFlowLogsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FlowLogsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.FlowLogsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &FlowLogsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *FlowLogsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[FlowLogsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[FlowLogsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[FlowLogsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[FlowLogsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *FlowLogsClient) createOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *FlowLogsClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +132,11 @@ func (client *FlowLogsClient) BeginDelete(ctx context.Context, resourceGroupName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[FlowLogsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[FlowLogsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[FlowLogsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[FlowLogsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -160,7 +149,7 @@ func (client *FlowLogsClient) deleteOperation(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +178,7 @@ func (client *FlowLogsClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +202,7 @@ func (client *FlowLogsClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return FlowLogsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return FlowLogsClientGetResponse{}, err
 	}
@@ -242,7 +231,7 @@ func (client *FlowLogsClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +273,7 @@ func (client *FlowLogsClient) NewListPager(resourceGroupName string, networkWatc
 			if err != nil {
 				return FlowLogsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return FlowLogsClientListResponse{}, err
 			}
@@ -311,7 +300,7 @@ func (client *FlowLogsClient) listCreateRequest(ctx context.Context, resourceGro
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_hubvirtualnetworkconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // HubVirtualNetworkConnectionsClient contains the methods for the HubVirtualNetworkConnections group.
 // Don't use this type directly, use NewHubVirtualNetworkConnectionsClient() instead.
 type HubVirtualNetworkConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewHubVirtualNetworkConnectionsClient creates a new instance of HubVirtualNetworkConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type HubVirtualNetworkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewHubVirtualNetworkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubVirtualNetworkConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.HubVirtualNetworkConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &HubVirtualNetworkConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *HubVirtualNetworkConnectionsClient) Get(ctx context.Context, resou
 	if err != nil {
 		return HubVirtualNetworkConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return HubVirtualNetworkConnectionsClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *HubVirtualNetworkConnectionsClient) getCreateRequest(ctx context.C
 		return nil, errors.New("parameter connectionName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *HubVirtualNetworkConnectionsClient) NewListPager(resourceGroupName
 			if err != nil {
 				return HubVirtualNetworkConnectionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return HubVirtualNetworkConnectionsClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *HubVirtualNetworkConnectionsClient) listCreateRequest(ctx context.
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_inboundnatrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // InboundNatRulesClient contains the methods for the InboundNatRules group.
 // Don't use this type directly, use NewInboundNatRulesClient() instead.
 type InboundNatRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewInboundNatRulesClient creates a new instance of InboundNatRulesClient with the specified values.
@@ -37,21 +34,13 @@ type InboundNatRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInboundNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundNatRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.InboundNatRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &InboundNatRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *InboundNatRulesClient) BeginCreateOrUpdate(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[InboundNatRulesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[InboundNatRulesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[InboundNatRulesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[InboundNatRulesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *InboundNatRulesClient) createOrUpdate(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *InboundNatRulesClient) createOrUpdateCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *InboundNatRulesClient) BeginDelete(ctx context.Context, resourceGr
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[InboundNatRulesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[InboundNatRulesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[InboundNatRulesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[InboundNatRulesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *InboundNatRulesClient) deleteOperation(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *InboundNatRulesClient) deleteCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +203,7 @@ func (client *InboundNatRulesClient) Get(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return InboundNatRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return InboundNatRulesClientGetResponse{}, err
 	}
@@ -243,7 +232,7 @@ func (client *InboundNatRulesClient) getCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +278,7 @@ func (client *InboundNatRulesClient) NewListPager(resourceGroupName string, load
 			if err != nil {
 				return InboundNatRulesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return InboundNatRulesClientListResponse{}, err
 			}
@@ -316,7 +305,7 @@ func (client *InboundNatRulesClient) listCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfaceipconfigurations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // InterfaceIPConfigurationsClient contains the methods for the NetworkInterfaceIPConfigurations group.
 // Don't use this type directly, use NewInterfaceIPConfigurationsClient() instead.
 type InterfaceIPConfigurationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewInterfaceIPConfigurationsClient creates a new instance of InterfaceIPConfigurationsClient with the specified values.
@@ -37,21 +34,13 @@ type InterfaceIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceIPConfigurationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.InterfaceIPConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &InterfaceIPConfigurationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *InterfaceIPConfigurationsClient) Get(ctx context.Context, resource
 	if err != nil {
 		return InterfaceIPConfigurationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return InterfaceIPConfigurationsClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *InterfaceIPConfigurationsClient) getCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *InterfaceIPConfigurationsClient) NewListPager(resourceGroupName st
 			if err != nil {
 				return InterfaceIPConfigurationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return InterfaceIPConfigurationsClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *InterfaceIPConfigurationsClient) listCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfaceloadbalancers_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // InterfaceLoadBalancersClient contains the methods for the NetworkInterfaceLoadBalancers group.
 // Don't use this type directly, use NewInterfaceLoadBalancersClient() instead.
 type InterfaceLoadBalancersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewInterfaceLoadBalancersClient creates a new instance of InterfaceLoadBalancersClient with the specified values.
@@ -37,21 +34,13 @@ type InterfaceLoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceLoadBalancersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.InterfaceLoadBalancersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &InterfaceLoadBalancersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -79,7 +68,7 @@ func (client *InterfaceLoadBalancersClient) NewListPager(resourceGroupName strin
 			if err != nil {
 				return InterfaceLoadBalancersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return InterfaceLoadBalancersClientListResponse{}, err
 			}
@@ -106,7 +95,7 @@ func (client *InterfaceLoadBalancersClient) listCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfacetapconfigurations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // InterfaceTapConfigurationsClient contains the methods for the NetworkInterfaceTapConfigurations group.
 // Don't use this type directly, use NewInterfaceTapConfigurationsClient() instead.
 type InterfaceTapConfigurationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewInterfaceTapConfigurationsClient creates a new instance of InterfaceTapConfigurationsClient with the specified values.
@@ -37,21 +34,13 @@ type InterfaceTapConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceTapConfigurationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.InterfaceTapConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &InterfaceTapConfigurationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *InterfaceTapConfigurationsClient) BeginCreateOrUpdate(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[InterfaceTapConfigurationsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[InterfaceTapConfigurationsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[InterfaceTapConfigurationsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[InterfaceTapConfigurationsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *InterfaceTapConfigurationsClient) createOrUpdate(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *InterfaceTapConfigurationsClient) createOrUpdateCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *InterfaceTapConfigurationsClient) BeginDelete(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[InterfaceTapConfigurationsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[InterfaceTapConfigurationsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[InterfaceTapConfigurationsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[InterfaceTapConfigurationsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *InterfaceTapConfigurationsClient) deleteOperation(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *InterfaceTapConfigurationsClient) deleteCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *InterfaceTapConfigurationsClient) Get(ctx context.Context, resourc
 	if err != nil {
 		return InterfaceTapConfigurationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return InterfaceTapConfigurationsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *InterfaceTapConfigurationsClient) getCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *InterfaceTapConfigurationsClient) NewListPager(resourceGroupName s
 			if err != nil {
 				return InterfaceTapConfigurationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return InterfaceTapConfigurationsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *InterfaceTapConfigurationsClient) listCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ipallocations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // IPAllocationsClient contains the methods for the IPAllocations group.
 // Don't use this type directly, use NewIPAllocationsClient() instead.
 type IPAllocationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewIPAllocationsClient creates a new instance of IPAllocationsClient with the specified values.
@@ -37,21 +34,13 @@ type IPAllocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPAllocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPAllocationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.IPAllocationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &IPAllocationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *IPAllocationsClient) BeginCreateOrUpdate(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[IPAllocationsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[IPAllocationsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[IPAllocationsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[IPAllocationsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *IPAllocationsClient) createOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *IPAllocationsClient) createOrUpdateCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *IPAllocationsClient) BeginDelete(ctx context.Context, resourceGrou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[IPAllocationsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[IPAllocationsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[IPAllocationsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[IPAllocationsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *IPAllocationsClient) deleteOperation(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *IPAllocationsClient) deleteCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *IPAllocationsClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return IPAllocationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IPAllocationsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *IPAllocationsClient) getCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *IPAllocationsClient) NewListPager(options *IPAllocationsClientList
 			if err != nil {
 				return IPAllocationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return IPAllocationsClientListResponse{}, err
 			}
@@ -290,7 +279,7 @@ func (client *IPAllocationsClient) listCreateRequest(ctx context.Context, option
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +321,7 @@ func (client *IPAllocationsClient) NewListByResourceGroupPager(resourceGroupName
 			if err != nil {
 				return IPAllocationsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return IPAllocationsClientListByResourceGroupResponse{}, err
 			}
@@ -355,7 +344,7 @@ func (client *IPAllocationsClient) listByResourceGroupCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +378,7 @@ func (client *IPAllocationsClient) UpdateTags(ctx context.Context, resourceGroup
 	if err != nil {
 		return IPAllocationsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IPAllocationsClientUpdateTagsResponse{}, err
 	}
@@ -414,7 +403,7 @@ func (client *IPAllocationsClient) updateTagsCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ipgroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // IPGroupsClient contains the methods for the IPGroups group.
 // Don't use this type directly, use NewIPGroupsClient() instead.
 type IPGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewIPGroupsClient creates a new instance of IPGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type IPGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.IPGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &IPGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *IPGroupsClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[IPGroupsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[IPGroupsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[IPGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[IPGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *IPGroupsClient) createOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *IPGroupsClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *IPGroupsClient) BeginDelete(ctx context.Context, resourceGroupName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[IPGroupsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[IPGroupsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[IPGroupsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[IPGroupsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *IPGroupsClient) deleteOperation(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *IPGroupsClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *IPGroupsClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return IPGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IPGroupsClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *IPGroupsClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +259,7 @@ func (client *IPGroupsClient) NewListPager(options *IPGroupsClientListOptions) *
 			if err != nil {
 				return IPGroupsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return IPGroupsClientListResponse{}, err
 			}
@@ -289,7 +278,7 @@ func (client *IPGroupsClient) listCreateRequest(ctx context.Context, options *IP
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +320,7 @@ func (client *IPGroupsClient) NewListByResourceGroupPager(resourceGroupName stri
 			if err != nil {
 				return IPGroupsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return IPGroupsClientListByResourceGroupResponse{}, err
 			}
@@ -354,7 +343,7 @@ func (client *IPGroupsClient) listByResourceGroupCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +376,7 @@ func (client *IPGroupsClient) UpdateGroups(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return IPGroupsClientUpdateGroupsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IPGroupsClientUpdateGroupsResponse{}, err
 	}
@@ -412,7 +401,7 @@ func (client *IPGroupsClient) updateGroupsCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerbackendaddresspools_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerBackendAddressPoolsClient contains the methods for the LoadBalancerBackendAddressPools group.
 // Don't use this type directly, use NewLoadBalancerBackendAddressPoolsClient() instead.
 type LoadBalancerBackendAddressPoolsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerBackendAddressPoolsClient creates a new instance of LoadBalancerBackendAddressPoolsClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerBackendAddressPoolsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerBackendAddressPoolsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerBackendAddressPoolsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerBackendAddressPoolsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerBackendAddressPoolsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) Get(ctx context.Context, re
 	if err != nil {
 		return LoadBalancerBackendAddressPoolsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancerBackendAddressPoolsClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) getCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) NewListPager(resourceGroupN
 			if err != nil {
 				return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerBackendAddressPoolsClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *LoadBalancerBackendAddressPoolsClient) listCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerFrontendIPConfigurationsClient contains the methods for the LoadBalancerFrontendIPConfigurations group.
 // Don't use this type directly, use NewLoadBalancerFrontendIPConfigurationsClient() instead.
 type LoadBalancerFrontendIPConfigurationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerFrontendIPConfigurationsClient creates a new instance of LoadBalancerFrontendIPConfigurationsClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerFrontendIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerFrontendIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerFrontendIPConfigurationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerFrontendIPConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerFrontendIPConfigurationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) Get(ctx context.Contex
 	if err != nil {
 		return LoadBalancerFrontendIPConfigurationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancerFrontendIPConfigurationsClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) getCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) NewListPager(resourceG
 			if err != nil {
 				return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerFrontendIPConfigurationsClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *LoadBalancerFrontendIPConfigurationsClient) listCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerloadbalancingrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerLoadBalancingRulesClient contains the methods for the LoadBalancerLoadBalancingRules group.
 // Don't use this type directly, use NewLoadBalancerLoadBalancingRulesClient() instead.
 type LoadBalancerLoadBalancingRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerLoadBalancingRulesClient creates a new instance of LoadBalancerLoadBalancingRulesClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerLoadBalancingRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerLoadBalancingRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerLoadBalancingRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerLoadBalancingRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerLoadBalancingRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) Get(ctx context.Context, res
 	if err != nil {
 		return LoadBalancerLoadBalancingRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancerLoadBalancingRulesClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) getCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) NewListPager(resourceGroupNa
 			if err != nil {
 				return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerLoadBalancingRulesClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *LoadBalancerLoadBalancingRulesClient) listCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancernetworkinterfaces_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerNetworkInterfacesClient contains the methods for the LoadBalancerNetworkInterfaces group.
 // Don't use this type directly, use NewLoadBalancerNetworkInterfacesClient() instead.
 type LoadBalancerNetworkInterfacesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerNetworkInterfacesClient creates a new instance of LoadBalancerNetworkInterfacesClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerNetworkInterfacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerNetworkInterfacesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerNetworkInterfacesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerNetworkInterfacesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -79,7 +68,7 @@ func (client *LoadBalancerNetworkInterfacesClient) NewListPager(resourceGroupNam
 			if err != nil {
 				return LoadBalancerNetworkInterfacesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerNetworkInterfacesClientListResponse{}, err
 			}
@@ -106,7 +95,7 @@ func (client *LoadBalancerNetworkInterfacesClient) listCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalanceroutboundrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerOutboundRulesClient contains the methods for the LoadBalancerOutboundRules group.
 // Don't use this type directly, use NewLoadBalancerOutboundRulesClient() instead.
 type LoadBalancerOutboundRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerOutboundRulesClient creates a new instance of LoadBalancerOutboundRulesClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerOutboundRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerOutboundRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerOutboundRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerOutboundRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerOutboundRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *LoadBalancerOutboundRulesClient) Get(ctx context.Context, resource
 	if err != nil {
 		return LoadBalancerOutboundRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancerOutboundRulesClientGetResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *LoadBalancerOutboundRulesClient) getCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +131,7 @@ func (client *LoadBalancerOutboundRulesClient) NewListPager(resourceGroupName st
 			if err != nil {
 				return LoadBalancerOutboundRulesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerOutboundRulesClientListResponse{}, err
 			}
@@ -169,7 +158,7 @@ func (client *LoadBalancerOutboundRulesClient) listCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerprobes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancerProbesClient contains the methods for the LoadBalancerProbes group.
 // Don't use this type directly, use NewLoadBalancerProbesClient() instead.
 type LoadBalancerProbesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancerProbesClient creates a new instance of LoadBalancerProbesClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancerProbesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerProbesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerProbesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancerProbesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancerProbesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *LoadBalancerProbesClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return LoadBalancerProbesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancerProbesClientGetResponse{}, err
 	}
@@ -98,7 +87,7 @@ func (client *LoadBalancerProbesClient) getCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +130,7 @@ func (client *LoadBalancerProbesClient) NewListPager(resourceGroupName string, l
 			if err != nil {
 				return LoadBalancerProbesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancerProbesClientListResponse{}, err
 			}
@@ -168,7 +157,7 @@ func (client *LoadBalancerProbesClient) listCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancers_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LoadBalancersClient contains the methods for the LoadBalancers group.
 // Don't use this type directly, use NewLoadBalancersClient() instead.
 type LoadBalancersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLoadBalancersClient creates a new instance of LoadBalancersClient with the specified values.
@@ -37,21 +34,13 @@ type LoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LoadBalancersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LoadBalancersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *LoadBalancersClient) BeginCreateOrUpdate(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LoadBalancersClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LoadBalancersClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LoadBalancersClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LoadBalancersClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *LoadBalancersClient) createOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *LoadBalancersClient) createOrUpdateCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *LoadBalancersClient) BeginDelete(ctx context.Context, resourceGrou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LoadBalancersClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LoadBalancersClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LoadBalancersClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LoadBalancersClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *LoadBalancersClient) deleteOperation(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *LoadBalancersClient) deleteCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *LoadBalancersClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return LoadBalancersClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancersClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *LoadBalancersClient) getCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +261,7 @@ func (client *LoadBalancersClient) NewListPager(resourceGroupName string, option
 			if err != nil {
 				return LoadBalancersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancersClientListResponse{}, err
 			}
@@ -295,7 +284,7 @@ func (client *LoadBalancersClient) listCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +325,7 @@ func (client *LoadBalancersClient) NewListAllPager(options *LoadBalancersClientL
 			if err != nil {
 				return LoadBalancersClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LoadBalancersClientListAllResponse{}, err
 			}
@@ -355,7 +344,7 @@ func (client *LoadBalancersClient) listAllCreateRequest(ctx context.Context, opt
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +378,7 @@ func (client *LoadBalancersClient) UpdateTags(ctx context.Context, resourceGroup
 	if err != nil {
 		return LoadBalancersClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LoadBalancersClientUpdateTagsResponse{}, err
 	}
@@ -414,7 +403,7 @@ func (client *LoadBalancersClient) updateTagsCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_localnetworkgateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // LocalNetworkGatewaysClient contains the methods for the LocalNetworkGateways group.
 // Don't use this type directly, use NewLocalNetworkGatewaysClient() instead.
 type LocalNetworkGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewLocalNetworkGatewaysClient creates a new instance of LocalNetworkGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type LocalNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLocalNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LocalNetworkGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.LocalNetworkGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &LocalNetworkGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *LocalNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LocalNetworkGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LocalNetworkGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LocalNetworkGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LocalNetworkGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *LocalNetworkGatewaysClient) createOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *LocalNetworkGatewaysClient) createOrUpdateCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *LocalNetworkGatewaysClient) BeginDelete(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[LocalNetworkGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[LocalNetworkGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[LocalNetworkGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LocalNetworkGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *LocalNetworkGatewaysClient) deleteOperation(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *LocalNetworkGatewaysClient) deleteCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *LocalNetworkGatewaysClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return LocalNetworkGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LocalNetworkGatewaysClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *LocalNetworkGatewaysClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *LocalNetworkGatewaysClient) NewListPager(resourceGroupName string,
 			if err != nil {
 				return LocalNetworkGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LocalNetworkGatewaysClientListResponse{}, err
 			}
@@ -294,7 +283,7 @@ func (client *LocalNetworkGatewaysClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +317,7 @@ func (client *LocalNetworkGatewaysClient) UpdateTags(ctx context.Context, resour
 	if err != nil {
 		return LocalNetworkGatewaysClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LocalNetworkGatewaysClientUpdateTagsResponse{}, err
 	}
@@ -353,7 +342,7 @@ func (client *LocalNetworkGatewaysClient) updateTagsCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_management_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ManagementClient contains the methods for the NetworkManagementClient group.
 // Don't use this type directly, use NewManagementClient() instead.
 type ManagementClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewManagementClient creates a new instance of ManagementClient with the specified values.
@@ -37,21 +34,13 @@ type ManagementClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ManagementClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ManagementClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *ManagementClient) CheckDNSNameAvailability(ctx context.Context, lo
 	if err != nil {
 		return ManagementClientCheckDNSNameAvailabilityResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ManagementClientCheckDNSNameAvailabilityResponse{}, err
 	}
@@ -90,7 +79,7 @@ func (client *ManagementClient) checkDNSNameAvailabilityCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -126,11 +115,11 @@ func (client *ManagementClient) BeginDeleteBastionShareableLink(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ManagementClientDeleteBastionShareableLinkResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ManagementClientDeleteBastionShareableLinkResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ManagementClientDeleteBastionShareableLinkResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ManagementClientDeleteBastionShareableLinkResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -143,7 +132,7 @@ func (client *ManagementClient) deleteBastionShareableLink(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +157,7 @@ func (client *ManagementClient) deleteBastionShareableLinkCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *ManagementClient) NewDisconnectActiveSessionsPager(resourceGroupNa
 			if err != nil {
 				return ManagementClientDisconnectActiveSessionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ManagementClientDisconnectActiveSessionsResponse{}, err
 			}
@@ -230,7 +219,7 @@ func (client *ManagementClient) disconnectActiveSessionsCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -266,11 +255,11 @@ func (client *ManagementClient) BeginGeneratevirtualwanvpnserverconfigurationvpn
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -284,7 +273,7 @@ func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofi
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +298,7 @@ func (client *ManagementClient) generatevirtualwanvpnserverconfigurationvpnprofi
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +326,7 @@ func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, reso
 			if err != nil {
 				return ManagementClientGetActiveSessionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ManagementClientGetActiveSessionsResponse{}, err
 			}
@@ -352,12 +341,12 @@ func (client *ManagementClient) BeginGetActiveSessions(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[*runtime.Pager[ManagementClientGetActiveSessionsResponse]]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[*runtime.Pager[ManagementClientGetActiveSessionsResponse]]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 			Response:      &pager,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.pl, &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ManagementClientGetActiveSessionsResponse]]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ManagementClientGetActiveSessionsResponse]]{
 			Response: &pager,
 		})
 	}
@@ -371,7 +360,7 @@ func (client *ManagementClient) getActiveSessions(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +385,7 @@ func (client *ManagementClient) getActiveSessionsCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -440,7 +429,7 @@ func (client *ManagementClient) NewGetBastionShareableLinkPager(resourceGroupNam
 			if err != nil {
 				return ManagementClientGetBastionShareableLinkResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ManagementClientGetBastionShareableLinkResponse{}, err
 			}
@@ -467,7 +456,7 @@ func (client *ManagementClient) getBastionShareableLinkCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +494,7 @@ func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context
 			if err != nil {
 				return ManagementClientPutBastionShareableLinkResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ManagementClientPutBastionShareableLinkResponse{}, err
 			}
@@ -520,12 +509,12 @@ func (client *ManagementClient) BeginPutBastionShareableLink(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[*runtime.Pager[ManagementClientPutBastionShareableLinkResponse]]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[*runtime.Pager[ManagementClientPutBastionShareableLinkResponse]]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 			Response:      &pager,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.pl, &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ManagementClientPutBastionShareableLinkResponse]]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ManagementClientPutBastionShareableLinkResponse]]{
 			Response: &pager,
 		})
 	}
@@ -539,7 +528,7 @@ func (client *ManagementClient) putBastionShareableLink(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +553,7 @@ func (client *ManagementClient) putBastionShareableLinkCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -597,7 +586,7 @@ func (client *ManagementClient) SupportedSecurityProviders(ctx context.Context, 
 	if err != nil {
 		return ManagementClientSupportedSecurityProvidersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ManagementClientSupportedSecurityProvidersResponse{}, err
 	}
@@ -622,7 +611,7 @@ func (client *ManagementClient) supportedSecurityProvidersCreateRequest(ctx cont
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_natgateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // NatGatewaysClient contains the methods for the NatGateways group.
 // Don't use this type directly, use NewNatGatewaysClient() instead.
 type NatGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewNatGatewaysClient creates a new instance of NatGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type NatGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNatGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.NatGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &NatGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *NatGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[NatGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[NatGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[NatGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[NatGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *NatGatewaysClient) createOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *NatGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *NatGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[NatGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[NatGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[NatGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[NatGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *NatGatewaysClient) deleteOperation(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *NatGatewaysClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *NatGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return NatGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NatGatewaysClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *NatGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *NatGatewaysClient) NewListPager(resourceGroupName string, options 
 			if err != nil {
 				return NatGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return NatGatewaysClientListResponse{}, err
 			}
@@ -294,7 +283,7 @@ func (client *NatGatewaysClient) listCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +323,7 @@ func (client *NatGatewaysClient) NewListAllPager(options *NatGatewaysClientListA
 			if err != nil {
 				return NatGatewaysClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return NatGatewaysClientListAllResponse{}, err
 			}
@@ -353,7 +342,7 @@ func (client *NatGatewaysClient) listAllCreateRequest(ctx context.Context, optio
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +375,7 @@ func (client *NatGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return NatGatewaysClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NatGatewaysClientUpdateTagsResponse{}, err
 	}
@@ -411,7 +400,7 @@ func (client *NatGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_operations_client.go
@@ -13,8 +13,6 @@ import (
 	"context"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,28 +21,19 @@ import (
 // OperationsClient contains the methods for the Operations group.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	host string
-	pl   runtime.Pipeline
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		host: ep,
-		pl:   pl,
+		internal: cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return OperationsClientListResponse{}, err
 			}
@@ -84,7 +73,7 @@ func (client *OperationsClient) NewListPager(options *OperationsClientListOption
 // listCreateRequest creates the List request.
 func (client *OperationsClient) listCreateRequest(ctx context.Context, options *OperationsClientListOptions) (*policy.Request, error) {
 	urlPath := "/providers/Microsoft.Network/operations"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_p2svpngateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // P2SVPNGatewaysClient contains the methods for the P2SVPNGateways group.
 // Don't use this type directly, use NewP2SVPNGatewaysClient() instead.
 type P2SVPNGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewP2SVPNGatewaysClient creates a new instance of P2SVPNGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type P2SVPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewP2SVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*P2SVPNGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.P2SVPNGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &P2SVPNGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *P2SVPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *P2SVPNGatewaysClient) createOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *P2SVPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *P2SVPNGatewaysClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *P2SVPNGatewaysClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *P2SVPNGatewaysClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,11 +196,11 @@ func (client *P2SVPNGatewaysClient) BeginDisconnectP2SVPNConnections(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -225,7 +214,7 @@ func (client *P2SVPNGatewaysClient) disconnectP2SVPNConnections(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +239,7 @@ func (client *P2SVPNGatewaysClient) disconnectP2SVPNConnectionsCreateRequest(ctx
 		return nil, errors.New("parameter p2SVPNGatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{p2sVpnGatewayName}", url.PathEscape(p2SVPNGatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -276,11 +265,11 @@ func (client *P2SVPNGatewaysClient) BeginGenerateVPNProfile(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientGenerateVPNProfileResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientGenerateVPNProfileResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGenerateVPNProfileResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGenerateVPNProfileResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -293,7 +282,7 @@ func (client *P2SVPNGatewaysClient) generateVPNProfile(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -318,7 +307,7 @@ func (client *P2SVPNGatewaysClient) generateVPNProfileCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +330,7 @@ func (client *P2SVPNGatewaysClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return P2SVPNGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return P2SVPNGatewaysClientGetResponse{}, err
 	}
@@ -366,7 +355,7 @@ func (client *P2SVPNGatewaysClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -401,11 +390,11 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealth(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -419,7 +408,7 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealth(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +433,7 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -471,11 +460,11 @@ func (client *P2SVPNGatewaysClient) BeginGetP2SVPNConnectionHealthDetailed(ctx c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -489,7 +478,7 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthDetailed(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +503,7 @@ func (client *P2SVPNGatewaysClient) getP2SVPNConnectionHealthDetailedCreateReque
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +534,7 @@ func (client *P2SVPNGatewaysClient) NewListPager(options *P2SVPNGatewaysClientLi
 			if err != nil {
 				return P2SVPNGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return P2SVPNGatewaysClientListResponse{}, err
 			}
@@ -564,7 +553,7 @@ func (client *P2SVPNGatewaysClient) listCreateRequest(ctx context.Context, optio
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -606,7 +595,7 @@ func (client *P2SVPNGatewaysClient) NewListByResourceGroupPager(resourceGroupNam
 			if err != nil {
 				return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return P2SVPNGatewaysClientListByResourceGroupResponse{}, err
 			}
@@ -629,7 +618,7 @@ func (client *P2SVPNGatewaysClient) listByResourceGroupCreateRequest(ctx context
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -663,7 +652,7 @@ func (client *P2SVPNGatewaysClient) UpdateTags(ctx context.Context, resourceGrou
 	if err != nil {
 		return P2SVPNGatewaysClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return P2SVPNGatewaysClientUpdateTagsResponse{}, err
 	}
@@ -688,7 +677,7 @@ func (client *P2SVPNGatewaysClient) updateTagsCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_packetcaptures_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PacketCapturesClient contains the methods for the PacketCaptures group.
 // Don't use this type directly, use NewPacketCapturesClient() instead.
 type PacketCapturesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPacketCapturesClient creates a new instance of PacketCapturesClient with the specified values.
@@ -37,21 +34,13 @@ type PacketCapturesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPacketCapturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PacketCapturesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PacketCapturesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PacketCapturesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *PacketCapturesClient) BeginCreate(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PacketCapturesClientCreateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PacketCapturesClientCreateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PacketCapturesClientCreateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PacketCapturesClientCreateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *PacketCapturesClient) create(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *PacketCapturesClient) createCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *PacketCapturesClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PacketCapturesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PacketCapturesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PacketCapturesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PacketCapturesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *PacketCapturesClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *PacketCapturesClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +203,7 @@ func (client *PacketCapturesClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return PacketCapturesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PacketCapturesClientGetResponse{}, err
 	}
@@ -243,7 +232,7 @@ func (client *PacketCapturesClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -278,11 +267,11 @@ func (client *PacketCapturesClient) BeginGetStatus(ctx context.Context, resource
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PacketCapturesClientGetStatusResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PacketCapturesClientGetStatusResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PacketCapturesClientGetStatusResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PacketCapturesClientGetStatusResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -295,7 +284,7 @@ func (client *PacketCapturesClient) getStatus(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +313,7 @@ func (client *PacketCapturesClient) getStatusCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -351,7 +340,7 @@ func (client *PacketCapturesClient) NewListPager(resourceGroupName string, netwo
 			if err != nil {
 				return PacketCapturesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PacketCapturesClientListResponse{}, err
 			}
@@ -378,7 +367,7 @@ func (client *PacketCapturesClient) listCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -413,11 +402,11 @@ func (client *PacketCapturesClient) BeginStop(ctx context.Context, resourceGroup
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PacketCapturesClientStopResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PacketCapturesClientStopResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PacketCapturesClientStopResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PacketCapturesClientStopResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -430,7 +419,7 @@ func (client *PacketCapturesClient) stop(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +448,7 @@ func (client *PacketCapturesClient) stopCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_peerexpressroutecircuitconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PeerExpressRouteCircuitConnectionsClient contains the methods for the PeerExpressRouteCircuitConnections group.
 // Don't use this type directly, use NewPeerExpressRouteCircuitConnectionsClient() instead.
 type PeerExpressRouteCircuitConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPeerExpressRouteCircuitConnectionsClient creates a new instance of PeerExpressRouteCircuitConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type PeerExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPeerExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PeerExpressRouteCircuitConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PeerExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PeerExpressRouteCircuitConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,7 +60,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) Get(ctx context.Context,
 	if err != nil {
 		return PeerExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PeerExpressRouteCircuitConnectionsClientGetResponse{}, err
 	}
@@ -104,7 +93,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) getCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +137,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) NewListPager(resourceGro
 			if err != nil {
 				return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PeerExpressRouteCircuitConnectionsClientListResponse{}, err
 			}
@@ -179,7 +168,7 @@ func (client *PeerExpressRouteCircuitConnectionsClient) listCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privatednszonegroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PrivateDNSZoneGroupsClient contains the methods for the PrivateDNSZoneGroups group.
 // Don't use this type directly, use NewPrivateDNSZoneGroupsClient() instead.
 type PrivateDNSZoneGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPrivateDNSZoneGroupsClient creates a new instance of PrivateDNSZoneGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type PrivateDNSZoneGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateDNSZoneGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateDNSZoneGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PrivateDNSZoneGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PrivateDNSZoneGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *PrivateDNSZoneGroupsClient) BeginCreateOrUpdate(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateDNSZoneGroupsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateDNSZoneGroupsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateDNSZoneGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateDNSZoneGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *PrivateDNSZoneGroupsClient) createOrUpdate(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *PrivateDNSZoneGroupsClient) createOrUpdateCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *PrivateDNSZoneGroupsClient) BeginDelete(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateDNSZoneGroupsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateDNSZoneGroupsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateDNSZoneGroupsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateDNSZoneGroupsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *PrivateDNSZoneGroupsClient) deleteOperation(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *PrivateDNSZoneGroupsClient) deleteCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *PrivateDNSZoneGroupsClient) Get(ctx context.Context, resourceGroup
 	if err != nil {
 		return PrivateDNSZoneGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrivateDNSZoneGroupsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *PrivateDNSZoneGroupsClient) getCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *PrivateDNSZoneGroupsClient) NewListPager(privateEndpointName strin
 			if err != nil {
 				return PrivateDNSZoneGroupsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateDNSZoneGroupsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *PrivateDNSZoneGroupsClient) listCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privateendpoints_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PrivateEndpointsClient contains the methods for the PrivateEndpoints group.
 // Don't use this type directly, use NewPrivateEndpointsClient() instead.
 type PrivateEndpointsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPrivateEndpointsClient creates a new instance of PrivateEndpointsClient with the specified values.
@@ -37,21 +34,13 @@ type PrivateEndpointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PrivateEndpointsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PrivateEndpointsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *PrivateEndpointsClient) BeginCreateOrUpdate(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateEndpointsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateEndpointsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateEndpointsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateEndpointsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *PrivateEndpointsClient) createOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *PrivateEndpointsClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *PrivateEndpointsClient) BeginDelete(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateEndpointsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateEndpointsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateEndpointsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateEndpointsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *PrivateEndpointsClient) deleteOperation(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *PrivateEndpointsClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *PrivateEndpointsClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return PrivateEndpointsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrivateEndpointsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *PrivateEndpointsClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +262,7 @@ func (client *PrivateEndpointsClient) NewListPager(resourceGroupName string, opt
 			if err != nil {
 				return PrivateEndpointsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateEndpointsClientListResponse{}, err
 			}
@@ -296,7 +285,7 @@ func (client *PrivateEndpointsClient) listCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +326,7 @@ func (client *PrivateEndpointsClient) NewListBySubscriptionPager(options *Privat
 			if err != nil {
 				return PrivateEndpointsClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateEndpointsClientListBySubscriptionResponse{}, err
 			}
@@ -356,7 +345,7 @@ func (client *PrivateEndpointsClient) listBySubscriptionCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privatelinkservices_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PrivateLinkServicesClient contains the methods for the PrivateLinkServices group.
 // Don't use this type directly, use NewPrivateLinkServicesClient() instead.
 type PrivateLinkServicesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPrivateLinkServicesClient creates a new instance of PrivateLinkServicesClient with the specified values.
@@ -37,21 +34,13 @@ type PrivateLinkServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateLinkServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkServicesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PrivateLinkServicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PrivateLinkServicesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,11 +59,11 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibility(
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -87,7 +76,7 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibility(ctx c
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +97,7 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityCreate
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -135,11 +124,11 @@ func (client *PrivateLinkServicesClient) BeginCheckPrivateLinkServiceVisibilityB
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -153,7 +142,7 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByReso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +167,7 @@ func (client *PrivateLinkServicesClient) checkPrivateLinkServiceVisibilityByReso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,11 +193,11 @@ func (client *PrivateLinkServicesClient) BeginCreateOrUpdate(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateLinkServicesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateLinkServicesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -221,7 +210,7 @@ func (client *PrivateLinkServicesClient) createOrUpdate(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +235,7 @@ func (client *PrivateLinkServicesClient) createOrUpdateCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,11 +260,11 @@ func (client *PrivateLinkServicesClient) BeginDelete(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateLinkServicesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateLinkServicesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -288,7 +277,7 @@ func (client *PrivateLinkServicesClient) deleteOperation(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -313,7 +302,7 @@ func (client *PrivateLinkServicesClient) deleteCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -339,11 +328,11 @@ func (client *PrivateLinkServicesClient) BeginDeletePrivateEndpointConnection(ct
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -356,7 +345,7 @@ func (client *PrivateLinkServicesClient) deletePrivateEndpointConnection(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +374,7 @@ func (client *PrivateLinkServicesClient) deletePrivateEndpointConnectionCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +397,7 @@ func (client *PrivateLinkServicesClient) Get(ctx context.Context, resourceGroupN
 	if err != nil {
 		return PrivateLinkServicesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrivateLinkServicesClientGetResponse{}, err
 	}
@@ -433,7 +422,7 @@ func (client *PrivateLinkServicesClient) getCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +460,7 @@ func (client *PrivateLinkServicesClient) GetPrivateEndpointConnection(ctx contex
 	if err != nil {
 		return PrivateLinkServicesClientGetPrivateEndpointConnectionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrivateLinkServicesClientGetPrivateEndpointConnectionResponse{}, err
 	}
@@ -500,7 +489,7 @@ func (client *PrivateLinkServicesClient) getPrivateEndpointConnectionCreateReque
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +534,7 @@ func (client *PrivateLinkServicesClient) NewListPager(resourceGroupName string, 
 			if err != nil {
 				return PrivateLinkServicesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateLinkServicesClientListResponse{}, err
 			}
@@ -568,7 +557,7 @@ func (client *PrivateLinkServicesClient) listCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -611,7 +600,7 @@ func (client *PrivateLinkServicesClient) NewListAutoApprovedPrivateLinkServicesP
 			if err != nil {
 				return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse{}, err
 			}
@@ -634,7 +623,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesCrea
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -678,7 +667,7 @@ func (client *PrivateLinkServicesClient) NewListAutoApprovedPrivateLinkServicesB
 			if err != nil {
 				return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse{}, err
 			}
@@ -705,7 +694,7 @@ func (client *PrivateLinkServicesClient) listAutoApprovedPrivateLinkServicesByRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -746,7 +735,7 @@ func (client *PrivateLinkServicesClient) NewListBySubscriptionPager(options *Pri
 			if err != nil {
 				return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateLinkServicesClientListBySubscriptionResponse{}, err
 			}
@@ -765,7 +754,7 @@ func (client *PrivateLinkServicesClient) listBySubscriptionCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -808,7 +797,7 @@ func (client *PrivateLinkServicesClient) NewListPrivateEndpointConnectionsPager(
 			if err != nil {
 				return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PrivateLinkServicesClientListPrivateEndpointConnectionsResponse{}, err
 			}
@@ -835,7 +824,7 @@ func (client *PrivateLinkServicesClient) listPrivateEndpointConnectionsCreateReq
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -870,7 +859,7 @@ func (client *PrivateLinkServicesClient) UpdatePrivateEndpointConnection(ctx con
 	if err != nil {
 		return PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PrivateLinkServicesClientUpdatePrivateEndpointConnectionResponse{}, err
 	}
@@ -899,7 +888,7 @@ func (client *PrivateLinkServicesClient) updatePrivateEndpointConnectionCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_profiles_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ProfilesClient contains the methods for the NetworkProfiles group.
 // Don't use this type directly, use NewProfilesClient() instead.
 type ProfilesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewProfilesClient creates a new instance of ProfilesClient with the specified values.
@@ -37,21 +34,13 @@ type ProfilesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProfilesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ProfilesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ProfilesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *ProfilesClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return ProfilesClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProfilesClientCreateOrUpdateResponse{}, err
 	}
@@ -94,7 +83,7 @@ func (client *ProfilesClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -127,11 +116,11 @@ func (client *ProfilesClient) BeginDelete(ctx context.Context, resourceGroupName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ProfilesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ProfilesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ProfilesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ProfilesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -144,7 +133,7 @@ func (client *ProfilesClient) deleteOperation(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -169,7 +158,7 @@ func (client *ProfilesClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +181,7 @@ func (client *ProfilesClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return ProfilesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProfilesClientGetResponse{}, err
 	}
@@ -217,7 +206,7 @@ func (client *ProfilesClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +250,7 @@ func (client *ProfilesClient) NewListPager(resourceGroupName string, options *Pr
 			if err != nil {
 				return ProfilesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ProfilesClientListResponse{}, err
 			}
@@ -284,7 +273,7 @@ func (client *ProfilesClient) listCreateRequest(ctx context.Context, resourceGro
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -324,7 +313,7 @@ func (client *ProfilesClient) NewListAllPager(options *ProfilesClientListAllOpti
 			if err != nil {
 				return ProfilesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ProfilesClientListAllResponse{}, err
 			}
@@ -343,7 +332,7 @@ func (client *ProfilesClient) listAllCreateRequest(ctx context.Context, options 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +365,7 @@ func (client *ProfilesClient) UpdateTags(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return ProfilesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ProfilesClientUpdateTagsResponse{}, err
 	}
@@ -401,7 +390,7 @@ func (client *ProfilesClient) updateTagsCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_publicipaddresses_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PublicIPAddressesClient contains the methods for the PublicIPAddresses group.
 // Don't use this type directly, use NewPublicIPAddressesClient() instead.
 type PublicIPAddressesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPublicIPAddressesClient creates a new instance of PublicIPAddressesClient with the specified values.
@@ -37,21 +34,13 @@ type PublicIPAddressesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPAddressesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPAddressesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PublicIPAddressesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PublicIPAddressesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *PublicIPAddressesClient) BeginCreateOrUpdate(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PublicIPAddressesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PublicIPAddressesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PublicIPAddressesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PublicIPAddressesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *PublicIPAddressesClient) createOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *PublicIPAddressesClient) createOrUpdateCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *PublicIPAddressesClient) BeginDelete(ctx context.Context, resource
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PublicIPAddressesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PublicIPAddressesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PublicIPAddressesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PublicIPAddressesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *PublicIPAddressesClient) deleteOperation(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *PublicIPAddressesClient) deleteCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *PublicIPAddressesClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return PublicIPAddressesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PublicIPAddressesClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *PublicIPAddressesClient) getCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +257,7 @@ func (client *PublicIPAddressesClient) GetVirtualMachineScaleSetPublicIPAddress(
 	if err != nil {
 		return PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PublicIPAddressesClientGetVirtualMachineScaleSetPublicIPAddressResponse{}, err
 	}
@@ -309,7 +298,7 @@ func (client *PublicIPAddressesClient) getVirtualMachineScaleSetPublicIPAddressC
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +343,7 @@ func (client *PublicIPAddressesClient) NewListPager(resourceGroupName string, op
 			if err != nil {
 				return PublicIPAddressesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPAddressesClientListResponse{}, err
 			}
@@ -377,7 +366,7 @@ func (client *PublicIPAddressesClient) listCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +407,7 @@ func (client *PublicIPAddressesClient) NewListAllPager(options *PublicIPAddresse
 			if err != nil {
 				return PublicIPAddressesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPAddressesClientListAllResponse{}, err
 			}
@@ -437,7 +426,7 @@ func (client *PublicIPAddressesClient) listAllCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +470,7 @@ func (client *PublicIPAddressesClient) NewListVirtualMachineScaleSetPublicIPAddr
 			if err != nil {
 				return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse{}, err
 			}
@@ -508,7 +497,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetPublicIPAddress
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -555,7 +544,7 @@ func (client *PublicIPAddressesClient) NewListVirtualMachineScaleSetVMPublicIPAd
 			if err != nil {
 				return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse{}, err
 			}
@@ -594,7 +583,7 @@ func (client *PublicIPAddressesClient) listVirtualMachineScaleSetVMPublicIPAddre
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -628,7 +617,7 @@ func (client *PublicIPAddressesClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return PublicIPAddressesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PublicIPAddressesClientUpdateTagsResponse{}, err
 	}
@@ -653,7 +642,7 @@ func (client *PublicIPAddressesClient) updateTagsCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_publicipprefixes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // PublicIPPrefixesClient contains the methods for the PublicIPPrefixes group.
 // Don't use this type directly, use NewPublicIPPrefixesClient() instead.
 type PublicIPPrefixesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewPublicIPPrefixesClient creates a new instance of PublicIPPrefixesClient with the specified values.
@@ -37,21 +34,13 @@ type PublicIPPrefixesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPPrefixesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.PublicIPPrefixesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &PublicIPPrefixesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *PublicIPPrefixesClient) BeginCreateOrUpdate(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PublicIPPrefixesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PublicIPPrefixesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PublicIPPrefixesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PublicIPPrefixesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *PublicIPPrefixesClient) createOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *PublicIPPrefixesClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *PublicIPPrefixesClient) BeginDelete(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[PublicIPPrefixesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[PublicIPPrefixesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[PublicIPPrefixesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PublicIPPrefixesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *PublicIPPrefixesClient) deleteOperation(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *PublicIPPrefixesClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *PublicIPPrefixesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return PublicIPPrefixesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PublicIPPrefixesClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *PublicIPPrefixesClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +262,7 @@ func (client *PublicIPPrefixesClient) NewListPager(resourceGroupName string, opt
 			if err != nil {
 				return PublicIPPrefixesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPPrefixesClientListResponse{}, err
 			}
@@ -296,7 +285,7 @@ func (client *PublicIPPrefixesClient) listCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +326,7 @@ func (client *PublicIPPrefixesClient) NewListAllPager(options *PublicIPPrefixesC
 			if err != nil {
 				return PublicIPPrefixesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PublicIPPrefixesClientListAllResponse{}, err
 			}
@@ -356,7 +345,7 @@ func (client *PublicIPPrefixesClient) listAllCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +379,7 @@ func (client *PublicIPPrefixesClient) UpdateTags(ctx context.Context, resourceGr
 	if err != nil {
 		return PublicIPPrefixesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PublicIPPrefixesClientUpdateTagsResponse{}, err
 	}
@@ -415,7 +404,7 @@ func (client *PublicIPPrefixesClient) updateTagsCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_resourcenavigationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_resourcenavigationlinks_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ResourceNavigationLinksClient contains the methods for the ResourceNavigationLinks group.
 // Don't use this type directly, use NewResourceNavigationLinksClient() instead.
 type ResourceNavigationLinksClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewResourceNavigationLinksClient creates a new instance of ResourceNavigationLinksClient with the specified values.
@@ -37,21 +34,13 @@ type ResourceNavigationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceNavigationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceNavigationLinksClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ResourceNavigationLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ResourceNavigationLinksClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *ResourceNavigationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return ResourceNavigationLinksClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ResourceNavigationLinksClientListResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *ResourceNavigationLinksClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routefilterrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // RouteFilterRulesClient contains the methods for the RouteFilterRules group.
 // Don't use this type directly, use NewRouteFilterRulesClient() instead.
 type RouteFilterRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewRouteFilterRulesClient creates a new instance of RouteFilterRulesClient with the specified values.
@@ -37,21 +34,13 @@ type RouteFilterRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFilterRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFilterRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.RouteFilterRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &RouteFilterRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *RouteFilterRulesClient) BeginCreateOrUpdate(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteFilterRulesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteFilterRulesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteFilterRulesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteFilterRulesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *RouteFilterRulesClient) createOrUpdate(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *RouteFilterRulesClient) createOrUpdateCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *RouteFilterRulesClient) BeginDelete(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteFilterRulesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteFilterRulesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteFilterRulesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteFilterRulesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *RouteFilterRulesClient) deleteOperation(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *RouteFilterRulesClient) deleteCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +203,7 @@ func (client *RouteFilterRulesClient) Get(ctx context.Context, resourceGroupName
 	if err != nil {
 		return RouteFilterRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RouteFilterRulesClientGetResponse{}, err
 	}
@@ -243,7 +232,7 @@ func (client *RouteFilterRulesClient) getCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +275,7 @@ func (client *RouteFilterRulesClient) NewListByRouteFilterPager(resourceGroupNam
 			if err != nil {
 				return RouteFilterRulesClientListByRouteFilterResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RouteFilterRulesClientListByRouteFilterResponse{}, err
 			}
@@ -313,7 +302,7 @@ func (client *RouteFilterRulesClient) listByRouteFilterCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routefilters_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // RouteFiltersClient contains the methods for the RouteFilters group.
 // Don't use this type directly, use NewRouteFiltersClient() instead.
 type RouteFiltersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewRouteFiltersClient creates a new instance of RouteFiltersClient with the specified values.
@@ -37,21 +34,13 @@ type RouteFiltersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFiltersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFiltersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.RouteFiltersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &RouteFiltersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *RouteFiltersClient) BeginCreateOrUpdate(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteFiltersClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteFiltersClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteFiltersClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteFiltersClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *RouteFiltersClient) createOrUpdate(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *RouteFiltersClient) createOrUpdateCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *RouteFiltersClient) BeginDelete(ctx context.Context, resourceGroup
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteFiltersClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteFiltersClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteFiltersClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteFiltersClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *RouteFiltersClient) deleteOperation(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *RouteFiltersClient) deleteCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *RouteFiltersClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return RouteFiltersClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RouteFiltersClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *RouteFiltersClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *RouteFiltersClient) NewListPager(options *RouteFiltersClientListOp
 			if err != nil {
 				return RouteFiltersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RouteFiltersClientListResponse{}, err
 			}
@@ -290,7 +279,7 @@ func (client *RouteFiltersClient) listCreateRequest(ctx context.Context, options
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +321,7 @@ func (client *RouteFiltersClient) NewListByResourceGroupPager(resourceGroupName 
 			if err != nil {
 				return RouteFiltersClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RouteFiltersClientListByResourceGroupResponse{}, err
 			}
@@ -355,7 +344,7 @@ func (client *RouteFiltersClient) listByResourceGroupCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +377,7 @@ func (client *RouteFiltersClient) UpdateTags(ctx context.Context, resourceGroupN
 	if err != nil {
 		return RouteFiltersClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RouteFiltersClientUpdateTagsResponse{}, err
 	}
@@ -413,7 +402,7 @@ func (client *RouteFiltersClient) updateTagsCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routes_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // RoutesClient contains the methods for the Routes group.
 // Don't use this type directly, use NewRoutesClient() instead.
 type RoutesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewRoutesClient creates a new instance of RoutesClient with the specified values.
@@ -37,21 +34,13 @@ type RoutesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRoutesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.RoutesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &RoutesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *RoutesClient) BeginCreateOrUpdate(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RoutesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RoutesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RoutesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RoutesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *RoutesClient) createOrUpdate(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *RoutesClient) createOrUpdateCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +132,11 @@ func (client *RoutesClient) BeginDelete(ctx context.Context, resourceGroupName s
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RoutesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RoutesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RoutesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RoutesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -160,7 +149,7 @@ func (client *RoutesClient) deleteOperation(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +178,7 @@ func (client *RoutesClient) deleteCreateRequest(ctx context.Context, resourceGro
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +202,7 @@ func (client *RoutesClient) Get(ctx context.Context, resourceGroupName string, r
 	if err != nil {
 		return RoutesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RoutesClientGetResponse{}, err
 	}
@@ -242,7 +231,7 @@ func (client *RoutesClient) getCreateRequest(ctx context.Context, resourceGroupN
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +273,7 @@ func (client *RoutesClient) NewListPager(resourceGroupName string, routeTableNam
 			if err != nil {
 				return RoutesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RoutesClientListResponse{}, err
 			}
@@ -311,7 +300,7 @@ func (client *RoutesClient) listCreateRequest(ctx context.Context, resourceGroup
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routetables_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // RouteTablesClient contains the methods for the RouteTables group.
 // Don't use this type directly, use NewRouteTablesClient() instead.
 type RouteTablesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewRouteTablesClient creates a new instance of RouteTablesClient with the specified values.
@@ -37,21 +34,13 @@ type RouteTablesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteTablesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.RouteTablesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &RouteTablesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *RouteTablesClient) BeginCreateOrUpdate(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteTablesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteTablesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteTablesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteTablesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *RouteTablesClient) createOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *RouteTablesClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *RouteTablesClient) BeginDelete(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[RouteTablesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RouteTablesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[RouteTablesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[RouteTablesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *RouteTablesClient) deleteOperation(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *RouteTablesClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *RouteTablesClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return RouteTablesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RouteTablesClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *RouteTablesClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *RouteTablesClient) NewListPager(resourceGroupName string, options 
 			if err != nil {
 				return RouteTablesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RouteTablesClientListResponse{}, err
 			}
@@ -294,7 +283,7 @@ func (client *RouteTablesClient) listCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +323,7 @@ func (client *RouteTablesClient) NewListAllPager(options *RouteTablesClientListA
 			if err != nil {
 				return RouteTablesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return RouteTablesClientListAllResponse{}, err
 			}
@@ -353,7 +342,7 @@ func (client *RouteTablesClient) listAllCreateRequest(ctx context.Context, optio
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -386,7 +375,7 @@ func (client *RouteTablesClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return RouteTablesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return RouteTablesClientUpdateTagsResponse{}, err
 	}
@@ -411,7 +400,7 @@ func (client *RouteTablesClient) updateTagsCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securitygroups_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // SecurityGroupsClient contains the methods for the NetworkSecurityGroups group.
 // Don't use this type directly, use NewSecurityGroupsClient() instead.
 type SecurityGroupsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewSecurityGroupsClient creates a new instance of SecurityGroupsClient with the specified values.
@@ -37,21 +34,13 @@ type SecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityGroupsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.SecurityGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &SecurityGroupsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *SecurityGroupsClient) BeginCreateOrUpdate(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityGroupsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityGroupsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityGroupsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *SecurityGroupsClient) createOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *SecurityGroupsClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *SecurityGroupsClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityGroupsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityGroupsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityGroupsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityGroupsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *SecurityGroupsClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *SecurityGroupsClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *SecurityGroupsClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return SecurityGroupsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SecurityGroupsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *SecurityGroupsClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +261,7 @@ func (client *SecurityGroupsClient) NewListPager(resourceGroupName string, optio
 			if err != nil {
 				return SecurityGroupsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SecurityGroupsClientListResponse{}, err
 			}
@@ -295,7 +284,7 @@ func (client *SecurityGroupsClient) listCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +325,7 @@ func (client *SecurityGroupsClient) NewListAllPager(options *SecurityGroupsClien
 			if err != nil {
 				return SecurityGroupsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SecurityGroupsClientListAllResponse{}, err
 			}
@@ -355,7 +344,7 @@ func (client *SecurityGroupsClient) listAllCreateRequest(ctx context.Context, op
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -389,7 +378,7 @@ func (client *SecurityGroupsClient) UpdateTags(ctx context.Context, resourceGrou
 	if err != nil {
 		return SecurityGroupsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SecurityGroupsClientUpdateTagsResponse{}, err
 	}
@@ -414,7 +403,7 @@ func (client *SecurityGroupsClient) updateTagsCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securitypartnerproviders_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // SecurityPartnerProvidersClient contains the methods for the SecurityPartnerProviders group.
 // Don't use this type directly, use NewSecurityPartnerProvidersClient() instead.
 type SecurityPartnerProvidersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewSecurityPartnerProvidersClient creates a new instance of SecurityPartnerProvidersClient with the specified values.
@@ -37,21 +34,13 @@ type SecurityPartnerProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityPartnerProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityPartnerProvidersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.SecurityPartnerProvidersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &SecurityPartnerProvidersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *SecurityPartnerProvidersClient) BeginCreateOrUpdate(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityPartnerProvidersClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityPartnerProvidersClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityPartnerProvidersClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityPartnerProvidersClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *SecurityPartnerProvidersClient) createOrUpdate(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *SecurityPartnerProvidersClient) createOrUpdateCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *SecurityPartnerProvidersClient) BeginDelete(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityPartnerProvidersClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityPartnerProvidersClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityPartnerProvidersClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityPartnerProvidersClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *SecurityPartnerProvidersClient) deleteOperation(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *SecurityPartnerProvidersClient) deleteCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *SecurityPartnerProvidersClient) Get(ctx context.Context, resourceG
 	if err != nil {
 		return SecurityPartnerProvidersClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SecurityPartnerProvidersClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *SecurityPartnerProvidersClient) getCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +259,7 @@ func (client *SecurityPartnerProvidersClient) NewListPager(options *SecurityPart
 			if err != nil {
 				return SecurityPartnerProvidersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SecurityPartnerProvidersClientListResponse{}, err
 			}
@@ -289,7 +278,7 @@ func (client *SecurityPartnerProvidersClient) listCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +320,7 @@ func (client *SecurityPartnerProvidersClient) NewListByResourceGroupPager(resour
 			if err != nil {
 				return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SecurityPartnerProvidersClientListByResourceGroupResponse{}, err
 			}
@@ -354,7 +343,7 @@ func (client *SecurityPartnerProvidersClient) listByResourceGroupCreateRequest(c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +377,7 @@ func (client *SecurityPartnerProvidersClient) UpdateTags(ctx context.Context, re
 	if err != nil {
 		return SecurityPartnerProvidersClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SecurityPartnerProvidersClientUpdateTagsResponse{}, err
 	}
@@ -413,7 +402,7 @@ func (client *SecurityPartnerProvidersClient) updateTagsCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securityrules_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // SecurityRulesClient contains the methods for the SecurityRules group.
 // Don't use this type directly, use NewSecurityRulesClient() instead.
 type SecurityRulesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewSecurityRulesClient creates a new instance of SecurityRulesClient with the specified values.
@@ -37,21 +34,13 @@ type SecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityRulesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.SecurityRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &SecurityRulesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *SecurityRulesClient) BeginCreateOrUpdate(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityRulesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityRulesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityRulesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityRulesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *SecurityRulesClient) createOrUpdate(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *SecurityRulesClient) createOrUpdateCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *SecurityRulesClient) BeginDelete(ctx context.Context, resourceGrou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SecurityRulesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SecurityRulesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SecurityRulesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SecurityRulesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *SecurityRulesClient) deleteOperation(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *SecurityRulesClient) deleteCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +203,7 @@ func (client *SecurityRulesClient) Get(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return SecurityRulesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SecurityRulesClientGetResponse{}, err
 	}
@@ -243,7 +232,7 @@ func (client *SecurityRulesClient) getCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +274,7 @@ func (client *SecurityRulesClient) NewListPager(resourceGroupName string, networ
 			if err != nil {
 				return SecurityRulesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SecurityRulesClientListResponse{}, err
 			}
@@ -312,7 +301,7 @@ func (client *SecurityRulesClient) listCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceassociationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceassociationlinks_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ServiceAssociationLinksClient contains the methods for the ServiceAssociationLinks group.
 // Don't use this type directly, use NewServiceAssociationLinksClient() instead.
 type ServiceAssociationLinksClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewServiceAssociationLinksClient creates a new instance of ServiceAssociationLinksClient with the specified values.
@@ -37,21 +34,13 @@ type ServiceAssociationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceAssociationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceAssociationLinksClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ServiceAssociationLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ServiceAssociationLinksClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *ServiceAssociationLinksClient) List(ctx context.Context, resourceG
 	if err != nil {
 		return ServiceAssociationLinksClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceAssociationLinksClientListResponse{}, err
 	}
@@ -99,7 +88,7 @@ func (client *ServiceAssociationLinksClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicies_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ServiceEndpointPoliciesClient contains the methods for the ServiceEndpointPolicies group.
 // Don't use this type directly, use NewServiceEndpointPoliciesClient() instead.
 type ServiceEndpointPoliciesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewServiceEndpointPoliciesClient creates a new instance of ServiceEndpointPoliciesClient with the specified values.
@@ -37,21 +34,13 @@ type ServiceEndpointPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPoliciesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ServiceEndpointPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ServiceEndpointPoliciesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *ServiceEndpointPoliciesClient) BeginCreateOrUpdate(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ServiceEndpointPoliciesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ServiceEndpointPoliciesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ServiceEndpointPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ServiceEndpointPoliciesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *ServiceEndpointPoliciesClient) createOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *ServiceEndpointPoliciesClient) createOrUpdateCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *ServiceEndpointPoliciesClient) BeginDelete(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ServiceEndpointPoliciesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ServiceEndpointPoliciesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ServiceEndpointPoliciesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ServiceEndpointPoliciesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *ServiceEndpointPoliciesClient) deleteOperation(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *ServiceEndpointPoliciesClient) deleteCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *ServiceEndpointPoliciesClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return ServiceEndpointPoliciesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceEndpointPoliciesClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *ServiceEndpointPoliciesClient) getCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +262,7 @@ func (client *ServiceEndpointPoliciesClient) NewListPager(options *ServiceEndpoi
 			if err != nil {
 				return ServiceEndpointPoliciesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ServiceEndpointPoliciesClientListResponse{}, err
 			}
@@ -292,7 +281,7 @@ func (client *ServiceEndpointPoliciesClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -334,7 +323,7 @@ func (client *ServiceEndpointPoliciesClient) NewListByResourceGroupPager(resourc
 			if err != nil {
 				return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ServiceEndpointPoliciesClientListByResourceGroupResponse{}, err
 			}
@@ -357,7 +346,7 @@ func (client *ServiceEndpointPoliciesClient) listByResourceGroupCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +380,7 @@ func (client *ServiceEndpointPoliciesClient) UpdateTags(ctx context.Context, res
 	if err != nil {
 		return ServiceEndpointPoliciesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceEndpointPoliciesClientUpdateTagsResponse{}, err
 	}
@@ -416,7 +405,7 @@ func (client *ServiceEndpointPoliciesClient) updateTagsCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicydefinitions_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ServiceEndpointPolicyDefinitionsClient contains the methods for the ServiceEndpointPolicyDefinitions group.
 // Don't use this type directly, use NewServiceEndpointPolicyDefinitionsClient() instead.
 type ServiceEndpointPolicyDefinitionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewServiceEndpointPolicyDefinitionsClient creates a new instance of ServiceEndpointPolicyDefinitionsClient with the specified values.
@@ -37,21 +34,13 @@ type ServiceEndpointPolicyDefinitionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPolicyDefinitionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPolicyDefinitionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ServiceEndpointPolicyDefinitionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ServiceEndpointPolicyDefinitionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginCreateOrUpdate(ctx co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdate(ctx context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) createOrUpdateCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *ServiceEndpointPolicyDefinitionsClient) BeginDelete(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[ServiceEndpointPolicyDefinitionsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ServiceEndpointPolicyDefinitionsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[ServiceEndpointPolicyDefinitionsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[ServiceEndpointPolicyDefinitionsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) deleteOperation(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) deleteCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) Get(ctx context.Context, r
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceEndpointPolicyDefinitionsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) getCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) NewListByResourceGroupPage
 			if err != nil {
 				return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *ServiceEndpointPolicyDefinitionsClient) listByResourceGroupCreateR
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_servicetags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_servicetags_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // ServiceTagsClient contains the methods for the ServiceTags group.
 // Don't use this type directly, use NewServiceTagsClient() instead.
 type ServiceTagsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewServiceTagsClient creates a new instance of ServiceTagsClient with the specified values.
@@ -37,21 +34,13 @@ type ServiceTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.ServiceTagsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &ServiceTagsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *ServiceTagsClient) List(ctx context.Context, location string, opti
 	if err != nil {
 		return ServiceTagsClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceTagsClientListResponse{}, err
 	}
@@ -90,7 +79,7 @@ func (client *ServiceTagsClient) listCreateRequest(ctx context.Context, location
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_subnets_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // SubnetsClient contains the methods for the Subnets group.
 // Don't use this type directly, use NewSubnetsClient() instead.
 type SubnetsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewSubnetsClient creates a new instance of SubnetsClient with the specified values.
@@ -37,21 +34,13 @@ type SubnetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubnetsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.SubnetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &SubnetsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *SubnetsClient) BeginCreateOrUpdate(ctx context.Context, resourceGr
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SubnetsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SubnetsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SubnetsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SubnetsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *SubnetsClient) createOrUpdate(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *SubnetsClient) createOrUpdateCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +132,11 @@ func (client *SubnetsClient) BeginDelete(ctx context.Context, resourceGroupName 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SubnetsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SubnetsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SubnetsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SubnetsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -160,7 +149,7 @@ func (client *SubnetsClient) deleteOperation(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +178,7 @@ func (client *SubnetsClient) deleteCreateRequest(ctx context.Context, resourceGr
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -213,7 +202,7 @@ func (client *SubnetsClient) Get(ctx context.Context, resourceGroupName string, 
 	if err != nil {
 		return SubnetsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SubnetsClientGetResponse{}, err
 	}
@@ -242,7 +231,7 @@ func (client *SubnetsClient) getCreateRequest(ctx context.Context, resourceGroup
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *SubnetsClient) NewListPager(resourceGroupName string, virtualNetwo
 			if err != nil {
 				return SubnetsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SubnetsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *SubnetsClient) listCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -350,11 +339,11 @@ func (client *SubnetsClient) BeginPrepareNetworkPolicies(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SubnetsClientPrepareNetworkPoliciesResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SubnetsClientPrepareNetworkPoliciesResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SubnetsClientPrepareNetworkPoliciesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SubnetsClientPrepareNetworkPoliciesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -367,7 +356,7 @@ func (client *SubnetsClient) prepareNetworkPolicies(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +385,7 @@ func (client *SubnetsClient) prepareNetworkPoliciesCreateRequest(ctx context.Con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -423,11 +412,11 @@ func (client *SubnetsClient) BeginUnprepareNetworkPolicies(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SubnetsClientUnprepareNetworkPoliciesResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SubnetsClientUnprepareNetworkPoliciesResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SubnetsClientUnprepareNetworkPoliciesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SubnetsClientUnprepareNetworkPoliciesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -440,7 +429,7 @@ func (client *SubnetsClient) unprepareNetworkPolicies(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +458,7 @@ func (client *SubnetsClient) unprepareNetworkPoliciesCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_usages_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // UsagesClient contains the methods for the Usages group.
 // Don't use this type directly, use NewUsagesClient() instead.
 type UsagesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewUsagesClient creates a new instance of UsagesClient with the specified values.
@@ -37,21 +34,13 @@ type UsagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.UsagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &UsagesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -77,7 +66,7 @@ func (client *UsagesClient) NewListPager(location string, options *UsagesClientL
 			if err != nil {
 				return UsagesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return UsagesClientListResponse{}, err
 			}
@@ -100,7 +89,7 @@ func (client *UsagesClient) listCreateRequest(ctx context.Context, location stri
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualappliances_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualAppliancesClient contains the methods for the NetworkVirtualAppliances group.
 // Don't use this type directly, use NewVirtualAppliancesClient() instead.
 type VirtualAppliancesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualAppliancesClient creates a new instance of VirtualAppliancesClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualAppliancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualAppliancesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualAppliancesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualAppliancesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualAppliancesClient) BeginCreateOrUpdate(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualAppliancesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualAppliancesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualAppliancesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualAppliancesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualAppliancesClient) createOrUpdate(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualAppliancesClient) createOrUpdateCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VirtualAppliancesClient) BeginDelete(ctx context.Context, resource
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualAppliancesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualAppliancesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualAppliancesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualAppliancesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VirtualAppliancesClient) deleteOperation(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VirtualAppliancesClient) deleteCreateRequest(ctx context.Context, 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *VirtualAppliancesClient) Get(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return VirtualAppliancesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualAppliancesClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *VirtualAppliancesClient) getCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +261,7 @@ func (client *VirtualAppliancesClient) NewListPager(options *VirtualAppliancesCl
 			if err != nil {
 				return VirtualAppliancesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualAppliancesClientListResponse{}, err
 			}
@@ -291,7 +280,7 @@ func (client *VirtualAppliancesClient) listCreateRequest(ctx context.Context, op
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +322,7 @@ func (client *VirtualAppliancesClient) NewListByResourceGroupPager(resourceGroup
 			if err != nil {
 				return VirtualAppliancesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualAppliancesClientListByResourceGroupResponse{}, err
 			}
@@ -356,7 +345,7 @@ func (client *VirtualAppliancesClient) listByResourceGroupCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +379,7 @@ func (client *VirtualAppliancesClient) UpdateTags(ctx context.Context, resourceG
 	if err != nil {
 		return VirtualAppliancesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualAppliancesClientUpdateTagsResponse{}, err
 	}
@@ -415,7 +404,7 @@ func (client *VirtualAppliancesClient) updateTagsCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter networkVirtualApplianceName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{networkVirtualApplianceName}", url.PathEscape(networkVirtualApplianceName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualhubroutetablev2s_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualHubRouteTableV2SClient contains the methods for the VirtualHubRouteTableV2S group.
 // Don't use this type directly, use NewVirtualHubRouteTableV2SClient() instead.
 type VirtualHubRouteTableV2SClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualHubRouteTableV2SClient creates a new instance of VirtualHubRouteTableV2SClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualHubRouteTableV2SClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubRouteTableV2SClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubRouteTableV2SClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualHubRouteTableV2SClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualHubRouteTableV2SClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *VirtualHubRouteTableV2SClient) BeginCreateOrUpdate(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualHubRouteTableV2SClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualHubRouteTableV2SClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualHubRouteTableV2SClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualHubRouteTableV2SClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *VirtualHubRouteTableV2SClient) createOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *VirtualHubRouteTableV2SClient) createOrUpdateCreateRequest(ctx con
 		return nil, errors.New("parameter routeTableName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *VirtualHubRouteTableV2SClient) BeginDelete(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualHubRouteTableV2SClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualHubRouteTableV2SClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualHubRouteTableV2SClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualHubRouteTableV2SClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *VirtualHubRouteTableV2SClient) deleteOperation(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *VirtualHubRouteTableV2SClient) deleteCreateRequest(ctx context.Con
 		return nil, errors.New("parameter routeTableName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *VirtualHubRouteTableV2SClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return VirtualHubRouteTableV2SClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualHubRouteTableV2SClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *VirtualHubRouteTableV2SClient) getCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter routeTableName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{routeTableName}", url.PathEscape(routeTableName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *VirtualHubRouteTableV2SClient) NewListPager(resourceGroupName stri
 			if err != nil {
 				return VirtualHubRouteTableV2SClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualHubRouteTableV2SClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *VirtualHubRouteTableV2SClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualhubs_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualHubsClient contains the methods for the VirtualHubs group.
 // Don't use this type directly, use NewVirtualHubsClient() instead.
 type VirtualHubsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualHubsClient creates a new instance of VirtualHubsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualHubsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualHubsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualHubsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualHubsClient) BeginCreateOrUpdate(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualHubsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualHubsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualHubsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualHubsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualHubsClient) createOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualHubsClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *VirtualHubsClient) BeginDelete(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualHubsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualHubsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualHubsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualHubsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *VirtualHubsClient) deleteOperation(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *VirtualHubsClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *VirtualHubsClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return VirtualHubsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualHubsClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *VirtualHubsClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +256,7 @@ func (client *VirtualHubsClient) NewListPager(options *VirtualHubsClientListOpti
 			if err != nil {
 				return VirtualHubsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualHubsClientListResponse{}, err
 			}
@@ -286,7 +275,7 @@ func (client *VirtualHubsClient) listCreateRequest(ctx context.Context, options 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +317,7 @@ func (client *VirtualHubsClient) NewListByResourceGroupPager(resourceGroupName s
 			if err != nil {
 				return VirtualHubsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualHubsClientListByResourceGroupResponse{}, err
 			}
@@ -351,7 +340,7 @@ func (client *VirtualHubsClient) listByResourceGroupCreateRequest(ctx context.Co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +373,7 @@ func (client *VirtualHubsClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return VirtualHubsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualHubsClientUpdateTagsResponse{}, err
 	}
@@ -409,7 +398,7 @@ func (client *VirtualHubsClient) updateTagsCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter virtualHubName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualHubName}", url.PathEscape(virtualHubName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkgatewayconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualNetworkGatewayConnectionsClient contains the methods for the VirtualNetworkGatewayConnections group.
 // Don't use this type directly, use NewVirtualNetworkGatewayConnectionsClient() instead.
 type VirtualNetworkGatewayConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualNetworkGatewayConnectionsClient creates a new instance of VirtualNetworkGatewayConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualNetworkGatewayConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewayConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualNetworkGatewayConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualNetworkGatewayConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginCreateOrUpdate(ctx co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdate(ctx context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) createOrUpdateCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginDelete(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) deleteOperation(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) deleteCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) Get(ctx context.Context, r
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +252,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) GetSharedKey(ctx context.C
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkGatewayConnectionsClientGetSharedKeyResponse{}, err
 	}
@@ -288,7 +277,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) getSharedKeyCreateRequest(
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +320,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) NewListPager(resourceGroup
 			if err != nil {
 				return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkGatewayConnectionsClientListResponse{}, err
 			}
@@ -354,7 +343,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) listCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -392,11 +381,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginResetSharedKey(ctx co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -411,7 +400,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKey(ctx context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +425,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) resetSharedKeyCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -465,11 +454,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginSetSharedKey(ctx cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -484,7 +473,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) setSharedKey(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +498,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) setSharedKeyCreateRequest(
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -534,11 +523,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStartPacketCapture(ct
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -551,7 +540,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) startPacketCapture(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +565,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) startPacketCaptureCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -605,11 +594,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginStopPacketCapture(ctx
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -622,7 +611,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCapture(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -647,7 +636,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) stopPacketCaptureCreateReq
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -673,11 +662,11 @@ func (client *VirtualNetworkGatewayConnectionsClient) BeginUpdateTags(ctx contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientUpdateTagsResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewayConnectionsClientUpdateTagsResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientUpdateTagsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewayConnectionsClientUpdateTagsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -690,7 +679,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) updateTags(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +704,7 @@ func (client *VirtualNetworkGatewayConnectionsClient) updateTagsCreateRequest(ct
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkgateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualNetworkGatewaysClient contains the methods for the VirtualNetworkGateways group.
 // Don't use this type directly, use NewVirtualNetworkGatewaysClient() instead.
 type VirtualNetworkGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualNetworkGatewaysClient creates a new instance of VirtualNetworkGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualNetworkGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualNetworkGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualNetworkGatewaysClient) BeginCreateOrUpdate(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualNetworkGatewaysClient) createOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualNetworkGatewaysClient) createOrUpdateCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VirtualNetworkGatewaysClient) BeginDelete(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VirtualNetworkGatewaysClient) deleteOperation(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VirtualNetworkGatewaysClient) deleteCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -207,11 +196,11 @@ func (client *VirtualNetworkGatewaysClient) BeginDisconnectVirtualNetworkGateway
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -225,7 +214,7 @@ func (client *VirtualNetworkGatewaysClient) disconnectVirtualNetworkGatewayVPNCo
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +239,7 @@ func (client *VirtualNetworkGatewaysClient) disconnectVirtualNetworkGatewayVPNCo
 		return nil, errors.New("parameter virtualNetworkGatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualNetworkGatewayName}", url.PathEscape(virtualNetworkGatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -277,11 +266,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGenerateVPNProfile(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGenerateVPNProfileResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGenerateVPNProfileResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGenerateVPNProfileResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGenerateVPNProfileResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -295,7 +284,7 @@ func (client *VirtualNetworkGatewaysClient) generateVPNProfile(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -320,7 +309,7 @@ func (client *VirtualNetworkGatewaysClient) generateVPNProfileCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -347,11 +336,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGeneratevpnclientpackage(ctx co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -365,7 +354,7 @@ func (client *VirtualNetworkGatewaysClient) generatevpnclientpackage(ctx context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -390,7 +379,7 @@ func (client *VirtualNetworkGatewaysClient) generatevpnclientpackageCreateReques
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +403,7 @@ func (client *VirtualNetworkGatewaysClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkGatewaysClientGetResponse{}, err
 	}
@@ -439,7 +428,7 @@ func (client *VirtualNetworkGatewaysClient) getCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -475,11 +464,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetAdvertisedRoutes(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -493,7 +482,7 @@ func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutes(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -518,7 +507,7 @@ func (client *VirtualNetworkGatewaysClient) getAdvertisedRoutesCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -544,11 +533,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetBgpPeerStatus(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetBgpPeerStatusResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetBgpPeerStatusResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetBgpPeerStatusResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetBgpPeerStatusResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -561,7 +550,7 @@ func (client *VirtualNetworkGatewaysClient) getBgpPeerStatus(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +575,7 @@ func (client *VirtualNetworkGatewaysClient) getBgpPeerStatusCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -615,11 +604,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetLearnedRoutes(ctx context.Co
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetLearnedRoutesResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetLearnedRoutesResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetLearnedRoutesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetLearnedRoutesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -633,7 +622,7 @@ func (client *VirtualNetworkGatewaysClient) getLearnedRoutes(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -658,7 +647,7 @@ func (client *VirtualNetworkGatewaysClient) getLearnedRoutesCreateRequest(ctx co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -684,11 +673,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVPNProfilePackageURL(ctx con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -702,7 +691,7 @@ func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURL(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -727,7 +716,7 @@ func (client *VirtualNetworkGatewaysClient) getVPNProfilePackageURLCreateRequest
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -753,11 +742,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientConnectionHealth(ct
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -771,7 +760,7 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientConnectionHealth(ctx con
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -796,7 +785,7 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientConnectionHealthCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -823,11 +812,11 @@ func (client *VirtualNetworkGatewaysClient) BeginGetVpnclientIPSecParameters(ctx
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -842,7 +831,7 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientIPSecParameters(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -867,7 +856,7 @@ func (client *VirtualNetworkGatewaysClient) getVpnclientIPSecParametersCreateReq
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -900,7 +889,7 @@ func (client *VirtualNetworkGatewaysClient) NewListPager(resourceGroupName strin
 			if err != nil {
 				return VirtualNetworkGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkGatewaysClientListResponse{}, err
 			}
@@ -923,7 +912,7 @@ func (client *VirtualNetworkGatewaysClient) listCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -966,7 +955,7 @@ func (client *VirtualNetworkGatewaysClient) NewListConnectionsPager(resourceGrou
 			if err != nil {
 				return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkGatewaysClientListConnectionsResponse{}, err
 			}
@@ -993,7 +982,7 @@ func (client *VirtualNetworkGatewaysClient) listConnectionsCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1027,11 +1016,11 @@ func (client *VirtualNetworkGatewaysClient) BeginReset(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientResetResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientResetResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientResetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientResetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1044,7 +1033,7 @@ func (client *VirtualNetworkGatewaysClient) reset(ctx context.Context, resourceG
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1069,7 +1058,7 @@ func (client *VirtualNetworkGatewaysClient) resetCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1098,11 +1087,11 @@ func (client *VirtualNetworkGatewaysClient) BeginResetVPNClientSharedKey(ctx con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1115,7 +1104,7 @@ func (client *VirtualNetworkGatewaysClient) resetVPNClientSharedKey(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1140,7 +1129,7 @@ func (client *VirtualNetworkGatewaysClient) resetVPNClientSharedKeyCreateRequest
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1168,11 +1157,11 @@ func (client *VirtualNetworkGatewaysClient) BeginSetVpnclientIPSecParameters(ctx
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1186,7 +1175,7 @@ func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParameters(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1211,7 +1200,7 @@ func (client *VirtualNetworkGatewaysClient) setVpnclientIPSecParametersCreateReq
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1236,11 +1225,11 @@ func (client *VirtualNetworkGatewaysClient) BeginStartPacketCapture(ctx context.
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientStartPacketCaptureResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientStartPacketCaptureResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientStartPacketCaptureResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientStartPacketCaptureResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1253,7 +1242,7 @@ func (client *VirtualNetworkGatewaysClient) startPacketCapture(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1278,7 +1267,7 @@ func (client *VirtualNetworkGatewaysClient) startPacketCaptureCreateRequest(ctx 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1307,11 +1296,11 @@ func (client *VirtualNetworkGatewaysClient) BeginStopPacketCapture(ctx context.C
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientStopPacketCaptureResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientStopPacketCaptureResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientStopPacketCaptureResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientStopPacketCaptureResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1324,7 +1313,7 @@ func (client *VirtualNetworkGatewaysClient) stopPacketCapture(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1349,7 +1338,7 @@ func (client *VirtualNetworkGatewaysClient) stopPacketCaptureCreateRequest(ctx c
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1373,7 +1362,7 @@ func (client *VirtualNetworkGatewaysClient) SupportedVPNDevices(ctx context.Cont
 	if err != nil {
 		return VirtualNetworkGatewaysClientSupportedVPNDevicesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkGatewaysClientSupportedVPNDevicesResponse{}, err
 	}
@@ -1398,7 +1387,7 @@ func (client *VirtualNetworkGatewaysClient) supportedVPNDevicesCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1433,11 +1422,11 @@ func (client *VirtualNetworkGatewaysClient) BeginUpdateTags(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkGatewaysClientUpdateTagsResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkGatewaysClientUpdateTagsResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientUpdateTagsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkGatewaysClientUpdateTagsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1450,7 +1439,7 @@ func (client *VirtualNetworkGatewaysClient) updateTags(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1475,7 +1464,7 @@ func (client *VirtualNetworkGatewaysClient) updateTagsCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1501,7 +1490,7 @@ func (client *VirtualNetworkGatewaysClient) VPNDeviceConfigurationScript(ctx con
 	if err != nil {
 		return VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptResponse{}, err
 	}
@@ -1526,7 +1515,7 @@ func (client *VirtualNetworkGatewaysClient) vpnDeviceConfigurationScriptCreateRe
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkpeerings_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualNetworkPeeringsClient contains the methods for the VirtualNetworkPeerings group.
 // Don't use this type directly, use NewVirtualNetworkPeeringsClient() instead.
 type VirtualNetworkPeeringsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualNetworkPeeringsClient creates a new instance of VirtualNetworkPeeringsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualNetworkPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkPeeringsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualNetworkPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualNetworkPeeringsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *VirtualNetworkPeeringsClient) BeginCreateOrUpdate(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkPeeringsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkPeeringsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *VirtualNetworkPeeringsClient) createOrUpdate(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *VirtualNetworkPeeringsClient) createOrUpdateCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *VirtualNetworkPeeringsClient) BeginDelete(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkPeeringsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkPeeringsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkPeeringsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkPeeringsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *VirtualNetworkPeeringsClient) deleteOperation(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *VirtualNetworkPeeringsClient) deleteCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *VirtualNetworkPeeringsClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return VirtualNetworkPeeringsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkPeeringsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *VirtualNetworkPeeringsClient) getCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *VirtualNetworkPeeringsClient) NewListPager(resourceGroupName strin
 			if err != nil {
 				return VirtualNetworkPeeringsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkPeeringsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *VirtualNetworkPeeringsClient) listCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworktaps_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualNetworkTapsClient contains the methods for the VirtualNetworkTaps group.
 // Don't use this type directly, use NewVirtualNetworkTapsClient() instead.
 type VirtualNetworkTapsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualNetworkTapsClient creates a new instance of VirtualNetworkTapsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualNetworkTapsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkTapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkTapsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualNetworkTapsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualNetworkTapsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualNetworkTapsClient) BeginCreateOrUpdate(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkTapsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkTapsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkTapsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkTapsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualNetworkTapsClient) createOrUpdate(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualNetworkTapsClient) createOrUpdateCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VirtualNetworkTapsClient) BeginDelete(ctx context.Context, resourc
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualNetworkTapsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualNetworkTapsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualNetworkTapsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualNetworkTapsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VirtualNetworkTapsClient) deleteOperation(ctx context.Context, res
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VirtualNetworkTapsClient) deleteCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *VirtualNetworkTapsClient) Get(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return VirtualNetworkTapsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkTapsClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *VirtualNetworkTapsClient) getCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +258,7 @@ func (client *VirtualNetworkTapsClient) NewListAllPager(options *VirtualNetworkT
 			if err != nil {
 				return VirtualNetworkTapsClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkTapsClientListAllResponse{}, err
 			}
@@ -288,7 +277,7 @@ func (client *VirtualNetworkTapsClient) listAllCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -330,7 +319,7 @@ func (client *VirtualNetworkTapsClient) NewListByResourceGroupPager(resourceGrou
 			if err != nil {
 				return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualNetworkTapsClientListByResourceGroupResponse{}, err
 			}
@@ -353,7 +342,7 @@ func (client *VirtualNetworkTapsClient) listByResourceGroupCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +376,7 @@ func (client *VirtualNetworkTapsClient) UpdateTags(ctx context.Context, resource
 	if err != nil {
 		return VirtualNetworkTapsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualNetworkTapsClientUpdateTagsResponse{}, err
 	}
@@ -412,7 +401,7 @@ func (client *VirtualNetworkTapsClient) updateTagsCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualrouterpeerings_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualRouterPeeringsClient contains the methods for the VirtualRouterPeerings group.
 // Don't use this type directly, use NewVirtualRouterPeeringsClient() instead.
 type VirtualRouterPeeringsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualRouterPeeringsClient creates a new instance of VirtualRouterPeeringsClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualRouterPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRouterPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRouterPeeringsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualRouterPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualRouterPeeringsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *VirtualRouterPeeringsClient) BeginCreateOrUpdate(ctx context.Conte
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualRouterPeeringsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualRouterPeeringsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualRouterPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualRouterPeeringsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -89,7 +78,7 @@ func (client *VirtualRouterPeeringsClient) createOrUpdate(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +107,7 @@ func (client *VirtualRouterPeeringsClient) createOrUpdateCreateRequest(ctx conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -144,11 +133,11 @@ func (client *VirtualRouterPeeringsClient) BeginDelete(ctx context.Context, reso
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualRouterPeeringsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualRouterPeeringsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualRouterPeeringsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualRouterPeeringsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -161,7 +150,7 @@ func (client *VirtualRouterPeeringsClient) deleteOperation(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -190,7 +179,7 @@ func (client *VirtualRouterPeeringsClient) deleteCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *VirtualRouterPeeringsClient) Get(ctx context.Context, resourceGrou
 	if err != nil {
 		return VirtualRouterPeeringsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualRouterPeeringsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *VirtualRouterPeeringsClient) getCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *VirtualRouterPeeringsClient) NewListPager(resourceGroupName string
 			if err != nil {
 				return VirtualRouterPeeringsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualRouterPeeringsClientListResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *VirtualRouterPeeringsClient) listCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualrouters_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualRoutersClient contains the methods for the VirtualRouters group.
 // Don't use this type directly, use NewVirtualRoutersClient() instead.
 type VirtualRoutersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualRoutersClient creates a new instance of VirtualRoutersClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualRoutersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRoutersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRoutersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualRoutersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualRoutersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualRoutersClient) BeginCreateOrUpdate(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualRoutersClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualRoutersClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualRoutersClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualRoutersClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualRoutersClient) createOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualRoutersClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VirtualRoutersClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualRoutersClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualRoutersClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualRoutersClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualRoutersClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VirtualRoutersClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VirtualRoutersClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +192,7 @@ func (client *VirtualRoutersClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return VirtualRoutersClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualRoutersClientGetResponse{}, err
 	}
@@ -228,7 +217,7 @@ func (client *VirtualRoutersClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +260,7 @@ func (client *VirtualRoutersClient) NewListPager(options *VirtualRoutersClientLi
 			if err != nil {
 				return VirtualRoutersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualRoutersClientListResponse{}, err
 			}
@@ -290,7 +279,7 @@ func (client *VirtualRoutersClient) listCreateRequest(ctx context.Context, optio
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +321,7 @@ func (client *VirtualRoutersClient) NewListByResourceGroupPager(resourceGroupNam
 			if err != nil {
 				return VirtualRoutersClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualRoutersClientListByResourceGroupResponse{}, err
 			}
@@ -355,7 +344,7 @@ func (client *VirtualRoutersClient) listByResourceGroupCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualwans_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VirtualWansClient contains the methods for the VirtualWans group.
 // Don't use this type directly, use NewVirtualWansClient() instead.
 type VirtualWansClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVirtualWansClient creates a new instance of VirtualWansClient with the specified values.
@@ -37,21 +34,13 @@ type VirtualWansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualWansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualWansClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VirtualWansClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VirtualWansClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VirtualWansClient) BeginCreateOrUpdate(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualWansClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualWansClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualWansClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualWansClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VirtualWansClient) createOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VirtualWansClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *VirtualWansClient) BeginDelete(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VirtualWansClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VirtualWansClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VirtualWansClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VirtualWansClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *VirtualWansClient) deleteOperation(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *VirtualWansClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *VirtualWansClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return VirtualWansClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualWansClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *VirtualWansClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +256,7 @@ func (client *VirtualWansClient) NewListPager(options *VirtualWansClientListOpti
 			if err != nil {
 				return VirtualWansClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualWansClientListResponse{}, err
 			}
@@ -286,7 +275,7 @@ func (client *VirtualWansClient) listCreateRequest(ctx context.Context, options 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +317,7 @@ func (client *VirtualWansClient) NewListByResourceGroupPager(resourceGroupName s
 			if err != nil {
 				return VirtualWansClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VirtualWansClientListByResourceGroupResponse{}, err
 			}
@@ -351,7 +340,7 @@ func (client *VirtualWansClient) listByResourceGroupCreateRequest(ctx context.Co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +373,7 @@ func (client *VirtualWansClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return VirtualWansClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VirtualWansClientUpdateTagsResponse{}, err
 	}
@@ -409,7 +398,7 @@ func (client *VirtualWansClient) updateTagsCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{VirtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNConnectionsClient contains the methods for the VPNConnections group.
 // Don't use this type directly, use NewVPNConnectionsClient() instead.
 type VPNConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNConnectionsClient creates a new instance of VPNConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type VPNConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -73,11 +62,11 @@ func (client *VPNConnectionsClient) BeginCreateOrUpdate(ctx context.Context, res
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNConnectionsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNConnectionsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNConnectionsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -90,7 +79,7 @@ func (client *VPNConnectionsClient) createOrUpdate(ctx context.Context, resource
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +108,7 @@ func (client *VPNConnectionsClient) createOrUpdateCreateRequest(ctx context.Cont
 		return nil, errors.New("parameter connectionName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -145,11 +134,11 @@ func (client *VPNConnectionsClient) BeginDelete(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNConnectionsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNConnectionsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNConnectionsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNConnectionsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -162,7 +151,7 @@ func (client *VPNConnectionsClient) deleteOperation(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +180,7 @@ func (client *VPNConnectionsClient) deleteCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter connectionName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +204,7 @@ func (client *VPNConnectionsClient) Get(ctx context.Context, resourceGroupName s
 	if err != nil {
 		return VPNConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNConnectionsClientGetResponse{}, err
 	}
@@ -244,7 +233,7 @@ func (client *VPNConnectionsClient) getCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter connectionName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{connectionName}", url.PathEscape(connectionName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +276,7 @@ func (client *VPNConnectionsClient) NewListByVPNGatewayPager(resourceGroupName s
 			if err != nil {
 				return VPNConnectionsClientListByVPNGatewayResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNConnectionsClientListByVPNGatewayResponse{}, err
 			}
@@ -314,7 +303,7 @@ func (client *VPNConnectionsClient) listByVPNGatewayCreateRequest(ctx context.Co
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpngateways_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNGatewaysClient contains the methods for the VPNGateways group.
 // Don't use this type directly, use NewVPNGatewaysClient() instead.
 type VPNGatewaysClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNGatewaysClient creates a new instance of VPNGatewaysClient with the specified values.
@@ -37,21 +34,13 @@ type VPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNGatewaysClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNGatewaysClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VPNGatewaysClient) BeginCreateOrUpdate(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNGatewaysClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNGatewaysClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNGatewaysClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VPNGatewaysClient) createOrUpdate(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VPNGatewaysClient) createOrUpdateCreateRequest(ctx context.Context
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *VPNGatewaysClient) BeginDelete(ctx context.Context, resourceGroupN
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNGatewaysClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNGatewaysClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNGatewaysClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNGatewaysClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *VPNGatewaysClient) deleteOperation(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *VPNGatewaysClient) deleteCreateRequest(ctx context.Context, resour
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *VPNGatewaysClient) Get(ctx context.Context, resourceGroupName stri
 	if err != nil {
 		return VPNGatewaysClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNGatewaysClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *VPNGatewaysClient) getCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +256,7 @@ func (client *VPNGatewaysClient) NewListPager(options *VPNGatewaysClientListOpti
 			if err != nil {
 				return VPNGatewaysClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNGatewaysClientListResponse{}, err
 			}
@@ -286,7 +275,7 @@ func (client *VPNGatewaysClient) listCreateRequest(ctx context.Context, options 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +317,7 @@ func (client *VPNGatewaysClient) NewListByResourceGroupPager(resourceGroupName s
 			if err != nil {
 				return VPNGatewaysClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNGatewaysClientListByResourceGroupResponse{}, err
 			}
@@ -351,7 +340,7 @@ func (client *VPNGatewaysClient) listByResourceGroupCreateRequest(ctx context.Co
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,11 +373,11 @@ func (client *VPNGatewaysClient) BeginReset(ctx context.Context, resourceGroupNa
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNGatewaysClientResetResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNGatewaysClientResetResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNGatewaysClientResetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNGatewaysClientResetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -401,7 +390,7 @@ func (client *VPNGatewaysClient) reset(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -426,7 +415,7 @@ func (client *VPNGatewaysClient) resetCreateRequest(ctx context.Context, resourc
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +439,7 @@ func (client *VPNGatewaysClient) UpdateTags(ctx context.Context, resourceGroupNa
 	if err != nil {
 		return VPNGatewaysClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNGatewaysClientUpdateTagsResponse{}, err
 	}
@@ -475,7 +464,7 @@ func (client *VPNGatewaysClient) updateTagsCreateRequest(ctx context.Context, re
 		return nil, errors.New("parameter gatewayName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{gatewayName}", url.PathEscape(gatewayName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurations_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNServerConfigurationsClient contains the methods for the VPNServerConfigurations group.
 // Don't use this type directly, use NewVPNServerConfigurationsClient() instead.
 type VPNServerConfigurationsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNServerConfigurationsClient creates a new instance of VPNServerConfigurationsClient with the specified values.
@@ -37,21 +34,13 @@ type VPNServerConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNServerConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNServerConfigurationsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VPNServerConfigurationsClient) BeginCreateOrUpdate(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNServerConfigurationsClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNServerConfigurationsClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VPNServerConfigurationsClient) createOrUpdate(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VPNServerConfigurationsClient) createOrUpdateCreateRequest(ctx con
 		return nil, errors.New("parameter vpnServerConfigurationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -138,11 +127,11 @@ func (client *VPNServerConfigurationsClient) BeginDelete(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNServerConfigurationsClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNServerConfigurationsClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -155,7 +144,7 @@ func (client *VPNServerConfigurationsClient) deleteOperation(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +169,7 @@ func (client *VPNServerConfigurationsClient) deleteCreateRequest(ctx context.Con
 		return nil, errors.New("parameter vpnServerConfigurationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +193,7 @@ func (client *VPNServerConfigurationsClient) Get(ctx context.Context, resourceGr
 	if err != nil {
 		return VPNServerConfigurationsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNServerConfigurationsClientGetResponse{}, err
 	}
@@ -229,7 +218,7 @@ func (client *VPNServerConfigurationsClient) getCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter vpnServerConfigurationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +259,7 @@ func (client *VPNServerConfigurationsClient) NewListPager(options *VPNServerConf
 			if err != nil {
 				return VPNServerConfigurationsClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNServerConfigurationsClientListResponse{}, err
 			}
@@ -289,7 +278,7 @@ func (client *VPNServerConfigurationsClient) listCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +320,7 @@ func (client *VPNServerConfigurationsClient) NewListByResourceGroupPager(resourc
 			if err != nil {
 				return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNServerConfigurationsClientListByResourceGroupResponse{}, err
 			}
@@ -354,7 +343,7 @@ func (client *VPNServerConfigurationsClient) listByResourceGroupCreateRequest(ct
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -388,7 +377,7 @@ func (client *VPNServerConfigurationsClient) UpdateTags(ctx context.Context, res
 	if err != nil {
 		return VPNServerConfigurationsClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNServerConfigurationsClientUpdateTagsResponse{}, err
 	}
@@ -413,7 +402,7 @@ func (client *VPNServerConfigurationsClient) updateTagsCreateRequest(ctx context
 		return nil, errors.New("parameter vpnServerConfigurationName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnServerConfigurationName}", url.PathEscape(vpnServerConfigurationName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNServerConfigurationsAssociatedWithVirtualWanClient contains the methods for the VPNServerConfigurationsAssociatedWithVirtualWan group.
 // Don't use this type directly, use NewVPNServerConfigurationsAssociatedWithVirtualWanClient() instead.
 type VPNServerConfigurationsAssociatedWithVirtualWanClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNServerConfigurationsAssociatedWithVirtualWanClient creates a new instance of VPNServerConfigurationsAssociatedWithVirtualWanClient with the specified values.
@@ -37,21 +34,13 @@ type VPNServerConfigurationsAssociatedWithVirtualWanClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsAssociatedWithVirtualWanClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsAssociatedWithVirtualWanClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNServerConfigurationsAssociatedWithVirtualWanClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,11 +59,11 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) BeginList(c
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -87,7 +76,7 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) listOperati
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +101,7 @@ func (client *VPNServerConfigurationsAssociatedWithVirtualWanClient) listCreateR
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitelinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitelinkconnections_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNSiteLinkConnectionsClient contains the methods for the VPNSiteLinkConnections group.
 // Don't use this type directly, use NewVPNSiteLinkConnectionsClient() instead.
 type VPNSiteLinkConnectionsClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNSiteLinkConnectionsClient creates a new instance of VPNSiteLinkConnectionsClient with the specified values.
@@ -37,21 +34,13 @@ type VPNSiteLinkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinkConnectionsClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNSiteLinkConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNSiteLinkConnectionsClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,7 +60,7 @@ func (client *VPNSiteLinkConnectionsClient) Get(ctx context.Context, resourceGro
 	if err != nil {
 		return VPNSiteLinkConnectionsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNSiteLinkConnectionsClientGetResponse{}, err
 	}
@@ -104,7 +93,7 @@ func (client *VPNSiteLinkConnectionsClient) getCreateRequest(ctx context.Context
 		return nil, errors.New("parameter linkConnectionName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{linkConnectionName}", url.PathEscape(linkConnectionName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitelinks_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNSiteLinksClient contains the methods for the VPNSiteLinks group.
 // Don't use this type directly, use NewVPNSiteLinksClient() instead.
 type VPNSiteLinksClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNSiteLinksClient creates a new instance of VPNSiteLinksClient with the specified values.
@@ -37,21 +34,13 @@ type VPNSiteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinksClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNSiteLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNSiteLinksClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -69,7 +58,7 @@ func (client *VPNSiteLinksClient) Get(ctx context.Context, resourceGroupName str
 	if err != nil {
 		return VPNSiteLinksClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNSiteLinksClientGetResponse{}, err
 	}
@@ -98,7 +87,7 @@ func (client *VPNSiteLinksClient) getCreateRequest(ctx context.Context, resource
 		return nil, errors.New("parameter vpnSiteLinkName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteLinkName}", url.PathEscape(vpnSiteLinkName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +130,7 @@ func (client *VPNSiteLinksClient) NewListByVPNSitePager(resourceGroupName string
 			if err != nil {
 				return VPNSiteLinksClientListByVPNSiteResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNSiteLinksClientListByVPNSiteResponse{}, err
 			}
@@ -168,7 +157,7 @@ func (client *VPNSiteLinksClient) listByVPNSiteCreateRequest(ctx context.Context
 		return nil, errors.New("parameter vpnSiteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsites_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNSitesClient contains the methods for the VPNSites group.
 // Don't use this type directly, use NewVPNSitesClient() instead.
 type VPNSitesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNSitesClient creates a new instance of VPNSitesClient with the specified values.
@@ -37,21 +34,13 @@ type VPNSitesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNSitesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNSitesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VPNSitesClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNSitesClientCreateOrUpdateResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNSitesClientCreateOrUpdateResponse]{
 			FinalStateVia: runtime.FinalStateViaAzureAsyncOp,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNSitesClientCreateOrUpdateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNSitesClientCreateOrUpdateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VPNSitesClient) createOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VPNSitesClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter vpnSiteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -137,11 +126,11 @@ func (client *VPNSitesClient) BeginDelete(ctx context.Context, resourceGroupName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNSitesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNSitesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNSitesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNSitesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -154,7 +143,7 @@ func (client *VPNSitesClient) deleteOperation(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +168,7 @@ func (client *VPNSitesClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter vpnSiteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +191,7 @@ func (client *VPNSitesClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return VPNSitesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNSitesClientGetResponse{}, err
 	}
@@ -227,7 +216,7 @@ func (client *VPNSitesClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter vpnSiteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +256,7 @@ func (client *VPNSitesClient) NewListPager(options *VPNSitesClientListOptions) *
 			if err != nil {
 				return VPNSitesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNSitesClientListResponse{}, err
 			}
@@ -286,7 +275,7 @@ func (client *VPNSitesClient) listCreateRequest(ctx context.Context, options *VP
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +317,7 @@ func (client *VPNSitesClient) NewListByResourceGroupPager(resourceGroupName stri
 			if err != nil {
 				return VPNSitesClientListByResourceGroupResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return VPNSitesClientListByResourceGroupResponse{}, err
 			}
@@ -351,7 +340,7 @@ func (client *VPNSitesClient) listByResourceGroupCreateRequest(ctx context.Conte
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -384,7 +373,7 @@ func (client *VPNSitesClient) UpdateTags(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return VPNSitesClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return VPNSitesClientUpdateTagsResponse{}, err
 	}
@@ -409,7 +398,7 @@ func (client *VPNSitesClient) updateTagsCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter vpnSiteName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{vpnSiteName}", url.PathEscape(vpnSiteName))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitesconfiguration_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // VPNSitesConfigurationClient contains the methods for the VPNSitesConfiguration group.
 // Don't use this type directly, use NewVPNSitesConfigurationClient() instead.
 type VPNSitesConfigurationClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewVPNSitesConfigurationClient creates a new instance of VPNSitesConfigurationClient with the specified values.
@@ -37,21 +34,13 @@ type VPNSitesConfigurationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesConfigurationClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.VPNSitesConfigurationClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &VPNSitesConfigurationClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -71,11 +60,11 @@ func (client *VPNSitesConfigurationClient) BeginDownload(ctx context.Context, re
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[VPNSitesConfigurationClientDownloadResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[VPNSitesConfigurationClientDownloadResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[VPNSitesConfigurationClientDownloadResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[VPNSitesConfigurationClientDownloadResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -88,7 +77,7 @@ func (client *VPNSitesConfigurationClient) download(ctx context.Context, resourc
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +102,7 @@ func (client *VPNSitesConfigurationClient) downloadCreateRequest(ctx context.Con
 		return nil, errors.New("parameter virtualWANName cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{virtualWANName}", url.PathEscape(virtualWANName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_watchers_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // WatchersClient contains the methods for the NetworkWatchers group.
 // Don't use this type directly, use NewWatchersClient() instead.
 type WatchersClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewWatchersClient creates a new instance of WatchersClient with the specified values.
@@ -37,21 +34,13 @@ type WatchersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WatchersClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.WatchersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &WatchersClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -72,11 +61,11 @@ func (client *WatchersClient) BeginCheckConnectivity(ctx context.Context, resour
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientCheckConnectivityResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientCheckConnectivityResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientCheckConnectivityResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientCheckConnectivityResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -90,7 +79,7 @@ func (client *WatchersClient) checkConnectivity(ctx context.Context, resourceGro
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +104,7 @@ func (client *WatchersClient) checkConnectivityCreateRequest(ctx context.Context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +128,7 @@ func (client *WatchersClient) CreateOrUpdate(ctx context.Context, resourceGroupN
 	if err != nil {
 		return WatchersClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WatchersClientCreateOrUpdateResponse{}, err
 	}
@@ -164,7 +153,7 @@ func (client *WatchersClient) createOrUpdateCreateRequest(ctx context.Context, r
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -197,11 +186,11 @@ func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -214,7 +203,7 @@ func (client *WatchersClient) deleteOperation(ctx context.Context, resourceGroup
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +228,7 @@ func (client *WatchersClient) deleteCreateRequest(ctx context.Context, resourceG
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +251,7 @@ func (client *WatchersClient) Get(ctx context.Context, resourceGroupName string,
 	if err != nil {
 		return WatchersClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WatchersClientGetResponse{}, err
 	}
@@ -287,7 +276,7 @@ func (client *WatchersClient) getCreateRequest(ctx context.Context, resourceGrou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -323,11 +312,11 @@ func (client *WatchersClient) BeginGetAzureReachabilityReport(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetAzureReachabilityReportResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetAzureReachabilityReportResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetAzureReachabilityReportResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetAzureReachabilityReportResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -341,7 +330,7 @@ func (client *WatchersClient) getAzureReachabilityReport(ctx context.Context, re
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +355,7 @@ func (client *WatchersClient) getAzureReachabilityReportCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -392,11 +381,11 @@ func (client *WatchersClient) BeginGetFlowLogStatus(ctx context.Context, resourc
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetFlowLogStatusResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetFlowLogStatusResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetFlowLogStatusResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetFlowLogStatusResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -409,7 +398,7 @@ func (client *WatchersClient) getFlowLogStatus(ctx context.Context, resourceGrou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +423,7 @@ func (client *WatchersClient) getFlowLogStatusCreateRequest(ctx context.Context,
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -464,11 +453,11 @@ func (client *WatchersClient) BeginGetNetworkConfigurationDiagnostic(ctx context
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetNetworkConfigurationDiagnosticResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetNetworkConfigurationDiagnosticResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetNetworkConfigurationDiagnosticResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetNetworkConfigurationDiagnosticResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -485,7 +474,7 @@ func (client *WatchersClient) getNetworkConfigurationDiagnostic(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +499,7 @@ func (client *WatchersClient) getNetworkConfigurationDiagnosticCreateRequest(ctx
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -536,11 +525,11 @@ func (client *WatchersClient) BeginGetNextHop(ctx context.Context, resourceGroup
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetNextHopResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetNextHopResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetNextHopResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetNextHopResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -553,7 +542,7 @@ func (client *WatchersClient) getNextHop(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -578,7 +567,7 @@ func (client *WatchersClient) getNextHopCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +591,7 @@ func (client *WatchersClient) GetTopology(ctx context.Context, resourceGroupName
 	if err != nil {
 		return WatchersClientGetTopologyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WatchersClientGetTopologyResponse{}, err
 	}
@@ -627,7 +616,7 @@ func (client *WatchersClient) getTopologyCreateRequest(ctx context.Context, reso
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -662,11 +651,11 @@ func (client *WatchersClient) BeginGetTroubleshooting(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetTroubleshootingResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetTroubleshootingResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetTroubleshootingResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetTroubleshootingResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -679,7 +668,7 @@ func (client *WatchersClient) getTroubleshooting(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +693,7 @@ func (client *WatchersClient) getTroubleshootingCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -730,11 +719,11 @@ func (client *WatchersClient) BeginGetTroubleshootingResult(ctx context.Context,
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetTroubleshootingResultResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetTroubleshootingResultResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetTroubleshootingResultResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetTroubleshootingResultResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -747,7 +736,7 @@ func (client *WatchersClient) getTroubleshootingResult(ctx context.Context, reso
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +761,7 @@ func (client *WatchersClient) getTroubleshootingResultCreateRequest(ctx context.
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -798,11 +787,11 @@ func (client *WatchersClient) BeginGetVMSecurityRules(ctx context.Context, resou
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientGetVMSecurityRulesResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientGetVMSecurityRulesResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientGetVMSecurityRulesResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientGetVMSecurityRulesResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -815,7 +804,7 @@ func (client *WatchersClient) getVMSecurityRules(ctx context.Context, resourceGr
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -840,7 +829,7 @@ func (client *WatchersClient) getVMSecurityRulesCreateRequest(ctx context.Contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -866,7 +855,7 @@ func (client *WatchersClient) NewListPager(resourceGroupName string, options *Wa
 			if err != nil {
 				return WatchersClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return WatchersClientListResponse{}, err
 			}
@@ -889,7 +878,7 @@ func (client *WatchersClient) listCreateRequest(ctx context.Context, resourceGro
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -923,7 +912,7 @@ func (client *WatchersClient) NewListAllPager(options *WatchersClientListAllOpti
 			if err != nil {
 				return WatchersClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return WatchersClientListAllResponse{}, err
 			}
@@ -942,7 +931,7 @@ func (client *WatchersClient) listAllCreateRequest(ctx context.Context, options 
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -978,11 +967,11 @@ func (client *WatchersClient) BeginListAvailableProviders(ctx context.Context, r
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientListAvailableProvidersResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientListAvailableProvidersResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientListAvailableProvidersResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientListAvailableProvidersResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -996,7 +985,7 @@ func (client *WatchersClient) listAvailableProviders(ctx context.Context, resour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1021,7 +1010,7 @@ func (client *WatchersClient) listAvailableProvidersCreateRequest(ctx context.Co
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1047,11 +1036,11 @@ func (client *WatchersClient) BeginSetFlowLogConfiguration(ctx context.Context, 
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientSetFlowLogConfigurationResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientSetFlowLogConfigurationResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientSetFlowLogConfigurationResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientSetFlowLogConfigurationResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1064,7 +1053,7 @@ func (client *WatchersClient) setFlowLogConfiguration(ctx context.Context, resou
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,7 +1078,7 @@ func (client *WatchersClient) setFlowLogConfigurationCreateRequest(ctx context.C
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1113,7 +1102,7 @@ func (client *WatchersClient) UpdateTags(ctx context.Context, resourceGroupName 
 	if err != nil {
 		return WatchersClientUpdateTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WatchersClientUpdateTagsResponse{}, err
 	}
@@ -1138,7 +1127,7 @@ func (client *WatchersClient) updateTagsCreateRequest(ctx context.Context, resou
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -1173,11 +1162,11 @@ func (client *WatchersClient) BeginVerifyIPFlow(ctx context.Context, resourceGro
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WatchersClientVerifyIPFlowResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WatchersClientVerifyIPFlowResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WatchersClientVerifyIPFlowResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WatchersClientVerifyIPFlowResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -1190,7 +1179,7 @@ func (client *WatchersClient) verifyIPFlow(ctx context.Context, resourceGroupNam
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -1215,7 +1204,7 @@ func (client *WatchersClient) verifyIPFlowCreateRequest(ctx context.Context, res
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_webapplicationfirewallpolicies_client.go
@@ -14,8 +14,6 @@ import (
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
-	armruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -26,9 +24,8 @@ import (
 // WebApplicationFirewallPoliciesClient contains the methods for the WebApplicationFirewallPolicies group.
 // Don't use this type directly, use NewWebApplicationFirewallPoliciesClient() instead.
 type WebApplicationFirewallPoliciesClient struct {
-	host           string
+	internal       *arm.Client
 	subscriptionID string
-	pl             runtime.Pipeline
 }
 
 // NewWebApplicationFirewallPoliciesClient creates a new instance of WebApplicationFirewallPoliciesClient with the specified values.
@@ -37,21 +34,13 @@ type WebApplicationFirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWebApplicationFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebApplicationFirewallPoliciesClient, error) {
-	if options == nil {
-		options = &arm.ClientOptions{}
-	}
-	ep := cloud.AzurePublic.Services[cloud.ResourceManager].Endpoint
-	if c, ok := options.Cloud.Services[cloud.ResourceManager]; ok {
-		ep = c.Endpoint
-	}
-	pl, err := armruntime.NewPipeline(moduleName, moduleVersion, credential, runtime.PipelineOptions{}, options)
+	cl, err := arm.NewClient("armnetwork.WebApplicationFirewallPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &WebApplicationFirewallPoliciesClient{
 		subscriptionID: subscriptionID,
-		host:           ep,
-		pl:             pl,
+		internal:       cl,
 	}
 	return client, nil
 }
@@ -70,7 +59,7 @@ func (client *WebApplicationFirewallPoliciesClient) CreateOrUpdate(ctx context.C
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientCreateOrUpdateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientCreateOrUpdateResponse{}, err
 	}
@@ -95,7 +84,7 @@ func (client *WebApplicationFirewallPoliciesClient) createOrUpdateCreateRequest(
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +118,11 @@ func (client *WebApplicationFirewallPoliciesClient) BeginDelete(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[WebApplicationFirewallPoliciesClientDeleteResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[WebApplicationFirewallPoliciesClientDeleteResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[WebApplicationFirewallPoliciesClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[WebApplicationFirewallPoliciesClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -146,7 +135,7 @@ func (client *WebApplicationFirewallPoliciesClient) deleteOperation(ctx context.
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +160,7 @@ func (client *WebApplicationFirewallPoliciesClient) deleteCreateRequest(ctx cont
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -195,7 +184,7 @@ func (client *WebApplicationFirewallPoliciesClient) Get(ctx context.Context, res
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WebApplicationFirewallPoliciesClientGetResponse{}, err
 	}
@@ -220,7 +209,7 @@ func (client *WebApplicationFirewallPoliciesClient) getCreateRequest(ctx context
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +251,7 @@ func (client *WebApplicationFirewallPoliciesClient) NewListPager(resourceGroupNa
 			if err != nil {
 				return WebApplicationFirewallPoliciesClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return WebApplicationFirewallPoliciesClientListResponse{}, err
 			}
@@ -285,7 +274,7 @@ func (client *WebApplicationFirewallPoliciesClient) listCreateRequest(ctx contex
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +315,7 @@ func (client *WebApplicationFirewallPoliciesClient) NewListAllPager(options *Web
 			if err != nil {
 				return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return WebApplicationFirewallPoliciesClientListAllResponse{}, err
 			}
@@ -345,7 +334,7 @@ func (client *WebApplicationFirewallPoliciesClient) listAllCreateRequest(ctx con
 		return nil, errors.New("parameter client.subscriptionID cannot be empty")
 	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.host, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/test/storage/2020-06-12/azblob/go.mod
+++ b/test/storage/2020-06-12/azblob/go.mod
@@ -2,10 +2,10 @@ module azstorage
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/storage/2020-06-12/azblob/go.sum
+++ b/test/storage/2020-06-12/azblob/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/storage/2020-06-12/azblob/zz_appendblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_appendblob_client.go
@@ -12,6 +12,7 @@ package azblob
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -20,23 +21,12 @@ import (
 	"time"
 )
 
-type appendBlobClient struct {
+// AppendBlobClient contains the methods for the AppendBlob group.
+// Don't use this type directly, use a constructor function instead.
+type AppendBlobClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum2
-	pl       runtime.Pipeline
-}
-
-// newAppendBlobClient creates a new instance of appendBlobClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newAppendBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *appendBlobClient {
-	client := &appendBlobClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // AppendBlock - The Append Block operation commits a new block of data to the end of an existing append blob. The Append
@@ -47,19 +37,19 @@ func newAppendBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *a
 // Generated from API version 2020-06-12
 //   - contentLength - The length of the request.
 //   - body - Initial data
-//   - options - AppendBlobClientAppendBlockOptions contains the optional parameters for the appendBlobClient.AppendBlock method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock
+//   - options - AppendBlobClientAppendBlockOptions contains the optional parameters for the AppendBlobClient.AppendBlock method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *appendBlobClient) AppendBlock(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *AppendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientAppendBlockResponse, error) {
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *AppendBlobClient) AppendBlock(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *AppendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientAppendBlockResponse, error) {
 	req, err := client.appendBlockCreateRequest(ctx, comp, contentLength, body, options, leaseAccessConditions, appendPositionAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return AppendBlobClientAppendBlockResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AppendBlobClientAppendBlockResponse{}, err
 	}
@@ -70,7 +60,7 @@ func (client *appendBlobClient) AppendBlock(ctx context.Context, comp Enum38, co
 }
 
 // appendBlockCreateRequest creates the AppendBlock request.
-func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *AppendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *AppendBlobClient) appendBlockCreateRequest(ctx context.Context, comp Enum38, contentLength int64, body io.ReadSeekCloser, options *AppendBlobClientAppendBlockOptions, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -133,7 +123,7 @@ func (client *appendBlobClient) appendBlockCreateRequest(ctx context.Context, co
 }
 
 // appendBlockHandleResponse handles the AppendBlock response.
-func (client *appendBlobClient) appendBlockHandleResponse(resp *http.Response) (AppendBlobClientAppendBlockResponse, error) {
+func (client *AppendBlobClient) appendBlockHandleResponse(resp *http.Response) (AppendBlobClientAppendBlockResponse, error) {
 	result := AppendBlobClientAppendBlockResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -210,22 +200,22 @@ func (client *appendBlobClient) appendBlockHandleResponse(resp *http.Response) (
 // Generated from API version 2020-06-12
 //   - sourceURL - Specify a URL to the copy source.
 //   - contentLength - The length of the request.
-//   - options - AppendBlobClientAppendBlockFromURLOptions contains the optional parameters for the appendBlobClient.AppendBlockFromURL
+//   - options - AppendBlobClientAppendBlockFromURLOptions contains the optional parameters for the AppendBlobClient.AppendBlockFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *AppendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (AppendBlobClientAppendBlockFromURLResponse, error) {
+func (client *AppendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *AppendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (AppendBlobClientAppendBlockFromURLResponse, error) {
 	req, err := client.appendBlockFromURLCreateRequest(ctx, comp, sourceURL, contentLength, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, appendPositionAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return AppendBlobClientAppendBlockFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AppendBlobClientAppendBlockFromURLResponse{}, err
 	}
@@ -236,7 +226,7 @@ func (client *appendBlobClient) AppendBlockFromURL(ctx context.Context, comp Enu
 }
 
 // appendBlockFromURLCreateRequest creates the AppendBlockFromURL request.
-func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *AppendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *AppendBlobClient) appendBlockFromURLCreateRequest(ctx context.Context, comp Enum38, sourceURL string, contentLength int64, options *AppendBlobClientAppendBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -318,7 +308,7 @@ func (client *appendBlobClient) appendBlockFromURLCreateRequest(ctx context.Cont
 }
 
 // appendBlockFromURLHandleResponse handles the AppendBlockFromURL response.
-func (client *appendBlobClient) appendBlockFromURLHandleResponse(resp *http.Response) (AppendBlobClientAppendBlockFromURLResponse, error) {
+func (client *AppendBlobClient) appendBlockFromURLHandleResponse(resp *http.Response) (AppendBlobClientAppendBlockFromURLResponse, error) {
 	result := AppendBlobClientAppendBlockFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -389,18 +379,18 @@ func (client *appendBlobClient) appendBlockFromURLHandleResponse(resp *http.Resp
 //
 // Generated from API version 2020-06-12
 //   - contentLength - The length of the request.
-//   - options - AppendBlobClientCreateOptions contains the optional parameters for the appendBlobClient.Create method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *appendBlobClient) Create(ctx context.Context, contentLength int64, options *AppendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientCreateResponse, error) {
+//   - options - AppendBlobClientCreateOptions contains the optional parameters for the AppendBlobClient.Create method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *AppendBlobClient) Create(ctx context.Context, contentLength int64, options *AppendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (AppendBlobClientCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, contentLength, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return AppendBlobClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AppendBlobClientCreateResponse{}, err
 	}
@@ -411,7 +401,7 @@ func (client *appendBlobClient) Create(ctx context.Context, contentLength int64,
 }
 
 // createCreateRequest creates the Create request.
-func (client *appendBlobClient) createCreateRequest(ctx context.Context, contentLength int64, options *AppendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *AppendBlobClient) createCreateRequest(ctx context.Context, contentLength int64, options *AppendBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -499,7 +489,7 @@ func (client *appendBlobClient) createCreateRequest(ctx context.Context, content
 }
 
 // createHandleResponse handles the Create response.
-func (client *appendBlobClient) createHandleResponse(resp *http.Response) (AppendBlobClientCreateResponse, error) {
+func (client *AppendBlobClient) createHandleResponse(resp *http.Response) (AppendBlobClientCreateResponse, error) {
 	result := AppendBlobClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -558,17 +548,17 @@ func (client *appendBlobClient) createHandleResponse(resp *http.Response) (Appen
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - AppendBlobClientSealOptions contains the optional parameters for the appendBlobClient.Seal method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock
+//   - options - AppendBlobClientSealOptions contains the optional parameters for the AppendBlobClient.Seal method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - AppendPositionAccessConditions - AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock
 //     method.
-func (client *appendBlobClient) Seal(ctx context.Context, comp Enum39, options *AppendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (AppendBlobClientSealResponse, error) {
+func (client *AppendBlobClient) Seal(ctx context.Context, comp Enum39, options *AppendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (AppendBlobClientSealResponse, error) {
 	req, err := client.sealCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions, appendPositionAccessConditions)
 	if err != nil {
 		return AppendBlobClientSealResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return AppendBlobClientSealResponse{}, err
 	}
@@ -579,7 +569,7 @@ func (client *appendBlobClient) Seal(ctx context.Context, comp Enum39, options *
 }
 
 // sealCreateRequest creates the Seal request.
-func (client *appendBlobClient) sealCreateRequest(ctx context.Context, comp Enum39, options *AppendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (*policy.Request, error) {
+func (client *AppendBlobClient) sealCreateRequest(ctx context.Context, comp Enum39, options *AppendBlobClientSealOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, appendPositionAccessConditions *AppendPositionAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -617,7 +607,7 @@ func (client *appendBlobClient) sealCreateRequest(ctx context.Context, comp Enum
 }
 
 // sealHandleResponse handles the Seal response.
-func (client *appendBlobClient) sealHandleResponse(resp *http.Response) (AppendBlobClientSealResponse, error) {
+func (client *AppendBlobClient) sealHandleResponse(resp *http.Response) (AppendBlobClientSealResponse, error) {
 	result := AppendBlobClientSealResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val

--- a/test/storage/2020-06-12/azblob/zz_blockblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_blockblob_client.go
@@ -12,6 +12,7 @@ package azblob
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -20,23 +21,12 @@ import (
 	"time"
 )
 
-type blockBlobClient struct {
+// BlockBlobClient contains the methods for the BlockBlob group.
+// Don't use this type directly, use a constructor function instead.
+type BlockBlobClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum2
-	pl       runtime.Pipeline
-}
-
-// newBlockBlobClient creates a new instance of blockBlobClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newBlockBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *blockBlobClient {
-	client := &blockBlobClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // CommitBlockList - The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob.
@@ -49,19 +39,19 @@ func newBlockBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *bl
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - BlockBlobClientCommitBlockListOptions contains the optional parameters for the blockBlobClient.CommitBlockList
+//   - options - BlockBlobClientCommitBlockListOptions contains the optional parameters for the BlockBlobClient.CommitBlockList
 //     method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) CommitBlockList(ctx context.Context, comp Enum34, blocks BlockLookupList, options *BlockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientCommitBlockListResponse, error) {
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *BlockBlobClient) CommitBlockList(ctx context.Context, comp Enum34, blocks BlockLookupList, options *BlockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientCommitBlockListResponse, error) {
 	req, err := client.commitBlockListCreateRequest(ctx, comp, blocks, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlockBlobClientCommitBlockListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientCommitBlockListResponse{}, err
 	}
@@ -72,7 +62,7 @@ func (client *blockBlobClient) CommitBlockList(ctx context.Context, comp Enum34,
 }
 
 // commitBlockListCreateRequest creates the CommitBlockList request.
-func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context, comp Enum34, blocks BlockLookupList, options *BlockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlockBlobClient) commitBlockListCreateRequest(ctx context.Context, comp Enum34, blocks BlockLookupList, options *BlockBlobClientCommitBlockListOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -168,7 +158,7 @@ func (client *blockBlobClient) commitBlockListCreateRequest(ctx context.Context,
 }
 
 // commitBlockListHandleResponse handles the CommitBlockList response.
-func (client *blockBlobClient) commitBlockListHandleResponse(resp *http.Response) (BlockBlobClientCommitBlockListResponse, error) {
+func (client *BlockBlobClient) commitBlockListHandleResponse(resp *http.Response) (BlockBlobClientCommitBlockListResponse, error) {
 	result := BlockBlobClientCommitBlockListResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -234,15 +224,15 @@ func (client *blockBlobClient) commitBlockListHandleResponse(resp *http.Response
 //
 // Generated from API version 2020-06-12
 //   - listType - Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists together.
-//   - options - BlockBlobClientGetBlockListOptions contains the optional parameters for the blockBlobClient.GetBlockList method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) GetBlockList(ctx context.Context, comp Enum34, listType BlockListType, options *BlockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientGetBlockListResponse, error) {
+//   - options - BlockBlobClientGetBlockListOptions contains the optional parameters for the BlockBlobClient.GetBlockList method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *BlockBlobClient) GetBlockList(ctx context.Context, comp Enum34, listType BlockListType, options *BlockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientGetBlockListResponse, error) {
 	req, err := client.getBlockListCreateRequest(ctx, comp, listType, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return BlockBlobClientGetBlockListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientGetBlockListResponse{}, err
 	}
@@ -253,7 +243,7 @@ func (client *blockBlobClient) GetBlockList(ctx context.Context, comp Enum34, li
 }
 
 // getBlockListCreateRequest creates the GetBlockList request.
-func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, comp Enum34, listType BlockListType, options *BlockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlockBlobClient) getBlockListCreateRequest(ctx context.Context, comp Enum34, listType BlockListType, options *BlockBlobClientGetBlockListOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -283,7 +273,7 @@ func (client *blockBlobClient) getBlockListCreateRequest(ctx context.Context, co
 }
 
 // getBlockListHandleResponse handles the GetBlockList response.
-func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (BlockBlobClientGetBlockListResponse, error) {
+func (client *BlockBlobClient) getBlockListHandleResponse(resp *http.Response) (BlockBlobClientGetBlockListResponse, error) {
 	result := BlockBlobClientGetBlockListResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -339,21 +329,21 @@ func (client *blockBlobClient) getBlockListHandleResponse(resp *http.Response) (
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - BlockBlobClientPutBlobFromURLOptions contains the optional parameters for the blockBlobClient.PutBlobFromURL
+//   - options - BlockBlobClientPutBlobFromURLOptions contains the optional parameters for the BlockBlobClient.PutBlobFromURL
 //     method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *blockBlobClient) PutBlobFromURL(ctx context.Context, contentLength int64, copySource string, options *BlockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientPutBlobFromURLResponse, error) {
+func (client *BlockBlobClient) PutBlobFromURL(ctx context.Context, contentLength int64, copySource string, options *BlockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientPutBlobFromURLResponse, error) {
 	req, err := client.putBlobFromURLCreateRequest(ctx, contentLength, copySource, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return BlockBlobClientPutBlobFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientPutBlobFromURLResponse{}, err
 	}
@@ -364,7 +354,7 @@ func (client *blockBlobClient) PutBlobFromURL(ctx context.Context, contentLength
 }
 
 // putBlobFromURLCreateRequest creates the PutBlobFromURL request.
-func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, contentLength int64, copySource string, options *BlockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, contentLength int64, copySource string, options *BlockBlobClientPutBlobFromURLOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -471,7 +461,7 @@ func (client *blockBlobClient) putBlobFromURLCreateRequest(ctx context.Context, 
 }
 
 // putBlobFromURLHandleResponse handles the PutBlobFromURL response.
-func (client *blockBlobClient) putBlobFromURLHandleResponse(resp *http.Response) (BlockBlobClientPutBlobFromURLResponse, error) {
+func (client *BlockBlobClient) putBlobFromURLHandleResponse(resp *http.Response) (BlockBlobClientPutBlobFromURLResponse, error) {
 	result := BlockBlobClientPutBlobFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -534,16 +524,16 @@ func (client *blockBlobClient) putBlobFromURLHandleResponse(resp *http.Response)
 //     parameter must be the same size for each block.
 //   - contentLength - The length of the request.
 //   - body - Initial data
-//   - options - BlockBlobClientStageBlockOptions contains the optional parameters for the blockBlobClient.StageBlock method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-func (client *blockBlobClient) StageBlock(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (BlockBlobClientStageBlockResponse, error) {
+//   - options - BlockBlobClientStageBlockOptions contains the optional parameters for the BlockBlobClient.StageBlock method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+func (client *BlockBlobClient) StageBlock(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (BlockBlobClientStageBlockResponse, error) {
 	req, err := client.stageBlockCreateRequest(ctx, comp, blockID, contentLength, body, options, leaseAccessConditions, cpkInfo, cpkScopeInfo)
 	if err != nil {
 		return BlockBlobClientStageBlockResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientStageBlockResponse{}, err
 	}
@@ -554,7 +544,7 @@ func (client *blockBlobClient) StageBlock(ctx context.Context, comp Enum33, bloc
 }
 
 // stageBlockCreateRequest creates the StageBlock request.
-func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
+func (client *BlockBlobClient) stageBlockCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientStageBlockOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -597,7 +587,7 @@ func (client *blockBlobClient) stageBlockCreateRequest(ctx context.Context, comp
 }
 
 // stageBlockHandleResponse handles the StageBlock response.
-func (client *blockBlobClient) stageBlockHandleResponse(resp *http.Response) (BlockBlobClientStageBlockResponse, error) {
+func (client *BlockBlobClient) stageBlockHandleResponse(resp *http.Response) (BlockBlobClientStageBlockResponse, error) {
 	result := BlockBlobClientStageBlockResponse{}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
@@ -655,19 +645,19 @@ func (client *blockBlobClient) stageBlockHandleResponse(resp *http.Response) (Bl
 //     parameter must be the same size for each block.
 //   - contentLength - The length of the request.
 //   - sourceURL - Specify a URL to the copy source.
-//   - options - BlockBlobClientStageBlockFromURLOptions contains the optional parameters for the blockBlobClient.StageBlockFromURL
+//   - options - BlockBlobClientStageBlockFromURLOptions contains the optional parameters for the BlockBlobClient.StageBlockFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *BlockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientStageBlockFromURLResponse, error) {
+func (client *BlockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *BlockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (BlockBlobClientStageBlockFromURLResponse, error) {
 	req, err := client.stageBlockFromURLCreateRequest(ctx, comp, blockID, contentLength, sourceURL, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return BlockBlobClientStageBlockFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientStageBlockFromURLResponse{}, err
 	}
@@ -678,7 +668,7 @@ func (client *blockBlobClient) StageBlockFromURL(ctx context.Context, comp Enum3
 }
 
 // stageBlockFromURLCreateRequest creates the StageBlockFromURL request.
-func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *BlockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlockBlobClient) stageBlockFromURLCreateRequest(ctx context.Context, comp Enum33, blockID string, contentLength int64, sourceURL string, options *BlockBlobClientStageBlockFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -737,7 +727,7 @@ func (client *blockBlobClient) stageBlockFromURLCreateRequest(ctx context.Contex
 }
 
 // stageBlockFromURLHandleResponse handles the StageBlockFromURL response.
-func (client *blockBlobClient) stageBlockFromURLHandleResponse(resp *http.Response) (BlockBlobClientStageBlockFromURLResponse, error) {
+func (client *BlockBlobClient) stageBlockFromURLHandleResponse(resp *http.Response) (BlockBlobClientStageBlockFromURLResponse, error) {
 	result := BlockBlobClientStageBlockFromURLResponse{}
 	if val := resp.Header.Get("Content-MD5"); val != "" {
 		contentMD5, err := base64.StdEncoding.DecodeString(val)
@@ -794,18 +784,18 @@ func (client *blockBlobClient) stageBlockFromURLHandleResponse(resp *http.Respon
 // Generated from API version 2020-06-12
 //   - contentLength - The length of the request.
 //   - body - Initial data
-//   - options - BlockBlobClientUploadOptions contains the optional parameters for the blockBlobClient.Upload method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientUploadResponse, error) {
+//   - options - BlockBlobClientUploadOptions contains the optional parameters for the BlockBlobClient.Upload method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *BlockBlobClient) Upload(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (BlockBlobClientUploadResponse, error) {
 	req, err := client.uploadCreateRequest(ctx, contentLength, body, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return BlockBlobClientUploadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BlockBlobClientUploadResponse{}, err
 	}
@@ -816,7 +806,7 @@ func (client *blockBlobClient) Upload(ctx context.Context, contentLength int64, 
 }
 
 // uploadCreateRequest creates the Upload request.
-func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *BlockBlobClient) uploadCreateRequest(ctx context.Context, contentLength int64, body io.ReadSeekCloser, options *BlockBlobClientUploadOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -910,7 +900,7 @@ func (client *blockBlobClient) uploadCreateRequest(ctx context.Context, contentL
 }
 
 // uploadHandleResponse handles the Upload response.
-func (client *blockBlobClient) uploadHandleResponse(resp *http.Response) (BlockBlobClientUploadResponse, error) {
+func (client *BlockBlobClient) uploadHandleResponse(resp *http.Response) (BlockBlobClientUploadResponse, error) {
 	result := BlockBlobClientUploadResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val

--- a/test/storage/2020-06-12/azblob/zz_client.go
+++ b/test/storage/2020-06-12/azblob/zz_client.go
@@ -12,6 +12,7 @@ package azblob
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -21,26 +22,13 @@ import (
 	"time"
 )
 
-type client struct {
+// Client contains the methods for the Blob group.
+// Don't use this type directly, use a constructor function instead.
+type Client struct {
+	internal       *azcore.Client
 	endpoint       string
 	version        Enum2
 	pathRenameMode *PathRenameMode
-	pl             runtime.Pipeline
-}
-
-// newClient creates a new instance of client with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pathRenameMode - Determines the behavior of the rename operation
-//   - pl - the pipeline used for sending requests and handling responses.
-func newClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, pl runtime.Pipeline) *client {
-	client := &client{
-		endpoint:       endpoint,
-		version:        version,
-		pathRenameMode: pathRenameMode,
-		pl:             pl,
-	}
-	return client
 }
 
 // AbortCopyFromURL - The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination
@@ -49,14 +37,14 @@ func newClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, p
 //
 // Generated from API version 2020-06-12
 //   - copyID - The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.
-//   - options - ClientAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (ClientAbortCopyFromURLResponse, error) {
+//   - options - ClientAbortCopyFromURLOptions contains the optional parameters for the Client.AbortCopyFromURL method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (ClientAbortCopyFromURLResponse, error) {
 	req, err := client.abortCopyFromURLCreateRequest(ctx, comp, copyActionAbortConstant, copyID, options, leaseAccessConditions)
 	if err != nil {
 		return ClientAbortCopyFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientAbortCopyFromURLResponse{}, err
 	}
@@ -67,7 +55,7 @@ func (client *client) AbortCopyFromURL(ctx context.Context, comp Enum30, copyAct
 }
 
 // abortCopyFromURLCreateRequest creates the AbortCopyFromURL request.
-func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) abortCopyFromURLCreateRequest(ctx context.Context, comp Enum30, copyActionAbortConstant Enum31, copyID string, options *ClientAbortCopyFromURLOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -92,7 +80,7 @@ func (client *client) abortCopyFromURLCreateRequest(ctx context.Context, comp En
 }
 
 // abortCopyFromURLHandleResponse handles the AbortCopyFromURL response.
-func (client *client) abortCopyFromURLHandleResponse(resp *http.Response) (ClientAbortCopyFromURLResponse, error) {
+func (client *Client) abortCopyFromURLHandleResponse(resp *http.Response) (ClientAbortCopyFromURLResponse, error) {
 	result := ClientAbortCopyFromURLResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -117,14 +105,14 @@ func (client *client) abortCopyFromURLHandleResponse(resp *http.Response) (Clien
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) AcquireLease(ctx context.Context, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientAcquireLeaseResponse, error) {
+//   - options - ClientAcquireLeaseOptions contains the optional parameters for the Client.AcquireLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) AcquireLease(ctx context.Context, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientAcquireLeaseResponse, error) {
 	req, err := client.acquireLeaseCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientAcquireLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientAcquireLeaseResponse{}, err
 	}
@@ -135,7 +123,7 @@ func (client *client) AcquireLease(ctx context.Context, comp Enum16, options *Cl
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, options *ClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -177,7 +165,7 @@ func (client *client) acquireLeaseCreateRequest(ctx context.Context, comp Enum16
 }
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
-func (client *client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcquireLeaseResponse, error) {
+func (client *Client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcquireLeaseResponse, error) {
 	result := ClientAcquireLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -215,14 +203,14 @@ func (client *client) acquireLeaseHandleResponse(resp *http.Response) (ClientAcq
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) BreakLease(ctx context.Context, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientBreakLeaseResponse, error) {
+//   - options - ClientBreakLeaseOptions contains the optional parameters for the Client.BreakLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) BreakLease(ctx context.Context, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientBreakLeaseResponse, error) {
 	req, err := client.breakLeaseCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientBreakLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientBreakLeaseResponse{}, err
 	}
@@ -233,7 +221,7 @@ func (client *client) BreakLease(ctx context.Context, comp Enum16, options *Clie
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, options *ClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -272,7 +260,7 @@ func (client *client) breakLeaseCreateRequest(ctx context.Context, comp Enum16, 
 }
 
 // breakLeaseHandleResponse handles the BreakLease response.
-func (client *client) breakLeaseHandleResponse(resp *http.Response) (ClientBreakLeaseResponse, error) {
+func (client *Client) breakLeaseHandleResponse(resp *http.Response) (ClientBreakLeaseResponse, error) {
 	result := ClientBreakLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -319,14 +307,14 @@ func (client *client) breakLeaseHandleResponse(resp *http.Response) (ClientBreak
 //   - proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 //     lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 //     string formats.
-//   - options - ClientChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientChangeLeaseResponse, error) {
+//   - options - ClientChangeLeaseOptions contains the optional parameters for the Client.ChangeLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) ChangeLease(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientChangeLeaseResponse, error) {
 	req, err := client.changeLeaseCreateRequest(ctx, comp, leaseID, proposedLeaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientChangeLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientChangeLeaseResponse{}, err
 	}
@@ -337,7 +325,7 @@ func (client *client) ChangeLease(ctx context.Context, comp Enum16, leaseID stri
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) changeLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, proposedLeaseID string, options *ClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -375,7 +363,7 @@ func (client *client) changeLeaseCreateRequest(ctx context.Context, comp Enum16,
 }
 
 // changeLeaseHandleResponse handles the ChangeLease response.
-func (client *client) changeLeaseHandleResponse(resp *http.Response) (ClientChangeLeaseResponse, error) {
+func (client *Client) changeLeaseHandleResponse(resp *http.Response) (ClientChangeLeaseResponse, error) {
 	result := ClientChangeLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -417,17 +405,17 @@ func (client *client) changeLeaseHandleResponse(resp *http.Response) (ClientChan
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - ClientCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - options - ClientCopyFromURLOptions contains the optional parameters for the Client.CopyFromURL method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientCopyFromURLResponse, error) {
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientCopyFromURLResponse, error) {
 	req, err := client.copyFromURLCreateRequest(ctx, xmsRequiresSync, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return ClientCopyFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCopyFromURLResponse{}, err
 	}
@@ -438,7 +426,7 @@ func (client *client) CopyFromURL(ctx context.Context, xmsRequiresSync Enum29, c
 }
 
 // copyFromURLCreateRequest creates the CopyFromURL request.
-func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresSync Enum29, copySource string, options *ClientCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -514,7 +502,7 @@ func (client *client) copyFromURLCreateRequest(ctx context.Context, xmsRequiresS
 }
 
 // copyFromURLHandleResponse handles the CopyFromURL response.
-func (client *client) copyFromURLHandleResponse(resp *http.Response) (ClientCopyFromURLResponse, error) {
+func (client *Client) copyFromURLHandleResponse(resp *http.Response) (ClientCopyFromURLResponse, error) {
 	result := ClientCopyFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -572,17 +560,17 @@ func (client *client) copyFromURLHandleResponse(resp *http.Response) (ClientCopy
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientCreateSnapshotResponse, error) {
+//   - options - ClientCreateSnapshotOptions contains the optional parameters for the Client.CreateSnapshot method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) CreateSnapshot(ctx context.Context, comp Enum28, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientCreateSnapshotResponse, error) {
 	req, err := client.createSnapshotCreateRequest(ctx, comp, options, cpkInfo, cpkScopeInfo, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return ClientCreateSnapshotResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCreateSnapshotResponse{}, err
 	}
@@ -593,7 +581,7 @@ func (client *client) CreateSnapshot(ctx context.Context, comp Enum28, options *
 }
 
 // createSnapshotCreateRequest creates the CreateSnapshot request.
-func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum28, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) createSnapshotCreateRequest(ctx context.Context, comp Enum28, options *ClientCreateSnapshotOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -650,7 +638,7 @@ func (client *client) createSnapshotCreateRequest(ctx context.Context, comp Enum
 }
 
 // createSnapshotHandleResponse handles the CreateSnapshot response.
-func (client *client) createSnapshotHandleResponse(resp *http.Response) (ClientCreateSnapshotResponse, error) {
+func (client *Client) createSnapshotHandleResponse(resp *http.Response) (ClientCreateSnapshotResponse, error) {
 	result := ClientCreateSnapshotResponse{}
 	if val := resp.Header.Get("x-ms-snapshot"); val != "" {
 		result.Snapshot = &val
@@ -708,15 +696,15 @@ func (client *client) createSnapshotHandleResponse(resp *http.Response) (ClientC
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientDeleteOptions contains the optional parameters for the client.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Delete(ctx context.Context, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientDeleteResponse, error) {
+//   - options - ClientDeleteOptions contains the optional parameters for the Client.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) Delete(ctx context.Context, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientDeleteResponse, error) {
 	req, err := client.deleteCreateRequest(ctx, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteResponse{}, err
 	}
@@ -727,7 +715,7 @@ func (client *client) Delete(ctx context.Context, options *ClientDeleteOptions, 
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *client) deleteCreateRequest(ctx context.Context, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) deleteCreateRequest(ctx context.Context, options *ClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -776,7 +764,7 @@ func (client *client) deleteCreateRequest(ctx context.Context, options *ClientDe
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *client) deleteHandleResponse(resp *http.Response) (ClientDeleteResponse, error) {
+func (client *Client) deleteHandleResponse(resp *http.Response) (ClientDeleteResponse, error) {
 	result := ClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -801,14 +789,14 @@ func (client *client) deleteHandleResponse(resp *http.Response) (ClientDeleteRes
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the client.DeleteImmutabilityPolicy
+//   - options - ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the Client.DeleteImmutabilityPolicy
 //     method.
-func (client *client) DeleteImmutabilityPolicy(ctx context.Context, comp Enum26, options *ClientDeleteImmutabilityPolicyOptions) (ClientDeleteImmutabilityPolicyResponse, error) {
+func (client *Client) DeleteImmutabilityPolicy(ctx context.Context, comp Enum26, options *ClientDeleteImmutabilityPolicyOptions) (ClientDeleteImmutabilityPolicyResponse, error) {
 	req, err := client.deleteImmutabilityPolicyCreateRequest(ctx, comp, options)
 	if err != nil {
 		return ClientDeleteImmutabilityPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteImmutabilityPolicyResponse{}, err
 	}
@@ -819,7 +807,7 @@ func (client *client) DeleteImmutabilityPolicy(ctx context.Context, comp Enum26,
 }
 
 // deleteImmutabilityPolicyCreateRequest creates the DeleteImmutabilityPolicy request.
-func (client *client) deleteImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *ClientDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
+func (client *Client) deleteImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *ClientDeleteImmutabilityPolicyOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -839,7 +827,7 @@ func (client *client) deleteImmutabilityPolicyCreateRequest(ctx context.Context,
 }
 
 // deleteImmutabilityPolicyHandleResponse handles the DeleteImmutabilityPolicy response.
-func (client *client) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (ClientDeleteImmutabilityPolicyResponse, error) {
+func (client *Client) deleteImmutabilityPolicyHandleResponse(resp *http.Response) (ClientDeleteImmutabilityPolicyResponse, error) {
 	result := ClientDeleteImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -865,16 +853,16 @@ func (client *client) deleteImmutabilityPolicyHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientDownloadOptions contains the optional parameters for the client.Download method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Download(ctx context.Context, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientDownloadResponse, error) {
+//   - options - ClientDownloadOptions contains the optional parameters for the Client.Download method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) Download(ctx context.Context, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientDownloadResponse, error) {
 	req, err := client.downloadCreateRequest(ctx, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return ClientDownloadResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDownloadResponse{}, err
 	}
@@ -885,7 +873,7 @@ func (client *client) Download(ctx context.Context, options *ClientDownloadOptio
 }
 
 // downloadCreateRequest creates the Download request.
-func (client *client) downloadCreateRequest(ctx context.Context, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) downloadCreateRequest(ctx context.Context, options *ClientDownloadOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -947,7 +935,7 @@ func (client *client) downloadCreateRequest(ctx context.Context, options *Client
 }
 
 // downloadHandleResponse handles the Download response.
-func (client *client) downloadHandleResponse(resp *http.Response) (ClientDownloadResponse, error) {
+func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloadResponse, error) {
 	result := ClientDownloadResponse{Body: resp.Body}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1160,15 +1148,15 @@ func (client *client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientGetAccessControlOptions contains the optional parameters for the client.GetAccessControl method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) GetAccessControl(ctx context.Context, action Enum22, options *ClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientGetAccessControlResponse, error) {
+//   - options - ClientGetAccessControlOptions contains the optional parameters for the Client.GetAccessControl method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) GetAccessControl(ctx context.Context, action Enum22, options *ClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientGetAccessControlResponse, error) {
 	req, err := client.getAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ClientGetAccessControlResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetAccessControlResponse{}, err
 	}
@@ -1179,7 +1167,7 @@ func (client *client) GetAccessControl(ctx context.Context, action Enum22, optio
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
-func (client *client) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *ClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *ClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1217,7 +1205,7 @@ func (client *client) getAccessControlCreateRequest(ctx context.Context, action 
 }
 
 // getAccessControlHandleResponse handles the GetAccessControl response.
-func (client *client) getAccessControlHandleResponse(resp *http.Response) (ClientGetAccessControlResponse, error) {
+func (client *Client) getAccessControlHandleResponse(resp *http.Response) (ClientGetAccessControlResponse, error) {
 	result := ClientGetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -1261,13 +1249,13 @@ func (client *client) getAccessControlHandleResponse(resp *http.Response) (Clien
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientGetAccountInfoOptions contains the optional parameters for the client.GetAccountInfo method.
-func (client *client) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ClientGetAccountInfoOptions) (ClientGetAccountInfoResponse, error) {
+//   - options - ClientGetAccountInfoOptions contains the optional parameters for the Client.GetAccountInfo method.
+func (client *Client) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ClientGetAccountInfoOptions) (ClientGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ClientGetAccountInfoResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetAccountInfoResponse{}, err
 	}
@@ -1278,7 +1266,7 @@ func (client *client) GetAccountInfo(ctx context.Context, restype Enum8, comp En
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *client) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ClientGetAccountInfoOptions) (*policy.Request, error) {
+func (client *Client) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ClientGetAccountInfoOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1293,7 +1281,7 @@ func (client *client) getAccountInfoCreateRequest(ctx context.Context, restype E
 }
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
-func (client *client) getAccountInfoHandleResponse(resp *http.Response) (ClientGetAccountInfoResponse, error) {
+func (client *Client) getAccountInfoHandleResponse(resp *http.Response) (ClientGetAccountInfoResponse, error) {
 	result := ClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1325,16 +1313,16 @@ func (client *client) getAccountInfoHandleResponse(resp *http.Response) (ClientG
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) GetProperties(ctx context.Context, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientGetPropertiesResponse, error) {
+//   - options - ClientGetPropertiesOptions contains the optional parameters for the Client.GetProperties method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) GetProperties(ctx context.Context, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientGetPropertiesResponse, error) {
 	req, err := client.getPropertiesCreateRequest(ctx, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return ClientGetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetPropertiesResponse{}, err
 	}
@@ -1345,7 +1333,7 @@ func (client *client) GetProperties(ctx context.Context, options *ClientGetPrope
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *client) getPropertiesCreateRequest(ctx context.Context, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) getPropertiesCreateRequest(ctx context.Context, options *ClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1397,7 +1385,7 @@ func (client *client) getPropertiesCreateRequest(ctx context.Context, options *C
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *client) getPropertiesHandleResponse(resp *http.Response) (ClientGetPropertiesResponse, error) {
+func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGetPropertiesResponse, error) {
 	result := ClientGetPropertiesResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1640,15 +1628,15 @@ func (client *client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientGetTagsOptions contains the optional parameters for the client.GetTags method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) GetTags(ctx context.Context, comp Enum42, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientGetTagsResponse, error) {
+//   - options - ClientGetTagsOptions contains the optional parameters for the Client.GetTags method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) GetTags(ctx context.Context, comp Enum42, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientGetTagsResponse, error) {
 	req, err := client.getTagsCreateRequest(ctx, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return ClientGetTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetTagsResponse{}, err
 	}
@@ -1659,7 +1647,7 @@ func (client *client) GetTags(ctx context.Context, comp Enum42, options *ClientG
 }
 
 // getTagsCreateRequest creates the GetTags request.
-func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) getTagsCreateRequest(ctx context.Context, comp Enum42, options *ClientGetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1691,7 +1679,7 @@ func (client *client) getTagsCreateRequest(ctx context.Context, comp Enum42, opt
 }
 
 // getTagsHandleResponse handles the GetTags response.
-func (client *client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsResponse, error) {
+func (client *Client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsResponse, error) {
 	result := ClientGetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1719,16 +1707,16 @@ func (client *client) getTagsHandleResponse(resp *http.Response) (ClientGetTagsR
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientQueryOptions contains the optional parameters for the client.Query method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) Query(ctx context.Context, comp Enum40, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientQueryResponse, error) {
+//   - options - ClientQueryOptions contains the optional parameters for the Client.Query method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) Query(ctx context.Context, comp Enum40, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientQueryResponse, error) {
 	req, err := client.queryCreateRequest(ctx, comp, options, leaseAccessConditions, cpkInfo, modifiedAccessConditions)
 	if err != nil {
 		return ClientQueryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientQueryResponse{}, err
 	}
@@ -1739,7 +1727,7 @@ func (client *client) Query(ctx context.Context, comp Enum40, options *ClientQue
 }
 
 // queryCreateRequest creates the Query request.
-func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) queryCreateRequest(ctx context.Context, comp Enum40, options *ClientQueryOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1793,7 +1781,7 @@ func (client *client) queryCreateRequest(ctx context.Context, comp Enum40, optio
 }
 
 // queryHandleResponse handles the Query response.
-func (client *client) queryHandleResponse(resp *http.Response) (ClientQueryResponse, error) {
+func (client *Client) queryHandleResponse(resp *http.Response) (ClientQueryResponse, error) {
 	result := ClientQueryResponse{Body: resp.Body}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -1948,14 +1936,14 @@ func (client *client) queryHandleResponse(resp *http.Response) (ClientQueryRespo
 //
 // Generated from API version 2020-06-12
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ClientReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientReleaseLeaseResponse, error) {
+//   - options - ClientReleaseLeaseOptions contains the optional parameters for the Client.ReleaseLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) ReleaseLease(ctx context.Context, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientReleaseLeaseResponse, error) {
 	req, err := client.releaseLeaseCreateRequest(ctx, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientReleaseLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientReleaseLeaseResponse{}, err
 	}
@@ -1966,7 +1954,7 @@ func (client *client) ReleaseLease(ctx context.Context, comp Enum16, leaseID str
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *ClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2003,7 +1991,7 @@ func (client *client) releaseLeaseCreateRequest(ctx context.Context, comp Enum16
 }
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
-func (client *client) releaseLeaseHandleResponse(resp *http.Response) (ClientReleaseLeaseResponse, error) {
+func (client *Client) releaseLeaseHandleResponse(resp *http.Response) (ClientReleaseLeaseResponse, error) {
 	result := ClientReleaseLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2045,18 +2033,18 @@ func (client *client) releaseLeaseHandleResponse(resp *http.Response) (ClientRel
 //   - renameSource - The file or directory to be renamed. The value must have the following format: "/{filesysystem}/{path}".
 //     If "x-ms-properties" is specified, the properties will overwrite the existing properties;
 //     otherwise, the existing properties will be preserved.
-//   - options - ClientRenameOptions contains the optional parameters for the client.Rename method.
-//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - options - ClientRenameOptions contains the optional parameters for the Client.Rename method.
+//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the DirectoryClient.Create method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *client) Rename(ctx context.Context, renameSource string, options *ClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (ClientRenameResponse, error) {
+func (client *Client) Rename(ctx context.Context, renameSource string, options *ClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (ClientRenameResponse, error) {
 	req, err := client.renameCreateRequest(ctx, renameSource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return ClientRenameResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRenameResponse{}, err
 	}
@@ -2067,7 +2055,7 @@ func (client *client) Rename(ctx context.Context, renameSource string, options *
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *client) renameCreateRequest(ctx context.Context, renameSource string, options *ClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) renameCreateRequest(ctx context.Context, renameSource string, options *ClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2144,7 +2132,7 @@ func (client *client) renameCreateRequest(ctx context.Context, renameSource stri
 }
 
 // renameHandleResponse handles the Rename response.
-func (client *client) renameHandleResponse(resp *http.Response) (ClientRenameResponse, error) {
+func (client *Client) renameHandleResponse(resp *http.Response) (ClientRenameResponse, error) {
 	result := ClientRenameResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2187,14 +2175,14 @@ func (client *client) renameHandleResponse(resp *http.Response) (ClientRenameRes
 //
 // Generated from API version 2020-06-12
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ClientRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientRenewLeaseResponse, error) {
+//   - options - ClientRenewLeaseOptions contains the optional parameters for the Client.RenewLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) RenewLease(ctx context.Context, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientRenewLeaseResponse, error) {
 	req, err := client.renewLeaseCreateRequest(ctx, comp, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientRenewLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientRenewLeaseResponse{}, err
 	}
@@ -2205,7 +2193,7 @@ func (client *client) RenewLease(ctx context.Context, comp Enum16, leaseID strin
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, leaseID string, options *ClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2242,7 +2230,7 @@ func (client *client) renewLeaseCreateRequest(ctx context.Context, comp Enum16, 
 }
 
 // renewLeaseHandleResponse handles the RenewLease response.
-func (client *client) renewLeaseHandleResponse(resp *http.Response) (ClientRenewLeaseResponse, error) {
+func (client *Client) renewLeaseHandleResponse(resp *http.Response) (ClientRenewLeaseResponse, error) {
 	result := ClientRenewLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2280,15 +2268,15 @@ func (client *client) renewLeaseHandleResponse(resp *http.Response) (ClientRenew
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientSetAccessControlOptions contains the optional parameters for the client.SetAccessControl method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetAccessControl(ctx context.Context, action Enum21, options *ClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetAccessControlResponse, error) {
+//   - options - ClientSetAccessControlOptions contains the optional parameters for the Client.SetAccessControl method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) SetAccessControl(ctx context.Context, action Enum21, options *ClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetAccessControlResponse, error) {
 	req, err := client.setAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ClientSetAccessControlResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetAccessControlResponse{}, err
 	}
@@ -2299,7 +2287,7 @@ func (client *client) SetAccessControl(ctx context.Context, action Enum21, optio
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
-func (client *client) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *ClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *ClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2346,7 +2334,7 @@ func (client *client) setAccessControlCreateRequest(ctx context.Context, action 
 }
 
 // setAccessControlHandleResponse handles the SetAccessControl response.
-func (client *client) setAccessControlHandleResponse(resp *http.Response) (ClientSetAccessControlResponse, error) {
+func (client *Client) setAccessControlHandleResponse(resp *http.Response) (ClientSetAccessControlResponse, error) {
 	result := ClientSetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -2379,13 +2367,13 @@ func (client *client) setAccessControlHandleResponse(resp *http.Response) (Clien
 //
 // Generated from API version 2020-06-12
 //   - expiryOptions - Required. Indicates mode of the expiry time
-//   - options - ClientSetExpiryOptions contains the optional parameters for the client.SetExpiry method.
-func (client *client) SetExpiry(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (ClientSetExpiryResponse, error) {
+//   - options - ClientSetExpiryOptions contains the optional parameters for the Client.SetExpiry method.
+func (client *Client) SetExpiry(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (ClientSetExpiryResponse, error) {
 	req, err := client.setExpiryCreateRequest(ctx, comp, expiryOptions, options)
 	if err != nil {
 		return ClientSetExpiryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetExpiryResponse{}, err
 	}
@@ -2396,7 +2384,7 @@ func (client *client) SetExpiry(ctx context.Context, comp Enum24, expiryOptions 
 }
 
 // setExpiryCreateRequest creates the SetExpiry request.
-func (client *client) setExpiryCreateRequest(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (*policy.Request, error) {
+func (client *Client) setExpiryCreateRequest(ctx context.Context, comp Enum24, expiryOptions BlobExpiryOptions, options *ClientSetExpiryOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2420,7 +2408,7 @@ func (client *client) setExpiryCreateRequest(ctx context.Context, comp Enum24, e
 }
 
 // setExpiryHandleResponse handles the SetExpiry response.
-func (client *client) setExpiryHandleResponse(resp *http.Response) (ClientSetExpiryResponse, error) {
+func (client *Client) setExpiryHandleResponse(resp *http.Response) (ClientSetExpiryResponse, error) {
 	result := ClientSetExpiryResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2455,16 +2443,16 @@ func (client *client) setExpiryHandleResponse(resp *http.Response) (ClientSetExp
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetHTTPHeadersResponse, error) {
+//   - options - ClientSetHTTPHeadersOptions contains the optional parameters for the Client.SetHTTPHeaders method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) SetHTTPHeaders(ctx context.Context, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetHTTPHeadersResponse, error) {
 	req, err := client.setHTTPHeadersCreateRequest(ctx, comp, options, blobHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ClientSetHTTPHeadersResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetHTTPHeadersResponse{}, err
 	}
@@ -2475,7 +2463,7 @@ func (client *client) SetHTTPHeaders(ctx context.Context, comp Enum1, options *C
 }
 
 // setHTTPHeadersCreateRequest creates the SetHTTPHeaders request.
-func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum1, options *ClientSetHTTPHeadersOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2531,7 +2519,7 @@ func (client *client) setHTTPHeadersCreateRequest(ctx context.Context, comp Enum
 }
 
 // setHTTPHeadersHandleResponse handles the SetHTTPHeaders response.
-func (client *client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientSetHTTPHeadersResponse, error) {
+func (client *Client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientSetHTTPHeadersResponse, error) {
 	result := ClientSetHTTPHeadersResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2573,14 +2561,14 @@ func (client *client) setHTTPHeadersHandleResponse(resp *http.Response) (ClientS
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetImmutabilityPolicyResponse, error) {
+//   - options - ClientSetImmutabilityPolicyOptions contains the optional parameters for the Client.SetImmutabilityPolicy method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetImmutabilityPolicyResponse, error) {
 	req, err := client.setImmutabilityPolicyCreateRequest(ctx, comp, options, modifiedAccessConditions)
 	if err != nil {
 		return ClientSetImmutabilityPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetImmutabilityPolicyResponse{}, err
 	}
@@ -2591,7 +2579,7 @@ func (client *client) SetImmutabilityPolicy(ctx context.Context, comp Enum26, op
 }
 
 // setImmutabilityPolicyCreateRequest creates the SetImmutabilityPolicy request.
-func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) setImmutabilityPolicyCreateRequest(ctx context.Context, comp Enum26, options *ClientSetImmutabilityPolicyOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2620,7 +2608,7 @@ func (client *client) setImmutabilityPolicyCreateRequest(ctx context.Context, co
 }
 
 // setImmutabilityPolicyHandleResponse handles the SetImmutabilityPolicy response.
-func (client *client) setImmutabilityPolicyHandleResponse(resp *http.Response) (ClientSetImmutabilityPolicyResponse, error) {
+func (client *Client) setImmutabilityPolicyHandleResponse(resp *http.Response) (ClientSetImmutabilityPolicyResponse, error) {
 	result := ClientSetImmutabilityPolicyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2656,13 +2644,13 @@ func (client *client) setImmutabilityPolicyHandleResponse(resp *http.Response) (
 //
 // Generated from API version 2020-06-12
 //   - legalHold - Specified if a legal hold should be set on the blob.
-//   - options - ClientSetLegalHoldOptions contains the optional parameters for the client.SetLegalHold method.
-func (client *client) SetLegalHold(ctx context.Context, comp Enum27, legalHold bool, options *ClientSetLegalHoldOptions) (ClientSetLegalHoldResponse, error) {
+//   - options - ClientSetLegalHoldOptions contains the optional parameters for the Client.SetLegalHold method.
+func (client *Client) SetLegalHold(ctx context.Context, comp Enum27, legalHold bool, options *ClientSetLegalHoldOptions) (ClientSetLegalHoldResponse, error) {
 	req, err := client.setLegalHoldCreateRequest(ctx, comp, legalHold, options)
 	if err != nil {
 		return ClientSetLegalHoldResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetLegalHoldResponse{}, err
 	}
@@ -2673,7 +2661,7 @@ func (client *client) SetLegalHold(ctx context.Context, comp Enum27, legalHold b
 }
 
 // setLegalHoldCreateRequest creates the SetLegalHold request.
-func (client *client) setLegalHoldCreateRequest(ctx context.Context, comp Enum27, legalHold bool, options *ClientSetLegalHoldOptions) (*policy.Request, error) {
+func (client *Client) setLegalHoldCreateRequest(ctx context.Context, comp Enum27, legalHold bool, options *ClientSetLegalHoldOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2694,7 +2682,7 @@ func (client *client) setLegalHoldCreateRequest(ctx context.Context, comp Enum27
 }
 
 // setLegalHoldHandleResponse handles the SetLegalHold response.
-func (client *client) setLegalHoldHandleResponse(resp *http.Response) (ClientSetLegalHoldResponse, error) {
+func (client *Client) setLegalHoldHandleResponse(resp *http.Response) (ClientSetLegalHoldResponse, error) {
 	result := ClientSetLegalHoldResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2727,17 +2715,17 @@ func (client *client) setLegalHoldHandleResponse(resp *http.Response) (ClientSet
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetMetadata(ctx context.Context, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetMetadataResponse, error) {
+//   - options - ClientSetMetadataOptions contains the optional parameters for the Client.SetMetadata method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) SetMetadata(ctx context.Context, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetMetadataResponse, error) {
 	req, err := client.setMetadataCreateRequest(ctx, comp, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return ClientSetMetadataResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetMetadataResponse{}, err
 	}
@@ -2748,7 +2736,7 @@ func (client *client) SetMetadata(ctx context.Context, comp Enum12, options *Cli
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) setMetadataCreateRequest(ctx context.Context, comp Enum12, options *ClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2805,7 +2793,7 @@ func (client *client) setMetadataCreateRequest(ctx context.Context, comp Enum12,
 }
 
 // setMetadataHandleResponse handles the SetMetadata response.
-func (client *client) setMetadataHandleResponse(resp *http.Response) (ClientSetMetadataResponse, error) {
+func (client *Client) setMetadataHandleResponse(resp *http.Response) (ClientSetMetadataResponse, error) {
 	result := ClientSetMetadataResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -2856,15 +2844,15 @@ func (client *client) setMetadataHandleResponse(resp *http.Response) (ClientSetM
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientSetTagsOptions contains the optional parameters for the client.SetTags method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) SetTags(ctx context.Context, comp Enum42, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientSetTagsResponse, error) {
+//   - options - ClientSetTagsOptions contains the optional parameters for the Client.SetTags method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) SetTags(ctx context.Context, comp Enum42, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientSetTagsResponse, error) {
 	req, err := client.setTagsCreateRequest(ctx, comp, options, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return ClientSetTagsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetTagsResponse{}, err
 	}
@@ -2875,7 +2863,7 @@ func (client *client) SetTags(ctx context.Context, comp Enum42, options *ClientS
 }
 
 // setTagsCreateRequest creates the SetTags request.
-func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) setTagsCreateRequest(ctx context.Context, comp Enum42, options *ClientSetTagsOptions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2913,7 +2901,7 @@ func (client *client) setTagsCreateRequest(ctx context.Context, comp Enum42, opt
 }
 
 // setTagsHandleResponse handles the SetTags response.
-func (client *client) setTagsHandleResponse(resp *http.Response) (ClientSetTagsResponse, error) {
+func (client *Client) setTagsHandleResponse(resp *http.Response) (ClientSetTagsResponse, error) {
 	result := ClientSetTagsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -2942,15 +2930,15 @@ func (client *client) setTagsHandleResponse(resp *http.Response) (ClientSetTagsR
 //
 // Generated from API version 2020-06-12
 //   - tier - Indicates the tier to be set on the blob.
-//   - options - ClientSetTierOptions contains the optional parameters for the client.SetTier method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetTierResponse, error) {
+//   - options - ClientSetTierOptions contains the optional parameters for the Client.SetTier method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *Client) SetTier(ctx context.Context, comp Enum32, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ClientSetTierResponse, error) {
 	req, err := client.setTierCreateRequest(ctx, comp, tier, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ClientSetTierResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetTierResponse{}, err
 	}
@@ -2961,7 +2949,7 @@ func (client *client) SetTier(ctx context.Context, comp Enum32, tier AccessTier,
 }
 
 // setTierCreateRequest creates the SetTier request.
-func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *Client) setTierCreateRequest(ctx context.Context, comp Enum32, tier AccessTier, options *ClientSetTierOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -2997,7 +2985,7 @@ func (client *client) setTierCreateRequest(ctx context.Context, comp Enum32, tie
 }
 
 // setTierHandleResponse handles the SetTier response.
-func (client *client) setTierHandleResponse(resp *http.Response) (ClientSetTierResponse, error) {
+func (client *Client) setTierHandleResponse(resp *http.Response) (ClientSetTierResponse, error) {
 	result := ClientSetTierResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -3018,17 +3006,17 @@ func (client *client) setTierHandleResponse(resp *http.Response) (ClientSetTierR
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - ClientStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - options - ClientStartCopyFromURLOptions contains the optional parameters for the Client.StartCopyFromURL method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *client) StartCopyFromURL(ctx context.Context, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientStartCopyFromURLResponse, error) {
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *Client) StartCopyFromURL(ctx context.Context, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (ClientStartCopyFromURLResponse, error) {
 	req, err := client.startCopyFromURLCreateRequest(ctx, copySource, options, sourceModifiedAccessConditions, modifiedAccessConditions, leaseAccessConditions)
 	if err != nil {
 		return ClientStartCopyFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientStartCopyFromURLResponse{}, err
 	}
@@ -3039,7 +3027,7 @@ func (client *client) StartCopyFromURL(ctx context.Context, copySource string, o
 }
 
 // startCopyFromURLCreateRequest creates the StartCopyFromURL request.
-func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *Client) startCopyFromURLCreateRequest(ctx context.Context, copySource string, options *ClientStartCopyFromURLOptions, sourceModifiedAccessConditions *SourceModifiedAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3120,7 +3108,7 @@ func (client *client) startCopyFromURLCreateRequest(ctx context.Context, copySou
 }
 
 // startCopyFromURLHandleResponse handles the StartCopyFromURL response.
-func (client *client) startCopyFromURLHandleResponse(resp *http.Response) (ClientStartCopyFromURLResponse, error) {
+func (client *Client) startCopyFromURLHandleResponse(resp *http.Response) (ClientStartCopyFromURLResponse, error) {
 	result := ClientStartCopyFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -3164,13 +3152,13 @@ func (client *client) startCopyFromURLHandleResponse(resp *http.Response) (Clien
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ClientUndeleteOptions contains the optional parameters for the client.Undelete method.
-func (client *client) Undelete(ctx context.Context, comp Enum14, options *ClientUndeleteOptions) (ClientUndeleteResponse, error) {
+//   - options - ClientUndeleteOptions contains the optional parameters for the Client.Undelete method.
+func (client *Client) Undelete(ctx context.Context, comp Enum14, options *ClientUndeleteOptions) (ClientUndeleteResponse, error) {
 	req, err := client.undeleteCreateRequest(ctx, comp, options)
 	if err != nil {
 		return ClientUndeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUndeleteResponse{}, err
 	}
@@ -3181,7 +3169,7 @@ func (client *client) Undelete(ctx context.Context, comp Enum14, options *Client
 }
 
 // undeleteCreateRequest creates the Undelete request.
-func (client *client) undeleteCreateRequest(ctx context.Context, comp Enum14, options *ClientUndeleteOptions) (*policy.Request, error) {
+func (client *Client) undeleteCreateRequest(ctx context.Context, comp Enum14, options *ClientUndeleteOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -3201,7 +3189,7 @@ func (client *client) undeleteCreateRequest(ctx context.Context, comp Enum14, op
 }
 
 // undeleteHandleResponse handles the Undelete response.
-func (client *client) undeleteHandleResponse(resp *http.Response) (ClientUndeleteResponse, error) {
+func (client *Client) undeleteHandleResponse(resp *http.Response) (ClientUndeleteResponse, error) {
 	result := ClientUndeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val

--- a/test/storage/2020-06-12/azblob/zz_container_client.go
+++ b/test/storage/2020-06-12/azblob/zz_container_client.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -23,23 +24,12 @@ import (
 	"time"
 )
 
-type containerClient struct {
+// ContainerClient contains the methods for the Container group.
+// Don't use this type directly, use a constructor function instead.
+type ContainerClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum2
-	pl       runtime.Pipeline
-}
-
-// newContainerClient creates a new instance of containerClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newContainerClient(endpoint string, version Enum2, pl runtime.Pipeline) *containerClient {
-	client := &containerClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // AcquireLease - [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15
@@ -47,14 +37,14 @@ func newContainerClient(endpoint string, version Enum2, pl runtime.Pipeline) *co
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientAcquireLeaseOptions contains the optional parameters for the containerClient.AcquireLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) AcquireLease(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientAcquireLeaseResponse, error) {
+//   - options - ContainerClientAcquireLeaseOptions contains the optional parameters for the ContainerClient.AcquireLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) AcquireLease(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientAcquireLeaseResponse, error) {
 	req, err := client.acquireLeaseCreateRequest(ctx, comp, restype, options, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientAcquireLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientAcquireLeaseResponse{}, err
 	}
@@ -65,7 +55,7 @@ func (client *containerClient) AcquireLease(ctx context.Context, comp Enum16, re
 }
 
 // acquireLeaseCreateRequest creates the AcquireLease request.
-func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) acquireLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientAcquireLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -99,7 +89,7 @@ func (client *containerClient) acquireLeaseCreateRequest(ctx context.Context, co
 }
 
 // acquireLeaseHandleResponse handles the AcquireLease response.
-func (client *containerClient) acquireLeaseHandleResponse(resp *http.Response) (ContainerClientAcquireLeaseResponse, error) {
+func (client *ContainerClient) acquireLeaseHandleResponse(resp *http.Response) (ContainerClientAcquireLeaseResponse, error) {
 	result := ContainerClientAcquireLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -138,14 +128,14 @@ func (client *containerClient) acquireLeaseHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientBreakLeaseOptions contains the optional parameters for the containerClient.BreakLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) BreakLease(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientBreakLeaseResponse, error) {
+//   - options - ContainerClientBreakLeaseOptions contains the optional parameters for the ContainerClient.BreakLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) BreakLease(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientBreakLeaseResponse, error) {
 	req, err := client.breakLeaseCreateRequest(ctx, comp, restype, options, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientBreakLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientBreakLeaseResponse{}, err
 	}
@@ -156,7 +146,7 @@ func (client *containerClient) BreakLease(ctx context.Context, comp Enum16, rest
 }
 
 // breakLeaseCreateRequest creates the BreakLease request.
-func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) breakLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, options *ContainerClientBreakLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -187,7 +177,7 @@ func (client *containerClient) breakLeaseCreateRequest(ctx context.Context, comp
 }
 
 // breakLeaseHandleResponse handles the BreakLease response.
-func (client *containerClient) breakLeaseHandleResponse(resp *http.Response) (ContainerClientBreakLeaseResponse, error) {
+func (client *ContainerClient) breakLeaseHandleResponse(resp *http.Response) (ContainerClientBreakLeaseResponse, error) {
 	result := ContainerClientBreakLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -235,14 +225,14 @@ func (client *containerClient) breakLeaseHandleResponse(resp *http.Response) (Co
 //   - proposedLeaseID - Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed
 //     lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID
 //     string formats.
-//   - options - ContainerClientChangeLeaseOptions contains the optional parameters for the containerClient.ChangeLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) ChangeLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *ContainerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientChangeLeaseResponse, error) {
+//   - options - ContainerClientChangeLeaseOptions contains the optional parameters for the ContainerClient.ChangeLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) ChangeLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *ContainerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientChangeLeaseResponse, error) {
 	req, err := client.changeLeaseCreateRequest(ctx, comp, restype, leaseID, proposedLeaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientChangeLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientChangeLeaseResponse{}, err
 	}
@@ -253,7 +243,7 @@ func (client *containerClient) ChangeLease(ctx context.Context, comp Enum16, res
 }
 
 // changeLeaseCreateRequest creates the ChangeLease request.
-func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *ContainerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) changeLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, proposedLeaseID string, options *ContainerClientChangeLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -283,7 +273,7 @@ func (client *containerClient) changeLeaseCreateRequest(ctx context.Context, com
 }
 
 // changeLeaseHandleResponse handles the ChangeLease response.
-func (client *containerClient) changeLeaseHandleResponse(resp *http.Response) (ContainerClientChangeLeaseResponse, error) {
+func (client *ContainerClient) changeLeaseHandleResponse(resp *http.Response) (ContainerClientChangeLeaseResponse, error) {
 	result := ContainerClientChangeLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -322,14 +312,14 @@ func (client *containerClient) changeLeaseHandleResponse(resp *http.Response) (C
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientCreateOptions contains the optional parameters for the containerClient.Create method.
-//   - ContainerCpkScopeInfo - ContainerCpkScopeInfo contains a group of parameters for the containerClient.Create method.
-func (client *containerClient) Create(ctx context.Context, restype Enum11, options *ContainerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (ContainerClientCreateResponse, error) {
+//   - options - ContainerClientCreateOptions contains the optional parameters for the ContainerClient.Create method.
+//   - ContainerCpkScopeInfo - ContainerCpkScopeInfo contains a group of parameters for the ContainerClient.Create method.
+func (client *ContainerClient) Create(ctx context.Context, restype Enum11, options *ContainerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (ContainerClientCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, restype, options, containerCpkScopeInfo)
 	if err != nil {
 		return ContainerClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientCreateResponse{}, err
 	}
@@ -340,7 +330,7 @@ func (client *containerClient) Create(ctx context.Context, restype Enum11, optio
 }
 
 // createCreateRequest creates the Create request.
-func (client *containerClient) createCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*policy.Request, error) {
+func (client *ContainerClient) createCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientCreateOptions, containerCpkScopeInfo *ContainerCpkScopeInfo) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -376,7 +366,7 @@ func (client *containerClient) createCreateRequest(ctx context.Context, restype 
 }
 
 // createHandleResponse handles the Create response.
-func (client *containerClient) createHandleResponse(resp *http.Response) (ContainerClientCreateResponse, error) {
+func (client *ContainerClient) createHandleResponse(resp *http.Response) (ContainerClientCreateResponse, error) {
 	result := ContainerClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -412,15 +402,15 @@ func (client *containerClient) createHandleResponse(resp *http.Response) (Contai
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientDeleteOptions contains the optional parameters for the containerClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) Delete(ctx context.Context, restype Enum11, options *ContainerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientDeleteResponse, error) {
+//   - options - ContainerClientDeleteOptions contains the optional parameters for the ContainerClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) Delete(ctx context.Context, restype Enum11, options *ContainerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientDeleteResponse, error) {
 	req, err := client.deleteCreateRequest(ctx, restype, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientDeleteResponse{}, err
 	}
@@ -431,7 +421,7 @@ func (client *containerClient) Delete(ctx context.Context, restype Enum11, optio
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *containerClient) deleteCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) deleteCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -460,7 +450,7 @@ func (client *containerClient) deleteCreateRequest(ctx context.Context, restype 
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *containerClient) deleteHandleResponse(resp *http.Response) (ContainerClientDeleteResponse, error) {
+func (client *ContainerClient) deleteHandleResponse(resp *http.Response) (ContainerClientDeleteResponse, error) {
 	result := ContainerClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -486,15 +476,15 @@ func (client *containerClient) deleteHandleResponse(resp *http.Response) (Contai
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientGetAccessPolicyOptions contains the optional parameters for the containerClient.GetAccessPolicy
+//   - options - ContainerClientGetAccessPolicyOptions contains the optional parameters for the ContainerClient.GetAccessPolicy
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *containerClient) GetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (ContainerClientGetAccessPolicyResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *ContainerClient) GetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (ContainerClientGetAccessPolicyResponse, error) {
 	req, err := client.getAccessPolicyCreateRequest(ctx, restype, comp, options, leaseAccessConditions)
 	if err != nil {
 		return ContainerClientGetAccessPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientGetAccessPolicyResponse{}, err
 	}
@@ -505,7 +495,7 @@ func (client *containerClient) GetAccessPolicy(ctx context.Context, restype Enum
 }
 
 // getAccessPolicyCreateRequest creates the GetAccessPolicy request.
-func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) getAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientGetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -529,7 +519,7 @@ func (client *containerClient) getAccessPolicyCreateRequest(ctx context.Context,
 }
 
 // getAccessPolicyHandleResponse handles the GetAccessPolicy response.
-func (client *containerClient) getAccessPolicyHandleResponse(resp *http.Response) (ContainerClientGetAccessPolicyResponse, error) {
+func (client *ContainerClient) getAccessPolicyHandleResponse(resp *http.Response) (ContainerClientGetAccessPolicyResponse, error) {
 	result := ContainerClientGetAccessPolicyResponse{}
 	if val := resp.Header.Get("x-ms-blob-public-access"); val != "" {
 		result.BlobPublicAccess = (*PublicAccessType)(&val)
@@ -570,14 +560,14 @@ func (client *containerClient) getAccessPolicyHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientGetAccountInfoOptions contains the optional parameters for the containerClient.GetAccountInfo
+//   - options - ContainerClientGetAccountInfoOptions contains the optional parameters for the ContainerClient.GetAccountInfo
 //     method.
-func (client *containerClient) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ContainerClientGetAccountInfoOptions) (ContainerClientGetAccountInfoResponse, error) {
+func (client *ContainerClient) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ContainerClientGetAccountInfoOptions) (ContainerClientGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ContainerClientGetAccountInfoResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientGetAccountInfoResponse{}, err
 	}
@@ -588,7 +578,7 @@ func (client *containerClient) GetAccountInfo(ctx context.Context, restype Enum8
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *containerClient) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ContainerClientGetAccountInfoOptions) (*policy.Request, error) {
+func (client *ContainerClient) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ContainerClientGetAccountInfoOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -603,7 +593,7 @@ func (client *containerClient) getAccountInfoCreateRequest(ctx context.Context, 
 }
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
-func (client *containerClient) getAccountInfoHandleResponse(resp *http.Response) (ContainerClientGetAccountInfoResponse, error) {
+func (client *ContainerClient) getAccountInfoHandleResponse(resp *http.Response) (ContainerClientGetAccountInfoResponse, error) {
 	result := ContainerClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -635,14 +625,14 @@ func (client *containerClient) getAccountInfoHandleResponse(resp *http.Response)
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientGetPropertiesOptions contains the optional parameters for the containerClient.GetProperties method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-func (client *containerClient) GetProperties(ctx context.Context, restype Enum11, options *ContainerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (ContainerClientGetPropertiesResponse, error) {
+//   - options - ContainerClientGetPropertiesOptions contains the optional parameters for the ContainerClient.GetProperties method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+func (client *ContainerClient) GetProperties(ctx context.Context, restype Enum11, options *ContainerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (ContainerClientGetPropertiesResponse, error) {
 	req, err := client.getPropertiesCreateRequest(ctx, restype, options, leaseAccessConditions)
 	if err != nil {
 		return ContainerClientGetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientGetPropertiesResponse{}, err
 	}
@@ -653,7 +643,7 @@ func (client *containerClient) GetProperties(ctx context.Context, restype Enum11
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) getPropertiesCreateRequest(ctx context.Context, restype Enum11, options *ContainerClientGetPropertiesOptions, leaseAccessConditions *LeaseAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -676,7 +666,7 @@ func (client *containerClient) getPropertiesCreateRequest(ctx context.Context, r
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *containerClient) getPropertiesHandleResponse(resp *http.Response) (ContainerClientGetPropertiesResponse, error) {
+func (client *ContainerClient) getPropertiesHandleResponse(resp *http.Response) (ContainerClientGetPropertiesResponse, error) {
 	result := ContainerClientGetPropertiesResponse{}
 	for hh := range resp.Header {
 		if len(hh) > len("x-ms-meta-") && strings.EqualFold(hh[:len("x-ms-meta-")], "x-ms-meta-") {
@@ -761,9 +751,9 @@ func (client *containerClient) getPropertiesHandleResponse(resp *http.Response) 
 // NewListBlobFlatSegmentPager - [Update] The List Blobs operation returns a list of the blobs under the specified container
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientListBlobFlatSegmentOptions contains the optional parameters for the containerClient.NewListBlobFlatSegmentPager
+//   - options - ContainerClientListBlobFlatSegmentOptions contains the optional parameters for the ContainerClient.NewListBlobFlatSegmentPager
 //     method.
-func (client *containerClient) NewListBlobFlatSegmentPager(restype Enum11, comp Enum5, options *ContainerClientListBlobFlatSegmentOptions) *runtime.Pager[ContainerClientListBlobFlatSegmentResponse] {
+func (client *ContainerClient) NewListBlobFlatSegmentPager(restype Enum11, comp Enum5, options *ContainerClientListBlobFlatSegmentOptions) *runtime.Pager[ContainerClientListBlobFlatSegmentResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainerClientListBlobFlatSegmentResponse]{
 		More: func(page ContainerClientListBlobFlatSegmentResponse) bool {
 			return page.NextMarker != nil && len(*page.NextMarker) > 0
@@ -779,7 +769,7 @@ func (client *containerClient) NewListBlobFlatSegmentPager(restype Enum11, comp 
 			if err != nil {
 				return ContainerClientListBlobFlatSegmentResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ContainerClientListBlobFlatSegmentResponse{}, err
 			}
@@ -792,7 +782,7 @@ func (client *containerClient) NewListBlobFlatSegmentPager(restype Enum11, comp 
 }
 
 // listBlobFlatSegmentCreateRequest creates the ListBlobFlatSegment request.
-func (client *containerClient) listBlobFlatSegmentCreateRequest(ctx context.Context, restype Enum11, comp Enum5, options *ContainerClientListBlobFlatSegmentOptions) (*policy.Request, error) {
+func (client *ContainerClient) listBlobFlatSegmentCreateRequest(ctx context.Context, restype Enum11, comp Enum5, options *ContainerClientListBlobFlatSegmentOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -825,7 +815,7 @@ func (client *containerClient) listBlobFlatSegmentCreateRequest(ctx context.Cont
 }
 
 // listBlobFlatSegmentHandleResponse handles the ListBlobFlatSegment response.
-func (client *containerClient) listBlobFlatSegmentHandleResponse(resp *http.Response) (ContainerClientListBlobFlatSegmentResponse, error) {
+func (client *ContainerClient) listBlobFlatSegmentHandleResponse(resp *http.Response) (ContainerClientListBlobFlatSegmentResponse, error) {
 	result := ContainerClientListBlobFlatSegmentResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -858,9 +848,9 @@ func (client *containerClient) listBlobFlatSegmentHandleResponse(resp *http.Resp
 //   - delimiter - When the request includes this parameter, the operation returns a BlobPrefix element in the response body that
 //     acts as a placeholder for all blobs whose names begin with the same substring up to the
 //     appearance of the delimiter character. The delimiter may be a single character or a string.
-//   - options - ContainerClientListBlobHierarchySegmentOptions contains the optional parameters for the containerClient.NewListBlobHierarchySegmentPager
+//   - options - ContainerClientListBlobHierarchySegmentOptions contains the optional parameters for the ContainerClient.NewListBlobHierarchySegmentPager
 //     method.
-func (client *containerClient) NewListBlobHierarchySegmentPager(restype Enum11, comp Enum5, delimiter string, options *ContainerClientListBlobHierarchySegmentOptions) *runtime.Pager[ContainerClientListBlobHierarchySegmentResponse] {
+func (client *ContainerClient) NewListBlobHierarchySegmentPager(restype Enum11, comp Enum5, delimiter string, options *ContainerClientListBlobHierarchySegmentOptions) *runtime.Pager[ContainerClientListBlobHierarchySegmentResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ContainerClientListBlobHierarchySegmentResponse]{
 		More: func(page ContainerClientListBlobHierarchySegmentResponse) bool {
 			return page.NextMarker != nil && len(*page.NextMarker) > 0
@@ -876,7 +866,7 @@ func (client *containerClient) NewListBlobHierarchySegmentPager(restype Enum11, 
 			if err != nil {
 				return ContainerClientListBlobHierarchySegmentResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ContainerClientListBlobHierarchySegmentResponse{}, err
 			}
@@ -889,7 +879,7 @@ func (client *containerClient) NewListBlobHierarchySegmentPager(restype Enum11, 
 }
 
 // listBlobHierarchySegmentCreateRequest creates the ListBlobHierarchySegment request.
-func (client *containerClient) listBlobHierarchySegmentCreateRequest(ctx context.Context, restype Enum11, comp Enum5, delimiter string, options *ContainerClientListBlobHierarchySegmentOptions) (*policy.Request, error) {
+func (client *ContainerClient) listBlobHierarchySegmentCreateRequest(ctx context.Context, restype Enum11, comp Enum5, delimiter string, options *ContainerClientListBlobHierarchySegmentOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -923,7 +913,7 @@ func (client *containerClient) listBlobHierarchySegmentCreateRequest(ctx context
 }
 
 // listBlobHierarchySegmentHandleResponse handles the ListBlobHierarchySegment response.
-func (client *containerClient) listBlobHierarchySegmentHandleResponse(resp *http.Response) (ContainerClientListBlobHierarchySegmentResponse, error) {
+func (client *ContainerClient) listBlobHierarchySegmentHandleResponse(resp *http.Response) (ContainerClientListBlobHierarchySegmentResponse, error) {
 	result := ContainerClientListBlobHierarchySegmentResponse{}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val
@@ -956,14 +946,14 @@ func (client *containerClient) listBlobHierarchySegmentHandleResponse(resp *http
 //
 // Generated from API version 2020-06-12
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ContainerClientReleaseLeaseOptions contains the optional parameters for the containerClient.ReleaseLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) ReleaseLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientReleaseLeaseResponse, error) {
+//   - options - ContainerClientReleaseLeaseOptions contains the optional parameters for the ContainerClient.ReleaseLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) ReleaseLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientReleaseLeaseResponse, error) {
 	req, err := client.releaseLeaseCreateRequest(ctx, comp, restype, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientReleaseLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientReleaseLeaseResponse{}, err
 	}
@@ -974,7 +964,7 @@ func (client *containerClient) ReleaseLease(ctx context.Context, comp Enum16, re
 }
 
 // releaseLeaseCreateRequest creates the ReleaseLease request.
-func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) releaseLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientReleaseLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1003,7 +993,7 @@ func (client *containerClient) releaseLeaseCreateRequest(ctx context.Context, co
 }
 
 // releaseLeaseHandleResponse handles the ReleaseLease response.
-func (client *containerClient) releaseLeaseHandleResponse(resp *http.Response) (ContainerClientReleaseLeaseResponse, error) {
+func (client *ContainerClient) releaseLeaseHandleResponse(resp *http.Response) (ContainerClientReleaseLeaseResponse, error) {
 	result := ContainerClientReleaseLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1039,13 +1029,13 @@ func (client *containerClient) releaseLeaseHandleResponse(resp *http.Response) (
 //
 // Generated from API version 2020-06-12
 //   - sourceContainerName - Required. Specifies the name of the container to rename.
-//   - options - ContainerClientRenameOptions contains the optional parameters for the containerClient.Rename method.
-func (client *containerClient) Rename(ctx context.Context, restype Enum11, comp Enum15, sourceContainerName string, options *ContainerClientRenameOptions) (ContainerClientRenameResponse, error) {
+//   - options - ContainerClientRenameOptions contains the optional parameters for the ContainerClient.Rename method.
+func (client *ContainerClient) Rename(ctx context.Context, restype Enum11, comp Enum15, sourceContainerName string, options *ContainerClientRenameOptions) (ContainerClientRenameResponse, error) {
 	req, err := client.renameCreateRequest(ctx, restype, comp, sourceContainerName, options)
 	if err != nil {
 		return ContainerClientRenameResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientRenameResponse{}, err
 	}
@@ -1056,7 +1046,7 @@ func (client *containerClient) Rename(ctx context.Context, restype Enum11, comp 
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *containerClient) renameCreateRequest(ctx context.Context, restype Enum11, comp Enum15, sourceContainerName string, options *ContainerClientRenameOptions) (*policy.Request, error) {
+func (client *ContainerClient) renameCreateRequest(ctx context.Context, restype Enum11, comp Enum15, sourceContainerName string, options *ContainerClientRenameOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1081,7 +1071,7 @@ func (client *containerClient) renameCreateRequest(ctx context.Context, restype 
 }
 
 // renameHandleResponse handles the Rename response.
-func (client *containerClient) renameHandleResponse(resp *http.Response) (ContainerClientRenameResponse, error) {
+func (client *ContainerClient) renameHandleResponse(resp *http.Response) (ContainerClientRenameResponse, error) {
 	result := ContainerClientRenameResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1108,14 +1098,14 @@ func (client *containerClient) renameHandleResponse(resp *http.Response) (Contai
 //
 // Generated from API version 2020-06-12
 //   - leaseID - Specifies the current lease ID on the resource.
-//   - options - ContainerClientRenewLeaseOptions contains the optional parameters for the containerClient.RenewLease method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) RenewLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientRenewLeaseResponse, error) {
+//   - options - ContainerClientRenewLeaseOptions contains the optional parameters for the ContainerClient.RenewLease method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) RenewLease(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientRenewLeaseResponse, error) {
 	req, err := client.renewLeaseCreateRequest(ctx, comp, restype, leaseID, options, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientRenewLeaseResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientRenewLeaseResponse{}, err
 	}
@@ -1126,7 +1116,7 @@ func (client *containerClient) RenewLease(ctx context.Context, comp Enum16, rest
 }
 
 // renewLeaseCreateRequest creates the RenewLease request.
-func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) renewLeaseCreateRequest(ctx context.Context, comp Enum16, restype Enum11, leaseID string, options *ContainerClientRenewLeaseOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1155,7 +1145,7 @@ func (client *containerClient) renewLeaseCreateRequest(ctx context.Context, comp
 }
 
 // renewLeaseHandleResponse handles the RenewLease response.
-func (client *containerClient) renewLeaseHandleResponse(resp *http.Response) (ContainerClientRenewLeaseResponse, error) {
+func (client *ContainerClient) renewLeaseHandleResponse(resp *http.Response) (ContainerClientRenewLeaseResponse, error) {
 	result := ContainerClientRenewLeaseResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1193,13 +1183,13 @@ func (client *containerClient) renewLeaseHandleResponse(resp *http.Response) (Co
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientRestoreOptions contains the optional parameters for the containerClient.Restore method.
-func (client *containerClient) Restore(ctx context.Context, restype Enum11, comp Enum14, options *ContainerClientRestoreOptions) (ContainerClientRestoreResponse, error) {
+//   - options - ContainerClientRestoreOptions contains the optional parameters for the ContainerClient.Restore method.
+func (client *ContainerClient) Restore(ctx context.Context, restype Enum11, comp Enum14, options *ContainerClientRestoreOptions) (ContainerClientRestoreResponse, error) {
 	req, err := client.restoreCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ContainerClientRestoreResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientRestoreResponse{}, err
 	}
@@ -1210,7 +1200,7 @@ func (client *containerClient) Restore(ctx context.Context, restype Enum11, comp
 }
 
 // restoreCreateRequest creates the Restore request.
-func (client *containerClient) restoreCreateRequest(ctx context.Context, restype Enum11, comp Enum14, options *ContainerClientRestoreOptions) (*policy.Request, error) {
+func (client *ContainerClient) restoreCreateRequest(ctx context.Context, restype Enum11, comp Enum14, options *ContainerClientRestoreOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1237,7 +1227,7 @@ func (client *containerClient) restoreCreateRequest(ctx context.Context, restype
 }
 
 // restoreHandleResponse handles the Restore response.
-func (client *containerClient) restoreHandleResponse(resp *http.Response) (ContainerClientRestoreResponse, error) {
+func (client *ContainerClient) restoreHandleResponse(resp *http.Response) (ContainerClientRestoreResponse, error) {
 	result := ContainerClientRestoreResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -1263,16 +1253,16 @@ func (client *containerClient) restoreHandleResponse(resp *http.Response) (Conta
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientSetAccessPolicyOptions contains the optional parameters for the containerClient.SetAccessPolicy
+//   - options - ContainerClientSetAccessPolicyOptions contains the optional parameters for the ContainerClient.SetAccessPolicy
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) SetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientSetAccessPolicyResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) SetAccessPolicy(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientSetAccessPolicyResponse, error) {
 	req, err := client.setAccessPolicyCreateRequest(ctx, restype, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientSetAccessPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientSetAccessPolicyResponse{}, err
 	}
@@ -1283,7 +1273,7 @@ func (client *containerClient) SetAccessPolicy(ctx context.Context, restype Enum
 }
 
 // setAccessPolicyCreateRequest creates the SetAccessPolicy request.
-func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) setAccessPolicyCreateRequest(ctx context.Context, restype Enum11, comp Enum13, options *ContainerClientSetAccessPolicyOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1323,7 +1313,7 @@ func (client *containerClient) setAccessPolicyCreateRequest(ctx context.Context,
 }
 
 // setAccessPolicyHandleResponse handles the SetAccessPolicy response.
-func (client *containerClient) setAccessPolicyHandleResponse(resp *http.Response) (ContainerClientSetAccessPolicyResponse, error) {
+func (client *ContainerClient) setAccessPolicyHandleResponse(resp *http.Response) (ContainerClientSetAccessPolicyResponse, error) {
 	result := ContainerClientSetAccessPolicyResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1358,15 +1348,15 @@ func (client *containerClient) setAccessPolicyHandleResponse(resp *http.Response
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ContainerClientSetMetadataOptions contains the optional parameters for the containerClient.SetMetadata method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *containerClient) SetMetadata(ctx context.Context, restype Enum11, comp Enum12, options *ContainerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientSetMetadataResponse, error) {
+//   - options - ContainerClientSetMetadataOptions contains the optional parameters for the ContainerClient.SetMetadata method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *ContainerClient) SetMetadata(ctx context.Context, restype Enum11, comp Enum12, options *ContainerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (ContainerClientSetMetadataResponse, error) {
 	req, err := client.setMetadataCreateRequest(ctx, restype, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return ContainerClientSetMetadataResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientSetMetadataResponse{}, err
 	}
@@ -1377,7 +1367,7 @@ func (client *containerClient) SetMetadata(ctx context.Context, restype Enum11, 
 }
 
 // setMetadataCreateRequest creates the SetMetadata request.
-func (client *containerClient) setMetadataCreateRequest(ctx context.Context, restype Enum11, comp Enum12, options *ContainerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *ContainerClient) setMetadataCreateRequest(ctx context.Context, restype Enum11, comp Enum12, options *ContainerClientSetMetadataOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1411,7 +1401,7 @@ func (client *containerClient) setMetadataCreateRequest(ctx context.Context, res
 }
 
 // setMetadataHandleResponse handles the SetMetadata response.
-func (client *containerClient) setMetadataHandleResponse(resp *http.Response) (ContainerClientSetMetadataResponse, error) {
+func (client *ContainerClient) setMetadataHandleResponse(resp *http.Response) (ContainerClientSetMetadataResponse, error) {
 	result := ContainerClientSetMetadataResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1450,13 +1440,13 @@ func (client *containerClient) setMetadataHandleResponse(resp *http.Response) (C
 //   - multipartContentType - Required. The value of this header must be multipart/mixed with a batch boundary. Example header
 //     value: multipart/mixed; boundary=batch_
 //   - body - Initial data
-//   - options - ContainerClientSubmitBatchOptions contains the optional parameters for the containerClient.SubmitBatch method.
-func (client *containerClient) SubmitBatch(ctx context.Context, restype Enum11, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (ContainerClientSubmitBatchResponse, error) {
+//   - options - ContainerClientSubmitBatchOptions contains the optional parameters for the ContainerClient.SubmitBatch method.
+func (client *ContainerClient) SubmitBatch(ctx context.Context, restype Enum11, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (ContainerClientSubmitBatchResponse, error) {
 	req, err := client.submitBatchCreateRequest(ctx, restype, comp, contentLength, multipartContentType, body, options)
 	if err != nil {
 		return ContainerClientSubmitBatchResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ContainerClientSubmitBatchResponse{}, err
 	}
@@ -1467,7 +1457,7 @@ func (client *containerClient) SubmitBatch(ctx context.Context, restype Enum11, 
 }
 
 // submitBatchCreateRequest creates the SubmitBatch request.
-func (client *containerClient) submitBatchCreateRequest(ctx context.Context, restype Enum11, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (*policy.Request, error) {
+func (client *ContainerClient) submitBatchCreateRequest(ctx context.Context, restype Enum11, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ContainerClientSubmitBatchOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1491,7 +1481,7 @@ func (client *containerClient) submitBatchCreateRequest(ctx context.Context, res
 }
 
 // submitBatchHandleResponse handles the SubmitBatch response.
-func (client *containerClient) submitBatchHandleResponse(resp *http.Response) (ContainerClientSubmitBatchResponse, error) {
+func (client *ContainerClient) submitBatchHandleResponse(resp *http.Response) (ContainerClientSubmitBatchResponse, error) {
 	result := ContainerClientSubmitBatchResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val

--- a/test/storage/2020-06-12/azblob/zz_directory_client.go
+++ b/test/storage/2020-06-12/azblob/zz_directory_client.go
@@ -11,6 +11,7 @@ package azblob
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -18,26 +19,13 @@ import (
 	"time"
 )
 
-type directoryClient struct {
+// DirectoryClient contains the methods for the Directory group.
+// Don't use this type directly, use a constructor function instead.
+type DirectoryClient struct {
+	internal       *azcore.Client
 	endpoint       string
 	version        Enum2
 	pathRenameMode *PathRenameMode
-	pl             runtime.Pipeline
-}
-
-// newDirectoryClient creates a new instance of directoryClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pathRenameMode - Determines the behavior of the rename operation
-//   - pl - the pipeline used for sending requests and handling responses.
-func newDirectoryClient(endpoint string, version Enum2, pathRenameMode *PathRenameMode, pl runtime.Pipeline) *directoryClient {
-	client := &directoryClient{
-		endpoint:       endpoint,
-		version:        version,
-		pathRenameMode: pathRenameMode,
-		pl:             pl,
-	}
-	return client
 }
 
 // Create - Create a directory. By default, the destination is overwritten and if the destination already exists and has a
@@ -48,16 +36,16 @@ func newDirectoryClient(endpoint string, version Enum2, pathRenameMode *PathRena
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - DirectoryClientCreateOptions contains the optional parameters for the directoryClient.Create method.
-//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) Create(ctx context.Context, resource Enum20, options *DirectoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientCreateResponse, error) {
+//   - options - DirectoryClientCreateOptions contains the optional parameters for the DirectoryClient.Create method.
+//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the DirectoryClient.Create method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *DirectoryClient) Create(ctx context.Context, resource Enum20, options *DirectoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, resource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return DirectoryClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DirectoryClientCreateResponse{}, err
 	}
@@ -68,7 +56,7 @@ func (client *directoryClient) Create(ctx context.Context, resource Enum20, opti
 }
 
 // createCreateRequest creates the Create request.
-func (client *directoryClient) createCreateRequest(ctx context.Context, resource Enum20, options *DirectoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *DirectoryClient) createCreateRequest(ctx context.Context, resource Enum20, options *DirectoryClientCreateOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -127,7 +115,7 @@ func (client *directoryClient) createCreateRequest(ctx context.Context, resource
 }
 
 // createHandleResponse handles the Create response.
-func (client *directoryClient) createHandleResponse(resp *http.Response) (DirectoryClientCreateResponse, error) {
+func (client *DirectoryClient) createHandleResponse(resp *http.Response) (DirectoryClientCreateResponse, error) {
 	result := DirectoryClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -171,15 +159,15 @@ func (client *directoryClient) createHandleResponse(resp *http.Response) (Direct
 // Generated from API version 2020-06-12
 //   - recursiveDirectoryDelete - If "true", all paths beneath the directory will be deleted. If "false" and the directory is
 //     non-empty, an error occurs.
-//   - options - DirectoryClientDeleteOptions contains the optional parameters for the directoryClient.Delete method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDelete bool, options *DirectoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientDeleteResponse, error) {
+//   - options - DirectoryClientDeleteOptions contains the optional parameters for the DirectoryClient.Delete method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *DirectoryClient) Delete(ctx context.Context, recursiveDirectoryDelete bool, options *DirectoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientDeleteResponse, error) {
 	req, err := client.deleteCreateRequest(ctx, recursiveDirectoryDelete, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return DirectoryClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DirectoryClientDeleteResponse{}, err
 	}
@@ -190,7 +178,7 @@ func (client *directoryClient) Delete(ctx context.Context, recursiveDirectoryDel
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiveDirectoryDelete bool, options *DirectoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *DirectoryClient) deleteCreateRequest(ctx context.Context, recursiveDirectoryDelete bool, options *DirectoryClientDeleteOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -228,7 +216,7 @@ func (client *directoryClient) deleteCreateRequest(ctx context.Context, recursiv
 }
 
 // deleteHandleResponse handles the Delete response.
-func (client *directoryClient) deleteHandleResponse(resp *http.Response) (DirectoryClientDeleteResponse, error) {
+func (client *DirectoryClient) deleteHandleResponse(resp *http.Response) (DirectoryClientDeleteResponse, error) {
 	result := DirectoryClientDeleteResponse{}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
@@ -256,16 +244,16 @@ func (client *directoryClient) deleteHandleResponse(resp *http.Response) (Direct
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - DirectoryClientGetAccessControlOptions contains the optional parameters for the directoryClient.GetAccessControl
+//   - options - DirectoryClientGetAccessControlOptions contains the optional parameters for the DirectoryClient.GetAccessControl
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) GetAccessControl(ctx context.Context, action Enum22, options *DirectoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientGetAccessControlResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *DirectoryClient) GetAccessControl(ctx context.Context, action Enum22, options *DirectoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientGetAccessControlResponse, error) {
 	req, err := client.getAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return DirectoryClientGetAccessControlResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DirectoryClientGetAccessControlResponse{}, err
 	}
@@ -276,7 +264,7 @@ func (client *directoryClient) GetAccessControl(ctx context.Context, action Enum
 }
 
 // getAccessControlCreateRequest creates the GetAccessControl request.
-func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *DirectoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *DirectoryClient) getAccessControlCreateRequest(ctx context.Context, action Enum22, options *DirectoryClientGetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodHead, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -314,7 +302,7 @@ func (client *directoryClient) getAccessControlCreateRequest(ctx context.Context
 }
 
 // getAccessControlHandleResponse handles the GetAccessControl response.
-func (client *directoryClient) getAccessControlHandleResponse(resp *http.Response) (DirectoryClientGetAccessControlResponse, error) {
+func (client *DirectoryClient) getAccessControlHandleResponse(resp *http.Response) (DirectoryClientGetAccessControlResponse, error) {
 	result := DirectoryClientGetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)
@@ -365,18 +353,18 @@ func (client *directoryClient) getAccessControlHandleResponse(resp *http.Respons
 //   - renameSource - The file or directory to be renamed. The value must have the following format: "/{filesysystem}/{path}".
 //     If "x-ms-properties" is specified, the properties will overwrite the existing properties;
 //     otherwise, the existing properties will be preserved.
-//   - options - DirectoryClientRenameOptions contains the optional parameters for the directoryClient.Rename method.
-//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - options - DirectoryClientRenameOptions contains the optional parameters for the DirectoryClient.Rename method.
+//   - DirectoryHTTPHeaders - DirectoryHTTPHeaders contains a group of parameters for the DirectoryClient.Create method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *directoryClient) Rename(ctx context.Context, renameSource string, options *DirectoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (DirectoryClientRenameResponse, error) {
+func (client *DirectoryClient) Rename(ctx context.Context, renameSource string, options *DirectoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (DirectoryClientRenameResponse, error) {
 	req, err := client.renameCreateRequest(ctx, renameSource, options, directoryHTTPHeaders, leaseAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return DirectoryClientRenameResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DirectoryClientRenameResponse{}, err
 	}
@@ -387,7 +375,7 @@ func (client *directoryClient) Rename(ctx context.Context, renameSource string, 
 }
 
 // renameCreateRequest creates the Rename request.
-func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSource string, options *DirectoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *DirectoryClient) renameCreateRequest(ctx context.Context, renameSource string, options *DirectoryClientRenameOptions, directoryHTTPHeaders *DirectoryHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -467,7 +455,7 @@ func (client *directoryClient) renameCreateRequest(ctx context.Context, renameSo
 }
 
 // renameHandleResponse handles the Rename response.
-func (client *directoryClient) renameHandleResponse(resp *http.Response) (DirectoryClientRenameResponse, error) {
+func (client *DirectoryClient) renameHandleResponse(resp *http.Response) (DirectoryClientRenameResponse, error) {
 	result := DirectoryClientRenameResponse{}
 	if val := resp.Header.Get("x-ms-continuation"); val != "" {
 		result.Marker = &val
@@ -512,16 +500,16 @@ func (client *directoryClient) renameHandleResponse(resp *http.Response) (Direct
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - DirectoryClientSetAccessControlOptions contains the optional parameters for the directoryClient.SetAccessControl
+//   - options - DirectoryClientSetAccessControlOptions contains the optional parameters for the DirectoryClient.SetAccessControl
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *directoryClient) SetAccessControl(ctx context.Context, action Enum21, options *DirectoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientSetAccessControlResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *DirectoryClient) SetAccessControl(ctx context.Context, action Enum21, options *DirectoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (DirectoryClientSetAccessControlResponse, error) {
 	req, err := client.setAccessControlCreateRequest(ctx, action, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return DirectoryClientSetAccessControlResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DirectoryClientSetAccessControlResponse{}, err
 	}
@@ -532,7 +520,7 @@ func (client *directoryClient) SetAccessControl(ctx context.Context, action Enum
 }
 
 // setAccessControlCreateRequest creates the SetAccessControl request.
-func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *DirectoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *DirectoryClient) setAccessControlCreateRequest(ctx context.Context, action Enum21, options *DirectoryClientSetAccessControlOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -579,7 +567,7 @@ func (client *directoryClient) setAccessControlCreateRequest(ctx context.Context
 }
 
 // setAccessControlHandleResponse handles the SetAccessControl response.
-func (client *directoryClient) setAccessControlHandleResponse(resp *http.Response) (DirectoryClientSetAccessControlResponse, error) {
+func (client *DirectoryClient) setAccessControlHandleResponse(resp *http.Response) (DirectoryClientSetAccessControlResponse, error) {
 	result := DirectoryClientSetAccessControlResponse{}
 	if val := resp.Header.Get("Date"); val != "" {
 		date, err := time.Parse(time.RFC1123, val)

--- a/test/storage/2020-06-12/azblob/zz_models.go
+++ b/test/storage/2020-06-12/azblob/zz_models.go
@@ -23,7 +23,7 @@ type AccessPolicy struct {
 	Start *time.Time `xml:"Start"`
 }
 
-// AppendBlobClientAppendBlockFromURLOptions contains the optional parameters for the appendBlobClient.AppendBlockFromURL
+// AppendBlobClientAppendBlockFromURLOptions contains the optional parameters for the AppendBlobClient.AppendBlockFromURL
 // method.
 type AppendBlobClientAppendBlockFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
@@ -42,7 +42,7 @@ type AppendBlobClientAppendBlockFromURLOptions struct {
 	TransactionalContentMD5 []byte
 }
 
-// AppendBlobClientAppendBlockOptions contains the optional parameters for the appendBlobClient.AppendBlock method.
+// AppendBlobClientAppendBlockOptions contains the optional parameters for the AppendBlobClient.AppendBlock method.
 type AppendBlobClientAppendBlockOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -56,7 +56,7 @@ type AppendBlobClientAppendBlockOptions struct {
 	TransactionalContentMD5 []byte
 }
 
-// AppendBlobClientCreateOptions contains the optional parameters for the appendBlobClient.Create method.
+// AppendBlobClientCreateOptions contains the optional parameters for the AppendBlobClient.Create method.
 type AppendBlobClientCreateOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -81,7 +81,7 @@ type AppendBlobClientCreateOptions struct {
 	Timeout *int32
 }
 
-// AppendBlobClientSealOptions contains the optional parameters for the appendBlobClient.Seal method.
+// AppendBlobClientSealOptions contains the optional parameters for the AppendBlobClient.Seal method.
 type AppendBlobClientSealOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -91,7 +91,7 @@ type AppendBlobClientSealOptions struct {
 	Timeout *int32
 }
 
-// AppendPositionAccessConditions contains a group of parameters for the appendBlobClient.AppendBlock method.
+// AppendPositionAccessConditions contains a group of parameters for the AppendBlobClient.AppendBlock method.
 type AppendPositionAccessConditions struct {
 	// Optional conditional header, used only for the Append Block operation. A number indicating the byte offset to compare.
 	// Append Block will succeed only if the append position is equal to this number. If
@@ -119,7 +119,7 @@ type ArrowField struct {
 	Scale     *int32  `xml:"Scale"`
 }
 
-// BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
+// BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
 type BlobHTTPHeaders struct {
 	// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.
 	BlobCacheControl *string
@@ -147,7 +147,7 @@ type Block struct {
 	Size *int64 `xml:"Size"`
 }
 
-// BlockBlobClientCommitBlockListOptions contains the optional parameters for the blockBlobClient.CommitBlockList method.
+// BlockBlobClientCommitBlockListOptions contains the optional parameters for the BlockBlobClient.CommitBlockList method.
 type BlockBlobClientCommitBlockListOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -178,7 +178,7 @@ type BlockBlobClientCommitBlockListOptions struct {
 	TransactionalContentMD5 []byte
 }
 
-// BlockBlobClientGetBlockListOptions contains the optional parameters for the blockBlobClient.GetBlockList method.
+// BlockBlobClientGetBlockListOptions contains the optional parameters for the BlockBlobClient.GetBlockList method.
 type BlockBlobClientGetBlockListOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -192,7 +192,7 @@ type BlockBlobClientGetBlockListOptions struct {
 	Timeout *int32
 }
 
-// BlockBlobClientPutBlobFromURLOptions contains the optional parameters for the blockBlobClient.PutBlobFromURL method.
+// BlockBlobClientPutBlobFromURLOptions contains the optional parameters for the BlockBlobClient.PutBlobFromURL method.
 type BlockBlobClientPutBlobFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -219,7 +219,7 @@ type BlockBlobClientPutBlobFromURLOptions struct {
 	TransactionalContentMD5 []byte
 }
 
-// BlockBlobClientStageBlockFromURLOptions contains the optional parameters for the blockBlobClient.StageBlockFromURL method.
+// BlockBlobClientStageBlockFromURLOptions contains the optional parameters for the BlockBlobClient.StageBlockFromURL method.
 type BlockBlobClientStageBlockFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -235,7 +235,7 @@ type BlockBlobClientStageBlockFromURLOptions struct {
 	Timeout *int32
 }
 
-// BlockBlobClientStageBlockOptions contains the optional parameters for the blockBlobClient.StageBlock method.
+// BlockBlobClientStageBlockOptions contains the optional parameters for the BlockBlobClient.StageBlock method.
 type BlockBlobClientStageBlockOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -249,7 +249,7 @@ type BlockBlobClientStageBlockOptions struct {
 	TransactionalContentMD5 []byte
 }
 
-// BlockBlobClientUploadOptions contains the optional parameters for the blockBlobClient.Upload method.
+// BlockBlobClientUploadOptions contains the optional parameters for the BlockBlobClient.Upload method.
 type BlockBlobClientUploadOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -297,7 +297,7 @@ type ClearRange struct {
 	Start *int64 `xml:"Start"`
 }
 
-// ClientAbortCopyFromURLOptions contains the optional parameters for the client.AbortCopyFromURL method.
+// ClientAbortCopyFromURLOptions contains the optional parameters for the Client.AbortCopyFromURL method.
 type ClientAbortCopyFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -307,7 +307,7 @@ type ClientAbortCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-// ClientAcquireLeaseOptions contains the optional parameters for the client.AcquireLease method.
+// ClientAcquireLeaseOptions contains the optional parameters for the Client.AcquireLease method.
 type ClientAcquireLeaseOptions struct {
 	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
 	// can be between 15 and 60 seconds. A lease duration cannot be changed using
@@ -325,7 +325,7 @@ type ClientAcquireLeaseOptions struct {
 	Timeout *int32
 }
 
-// ClientBreakLeaseOptions contains the optional parameters for the client.BreakLease method.
+// ClientBreakLeaseOptions contains the optional parameters for the Client.BreakLease method.
 type ClientBreakLeaseOptions struct {
 	// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This
 	// break period is only used if it is shorter than the time remaining on the
@@ -342,7 +342,7 @@ type ClientBreakLeaseOptions struct {
 	Timeout *int32
 }
 
-// ClientChangeLeaseOptions contains the optional parameters for the client.ChangeLease method.
+// ClientChangeLeaseOptions contains the optional parameters for the Client.ChangeLease method.
 type ClientChangeLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -352,7 +352,7 @@ type ClientChangeLeaseOptions struct {
 	Timeout *int32
 }
 
-// ClientCopyFromURLOptions contains the optional parameters for the client.CopyFromURL method.
+// ClientCopyFromURLOptions contains the optional parameters for the Client.CopyFromURL method.
 type ClientCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -381,7 +381,7 @@ type ClientCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-// ClientCreateSnapshotOptions contains the optional parameters for the client.CreateSnapshot method.
+// ClientCreateSnapshotOptions contains the optional parameters for the Client.CreateSnapshot method.
 type ClientCreateSnapshotOptions struct {
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
@@ -398,7 +398,7 @@ type ClientCreateSnapshotOptions struct {
 	Timeout *int32
 }
 
-// ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the client.DeleteImmutabilityPolicy method.
+// ClientDeleteImmutabilityPolicyOptions contains the optional parameters for the Client.DeleteImmutabilityPolicy method.
 type ClientDeleteImmutabilityPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -408,7 +408,7 @@ type ClientDeleteImmutabilityPolicyOptions struct {
 	Timeout *int32
 }
 
-// ClientDeleteOptions contains the optional parameters for the client.Delete method.
+// ClientDeleteOptions contains the optional parameters for the Client.Delete method.
 type ClientDeleteOptions struct {
 	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled..
 	// Specifying any value will set the value to Permanent.
@@ -432,7 +432,7 @@ type ClientDeleteOptions struct {
 	VersionID *string
 }
 
-// ClientDownloadOptions contains the optional parameters for the client.Download method.
+// ClientDownloadOptions contains the optional parameters for the Client.Download method.
 type ClientDownloadOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -457,7 +457,7 @@ type ClientDownloadOptions struct {
 	VersionID *string
 }
 
-// ClientGetAccessControlOptions contains the optional parameters for the client.GetAccessControl method.
+// ClientGetAccessControlOptions contains the optional parameters for the Client.GetAccessControl method.
 type ClientGetAccessControlOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -472,12 +472,12 @@ type ClientGetAccessControlOptions struct {
 	Upn *bool
 }
 
-// ClientGetAccountInfoOptions contains the optional parameters for the client.GetAccountInfo method.
+// ClientGetAccountInfoOptions contains the optional parameters for the Client.GetAccountInfo method.
 type ClientGetAccountInfoOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ClientGetPropertiesOptions contains the optional parameters for the client.GetProperties method.
+// ClientGetPropertiesOptions contains the optional parameters for the Client.GetProperties method.
 type ClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -494,7 +494,7 @@ type ClientGetPropertiesOptions struct {
 	VersionID *string
 }
 
-// ClientGetTagsOptions contains the optional parameters for the client.GetTags method.
+// ClientGetTagsOptions contains the optional parameters for the Client.GetTags method.
 type ClientGetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -511,7 +511,7 @@ type ClientGetTagsOptions struct {
 	VersionID *string
 }
 
-// ClientQueryOptions contains the optional parameters for the client.Query method.
+// ClientQueryOptions contains the optional parameters for the Client.Query method.
 type ClientQueryOptions struct {
 	// the query request
 	QueryRequest *QueryRequest
@@ -527,7 +527,7 @@ type ClientQueryOptions struct {
 	Timeout *int32
 }
 
-// ClientReleaseLeaseOptions contains the optional parameters for the client.ReleaseLease method.
+// ClientReleaseLeaseOptions contains the optional parameters for the Client.ReleaseLease method.
 type ClientReleaseLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -537,7 +537,7 @@ type ClientReleaseLeaseOptions struct {
 	Timeout *int32
 }
 
-// ClientRenameOptions contains the optional parameters for the client.Rename method.
+// ClientRenameOptions contains the optional parameters for the Client.Rename method.
 type ClientRenameOptions struct {
 	// Optional. User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name
 	// and value pairs "n1=v1, n2=v2, …", where each value is base64 encoded.
@@ -563,7 +563,7 @@ type ClientRenameOptions struct {
 	Timeout *int32
 }
 
-// ClientRenewLeaseOptions contains the optional parameters for the client.RenewLease method.
+// ClientRenewLeaseOptions contains the optional parameters for the Client.RenewLease method.
 type ClientRenewLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -573,7 +573,7 @@ type ClientRenewLeaseOptions struct {
 	Timeout *int32
 }
 
-// ClientSetAccessControlOptions contains the optional parameters for the client.SetAccessControl method.
+// ClientSetAccessControlOptions contains the optional parameters for the Client.SetAccessControl method.
 type ClientSetAccessControlOptions struct {
 	// Optional. The owning group of the blob or directory.
 	Group *string
@@ -596,7 +596,7 @@ type ClientSetAccessControlOptions struct {
 	Timeout *int32
 }
 
-// ClientSetExpiryOptions contains the optional parameters for the client.SetExpiry method.
+// ClientSetExpiryOptions contains the optional parameters for the Client.SetExpiry method.
 type ClientSetExpiryOptions struct {
 	// The time to set the blob to expiry
 	ExpiresOn *string
@@ -608,7 +608,7 @@ type ClientSetExpiryOptions struct {
 	Timeout *int32
 }
 
-// ClientSetHTTPHeadersOptions contains the optional parameters for the client.SetHTTPHeaders method.
+// ClientSetHTTPHeadersOptions contains the optional parameters for the Client.SetHTTPHeaders method.
 type ClientSetHTTPHeadersOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -618,7 +618,7 @@ type ClientSetHTTPHeadersOptions struct {
 	Timeout *int32
 }
 
-// ClientSetImmutabilityPolicyOptions contains the optional parameters for the client.SetImmutabilityPolicy method.
+// ClientSetImmutabilityPolicyOptions contains the optional parameters for the Client.SetImmutabilityPolicy method.
 type ClientSetImmutabilityPolicyOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
@@ -632,7 +632,7 @@ type ClientSetImmutabilityPolicyOptions struct {
 	Timeout *int32
 }
 
-// ClientSetLegalHoldOptions contains the optional parameters for the client.SetLegalHold method.
+// ClientSetLegalHoldOptions contains the optional parameters for the Client.SetLegalHold method.
 type ClientSetLegalHoldOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -642,7 +642,7 @@ type ClientSetLegalHoldOptions struct {
 	Timeout *int32
 }
 
-// ClientSetMetadataOptions contains the optional parameters for the client.SetMetadata method.
+// ClientSetMetadataOptions contains the optional parameters for the Client.SetMetadata method.
 type ClientSetMetadataOptions struct {
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
@@ -659,7 +659,7 @@ type ClientSetMetadataOptions struct {
 	Timeout *int32
 }
 
-// ClientSetTagsOptions contains the optional parameters for the client.SetTags method.
+// ClientSetTagsOptions contains the optional parameters for the Client.SetTags method.
 type ClientSetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -678,7 +678,7 @@ type ClientSetTagsOptions struct {
 	VersionID *string
 }
 
-// ClientSetTierOptions contains the optional parameters for the client.SetTier method.
+// ClientSetTierOptions contains the optional parameters for the Client.SetTier method.
 type ClientSetTierOptions struct {
 	// Optional: Indicates the priority with which to rehydrate an archived blob.
 	RehydratePriority *RehydratePriority
@@ -697,7 +697,7 @@ type ClientSetTierOptions struct {
 	VersionID *string
 }
 
-// ClientStartCopyFromURLOptions contains the optional parameters for the client.StartCopyFromURL method.
+// ClientStartCopyFromURLOptions contains the optional parameters for the Client.StartCopyFromURL method.
 type ClientStartCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
@@ -728,7 +728,7 @@ type ClientStartCopyFromURLOptions struct {
 	Timeout *int32
 }
 
-// ClientUndeleteOptions contains the optional parameters for the client.Undelete method.
+// ClientUndeleteOptions contains the optional parameters for the Client.Undelete method.
 type ClientUndeleteOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -738,7 +738,7 @@ type ClientUndeleteOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientAcquireLeaseOptions contains the optional parameters for the containerClient.AcquireLease method.
+// ContainerClientAcquireLeaseOptions contains the optional parameters for the ContainerClient.AcquireLease method.
 type ContainerClientAcquireLeaseOptions struct {
 	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease
 	// can be between 15 and 60 seconds. A lease duration cannot be changed using
@@ -756,7 +756,7 @@ type ContainerClientAcquireLeaseOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientBreakLeaseOptions contains the optional parameters for the containerClient.BreakLease method.
+// ContainerClientBreakLeaseOptions contains the optional parameters for the ContainerClient.BreakLease method.
 type ContainerClientBreakLeaseOptions struct {
 	// For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This
 	// break period is only used if it is shorter than the time remaining on the
@@ -773,7 +773,7 @@ type ContainerClientBreakLeaseOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientChangeLeaseOptions contains the optional parameters for the containerClient.ChangeLease method.
+// ContainerClientChangeLeaseOptions contains the optional parameters for the ContainerClient.ChangeLease method.
 type ContainerClientChangeLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -783,7 +783,7 @@ type ContainerClientChangeLeaseOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientCreateOptions contains the optional parameters for the containerClient.Create method.
+// ContainerClientCreateOptions contains the optional parameters for the ContainerClient.Create method.
 type ContainerClientCreateOptions struct {
 	// Specifies whether data in the container may be accessed publicly and the level of access
 	Access *PublicAccessType
@@ -802,7 +802,7 @@ type ContainerClientCreateOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientDeleteOptions contains the optional parameters for the containerClient.Delete method.
+// ContainerClientDeleteOptions contains the optional parameters for the ContainerClient.Delete method.
 type ContainerClientDeleteOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -812,7 +812,7 @@ type ContainerClientDeleteOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientGetAccessPolicyOptions contains the optional parameters for the containerClient.GetAccessPolicy method.
+// ContainerClientGetAccessPolicyOptions contains the optional parameters for the ContainerClient.GetAccessPolicy method.
 type ContainerClientGetAccessPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -822,12 +822,12 @@ type ContainerClientGetAccessPolicyOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientGetAccountInfoOptions contains the optional parameters for the containerClient.GetAccountInfo method.
+// ContainerClientGetAccountInfoOptions contains the optional parameters for the ContainerClient.GetAccountInfo method.
 type ContainerClientGetAccountInfoOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ContainerClientGetPropertiesOptions contains the optional parameters for the containerClient.GetProperties method.
+// ContainerClientGetPropertiesOptions contains the optional parameters for the ContainerClient.GetProperties method.
 type ContainerClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -837,7 +837,7 @@ type ContainerClientGetPropertiesOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientListBlobFlatSegmentOptions contains the optional parameters for the containerClient.NewListBlobFlatSegmentPager
+// ContainerClientListBlobFlatSegmentOptions contains the optional parameters for the ContainerClient.NewListBlobFlatSegmentPager
 // method.
 type ContainerClientListBlobFlatSegmentOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
@@ -864,7 +864,7 @@ type ContainerClientListBlobFlatSegmentOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientListBlobHierarchySegmentOptions contains the optional parameters for the containerClient.NewListBlobHierarchySegmentPager
+// ContainerClientListBlobHierarchySegmentOptions contains the optional parameters for the ContainerClient.NewListBlobHierarchySegmentPager
 // method.
 type ContainerClientListBlobHierarchySegmentOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
@@ -891,7 +891,7 @@ type ContainerClientListBlobHierarchySegmentOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientReleaseLeaseOptions contains the optional parameters for the containerClient.ReleaseLease method.
+// ContainerClientReleaseLeaseOptions contains the optional parameters for the ContainerClient.ReleaseLease method.
 type ContainerClientReleaseLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -901,7 +901,7 @@ type ContainerClientReleaseLeaseOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientRenameOptions contains the optional parameters for the containerClient.Rename method.
+// ContainerClientRenameOptions contains the optional parameters for the ContainerClient.Rename method.
 type ContainerClientRenameOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -913,7 +913,7 @@ type ContainerClientRenameOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientRenewLeaseOptions contains the optional parameters for the containerClient.RenewLease method.
+// ContainerClientRenewLeaseOptions contains the optional parameters for the ContainerClient.RenewLease method.
 type ContainerClientRenewLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -923,7 +923,7 @@ type ContainerClientRenewLeaseOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientRestoreOptions contains the optional parameters for the containerClient.Restore method.
+// ContainerClientRestoreOptions contains the optional parameters for the ContainerClient.Restore method.
 type ContainerClientRestoreOptions struct {
 	// Optional. Version 2019-12-12 and later. Specifies the name of the deleted container to restore.
 	DeletedContainerName *string
@@ -937,7 +937,7 @@ type ContainerClientRestoreOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientSetAccessPolicyOptions contains the optional parameters for the containerClient.SetAccessPolicy method.
+// ContainerClientSetAccessPolicyOptions contains the optional parameters for the ContainerClient.SetAccessPolicy method.
 type ContainerClientSetAccessPolicyOptions struct {
 	// Specifies whether data in the container may be accessed publicly and the level of access
 	Access *PublicAccessType
@@ -951,7 +951,7 @@ type ContainerClientSetAccessPolicyOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientSetMetadataOptions contains the optional parameters for the containerClient.SetMetadata method.
+// ContainerClientSetMetadataOptions contains the optional parameters for the ContainerClient.SetMetadata method.
 type ContainerClientSetMetadataOptions struct {
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
@@ -968,7 +968,7 @@ type ContainerClientSetMetadataOptions struct {
 	Timeout *int32
 }
 
-// ContainerClientSubmitBatchOptions contains the optional parameters for the containerClient.SubmitBatch method.
+// ContainerClientSubmitBatchOptions contains the optional parameters for the ContainerClient.SubmitBatch method.
 type ContainerClientSubmitBatchOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -978,7 +978,7 @@ type ContainerClientSubmitBatchOptions struct {
 	Timeout *int32
 }
 
-// ContainerCpkScopeInfo contains a group of parameters for the containerClient.Create method.
+// ContainerCpkScopeInfo contains a group of parameters for the ContainerClient.Create method.
 type ContainerCpkScopeInfo struct {
 	// Optional. Version 2019-07-07 and later. Specifies the default encryption scope to set on the container and use for all
 	// future writes.
@@ -1049,7 +1049,7 @@ type CorsRule struct {
 	MaxAgeInSeconds *int32 `xml:"MaxAgeInSeconds"`
 }
 
-// CpkInfo contains a group of parameters for the client.Download method.
+// CpkInfo contains a group of parameters for the Client.Download method.
 type CpkInfo struct {
 	// The algorithm used to produce the encryption key hash. Currently, the only accepted value is "AES256". Must be provided
 	// if the x-ms-encryption-key header is provided.. Specifying any value will set the value to AES256.
@@ -1062,7 +1062,7 @@ type CpkInfo struct {
 	EncryptionKeySHA256 *string
 }
 
-// CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
+// CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
 type CpkScopeInfo struct {
 	// Optional. Version 2019-07-07 and later. Specifies the name of the encryption scope to use to encrypt the data provided
 	// in the request. If not specified, encryption is performed with the default
@@ -1102,7 +1102,7 @@ type DelimitedTextConfiguration struct {
 	RecordSeparator *string `xml:"RecordSeparator"`
 }
 
-// DirectoryClientCreateOptions contains the optional parameters for the directoryClient.Create method.
+// DirectoryClientCreateOptions contains the optional parameters for the DirectoryClient.Create method.
 type DirectoryClientCreateOptions struct {
 	// Optional. User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name
 	// and value pairs "n1=v1, n2=v2, …", where each value is base64 encoded.
@@ -1126,7 +1126,7 @@ type DirectoryClientCreateOptions struct {
 	Timeout *int32
 }
 
-// DirectoryClientDeleteOptions contains the optional parameters for the directoryClient.Delete method.
+// DirectoryClientDeleteOptions contains the optional parameters for the DirectoryClient.Delete method.
 type DirectoryClientDeleteOptions struct {
 	// When renaming a directory, the number of paths that are renamed with each invocation is limited. If the number of paths
 	// to be renamed exceeds this limit, a continuation token is returned in this
@@ -1141,7 +1141,7 @@ type DirectoryClientDeleteOptions struct {
 	Timeout *int32
 }
 
-// DirectoryClientGetAccessControlOptions contains the optional parameters for the directoryClient.GetAccessControl method.
+// DirectoryClientGetAccessControlOptions contains the optional parameters for the DirectoryClient.GetAccessControl method.
 type DirectoryClientGetAccessControlOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1156,7 +1156,7 @@ type DirectoryClientGetAccessControlOptions struct {
 	Upn *bool
 }
 
-// DirectoryClientRenameOptions contains the optional parameters for the directoryClient.Rename method.
+// DirectoryClientRenameOptions contains the optional parameters for the DirectoryClient.Rename method.
 type DirectoryClientRenameOptions struct {
 	// Optional. User-defined properties to be stored with the file or directory, in the format of a comma-separated list of name
 	// and value pairs "n1=v1, n2=v2, …", where each value is base64 encoded.
@@ -1187,7 +1187,7 @@ type DirectoryClientRenameOptions struct {
 	Timeout *int32
 }
 
-// DirectoryClientSetAccessControlOptions contains the optional parameters for the directoryClient.SetAccessControl method.
+// DirectoryClientSetAccessControlOptions contains the optional parameters for the DirectoryClient.SetAccessControl method.
 type DirectoryClientSetAccessControlOptions struct {
 	// Optional. The owning group of the blob or directory.
 	Group *string
@@ -1210,7 +1210,7 @@ type DirectoryClientSetAccessControlOptions struct {
 	Timeout *int32
 }
 
-// DirectoryHTTPHeaders contains a group of parameters for the directoryClient.Create method.
+// DirectoryHTTPHeaders contains a group of parameters for the DirectoryClient.Create method.
 type DirectoryHTTPHeaders struct {
 	// Cache control for given resource
 	CacheControl *string
@@ -1310,7 +1310,7 @@ type KeyInfo struct {
 	Start *string `xml:"Start"`
 }
 
-// LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
+// LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
 type LeaseAccessConditions struct {
 	// If specified, the operation only succeeds if the resource's lease is active and matches this ID.
 	LeaseID *string
@@ -1401,7 +1401,7 @@ type Metrics struct {
 	Version *string `xml:"Version"`
 }
 
-// ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
+// ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
 type ModifiedAccessConditions struct {
 	// Specify an ETag value to operate only on blobs with a matching value.
 	IfMatch *string
@@ -1415,7 +1415,7 @@ type ModifiedAccessConditions struct {
 	IfUnmodifiedSince *time.Time
 }
 
-// PageBlobClientClearPagesOptions contains the optional parameters for the pageBlobClient.ClearPages method.
+// PageBlobClientClearPagesOptions contains the optional parameters for the PageBlobClient.ClearPages method.
 type PageBlobClientClearPagesOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -1427,7 +1427,7 @@ type PageBlobClientClearPagesOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientCopyIncrementalOptions contains the optional parameters for the pageBlobClient.CopyIncremental method.
+// PageBlobClientCopyIncrementalOptions contains the optional parameters for the PageBlobClient.CopyIncremental method.
 type PageBlobClientCopyIncrementalOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1437,7 +1437,7 @@ type PageBlobClientCopyIncrementalOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientCreateOptions contains the optional parameters for the pageBlobClient.Create method.
+// PageBlobClientCreateOptions contains the optional parameters for the PageBlobClient.Create method.
 type PageBlobClientCreateOptions struct {
 	// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value of
 	// the sequence number must be between 0 and 2^63 - 1.
@@ -1467,7 +1467,7 @@ type PageBlobClientCreateOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientGetPageRangesDiffOptions contains the optional parameters for the pageBlobClient.GetPageRangesDiff method.
+// PageBlobClientGetPageRangesDiffOptions contains the optional parameters for the PageBlobClient.GetPageRangesDiff method.
 type PageBlobClientGetPageRangesDiffOptions struct {
 	// Optional. This header is only supported in service versions 2019-04-19 and after and specifies the URL of a previous snapshot
 	// of the target blob. The response will only contain pages that were changed
@@ -1493,7 +1493,7 @@ type PageBlobClientGetPageRangesDiffOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientGetPageRangesOptions contains the optional parameters for the pageBlobClient.GetPageRanges method.
+// PageBlobClientGetPageRangesOptions contains the optional parameters for the PageBlobClient.GetPageRanges method.
 type PageBlobClientGetPageRangesOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -1509,7 +1509,7 @@ type PageBlobClientGetPageRangesOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientResizeOptions contains the optional parameters for the pageBlobClient.Resize method.
+// PageBlobClientResizeOptions contains the optional parameters for the PageBlobClient.Resize method.
 type PageBlobClientResizeOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1519,7 +1519,7 @@ type PageBlobClientResizeOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientUpdateSequenceNumberOptions contains the optional parameters for the pageBlobClient.UpdateSequenceNumber
+// PageBlobClientUpdateSequenceNumberOptions contains the optional parameters for the PageBlobClient.UpdateSequenceNumber
 // method.
 type PageBlobClientUpdateSequenceNumberOptions struct {
 	// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value of
@@ -1533,7 +1533,7 @@ type PageBlobClientUpdateSequenceNumberOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientUploadPagesFromURLOptions contains the optional parameters for the pageBlobClient.UploadPagesFromURL method.
+// PageBlobClientUploadPagesFromURLOptions contains the optional parameters for the PageBlobClient.UploadPagesFromURL method.
 type PageBlobClientUploadPagesFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1547,7 +1547,7 @@ type PageBlobClientUploadPagesFromURLOptions struct {
 	Timeout *int32
 }
 
-// PageBlobClientUploadPagesOptions contains the optional parameters for the pageBlobClient.UploadPages method.
+// PageBlobClientUploadPagesOptions contains the optional parameters for the PageBlobClient.UploadPages method.
 type PageBlobClientUploadPagesOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
@@ -1679,7 +1679,7 @@ type RetentionPolicy struct {
 	Days *int32 `xml:"Days"`
 }
 
-// SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages method.
+// SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages method.
 type SequenceNumberAccessConditions struct {
 	// Specify this header value to operate only on a blob if it has the specified sequence number.
 	IfSequenceNumberEqualTo *int64
@@ -1689,7 +1689,7 @@ type SequenceNumberAccessConditions struct {
 	IfSequenceNumberLessThanOrEqualTo *int64
 }
 
-// ServiceClientFilterBlobsOptions contains the optional parameters for the serviceClient.FilterBlobs method.
+// ServiceClientFilterBlobsOptions contains the optional parameters for the ServiceClient.FilterBlobs method.
 type ServiceClientFilterBlobsOptions struct {
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
@@ -1713,12 +1713,12 @@ type ServiceClientFilterBlobsOptions struct {
 	Where *string
 }
 
-// ServiceClientGetAccountInfoOptions contains the optional parameters for the serviceClient.GetAccountInfo method.
+// ServiceClientGetAccountInfoOptions contains the optional parameters for the ServiceClient.GetAccountInfo method.
 type ServiceClientGetAccountInfoOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ServiceClientGetPropertiesOptions contains the optional parameters for the serviceClient.GetProperties method.
+// ServiceClientGetPropertiesOptions contains the optional parameters for the ServiceClient.GetProperties method.
 type ServiceClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1728,7 +1728,7 @@ type ServiceClientGetPropertiesOptions struct {
 	Timeout *int32
 }
 
-// ServiceClientGetStatisticsOptions contains the optional parameters for the serviceClient.GetStatistics method.
+// ServiceClientGetStatisticsOptions contains the optional parameters for the ServiceClient.GetStatistics method.
 type ServiceClientGetStatisticsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1738,7 +1738,7 @@ type ServiceClientGetStatisticsOptions struct {
 	Timeout *int32
 }
 
-// ServiceClientGetUserDelegationKeyOptions contains the optional parameters for the serviceClient.GetUserDelegationKey method.
+// ServiceClientGetUserDelegationKeyOptions contains the optional parameters for the ServiceClient.GetUserDelegationKey method.
 type ServiceClientGetUserDelegationKeyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1748,7 +1748,7 @@ type ServiceClientGetUserDelegationKeyOptions struct {
 	Timeout *int32
 }
 
-// ServiceClientListContainersSegmentOptions contains the optional parameters for the serviceClient.NewListContainersSegmentPager
+// ServiceClientListContainersSegmentOptions contains the optional parameters for the ServiceClient.NewListContainersSegmentPager
 // method.
 type ServiceClientListContainersSegmentOptions struct {
 	// Include this parameter to specify that the container's metadata be returned as part of the response body.
@@ -1775,7 +1775,7 @@ type ServiceClientListContainersSegmentOptions struct {
 	Timeout *int32
 }
 
-// ServiceClientSetPropertiesOptions contains the optional parameters for the serviceClient.SetProperties method.
+// ServiceClientSetPropertiesOptions contains the optional parameters for the ServiceClient.SetProperties method.
 type ServiceClientSetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1785,7 +1785,7 @@ type ServiceClientSetPropertiesOptions struct {
 	Timeout *int32
 }
 
-// ServiceClientSubmitBatchOptions contains the optional parameters for the serviceClient.SubmitBatch method.
+// ServiceClientSubmitBatchOptions contains the optional parameters for the ServiceClient.SubmitBatch method.
 type ServiceClientSubmitBatchOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
@@ -1804,7 +1804,7 @@ type SignedIdentifier struct {
 	ID *string `xml:"Id"`
 }
 
-// SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename method.
+// SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename method.
 type SourceModifiedAccessConditions struct {
 	// Specify an ETag value to operate only on blobs with a matching value.
 	SourceIfMatch *string

--- a/test/storage/2020-06-12/azblob/zz_pageblob_client.go
+++ b/test/storage/2020-06-12/azblob/zz_pageblob_client.go
@@ -12,6 +12,7 @@ package azblob
 import (
 	"context"
 	"encoding/base64"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -20,23 +21,12 @@ import (
 	"time"
 )
 
-type pageBlobClient struct {
+// PageBlobClient contains the methods for the PageBlob group.
+// Don't use this type directly, use a constructor function instead.
+type PageBlobClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum2
-	pl       runtime.Pipeline
-}
-
-// newPageBlobClient creates a new instance of pageBlobClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newPageBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *pageBlobClient {
-	client := &pageBlobClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // ClearPages - The Clear Pages operation clears a set of pages from a page blob
@@ -44,19 +34,19 @@ func newPageBlobClient(endpoint string, version Enum2, pl runtime.Pipeline) *pag
 //
 // Generated from API version 2020-06-12
 //   - contentLength - The length of the request.
-//   - options - PageBlobClientClearPagesOptions contains the optional parameters for the pageBlobClient.ClearPages method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages
+//   - options - PageBlobClientClearPagesOptions contains the optional parameters for the PageBlobClient.ClearPages method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) ClearPages(ctx context.Context, comp Enum35, contentLength int64, options *PageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientClearPagesResponse, error) {
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) ClearPages(ctx context.Context, comp Enum35, contentLength int64, options *PageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientClearPagesResponse, error) {
 	req, err := client.clearPagesCreateRequest(ctx, comp, contentLength, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientClearPagesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientClearPagesResponse{}, err
 	}
@@ -67,7 +57,7 @@ func (client *pageBlobClient) ClearPages(ctx context.Context, comp Enum35, conte
 }
 
 // clearPagesCreateRequest creates the ClearPages request.
-func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, options *PageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) clearPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, options *PageBlobClientClearPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -131,7 +121,7 @@ func (client *pageBlobClient) clearPagesCreateRequest(ctx context.Context, comp 
 }
 
 // clearPagesHandleResponse handles the ClearPages response.
-func (client *pageBlobClient) clearPagesHandleResponse(resp *http.Response) (PageBlobClientClearPagesResponse, error) {
+func (client *PageBlobClient) clearPagesHandleResponse(resp *http.Response) (PageBlobClientClearPagesResponse, error) {
 	result := PageBlobClientClearPagesResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -194,15 +184,15 @@ func (client *pageBlobClient) clearPagesHandleResponse(resp *http.Response) (Pag
 //   - copySource - Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies
 //     a page blob snapshot. The value should be URL-encoded as it would appear in a request
 //     URI. The source blob must either be public or must be authenticated via a shared access signature.
-//   - options - PageBlobClientCopyIncrementalOptions contains the optional parameters for the pageBlobClient.CopyIncremental
+//   - options - PageBlobClientCopyIncrementalOptions contains the optional parameters for the PageBlobClient.CopyIncremental
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, copySource string, options *PageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientCopyIncrementalResponse, error) {
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, copySource string, options *PageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientCopyIncrementalResponse, error) {
 	req, err := client.copyIncrementalCreateRequest(ctx, comp, copySource, options, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientCopyIncrementalResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientCopyIncrementalResponse{}, err
 	}
@@ -213,7 +203,7 @@ func (client *pageBlobClient) CopyIncremental(ctx context.Context, comp Enum37, 
 }
 
 // copyIncrementalCreateRequest creates the CopyIncremental request.
-func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, comp Enum37, copySource string, options *PageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) copyIncrementalCreateRequest(ctx context.Context, comp Enum37, copySource string, options *PageBlobClientCopyIncrementalOptions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -249,7 +239,7 @@ func (client *pageBlobClient) copyIncrementalCreateRequest(ctx context.Context, 
 }
 
 // copyIncrementalHandleResponse handles the CopyIncremental response.
-func (client *pageBlobClient) copyIncrementalHandleResponse(resp *http.Response) (PageBlobClientCopyIncrementalResponse, error) {
+func (client *PageBlobClient) copyIncrementalHandleResponse(resp *http.Response) (PageBlobClientCopyIncrementalResponse, error) {
 	result := PageBlobClientCopyIncrementalResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -293,18 +283,18 @@ func (client *pageBlobClient) copyIncrementalHandleResponse(resp *http.Response)
 //   - contentLength - The length of the request.
 //   - blobContentLength - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned
 //     to a 512-byte boundary.
-//   - options - PageBlobClientCreateOptions contains the optional parameters for the pageBlobClient.Create method.
-//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the client.SetHTTPHeaders method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, blobContentLength int64, options *PageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientCreateResponse, error) {
+//   - options - PageBlobClientCreateOptions contains the optional parameters for the PageBlobClient.Create method.
+//   - BlobHTTPHeaders - BlobHTTPHeaders contains a group of parameters for the Client.SetHTTPHeaders method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) Create(ctx context.Context, contentLength int64, blobContentLength int64, options *PageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientCreateResponse, error) {
 	req, err := client.createCreateRequest(ctx, contentLength, blobContentLength, options, blobHTTPHeaders, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientCreateResponse{}, err
 	}
@@ -315,7 +305,7 @@ func (client *pageBlobClient) Create(ctx context.Context, contentLength int64, b
 }
 
 // createCreateRequest creates the Create request.
-func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLength int64, blobContentLength int64, options *PageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) createCreateRequest(ctx context.Context, contentLength int64, blobContentLength int64, options *PageBlobClientCreateOptions, blobHTTPHeaders *BlobHTTPHeaders, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -410,7 +400,7 @@ func (client *pageBlobClient) createCreateRequest(ctx context.Context, contentLe
 }
 
 // createHandleResponse handles the Create response.
-func (client *pageBlobClient) createHandleResponse(resp *http.Response) (PageBlobClientCreateResponse, error) {
+func (client *PageBlobClient) createHandleResponse(resp *http.Response) (PageBlobClientCreateResponse, error) {
 	result := PageBlobClientCreateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -469,15 +459,15 @@ func (client *pageBlobClient) createHandleResponse(resp *http.Response) (PageBlo
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - PageBlobClientGetPageRangesOptions contains the optional parameters for the pageBlobClient.GetPageRanges method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientGetPageRangesResponse, error) {
+//   - options - PageBlobClientGetPageRangesOptions contains the optional parameters for the PageBlobClient.GetPageRanges method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientGetPageRangesResponse, error) {
 	req, err := client.getPageRangesCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientGetPageRangesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientGetPageRangesResponse{}, err
 	}
@@ -488,7 +478,7 @@ func (client *pageBlobClient) GetPageRanges(ctx context.Context, comp Enum36, op
 }
 
 // getPageRangesCreateRequest creates the GetPageRanges request.
-func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) getPageRangesCreateRequest(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -532,7 +522,7 @@ func (client *pageBlobClient) getPageRangesCreateRequest(ctx context.Context, co
 }
 
 // getPageRangesHandleResponse handles the GetPageRanges response.
-func (client *pageBlobClient) getPageRangesHandleResponse(resp *http.Response) (PageBlobClientGetPageRangesResponse, error) {
+func (client *PageBlobClient) getPageRangesHandleResponse(resp *http.Response) (PageBlobClientGetPageRangesResponse, error) {
 	result := PageBlobClientGetPageRangesResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -578,16 +568,16 @@ func (client *pageBlobClient) getPageRangesHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - PageBlobClientGetPageRangesDiffOptions contains the optional parameters for the pageBlobClient.GetPageRangesDiff
+//   - options - PageBlobClientGetPageRangesDiffOptions contains the optional parameters for the PageBlobClient.GetPageRangesDiff
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientGetPageRangesDiffResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientGetPageRangesDiffResponse, error) {
 	req, err := client.getPageRangesDiffCreateRequest(ctx, comp, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientGetPageRangesDiffResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientGetPageRangesDiffResponse{}, err
 	}
@@ -598,7 +588,7 @@ func (client *pageBlobClient) GetPageRangesDiff(ctx context.Context, comp Enum36
 }
 
 // getPageRangesDiffCreateRequest creates the GetPageRangesDiff request.
-func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context, comp Enum36, options *PageBlobClientGetPageRangesDiffOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -648,7 +638,7 @@ func (client *pageBlobClient) getPageRangesDiffCreateRequest(ctx context.Context
 }
 
 // getPageRangesDiffHandleResponse handles the GetPageRangesDiff response.
-func (client *pageBlobClient) getPageRangesDiffHandleResponse(resp *http.Response) (PageBlobClientGetPageRangesDiffResponse, error) {
+func (client *PageBlobClient) getPageRangesDiffHandleResponse(resp *http.Response) (PageBlobClientGetPageRangesDiffResponse, error) {
 	result := PageBlobClientGetPageRangesDiffResponse{}
 	if val := resp.Header.Get("Last-Modified"); val != "" {
 		lastModified, err := time.Parse(time.RFC1123, val)
@@ -695,17 +685,17 @@ func (client *pageBlobClient) getPageRangesDiffHandleResponse(resp *http.Respons
 // Generated from API version 2020-06-12
 //   - blobContentLength - This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned
 //     to a 512-byte boundary.
-//   - options - PageBlobClientResizeOptions contains the optional parameters for the pageBlobClient.Resize method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) Resize(ctx context.Context, comp Enum1, blobContentLength int64, options *PageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientResizeResponse, error) {
+//   - options - PageBlobClientResizeOptions contains the optional parameters for the PageBlobClient.Resize method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) Resize(ctx context.Context, comp Enum1, blobContentLength int64, options *PageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientResizeResponse, error) {
 	req, err := client.resizeCreateRequest(ctx, comp, blobContentLength, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientResizeResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientResizeResponse{}, err
 	}
@@ -716,7 +706,7 @@ func (client *pageBlobClient) Resize(ctx context.Context, comp Enum1, blobConten
 }
 
 // resizeCreateRequest creates the Resize request.
-func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum1, blobContentLength int64, options *PageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum1, blobContentLength int64, options *PageBlobClientResizeOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -767,7 +757,7 @@ func (client *pageBlobClient) resizeCreateRequest(ctx context.Context, comp Enum
 }
 
 // resizeHandleResponse handles the Resize response.
-func (client *pageBlobClient) resizeHandleResponse(resp *http.Response) (PageBlobClientResizeResponse, error) {
+func (client *PageBlobClient) resizeHandleResponse(resp *http.Response) (PageBlobClientResizeResponse, error) {
 	result := PageBlobClientResizeResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -811,16 +801,16 @@ func (client *pageBlobClient) resizeHandleResponse(resp *http.Response) (PageBlo
 // Generated from API version 2020-06-12
 //   - sequenceNumberAction - Required if the x-ms-blob-sequence-number header is set for the request. This property applies to
 //     page blobs only. This property indicates how the service should modify the blob's sequence number
-//   - options - PageBlobClientUpdateSequenceNumberOptions contains the optional parameters for the pageBlobClient.UpdateSequenceNumber
+//   - options - PageBlobClientUpdateSequenceNumberOptions contains the optional parameters for the PageBlobClient.UpdateSequenceNumber
 //     method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *PageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientUpdateSequenceNumberResponse, error) {
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *PageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientUpdateSequenceNumberResponse, error) {
 	req, err := client.updateSequenceNumberCreateRequest(ctx, comp, sequenceNumberAction, options, leaseAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientUpdateSequenceNumberResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientUpdateSequenceNumberResponse{}, err
 	}
@@ -831,7 +821,7 @@ func (client *pageBlobClient) UpdateSequenceNumber(ctx context.Context, comp Enu
 }
 
 // updateSequenceNumberCreateRequest creates the UpdateSequenceNumber request.
-func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *PageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) updateSequenceNumberCreateRequest(ctx context.Context, comp Enum1, sequenceNumberAction SequenceNumberActionType, options *PageBlobClientUpdateSequenceNumberOptions, leaseAccessConditions *LeaseAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -873,7 +863,7 @@ func (client *pageBlobClient) updateSequenceNumberCreateRequest(ctx context.Cont
 }
 
 // updateSequenceNumberHandleResponse handles the UpdateSequenceNumber response.
-func (client *pageBlobClient) updateSequenceNumberHandleResponse(resp *http.Response) (PageBlobClientUpdateSequenceNumberResponse, error) {
+func (client *PageBlobClient) updateSequenceNumberHandleResponse(resp *http.Response) (PageBlobClientUpdateSequenceNumberResponse, error) {
 	result := PageBlobClientUpdateSequenceNumberResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -917,19 +907,19 @@ func (client *pageBlobClient) updateSequenceNumberHandleResponse(resp *http.Resp
 // Generated from API version 2020-06-12
 //   - contentLength - The length of the request.
 //   - body - Initial data
-//   - options - PageBlobClientUploadPagesOptions contains the optional parameters for the pageBlobClient.UploadPages method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages
+//   - options - PageBlobClientUploadPagesOptions contains the optional parameters for the PageBlobClient.UploadPages method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-func (client *pageBlobClient) UploadPages(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *PageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientUploadPagesResponse, error) {
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+func (client *PageBlobClient) UploadPages(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *PageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (PageBlobClientUploadPagesResponse, error) {
 	req, err := client.uploadPagesCreateRequest(ctx, comp, contentLength, body, options, leaseAccessConditions, cpkInfo, cpkScopeInfo, sequenceNumberAccessConditions, modifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientUploadPagesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientUploadPagesResponse{}, err
 	}
@@ -940,7 +930,7 @@ func (client *pageBlobClient) UploadPages(ctx context.Context, comp Enum35, cont
 }
 
 // uploadPagesCreateRequest creates the UploadPages request.
-func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *PageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp Enum35, contentLength int64, body io.ReadSeekCloser, options *PageBlobClientUploadPagesOptions, leaseAccessConditions *LeaseAccessConditions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1010,7 +1000,7 @@ func (client *pageBlobClient) uploadPagesCreateRequest(ctx context.Context, comp
 }
 
 // uploadPagesHandleResponse handles the UploadPages response.
-func (client *pageBlobClient) uploadPagesHandleResponse(resp *http.Response) (PageBlobClientUploadPagesResponse, error) {
+func (client *PageBlobClient) uploadPagesHandleResponse(resp *http.Response) (PageBlobClientUploadPagesResponse, error) {
 	result := PageBlobClientUploadPagesResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
@@ -1086,22 +1076,22 @@ func (client *pageBlobClient) uploadPagesHandleResponse(resp *http.Response) (Pa
 //   - contentLength - The length of the request.
 //   - rangeParam - The range of bytes to which the source range would be written. The range should be 512 aligned and range-end
 //     is required.
-//   - options - PageBlobClientUploadPagesFromURLOptions contains the optional parameters for the pageBlobClient.UploadPagesFromURL
+//   - options - PageBlobClientUploadPagesFromURLOptions contains the optional parameters for the PageBlobClient.UploadPagesFromURL
 //     method.
-//   - CpkInfo - CpkInfo contains a group of parameters for the client.Download method.
-//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the client.SetMetadata method.
-//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the containerClient.GetProperties method.
-//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the pageBlobClient.UploadPages
+//   - CpkInfo - CpkInfo contains a group of parameters for the Client.Download method.
+//   - CpkScopeInfo - CpkScopeInfo contains a group of parameters for the Client.SetMetadata method.
+//   - LeaseAccessConditions - LeaseAccessConditions contains a group of parameters for the ContainerClient.GetProperties method.
+//   - SequenceNumberAccessConditions - SequenceNumberAccessConditions contains a group of parameters for the PageBlobClient.UploadPages
 //     method.
-//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the containerClient.Delete method.
-//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the directoryClient.Rename
+//   - ModifiedAccessConditions - ModifiedAccessConditions contains a group of parameters for the ContainerClient.Delete method.
+//   - SourceModifiedAccessConditions - SourceModifiedAccessConditions contains a group of parameters for the DirectoryClient.Rename
 //     method.
-func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *PageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (PageBlobClientUploadPagesFromURLResponse, error) {
+func (client *PageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *PageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (PageBlobClientUploadPagesFromURLResponse, error) {
 	req, err := client.uploadPagesFromURLCreateRequest(ctx, comp, sourceURL, sourceRange, contentLength, rangeParam, options, cpkInfo, cpkScopeInfo, leaseAccessConditions, sequenceNumberAccessConditions, modifiedAccessConditions, sourceModifiedAccessConditions)
 	if err != nil {
 		return PageBlobClientUploadPagesFromURLResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PageBlobClientUploadPagesFromURLResponse{}, err
 	}
@@ -1112,7 +1102,7 @@ func (client *pageBlobClient) UploadPagesFromURL(ctx context.Context, comp Enum3
 }
 
 // uploadPagesFromURLCreateRequest creates the UploadPagesFromURL request.
-func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *PageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
+func (client *PageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Context, comp Enum35, sourceURL string, sourceRange string, contentLength int64, rangeParam string, options *PageBlobClientUploadPagesFromURLOptions, cpkInfo *CpkInfo, cpkScopeInfo *CpkScopeInfo, leaseAccessConditions *LeaseAccessConditions, sequenceNumberAccessConditions *SequenceNumberAccessConditions, modifiedAccessConditions *ModifiedAccessConditions, sourceModifiedAccessConditions *SourceModifiedAccessConditions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -1194,7 +1184,7 @@ func (client *pageBlobClient) uploadPagesFromURLCreateRequest(ctx context.Contex
 }
 
 // uploadPagesFromURLHandleResponse handles the UploadPagesFromURL response.
-func (client *pageBlobClient) uploadPagesFromURLHandleResponse(resp *http.Response) (PageBlobClientUploadPagesFromURLResponse, error) {
+func (client *PageBlobClient) uploadPagesFromURLHandleResponse(resp *http.Response) (PageBlobClientUploadPagesFromURLResponse, error) {
 	result := PageBlobClientUploadPagesFromURLResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val

--- a/test/storage/2020-06-12/azblob/zz_response_types.go
+++ b/test/storage/2020-06-12/azblob/zz_response_types.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// AppendBlobClientAppendBlockFromURLResponse contains the response from method appendBlobClient.AppendBlockFromURL.
+// AppendBlobClientAppendBlockFromURLResponse contains the response from method AppendBlobClient.AppendBlockFromURL.
 type AppendBlobClientAppendBlockFromURLResponse struct {
 	// BlobAppendOffset contains the information returned from the x-ms-blob-append-offset header response.
 	BlobAppendOffset *string
@@ -53,7 +53,7 @@ type AppendBlobClientAppendBlockFromURLResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// AppendBlobClientAppendBlockResponse contains the response from method appendBlobClient.AppendBlock.
+// AppendBlobClientAppendBlockResponse contains the response from method AppendBlobClient.AppendBlock.
 type AppendBlobClientAppendBlockResponse struct {
 	// BlobAppendOffset contains the information returned from the x-ms-blob-append-offset header response.
 	BlobAppendOffset *string
@@ -95,7 +95,7 @@ type AppendBlobClientAppendBlockResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// AppendBlobClientCreateResponse contains the response from method appendBlobClient.Create.
+// AppendBlobClientCreateResponse contains the response from method AppendBlobClient.Create.
 type AppendBlobClientCreateResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -131,7 +131,7 @@ type AppendBlobClientCreateResponse struct {
 	VersionID *string
 }
 
-// AppendBlobClientSealResponse contains the response from method appendBlobClient.Seal.
+// AppendBlobClientSealResponse contains the response from method AppendBlobClient.Seal.
 type AppendBlobClientSealResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -155,7 +155,7 @@ type AppendBlobClientSealResponse struct {
 	Version *string
 }
 
-// BlockBlobClientCommitBlockListResponse contains the response from method blockBlobClient.CommitBlockList.
+// BlockBlobClientCommitBlockListResponse contains the response from method BlockBlobClient.CommitBlockList.
 type BlockBlobClientCommitBlockListResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -194,7 +194,7 @@ type BlockBlobClientCommitBlockListResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// BlockBlobClientGetBlockListResponse contains the response from method blockBlobClient.GetBlockList.
+// BlockBlobClientGetBlockListResponse contains the response from method BlockBlobClient.GetBlockList.
 type BlockBlobClientGetBlockListResponse struct {
 	BlockList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
@@ -222,7 +222,7 @@ type BlockBlobClientGetBlockListResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// BlockBlobClientPutBlobFromURLResponse contains the response from method blockBlobClient.PutBlobFromURL.
+// BlockBlobClientPutBlobFromURLResponse contains the response from method BlockBlobClient.PutBlobFromURL.
 type BlockBlobClientPutBlobFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -258,7 +258,7 @@ type BlockBlobClientPutBlobFromURLResponse struct {
 	VersionID *string
 }
 
-// BlockBlobClientStageBlockFromURLResponse contains the response from method blockBlobClient.StageBlockFromURL.
+// BlockBlobClientStageBlockFromURLResponse contains the response from method BlockBlobClient.StageBlockFromURL.
 type BlockBlobClientStageBlockFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -288,7 +288,7 @@ type BlockBlobClientStageBlockFromURLResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// BlockBlobClientStageBlockResponse contains the response from method blockBlobClient.StageBlock.
+// BlockBlobClientStageBlockResponse contains the response from method BlockBlobClient.StageBlock.
 type BlockBlobClientStageBlockResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -318,7 +318,7 @@ type BlockBlobClientStageBlockResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// BlockBlobClientUploadResponse contains the response from method blockBlobClient.Upload.
+// BlockBlobClientUploadResponse contains the response from method BlockBlobClient.Upload.
 type BlockBlobClientUploadResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -354,7 +354,7 @@ type BlockBlobClientUploadResponse struct {
 	VersionID *string
 }
 
-// ClientAbortCopyFromURLResponse contains the response from method client.AbortCopyFromURL.
+// ClientAbortCopyFromURLResponse contains the response from method Client.AbortCopyFromURL.
 type ClientAbortCopyFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -369,7 +369,7 @@ type ClientAbortCopyFromURLResponse struct {
 	Version *string
 }
 
-// ClientAcquireLeaseResponse contains the response from method client.AcquireLease.
+// ClientAcquireLeaseResponse contains the response from method Client.AcquireLease.
 type ClientAcquireLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -393,7 +393,7 @@ type ClientAcquireLeaseResponse struct {
 	Version *string
 }
 
-// ClientBreakLeaseResponse contains the response from method client.BreakLease.
+// ClientBreakLeaseResponse contains the response from method Client.BreakLease.
 type ClientBreakLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -417,7 +417,7 @@ type ClientBreakLeaseResponse struct {
 	Version *string
 }
 
-// ClientChangeLeaseResponse contains the response from method client.ChangeLease.
+// ClientChangeLeaseResponse contains the response from method Client.ChangeLease.
 type ClientChangeLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -441,7 +441,7 @@ type ClientChangeLeaseResponse struct {
 	Version *string
 }
 
-// ClientCopyFromURLResponse contains the response from method client.CopyFromURL.
+// ClientCopyFromURLResponse contains the response from method Client.CopyFromURL.
 type ClientCopyFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -477,7 +477,7 @@ type ClientCopyFromURLResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// ClientCreateSnapshotResponse contains the response from method client.CreateSnapshot.
+// ClientCreateSnapshotResponse contains the response from method Client.CreateSnapshot.
 type ClientCreateSnapshotResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -507,7 +507,7 @@ type ClientCreateSnapshotResponse struct {
 	VersionID *string
 }
 
-// ClientDeleteImmutabilityPolicyResponse contains the response from method client.DeleteImmutabilityPolicy.
+// ClientDeleteImmutabilityPolicyResponse contains the response from method Client.DeleteImmutabilityPolicy.
 type ClientDeleteImmutabilityPolicyResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -522,7 +522,7 @@ type ClientDeleteImmutabilityPolicyResponse struct {
 	Version *string
 }
 
-// ClientDeleteResponse contains the response from method client.Delete.
+// ClientDeleteResponse contains the response from method Client.Delete.
 type ClientDeleteResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -537,7 +537,7 @@ type ClientDeleteResponse struct {
 	Version *string
 }
 
-// ClientDownloadResponse contains the response from method client.Download.
+// ClientDownloadResponse contains the response from method Client.Download.
 type ClientDownloadResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
@@ -672,7 +672,7 @@ type ClientDownloadResponse struct {
 	VersionID *string
 }
 
-// ClientGetAccessControlResponse contains the response from method client.GetAccessControl.
+// ClientGetAccessControlResponse contains the response from method Client.GetAccessControl.
 type ClientGetAccessControlResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
@@ -702,7 +702,7 @@ type ClientGetAccessControlResponse struct {
 	XMSPermissions *string
 }
 
-// ClientGetAccountInfoResponse contains the response from method client.GetAccountInfo.
+// ClientGetAccountInfoResponse contains the response from method Client.GetAccountInfo.
 type ClientGetAccountInfoResponse struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
@@ -723,7 +723,7 @@ type ClientGetAccountInfoResponse struct {
 	Version *string
 }
 
-// ClientGetPropertiesResponse contains the response from method client.GetProperties.
+// ClientGetPropertiesResponse contains the response from method Client.GetProperties.
 type ClientGetPropertiesResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
@@ -873,7 +873,7 @@ type ClientGetPropertiesResponse struct {
 	VersionID *string
 }
 
-// ClientGetTagsResponse contains the response from method client.GetTags.
+// ClientGetTagsResponse contains the response from method Client.GetTags.
 type ClientGetTagsResponse struct {
 	Tags
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -889,7 +889,7 @@ type ClientGetTagsResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ClientQueryResponse contains the response from method client.Query.
+// ClientQueryResponse contains the response from method Client.Query.
 type ClientQueryResponse struct {
 	// AcceptRanges contains the information returned from the Accept-Ranges header response.
 	AcceptRanges *string
@@ -994,7 +994,7 @@ type ClientQueryResponse struct {
 	Version *string
 }
 
-// ClientReleaseLeaseResponse contains the response from method client.ReleaseLease.
+// ClientReleaseLeaseResponse contains the response from method Client.ReleaseLease.
 type ClientReleaseLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1015,7 +1015,7 @@ type ClientReleaseLeaseResponse struct {
 	Version *string
 }
 
-// ClientRenameResponse contains the response from method client.Rename.
+// ClientRenameResponse contains the response from method Client.Rename.
 type ClientRenameResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1039,7 +1039,7 @@ type ClientRenameResponse struct {
 	Version *string
 }
 
-// ClientRenewLeaseResponse contains the response from method client.RenewLease.
+// ClientRenewLeaseResponse contains the response from method Client.RenewLease.
 type ClientRenewLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1063,7 +1063,7 @@ type ClientRenewLeaseResponse struct {
 	Version *string
 }
 
-// ClientSetAccessControlResponse contains the response from method client.SetAccessControl.
+// ClientSetAccessControlResponse contains the response from method Client.SetAccessControl.
 type ClientSetAccessControlResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
@@ -1081,7 +1081,7 @@ type ClientSetAccessControlResponse struct {
 	Version *string
 }
 
-// ClientSetExpiryResponse contains the response from method client.SetExpiry.
+// ClientSetExpiryResponse contains the response from method Client.SetExpiry.
 type ClientSetExpiryResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1102,7 +1102,7 @@ type ClientSetExpiryResponse struct {
 	Version *string
 }
 
-// ClientSetHTTPHeadersResponse contains the response from method client.SetHTTPHeaders.
+// ClientSetHTTPHeadersResponse contains the response from method Client.SetHTTPHeaders.
 type ClientSetHTTPHeadersResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -1126,7 +1126,7 @@ type ClientSetHTTPHeadersResponse struct {
 	Version *string
 }
 
-// ClientSetImmutabilityPolicyResponse contains the response from method client.SetImmutabilityPolicy.
+// ClientSetImmutabilityPolicyResponse contains the response from method Client.SetImmutabilityPolicy.
 type ClientSetImmutabilityPolicyResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1147,7 +1147,7 @@ type ClientSetImmutabilityPolicyResponse struct {
 	Version *string
 }
 
-// ClientSetLegalHoldResponse contains the response from method client.SetLegalHold.
+// ClientSetLegalHoldResponse contains the response from method Client.SetLegalHold.
 type ClientSetLegalHoldResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1165,7 +1165,7 @@ type ClientSetLegalHoldResponse struct {
 	Version *string
 }
 
-// ClientSetMetadataResponse contains the response from method client.SetMetadata.
+// ClientSetMetadataResponse contains the response from method Client.SetMetadata.
 type ClientSetMetadataResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1198,7 +1198,7 @@ type ClientSetMetadataResponse struct {
 	VersionID *string
 }
 
-// ClientSetTagsResponse contains the response from method client.SetTags.
+// ClientSetTagsResponse contains the response from method Client.SetTags.
 type ClientSetTagsResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1213,7 +1213,7 @@ type ClientSetTagsResponse struct {
 	Version *string
 }
 
-// ClientSetTierResponse contains the response from method client.SetTier.
+// ClientSetTierResponse contains the response from method Client.SetTier.
 type ClientSetTierResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1225,7 +1225,7 @@ type ClientSetTierResponse struct {
 	Version *string
 }
 
-// ClientStartCopyFromURLResponse contains the response from method client.StartCopyFromURL.
+// ClientStartCopyFromURLResponse contains the response from method Client.StartCopyFromURL.
 type ClientStartCopyFromURLResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1255,7 +1255,7 @@ type ClientStartCopyFromURLResponse struct {
 	VersionID *string
 }
 
-// ClientUndeleteResponse contains the response from method client.Undelete.
+// ClientUndeleteResponse contains the response from method Client.Undelete.
 type ClientUndeleteResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1270,7 +1270,7 @@ type ClientUndeleteResponse struct {
 	Version *string
 }
 
-// ContainerClientAcquireLeaseResponse contains the response from method containerClient.AcquireLease.
+// ContainerClientAcquireLeaseResponse contains the response from method ContainerClient.AcquireLease.
 type ContainerClientAcquireLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1294,7 +1294,7 @@ type ContainerClientAcquireLeaseResponse struct {
 	Version *string
 }
 
-// ContainerClientBreakLeaseResponse contains the response from method containerClient.BreakLease.
+// ContainerClientBreakLeaseResponse contains the response from method ContainerClient.BreakLease.
 type ContainerClientBreakLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1318,7 +1318,7 @@ type ContainerClientBreakLeaseResponse struct {
 	Version *string
 }
 
-// ContainerClientChangeLeaseResponse contains the response from method containerClient.ChangeLease.
+// ContainerClientChangeLeaseResponse contains the response from method ContainerClient.ChangeLease.
 type ContainerClientChangeLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1342,7 +1342,7 @@ type ContainerClientChangeLeaseResponse struct {
 	Version *string
 }
 
-// ContainerClientCreateResponse contains the response from method containerClient.Create.
+// ContainerClientCreateResponse contains the response from method ContainerClient.Create.
 type ContainerClientCreateResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1363,7 +1363,7 @@ type ContainerClientCreateResponse struct {
 	Version *string
 }
 
-// ContainerClientDeleteResponse contains the response from method containerClient.Delete.
+// ContainerClientDeleteResponse contains the response from method ContainerClient.Delete.
 type ContainerClientDeleteResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1378,7 +1378,7 @@ type ContainerClientDeleteResponse struct {
 	Version *string
 }
 
-// ContainerClientGetAccessPolicyResponse contains the response from method containerClient.GetAccessPolicy.
+// ContainerClientGetAccessPolicyResponse contains the response from method ContainerClient.GetAccessPolicy.
 type ContainerClientGetAccessPolicyResponse struct {
 	// BlobPublicAccess contains the information returned from the x-ms-blob-public-access header response.
 	BlobPublicAccess *PublicAccessType `xml:"BlobPublicAccess"`
@@ -1405,7 +1405,7 @@ type ContainerClientGetAccessPolicyResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ContainerClientGetAccountInfoResponse contains the response from method containerClient.GetAccountInfo.
+// ContainerClientGetAccountInfoResponse contains the response from method ContainerClient.GetAccountInfo.
 type ContainerClientGetAccountInfoResponse struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
@@ -1426,7 +1426,7 @@ type ContainerClientGetAccountInfoResponse struct {
 	Version *string
 }
 
-// ContainerClientGetPropertiesResponse contains the response from method containerClient.GetProperties.
+// ContainerClientGetPropertiesResponse contains the response from method ContainerClient.GetProperties.
 type ContainerClientGetPropertiesResponse struct {
 	// BlobPublicAccess contains the information returned from the x-ms-blob-public-access header response.
 	BlobPublicAccess *PublicAccessType
@@ -1477,7 +1477,7 @@ type ContainerClientGetPropertiesResponse struct {
 	Version *string
 }
 
-// ContainerClientListBlobFlatSegmentResponse contains the response from method containerClient.NewListBlobFlatSegmentPager.
+// ContainerClientListBlobFlatSegmentResponse contains the response from method ContainerClient.NewListBlobFlatSegmentPager.
 type ContainerClientListBlobFlatSegmentResponse struct {
 	ListBlobsFlatSegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -1496,7 +1496,7 @@ type ContainerClientListBlobFlatSegmentResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ContainerClientListBlobHierarchySegmentResponse contains the response from method containerClient.NewListBlobHierarchySegmentPager.
+// ContainerClientListBlobHierarchySegmentResponse contains the response from method ContainerClient.NewListBlobHierarchySegmentPager.
 type ContainerClientListBlobHierarchySegmentResponse struct {
 	ListBlobsHierarchySegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -1515,7 +1515,7 @@ type ContainerClientListBlobHierarchySegmentResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ContainerClientReleaseLeaseResponse contains the response from method containerClient.ReleaseLease.
+// ContainerClientReleaseLeaseResponse contains the response from method ContainerClient.ReleaseLease.
 type ContainerClientReleaseLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1536,7 +1536,7 @@ type ContainerClientReleaseLeaseResponse struct {
 	Version *string
 }
 
-// ContainerClientRenameResponse contains the response from method containerClient.Rename.
+// ContainerClientRenameResponse contains the response from method ContainerClient.Rename.
 type ContainerClientRenameResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1551,7 +1551,7 @@ type ContainerClientRenameResponse struct {
 	Version *string
 }
 
-// ContainerClientRenewLeaseResponse contains the response from method containerClient.RenewLease.
+// ContainerClientRenewLeaseResponse contains the response from method ContainerClient.RenewLease.
 type ContainerClientRenewLeaseResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1575,7 +1575,7 @@ type ContainerClientRenewLeaseResponse struct {
 	Version *string
 }
 
-// ContainerClientRestoreResponse contains the response from method containerClient.Restore.
+// ContainerClientRestoreResponse contains the response from method ContainerClient.Restore.
 type ContainerClientRestoreResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1590,7 +1590,7 @@ type ContainerClientRestoreResponse struct {
 	Version *string
 }
 
-// ContainerClientSetAccessPolicyResponse contains the response from method containerClient.SetAccessPolicy.
+// ContainerClientSetAccessPolicyResponse contains the response from method ContainerClient.SetAccessPolicy.
 type ContainerClientSetAccessPolicyResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1611,7 +1611,7 @@ type ContainerClientSetAccessPolicyResponse struct {
 	Version *string
 }
 
-// ContainerClientSetMetadataResponse contains the response from method containerClient.SetMetadata.
+// ContainerClientSetMetadataResponse contains the response from method ContainerClient.SetMetadata.
 type ContainerClientSetMetadataResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1632,7 +1632,7 @@ type ContainerClientSetMetadataResponse struct {
 	Version *string
 }
 
-// ContainerClientSubmitBatchResponse contains the response from method containerClient.SubmitBatch.
+// ContainerClientSubmitBatchResponse contains the response from method ContainerClient.SubmitBatch.
 type ContainerClientSubmitBatchResponse struct {
 	// Body contains the streaming response.
 	Body io.ReadCloser
@@ -1647,7 +1647,7 @@ type ContainerClientSubmitBatchResponse struct {
 	Version *string
 }
 
-// DirectoryClientCreateResponse contains the response from method directoryClient.Create.
+// DirectoryClientCreateResponse contains the response from method DirectoryClient.Create.
 type DirectoryClientCreateResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1671,7 +1671,7 @@ type DirectoryClientCreateResponse struct {
 	Version *string
 }
 
-// DirectoryClientDeleteResponse contains the response from method directoryClient.Delete.
+// DirectoryClientDeleteResponse contains the response from method DirectoryClient.Delete.
 type DirectoryClientDeleteResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1689,7 +1689,7 @@ type DirectoryClientDeleteResponse struct {
 	Version *string
 }
 
-// DirectoryClientGetAccessControlResponse contains the response from method directoryClient.GetAccessControl.
+// DirectoryClientGetAccessControlResponse contains the response from method DirectoryClient.GetAccessControl.
 type DirectoryClientGetAccessControlResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
@@ -1719,7 +1719,7 @@ type DirectoryClientGetAccessControlResponse struct {
 	XMSPermissions *string
 }
 
-// DirectoryClientRenameResponse contains the response from method directoryClient.Rename.
+// DirectoryClientRenameResponse contains the response from method DirectoryClient.Rename.
 type DirectoryClientRenameResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1746,7 +1746,7 @@ type DirectoryClientRenameResponse struct {
 	Version *string
 }
 
-// DirectoryClientSetAccessControlResponse contains the response from method directoryClient.SetAccessControl.
+// DirectoryClientSetAccessControlResponse contains the response from method DirectoryClient.SetAccessControl.
 type DirectoryClientSetAccessControlResponse struct {
 	// Date contains the information returned from the Date header response.
 	Date *time.Time
@@ -1764,7 +1764,7 @@ type DirectoryClientSetAccessControlResponse struct {
 	Version *string
 }
 
-// PageBlobClientClearPagesResponse contains the response from method pageBlobClient.ClearPages.
+// PageBlobClientClearPagesResponse contains the response from method PageBlobClient.ClearPages.
 type PageBlobClientClearPagesResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -1794,7 +1794,7 @@ type PageBlobClientClearPagesResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// PageBlobClientCopyIncrementalResponse contains the response from method pageBlobClient.CopyIncremental.
+// PageBlobClientCopyIncrementalResponse contains the response from method PageBlobClient.CopyIncremental.
 type PageBlobClientCopyIncrementalResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1821,7 +1821,7 @@ type PageBlobClientCopyIncrementalResponse struct {
 	Version *string
 }
 
-// PageBlobClientCreateResponse contains the response from method pageBlobClient.Create.
+// PageBlobClientCreateResponse contains the response from method PageBlobClient.Create.
 type PageBlobClientCreateResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -1857,7 +1857,7 @@ type PageBlobClientCreateResponse struct {
 	VersionID *string
 }
 
-// PageBlobClientGetPageRangesDiffResponse contains the response from method pageBlobClient.GetPageRangesDiff.
+// PageBlobClientGetPageRangesDiffResponse contains the response from method PageBlobClient.GetPageRangesDiff.
 type PageBlobClientGetPageRangesDiffResponse struct {
 	PageList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
@@ -1882,7 +1882,7 @@ type PageBlobClientGetPageRangesDiffResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// PageBlobClientGetPageRangesResponse contains the response from method pageBlobClient.GetPageRanges.
+// PageBlobClientGetPageRangesResponse contains the response from method PageBlobClient.GetPageRanges.
 type PageBlobClientGetPageRangesResponse struct {
 	PageList
 	// BlobContentLength contains the information returned from the x-ms-blob-content-length header response.
@@ -1907,7 +1907,7 @@ type PageBlobClientGetPageRangesResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// PageBlobClientResizeResponse contains the response from method pageBlobClient.Resize.
+// PageBlobClientResizeResponse contains the response from method PageBlobClient.Resize.
 type PageBlobClientResizeResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -1931,7 +1931,7 @@ type PageBlobClientResizeResponse struct {
 	Version *string
 }
 
-// PageBlobClientUpdateSequenceNumberResponse contains the response from method pageBlobClient.UpdateSequenceNumber.
+// PageBlobClientUpdateSequenceNumberResponse contains the response from method PageBlobClient.UpdateSequenceNumber.
 type PageBlobClientUpdateSequenceNumberResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -1955,7 +1955,7 @@ type PageBlobClientUpdateSequenceNumberResponse struct {
 	Version *string
 }
 
-// PageBlobClientUploadPagesFromURLResponse contains the response from method pageBlobClient.UploadPagesFromURL.
+// PageBlobClientUploadPagesFromURLResponse contains the response from method PageBlobClient.UploadPagesFromURL.
 type PageBlobClientUploadPagesFromURLResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -1991,7 +1991,7 @@ type PageBlobClientUploadPagesFromURLResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// PageBlobClientUploadPagesResponse contains the response from method pageBlobClient.UploadPages.
+// PageBlobClientUploadPagesResponse contains the response from method PageBlobClient.UploadPages.
 type PageBlobClientUploadPagesResponse struct {
 	// BlobSequenceNumber contains the information returned from the x-ms-blob-sequence-number header response.
 	BlobSequenceNumber *int64
@@ -2030,7 +2030,7 @@ type PageBlobClientUploadPagesResponse struct {
 	XMSContentCRC64 []byte
 }
 
-// ServiceClientFilterBlobsResponse contains the response from method serviceClient.FilterBlobs.
+// ServiceClientFilterBlobsResponse contains the response from method ServiceClient.FilterBlobs.
 type ServiceClientFilterBlobsResponse struct {
 	FilterBlobSegment
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -2046,7 +2046,7 @@ type ServiceClientFilterBlobsResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ServiceClientGetAccountInfoResponse contains the response from method serviceClient.GetAccountInfo.
+// ServiceClientGetAccountInfoResponse contains the response from method ServiceClient.GetAccountInfo.
 type ServiceClientGetAccountInfoResponse struct {
 	// AccountKind contains the information returned from the x-ms-account-kind header response.
 	AccountKind *AccountKind
@@ -2070,7 +2070,7 @@ type ServiceClientGetAccountInfoResponse struct {
 	Version *string
 }
 
-// ServiceClientGetPropertiesResponse contains the response from method serviceClient.GetProperties.
+// ServiceClientGetPropertiesResponse contains the response from method ServiceClient.GetProperties.
 type ServiceClientGetPropertiesResponse struct {
 	StorageServiceProperties
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -2083,7 +2083,7 @@ type ServiceClientGetPropertiesResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ServiceClientGetStatisticsResponse contains the response from method serviceClient.GetStatistics.
+// ServiceClientGetStatisticsResponse contains the response from method ServiceClient.GetStatistics.
 type ServiceClientGetStatisticsResponse struct {
 	StorageServiceStats
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -2099,7 +2099,7 @@ type ServiceClientGetStatisticsResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ServiceClientGetUserDelegationKeyResponse contains the response from method serviceClient.GetUserDelegationKey.
+// ServiceClientGetUserDelegationKeyResponse contains the response from method ServiceClient.GetUserDelegationKey.
 type ServiceClientGetUserDelegationKeyResponse struct {
 	UserDelegationKey
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -2115,7 +2115,7 @@ type ServiceClientGetUserDelegationKeyResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ServiceClientListContainersSegmentResponse contains the response from method serviceClient.NewListContainersSegmentPager.
+// ServiceClientListContainersSegmentResponse contains the response from method ServiceClient.NewListContainersSegmentPager.
 type ServiceClientListContainersSegmentResponse struct {
 	ListContainersSegmentResponse
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
@@ -2128,7 +2128,7 @@ type ServiceClientListContainersSegmentResponse struct {
 	Version *string `xml:"Version"`
 }
 
-// ServiceClientSetPropertiesResponse contains the response from method serviceClient.SetProperties.
+// ServiceClientSetPropertiesResponse contains the response from method ServiceClient.SetProperties.
 type ServiceClientSetPropertiesResponse struct {
 	// ClientRequestID contains the information returned from the x-ms-client-request-id header response.
 	ClientRequestID *string
@@ -2140,7 +2140,7 @@ type ServiceClientSetPropertiesResponse struct {
 	Version *string
 }
 
-// ServiceClientSubmitBatchResponse contains the response from method serviceClient.SubmitBatch.
+// ServiceClientSubmitBatchResponse contains the response from method ServiceClient.SubmitBatch.
 type ServiceClientSubmitBatchResponse struct {
 	// Body contains the streaming response.
 	Body io.ReadCloser

--- a/test/storage/2020-06-12/azblob/zz_service_client.go
+++ b/test/storage/2020-06-12/azblob/zz_service_client.go
@@ -12,6 +12,7 @@ package azblob
 import (
 	"context"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -21,23 +22,12 @@ import (
 	"time"
 )
 
-type serviceClient struct {
+// ServiceClient contains the methods for the Service group.
+// Don't use this type directly, use a constructor function instead.
+type ServiceClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum2
-	pl       runtime.Pipeline
-}
-
-// newServiceClient creates a new instance of serviceClient with the specified values.
-//   - endpoint - The URL of the service account, container, or blob that is the targe of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newServiceClient(endpoint string, version Enum2, pl runtime.Pipeline) *serviceClient {
-	client := &serviceClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // FilterBlobs - The Filter Blobs operation enables callers to list blobs across all containers whose tags match a given search
@@ -46,13 +36,13 @@ func newServiceClient(endpoint string, version Enum2, pl runtime.Pipeline) *serv
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientFilterBlobsOptions contains the optional parameters for the serviceClient.FilterBlobs method.
-func (client *serviceClient) FilterBlobs(ctx context.Context, comp Enum10, options *ServiceClientFilterBlobsOptions) (ServiceClientFilterBlobsResponse, error) {
+//   - options - ServiceClientFilterBlobsOptions contains the optional parameters for the ServiceClient.FilterBlobs method.
+func (client *ServiceClient) FilterBlobs(ctx context.Context, comp Enum10, options *ServiceClientFilterBlobsOptions) (ServiceClientFilterBlobsResponse, error) {
 	req, err := client.filterBlobsCreateRequest(ctx, comp, options)
 	if err != nil {
 		return ServiceClientFilterBlobsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientFilterBlobsResponse{}, err
 	}
@@ -63,7 +53,7 @@ func (client *serviceClient) FilterBlobs(ctx context.Context, comp Enum10, optio
 }
 
 // filterBlobsCreateRequest creates the FilterBlobs request.
-func (client *serviceClient) filterBlobsCreateRequest(ctx context.Context, comp Enum10, options *ServiceClientFilterBlobsOptions) (*policy.Request, error) {
+func (client *ServiceClient) filterBlobsCreateRequest(ctx context.Context, comp Enum10, options *ServiceClientFilterBlobsOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -92,7 +82,7 @@ func (client *serviceClient) filterBlobsCreateRequest(ctx context.Context, comp 
 }
 
 // filterBlobsHandleResponse handles the FilterBlobs response.
-func (client *serviceClient) filterBlobsHandleResponse(resp *http.Response) (ServiceClientFilterBlobsResponse, error) {
+func (client *ServiceClient) filterBlobsHandleResponse(resp *http.Response) (ServiceClientFilterBlobsResponse, error) {
 	result := ServiceClientFilterBlobsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -120,13 +110,13 @@ func (client *serviceClient) filterBlobsHandleResponse(resp *http.Response) (Ser
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientGetAccountInfoOptions contains the optional parameters for the serviceClient.GetAccountInfo method.
-func (client *serviceClient) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ServiceClientGetAccountInfoOptions) (ServiceClientGetAccountInfoResponse, error) {
+//   - options - ServiceClientGetAccountInfoOptions contains the optional parameters for the ServiceClient.GetAccountInfo method.
+func (client *ServiceClient) GetAccountInfo(ctx context.Context, restype Enum8, comp Enum1, options *ServiceClientGetAccountInfoOptions) (ServiceClientGetAccountInfoResponse, error) {
 	req, err := client.getAccountInfoCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ServiceClientGetAccountInfoResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetAccountInfoResponse{}, err
 	}
@@ -137,7 +127,7 @@ func (client *serviceClient) GetAccountInfo(ctx context.Context, restype Enum8, 
 }
 
 // getAccountInfoCreateRequest creates the GetAccountInfo request.
-func (client *serviceClient) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ServiceClientGetAccountInfoOptions) (*policy.Request, error) {
+func (client *ServiceClient) getAccountInfoCreateRequest(ctx context.Context, restype Enum8, comp Enum1, options *ServiceClientGetAccountInfoOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -152,7 +142,7 @@ func (client *serviceClient) getAccountInfoCreateRequest(ctx context.Context, re
 }
 
 // getAccountInfoHandleResponse handles the GetAccountInfo response.
-func (client *serviceClient) getAccountInfoHandleResponse(resp *http.Response) (ServiceClientGetAccountInfoResponse, error) {
+func (client *ServiceClient) getAccountInfoHandleResponse(resp *http.Response) (ServiceClientGetAccountInfoResponse, error) {
 	result := ServiceClientGetAccountInfoResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -191,13 +181,13 @@ func (client *serviceClient) getAccountInfoHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientGetPropertiesOptions contains the optional parameters for the serviceClient.GetProperties method.
-func (client *serviceClient) GetProperties(ctx context.Context, restype Enum0, comp Enum1, options *ServiceClientGetPropertiesOptions) (ServiceClientGetPropertiesResponse, error) {
+//   - options - ServiceClientGetPropertiesOptions contains the optional parameters for the ServiceClient.GetProperties method.
+func (client *ServiceClient) GetProperties(ctx context.Context, restype Enum0, comp Enum1, options *ServiceClientGetPropertiesOptions) (ServiceClientGetPropertiesResponse, error) {
 	req, err := client.getPropertiesCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ServiceClientGetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetPropertiesResponse{}, err
 	}
@@ -208,7 +198,7 @@ func (client *serviceClient) GetProperties(ctx context.Context, restype Enum0, c
 }
 
 // getPropertiesCreateRequest creates the GetProperties request.
-func (client *serviceClient) getPropertiesCreateRequest(ctx context.Context, restype Enum0, comp Enum1, options *ServiceClientGetPropertiesOptions) (*policy.Request, error) {
+func (client *ServiceClient) getPropertiesCreateRequest(ctx context.Context, restype Enum0, comp Enum1, options *ServiceClientGetPropertiesOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -229,7 +219,7 @@ func (client *serviceClient) getPropertiesCreateRequest(ctx context.Context, res
 }
 
 // getPropertiesHandleResponse handles the GetProperties response.
-func (client *serviceClient) getPropertiesHandleResponse(resp *http.Response) (ServiceClientGetPropertiesResponse, error) {
+func (client *ServiceClient) getPropertiesHandleResponse(resp *http.Response) (ServiceClientGetPropertiesResponse, error) {
 	result := ServiceClientGetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -251,13 +241,13 @@ func (client *serviceClient) getPropertiesHandleResponse(resp *http.Response) (S
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientGetStatisticsOptions contains the optional parameters for the serviceClient.GetStatistics method.
-func (client *serviceClient) GetStatistics(ctx context.Context, restype Enum0, comp Enum3, options *ServiceClientGetStatisticsOptions) (ServiceClientGetStatisticsResponse, error) {
+//   - options - ServiceClientGetStatisticsOptions contains the optional parameters for the ServiceClient.GetStatistics method.
+func (client *ServiceClient) GetStatistics(ctx context.Context, restype Enum0, comp Enum3, options *ServiceClientGetStatisticsOptions) (ServiceClientGetStatisticsResponse, error) {
 	req, err := client.getStatisticsCreateRequest(ctx, restype, comp, options)
 	if err != nil {
 		return ServiceClientGetStatisticsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetStatisticsResponse{}, err
 	}
@@ -268,7 +258,7 @@ func (client *serviceClient) GetStatistics(ctx context.Context, restype Enum0, c
 }
 
 // getStatisticsCreateRequest creates the GetStatistics request.
-func (client *serviceClient) getStatisticsCreateRequest(ctx context.Context, restype Enum0, comp Enum3, options *ServiceClientGetStatisticsOptions) (*policy.Request, error) {
+func (client *ServiceClient) getStatisticsCreateRequest(ctx context.Context, restype Enum0, comp Enum3, options *ServiceClientGetStatisticsOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -289,7 +279,7 @@ func (client *serviceClient) getStatisticsCreateRequest(ctx context.Context, res
 }
 
 // getStatisticsHandleResponse handles the GetStatistics response.
-func (client *serviceClient) getStatisticsHandleResponse(resp *http.Response) (ServiceClientGetStatisticsResponse, error) {
+func (client *ServiceClient) getStatisticsHandleResponse(resp *http.Response) (ServiceClientGetStatisticsResponse, error) {
 	result := ServiceClientGetStatisticsResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -318,14 +308,14 @@ func (client *serviceClient) getStatisticsHandleResponse(resp *http.Response) (S
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientGetUserDelegationKeyOptions contains the optional parameters for the serviceClient.GetUserDelegationKey
+//   - options - ServiceClientGetUserDelegationKeyOptions contains the optional parameters for the ServiceClient.GetUserDelegationKey
 //     method.
-func (client *serviceClient) GetUserDelegationKey(ctx context.Context, restype Enum0, comp Enum7, keyInfo KeyInfo, options *ServiceClientGetUserDelegationKeyOptions) (ServiceClientGetUserDelegationKeyResponse, error) {
+func (client *ServiceClient) GetUserDelegationKey(ctx context.Context, restype Enum0, comp Enum7, keyInfo KeyInfo, options *ServiceClientGetUserDelegationKeyOptions) (ServiceClientGetUserDelegationKeyResponse, error) {
 	req, err := client.getUserDelegationKeyCreateRequest(ctx, restype, comp, keyInfo, options)
 	if err != nil {
 		return ServiceClientGetUserDelegationKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetUserDelegationKeyResponse{}, err
 	}
@@ -336,7 +326,7 @@ func (client *serviceClient) GetUserDelegationKey(ctx context.Context, restype E
 }
 
 // getUserDelegationKeyCreateRequest creates the GetUserDelegationKey request.
-func (client *serviceClient) getUserDelegationKeyCreateRequest(ctx context.Context, restype Enum0, comp Enum7, keyInfo KeyInfo, options *ServiceClientGetUserDelegationKeyOptions) (*policy.Request, error) {
+func (client *ServiceClient) getUserDelegationKeyCreateRequest(ctx context.Context, restype Enum0, comp Enum7, keyInfo KeyInfo, options *ServiceClientGetUserDelegationKeyOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -357,7 +347,7 @@ func (client *serviceClient) getUserDelegationKeyCreateRequest(ctx context.Conte
 }
 
 // getUserDelegationKeyHandleResponse handles the GetUserDelegationKey response.
-func (client *serviceClient) getUserDelegationKeyHandleResponse(resp *http.Response) (ServiceClientGetUserDelegationKeyResponse, error) {
+func (client *ServiceClient) getUserDelegationKeyHandleResponse(resp *http.Response) (ServiceClientGetUserDelegationKeyResponse, error) {
 	result := ServiceClientGetUserDelegationKeyResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -385,9 +375,9 @@ func (client *serviceClient) getUserDelegationKeyHandleResponse(resp *http.Respo
 // account
 //
 // Generated from API version 2020-06-12
-//   - options - ServiceClientListContainersSegmentOptions contains the optional parameters for the serviceClient.NewListContainersSegmentPager
+//   - options - ServiceClientListContainersSegmentOptions contains the optional parameters for the ServiceClient.NewListContainersSegmentPager
 //     method.
-func (client *serviceClient) NewListContainersSegmentPager(comp Enum5, options *ServiceClientListContainersSegmentOptions) *runtime.Pager[ServiceClientListContainersSegmentResponse] {
+func (client *ServiceClient) NewListContainersSegmentPager(comp Enum5, options *ServiceClientListContainersSegmentOptions) *runtime.Pager[ServiceClientListContainersSegmentResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ServiceClientListContainersSegmentResponse]{
 		More: func(page ServiceClientListContainersSegmentResponse) bool {
 			return page.NextMarker != nil && len(*page.NextMarker) > 0
@@ -403,7 +393,7 @@ func (client *serviceClient) NewListContainersSegmentPager(comp Enum5, options *
 			if err != nil {
 				return ServiceClientListContainersSegmentResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return ServiceClientListContainersSegmentResponse{}, err
 			}
@@ -416,7 +406,7 @@ func (client *serviceClient) NewListContainersSegmentPager(comp Enum5, options *
 }
 
 // listContainersSegmentCreateRequest creates the ListContainersSegment request.
-func (client *serviceClient) listContainersSegmentCreateRequest(ctx context.Context, comp Enum5, options *ServiceClientListContainersSegmentOptions) (*policy.Request, error) {
+func (client *ServiceClient) listContainersSegmentCreateRequest(ctx context.Context, comp Enum5, options *ServiceClientListContainersSegmentOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -448,7 +438,7 @@ func (client *serviceClient) listContainersSegmentCreateRequest(ctx context.Cont
 }
 
 // listContainersSegmentHandleResponse handles the ListContainersSegment response.
-func (client *serviceClient) listContainersSegmentHandleResponse(resp *http.Response) (ServiceClientListContainersSegmentResponse, error) {
+func (client *ServiceClient) listContainersSegmentHandleResponse(resp *http.Response) (ServiceClientListContainersSegmentResponse, error) {
 	result := ServiceClientListContainersSegmentResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -471,13 +461,13 @@ func (client *serviceClient) listContainersSegmentHandleResponse(resp *http.Resp
 //
 // Generated from API version 2020-06-12
 //   - storageServiceProperties - The StorageService properties.
-//   - options - ServiceClientSetPropertiesOptions contains the optional parameters for the serviceClient.SetProperties method.
-func (client *serviceClient) SetProperties(ctx context.Context, restype Enum0, comp Enum1, storageServiceProperties StorageServiceProperties, options *ServiceClientSetPropertiesOptions) (ServiceClientSetPropertiesResponse, error) {
+//   - options - ServiceClientSetPropertiesOptions contains the optional parameters for the ServiceClient.SetProperties method.
+func (client *ServiceClient) SetProperties(ctx context.Context, restype Enum0, comp Enum1, storageServiceProperties StorageServiceProperties, options *ServiceClientSetPropertiesOptions) (ServiceClientSetPropertiesResponse, error) {
 	req, err := client.setPropertiesCreateRequest(ctx, restype, comp, storageServiceProperties, options)
 	if err != nil {
 		return ServiceClientSetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientSetPropertiesResponse{}, err
 	}
@@ -488,7 +478,7 @@ func (client *serviceClient) SetProperties(ctx context.Context, restype Enum0, c
 }
 
 // setPropertiesCreateRequest creates the SetProperties request.
-func (client *serviceClient) setPropertiesCreateRequest(ctx context.Context, restype Enum0, comp Enum1, storageServiceProperties StorageServiceProperties, options *ServiceClientSetPropertiesOptions) (*policy.Request, error) {
+func (client *ServiceClient) setPropertiesCreateRequest(ctx context.Context, restype Enum0, comp Enum1, storageServiceProperties StorageServiceProperties, options *ServiceClientSetPropertiesOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPut, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -509,7 +499,7 @@ func (client *serviceClient) setPropertiesCreateRequest(ctx context.Context, res
 }
 
 // setPropertiesHandleResponse handles the SetProperties response.
-func (client *serviceClient) setPropertiesHandleResponse(resp *http.Response) (ServiceClientSetPropertiesResponse, error) {
+func (client *ServiceClient) setPropertiesHandleResponse(resp *http.Response) (ServiceClientSetPropertiesResponse, error) {
 	result := ServiceClientSetPropertiesResponse{}
 	if val := resp.Header.Get("x-ms-client-request-id"); val != "" {
 		result.ClientRequestID = &val
@@ -531,13 +521,13 @@ func (client *serviceClient) setPropertiesHandleResponse(resp *http.Response) (S
 //   - multipartContentType - Required. The value of this header must be multipart/mixed with a batch boundary. Example header
 //     value: multipart/mixed; boundary=batch_
 //   - body - Initial data
-//   - options - ServiceClientSubmitBatchOptions contains the optional parameters for the serviceClient.SubmitBatch method.
-func (client *serviceClient) SubmitBatch(ctx context.Context, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (ServiceClientSubmitBatchResponse, error) {
+//   - options - ServiceClientSubmitBatchOptions contains the optional parameters for the ServiceClient.SubmitBatch method.
+func (client *ServiceClient) SubmitBatch(ctx context.Context, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (ServiceClientSubmitBatchResponse, error) {
 	req, err := client.submitBatchCreateRequest(ctx, comp, contentLength, multipartContentType, body, options)
 	if err != nil {
 		return ServiceClientSubmitBatchResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientSubmitBatchResponse{}, err
 	}
@@ -548,7 +538,7 @@ func (client *serviceClient) SubmitBatch(ctx context.Context, comp Enum9, conten
 }
 
 // submitBatchCreateRequest creates the SubmitBatch request.
-func (client *serviceClient) submitBatchCreateRequest(ctx context.Context, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (*policy.Request, error) {
+func (client *ServiceClient) submitBatchCreateRequest(ctx context.Context, comp Enum9, contentLength int64, multipartContentType string, body io.ReadSeekCloser, options *ServiceClientSubmitBatchOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodPost, client.endpoint)
 	if err != nil {
 		return nil, err
@@ -571,7 +561,7 @@ func (client *serviceClient) submitBatchCreateRequest(ctx context.Context, comp 
 }
 
 // submitBatchHandleResponse handles the SubmitBatch response.
-func (client *serviceClient) submitBatchHandleResponse(resp *http.Response) (ServiceClientSubmitBatchResponse, error) {
+func (client *ServiceClient) submitBatchHandleResponse(resp *http.Response) (ServiceClientSubmitBatchResponse, error) {
 	result := ServiceClientSubmitBatchResponse{Body: resp.Body}
 	if val := resp.Header.Get("Content-Type"); val != "" {
 		result.ContentType = &val

--- a/test/synapse/2019-06-01/azartifacts/go.mod
+++ b/test/synapse/2019-06-01/azartifacts/go.mod
@@ -2,10 +2,10 @@ module azartifacts
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/synapse/2019-06-01/azartifacts/go.sum
+++ b/test/synapse/2019-06-01/azartifacts/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/synapse/2019-06-01/azartifacts/zz_bigdatapools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_bigdatapools_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type bigDataPoolsClient struct {
+// BigDataPoolsClient contains the methods for the BigDataPools group.
+// Don't use this type directly, use a constructor function instead.
+type BigDataPoolsClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newBigDataPoolsClient creates a new instance of bigDataPoolsClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newBigDataPoolsClient(endpoint string, pl runtime.Pipeline) *bigDataPoolsClient {
-	client := &bigDataPoolsClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // Get - Get Big Data Pool
@@ -40,13 +32,13 @@ func newBigDataPoolsClient(endpoint string, pl runtime.Pipeline) *bigDataPoolsCl
 //
 // Generated from API version 2019-06-01-preview
 //   - bigDataPoolName - The Big Data Pool name
-//   - options - BigDataPoolsClientGetOptions contains the optional parameters for the bigDataPoolsClient.Get method.
-func (client *bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName string, options *BigDataPoolsClientGetOptions) (BigDataPoolsClientGetResponse, error) {
+//   - options - BigDataPoolsClientGetOptions contains the optional parameters for the BigDataPoolsClient.Get method.
+func (client *BigDataPoolsClient) Get(ctx context.Context, bigDataPoolName string, options *BigDataPoolsClientGetOptions) (BigDataPoolsClientGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, bigDataPoolName, options)
 	if err != nil {
 		return BigDataPoolsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BigDataPoolsClientGetResponse{}, err
 	}
@@ -57,7 +49,7 @@ func (client *bigDataPoolsClient) Get(ctx context.Context, bigDataPoolName strin
 }
 
 // getCreateRequest creates the Get request.
-func (client *bigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataPoolName string, options *BigDataPoolsClientGetOptions) (*policy.Request, error) {
+func (client *BigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataPoolName string, options *BigDataPoolsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/bigDataPools/{bigDataPoolName}"
 	if bigDataPoolName == "" {
 		return nil, errors.New("parameter bigDataPoolName cannot be empty")
@@ -75,7 +67,7 @@ func (client *bigDataPoolsClient) getCreateRequest(ctx context.Context, bigDataP
 }
 
 // getHandleResponse handles the Get response.
-func (client *bigDataPoolsClient) getHandleResponse(resp *http.Response) (BigDataPoolsClientGetResponse, error) {
+func (client *BigDataPoolsClient) getHandleResponse(resp *http.Response) (BigDataPoolsClientGetResponse, error) {
 	result := BigDataPoolsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfo); err != nil {
 		return BigDataPoolsClientGetResponse{}, err
@@ -87,13 +79,13 @@ func (client *bigDataPoolsClient) getHandleResponse(resp *http.Response) (BigDat
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - BigDataPoolsClientListOptions contains the optional parameters for the bigDataPoolsClient.List method.
-func (client *bigDataPoolsClient) List(ctx context.Context, options *BigDataPoolsClientListOptions) (BigDataPoolsClientListResponse, error) {
+//   - options - BigDataPoolsClientListOptions contains the optional parameters for the BigDataPoolsClient.List method.
+func (client *BigDataPoolsClient) List(ctx context.Context, options *BigDataPoolsClientListOptions) (BigDataPoolsClientListResponse, error) {
 	req, err := client.listCreateRequest(ctx, options)
 	if err != nil {
 		return BigDataPoolsClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BigDataPoolsClientListResponse{}, err
 	}
@@ -104,7 +96,7 @@ func (client *bigDataPoolsClient) List(ctx context.Context, options *BigDataPool
 }
 
 // listCreateRequest creates the List request.
-func (client *bigDataPoolsClient) listCreateRequest(ctx context.Context, options *BigDataPoolsClientListOptions) (*policy.Request, error) {
+func (client *BigDataPoolsClient) listCreateRequest(ctx context.Context, options *BigDataPoolsClientListOptions) (*policy.Request, error) {
 	urlPath := "/bigDataPools"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -118,7 +110,7 @@ func (client *bigDataPoolsClient) listCreateRequest(ctx context.Context, options
 }
 
 // listHandleResponse handles the List response.
-func (client *bigDataPoolsClient) listHandleResponse(resp *http.Response) (BigDataPoolsClientListResponse, error) {
+func (client *BigDataPoolsClient) listHandleResponse(resp *http.Response) (BigDataPoolsClientListResponse, error) {
 	result := BigDataPoolsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BigDataPoolResourceInfoListResult); err != nil {
 		return BigDataPoolsClientListResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_dataflow_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_dataflow_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type dataFlowClient struct {
+// DataFlowClient contains the methods for the DataFlow group.
+// Don't use this type directly, use a constructor function instead.
+type DataFlowClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newDataFlowClient creates a new instance of dataFlowClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newDataFlowClient(endpoint string, pl runtime.Pipeline) *dataFlowClient {
-	client := &dataFlowClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateDataFlow - Creates or updates a data flow.
@@ -41,17 +33,17 @@ func newDataFlowClient(endpoint string, pl runtime.Pipeline) *dataFlowClient {
 // Generated from API version 2019-06-01-preview
 //   - dataFlowName - The data flow name.
 //   - dataFlow - Data flow resource definition.
-//   - options - DataFlowClientBeginCreateOrUpdateDataFlowOptions contains the optional parameters for the dataFlowClient.BeginCreateOrUpdateDataFlow
+//   - options - DataFlowClientBeginCreateOrUpdateDataFlowOptions contains the optional parameters for the DataFlowClient.BeginCreateOrUpdateDataFlow
 //     method.
-func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*runtime.Poller[DataFlowClientCreateOrUpdateDataFlowResponse], error) {
+func (client *DataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*runtime.Poller[DataFlowClientCreateOrUpdateDataFlowResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateDataFlow(ctx, dataFlowName, dataFlow, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DataFlowClientCreateOrUpdateDataFlowResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DataFlowClientCreateOrUpdateDataFlowResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DataFlowClientCreateOrUpdateDataFlowResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DataFlowClientCreateOrUpdateDataFlowResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *dataFlowClient) BeginCreateOrUpdateDataFlow(ctx context.Context, d
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *dataFlowClient) createOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*http.Response, error) {
+func (client *DataFlowClient) createOrUpdateDataFlow(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateDataFlowCreateRequest(ctx, dataFlowName, dataFlow, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *dataFlowClient) createOrUpdateDataFlow(ctx context.Context, dataFl
 }
 
 // createOrUpdateDataFlowCreateRequest creates the CreateOrUpdateDataFlow request.
-func (client *dataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*policy.Request, error) {
+func (client *DataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Context, dataFlowName string, dataFlow DataFlowResource, options *DataFlowClientBeginCreateOrUpdateDataFlowOptions) (*policy.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	if dataFlowName == "" {
 		return nil, errors.New("parameter dataFlowName cannot be empty")
@@ -100,17 +92,17 @@ func (client *dataFlowClient) createOrUpdateDataFlowCreateRequest(ctx context.Co
 //
 // Generated from API version 2019-06-01-preview
 //   - dataFlowName - The data flow name.
-//   - options - DataFlowClientBeginDeleteDataFlowOptions contains the optional parameters for the dataFlowClient.BeginDeleteDataFlow
+//   - options - DataFlowClientBeginDeleteDataFlowOptions contains the optional parameters for the DataFlowClient.BeginDeleteDataFlow
 //     method.
-func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*runtime.Poller[DataFlowClientDeleteDataFlowResponse], error) {
+func (client *DataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*runtime.Poller[DataFlowClientDeleteDataFlowResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteDataFlow(ctx, dataFlowName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DataFlowClientDeleteDataFlowResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DataFlowClientDeleteDataFlowResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DataFlowClientDeleteDataFlowResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DataFlowClientDeleteDataFlowResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *dataFlowClient) BeginDeleteDataFlow(ctx context.Context, dataFlowN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *dataFlowClient) deleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*http.Response, error) {
+func (client *DataFlowClient) deleteDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*http.Response, error) {
 	req, err := client.deleteDataFlowCreateRequest(ctx, dataFlowName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *dataFlowClient) deleteDataFlow(ctx context.Context, dataFlowName s
 }
 
 // deleteDataFlowCreateRequest creates the DeleteDataFlow request.
-func (client *dataFlowClient) deleteDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*policy.Request, error) {
+func (client *DataFlowClient) deleteDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowClientBeginDeleteDataFlowOptions) (*policy.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	if dataFlowName == "" {
 		return nil, errors.New("parameter dataFlowName cannot be empty")
@@ -156,13 +148,13 @@ func (client *dataFlowClient) deleteDataFlowCreateRequest(ctx context.Context, d
 //
 // Generated from API version 2019-06-01-preview
 //   - dataFlowName - The data flow name.
-//   - options - DataFlowClientGetDataFlowOptions contains the optional parameters for the dataFlowClient.GetDataFlow method.
-func (client *dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientGetDataFlowOptions) (DataFlowClientGetDataFlowResponse, error) {
+//   - options - DataFlowClientGetDataFlowOptions contains the optional parameters for the DataFlowClient.GetDataFlow method.
+func (client *DataFlowClient) GetDataFlow(ctx context.Context, dataFlowName string, options *DataFlowClientGetDataFlowOptions) (DataFlowClientGetDataFlowResponse, error) {
 	req, err := client.getDataFlowCreateRequest(ctx, dataFlowName, options)
 	if err != nil {
 		return DataFlowClientGetDataFlowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DataFlowClientGetDataFlowResponse{}, err
 	}
@@ -173,7 +165,7 @@ func (client *dataFlowClient) GetDataFlow(ctx context.Context, dataFlowName stri
 }
 
 // getDataFlowCreateRequest creates the GetDataFlow request.
-func (client *dataFlowClient) getDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowClientGetDataFlowOptions) (*policy.Request, error) {
+func (client *DataFlowClient) getDataFlowCreateRequest(ctx context.Context, dataFlowName string, options *DataFlowClientGetDataFlowOptions) (*policy.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}"
 	if dataFlowName == "" {
 		return nil, errors.New("parameter dataFlowName cannot be empty")
@@ -194,7 +186,7 @@ func (client *dataFlowClient) getDataFlowCreateRequest(ctx context.Context, data
 }
 
 // getDataFlowHandleResponse handles the GetDataFlow response.
-func (client *dataFlowClient) getDataFlowHandleResponse(resp *http.Response) (DataFlowClientGetDataFlowResponse, error) {
+func (client *DataFlowClient) getDataFlowHandleResponse(resp *http.Response) (DataFlowClientGetDataFlowResponse, error) {
 	result := DataFlowClientGetDataFlowResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowResource); err != nil {
 		return DataFlowClientGetDataFlowResponse{}, err
@@ -205,9 +197,9 @@ func (client *dataFlowClient) getDataFlowHandleResponse(resp *http.Response) (Da
 // NewGetDataFlowsByWorkspacePager - Lists data flows.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - DataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the dataFlowClient.NewGetDataFlowsByWorkspacePager
+//   - options - DataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the DataFlowClient.NewGetDataFlowsByWorkspacePager
 //     method.
-func (client *dataFlowClient) NewGetDataFlowsByWorkspacePager(options *DataFlowClientGetDataFlowsByWorkspaceOptions) *runtime.Pager[DataFlowClientGetDataFlowsByWorkspaceResponse] {
+func (client *DataFlowClient) NewGetDataFlowsByWorkspacePager(options *DataFlowClientGetDataFlowsByWorkspaceOptions) *runtime.Pager[DataFlowClientGetDataFlowsByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[DataFlowClientGetDataFlowsByWorkspaceResponse]{
 		More: func(page DataFlowClientGetDataFlowsByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -223,7 +215,7 @@ func (client *dataFlowClient) NewGetDataFlowsByWorkspacePager(options *DataFlowC
 			if err != nil {
 				return DataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DataFlowClientGetDataFlowsByWorkspaceResponse{}, err
 			}
@@ -236,7 +228,7 @@ func (client *dataFlowClient) NewGetDataFlowsByWorkspacePager(options *DataFlowC
 }
 
 // getDataFlowsByWorkspaceCreateRequest creates the GetDataFlowsByWorkspace request.
-func (client *dataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowClientGetDataFlowsByWorkspaceOptions) (*policy.Request, error) {
+func (client *DataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowClientGetDataFlowsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/dataflows"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -250,7 +242,7 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceCreateRequest(ctx context.C
 }
 
 // getDataFlowsByWorkspaceHandleResponse handles the GetDataFlowsByWorkspace response.
-func (client *dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.Response) (DataFlowClientGetDataFlowsByWorkspaceResponse, error) {
+func (client *DataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.Response) (DataFlowClientGetDataFlowsByWorkspaceResponse, error) {
 	result := DataFlowClientGetDataFlowsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DataFlowListResponse); err != nil {
 		return DataFlowClientGetDataFlowsByWorkspaceResponse{}, err
@@ -264,17 +256,17 @@ func (client *dataFlowClient) getDataFlowsByWorkspaceHandleResponse(resp *http.R
 // Generated from API version 2019-06-01-preview
 //   - dataFlowName - The data flow name.
 //   - request - proposed new name.
-//   - options - DataFlowClientBeginRenameDataFlowOptions contains the optional parameters for the dataFlowClient.BeginRenameDataFlow
+//   - options - DataFlowClientBeginRenameDataFlowOptions contains the optional parameters for the DataFlowClient.BeginRenameDataFlow
 //     method.
-func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*runtime.Poller[DataFlowClientRenameDataFlowResponse], error) {
+func (client *DataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*runtime.Poller[DataFlowClientRenameDataFlowResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameDataFlow(ctx, dataFlowName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DataFlowClientRenameDataFlowResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DataFlowClientRenameDataFlowResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DataFlowClientRenameDataFlowResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DataFlowClientRenameDataFlowResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -282,12 +274,12 @@ func (client *dataFlowClient) BeginRenameDataFlow(ctx context.Context, dataFlowN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *dataFlowClient) renameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*http.Response, error) {
+func (client *DataFlowClient) renameDataFlow(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*http.Response, error) {
 	req, err := client.renameDataFlowCreateRequest(ctx, dataFlowName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +290,7 @@ func (client *dataFlowClient) renameDataFlow(ctx context.Context, dataFlowName s
 }
 
 // renameDataFlowCreateRequest creates the RenameDataFlow request.
-func (client *dataFlowClient) renameDataFlowCreateRequest(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*policy.Request, error) {
+func (client *DataFlowClient) renameDataFlowCreateRequest(ctx context.Context, dataFlowName string, request ArtifactRenameRequest, options *DataFlowClientBeginRenameDataFlowOptions) (*policy.Request, error) {
 	urlPath := "/dataflows/{dataFlowName}/rename"
 	if dataFlowName == "" {
 		return nil, errors.New("parameter dataFlowName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_dataflowdebugsession_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_dataflowdebugsession_client.go
@@ -11,25 +11,17 @@ package azartifacts
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
-type dataFlowDebugSessionClient struct {
+// DataFlowDebugSessionClient contains the methods for the DataFlowDebugSession group.
+// Don't use this type directly, use a constructor function instead.
+type DataFlowDebugSessionClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newDataFlowDebugSessionClient creates a new instance of dataFlowDebugSessionClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newDataFlowDebugSessionClient(endpoint string, pl runtime.Pipeline) *dataFlowDebugSessionClient {
-	client := &dataFlowDebugSessionClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // AddDataFlow - Add a data flow into debug session.
@@ -37,14 +29,14 @@ func newDataFlowDebugSessionClient(endpoint string, pl runtime.Pipeline) *dataFl
 //
 // Generated from API version 2019-06-01-preview
 //   - request - Data flow debug session definition with debug content.
-//   - options - DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the dataFlowDebugSessionClient.AddDataFlow
+//   - options - DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the DataFlowDebugSessionClient.AddDataFlow
 //     method.
-func (client *dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionClientAddDataFlowOptions) (DataFlowDebugSessionClientAddDataFlowResponse, error) {
+func (client *DataFlowDebugSessionClient) AddDataFlow(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionClientAddDataFlowOptions) (DataFlowDebugSessionClientAddDataFlowResponse, error) {
 	req, err := client.addDataFlowCreateRequest(ctx, request, options)
 	if err != nil {
 		return DataFlowDebugSessionClientAddDataFlowResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DataFlowDebugSessionClientAddDataFlowResponse{}, err
 	}
@@ -55,7 +47,7 @@ func (client *dataFlowDebugSessionClient) AddDataFlow(ctx context.Context, reque
 }
 
 // addDataFlowCreateRequest creates the AddDataFlow request.
-func (client *dataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionClientAddDataFlowOptions) (*policy.Request, error) {
+func (client *DataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.Context, request DataFlowDebugPackage, options *DataFlowDebugSessionClientAddDataFlowOptions) (*policy.Request, error) {
 	urlPath := "/addDataFlowToDebugSession"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -69,7 +61,7 @@ func (client *dataFlowDebugSessionClient) addDataFlowCreateRequest(ctx context.C
 }
 
 // addDataFlowHandleResponse handles the AddDataFlow response.
-func (client *dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.Response) (DataFlowDebugSessionClientAddDataFlowResponse, error) {
+func (client *DataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.Response) (DataFlowDebugSessionClientAddDataFlowResponse, error) {
 	result := DataFlowDebugSessionClientAddDataFlowResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AddDataFlowToDebugSessionResponse); err != nil {
 		return DataFlowDebugSessionClientAddDataFlowResponse{}, err
@@ -82,17 +74,17 @@ func (client *dataFlowDebugSessionClient) addDataFlowHandleResponse(resp *http.R
 //
 // Generated from API version 2019-06-01-preview
 //   - request - Data flow debug session definition
-//   - options - DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginCreateDataFlowDebugSession
+//   - options - DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSessionClient.BeginCreateDataFlowDebugSession
 //     method.
-func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*runtime.Poller[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse], error) {
+func (client *DataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*runtime.Poller[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createDataFlowDebugSession(ctx, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -100,12 +92,12 @@ func (client *dataFlowDebugSessionClient) BeginCreateDataFlowDebugSession(ctx co
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *dataFlowDebugSessionClient) createDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*http.Response, error) {
+func (client *DataFlowDebugSessionClient) createDataFlowDebugSession(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*http.Response, error) {
 	req, err := client.createDataFlowDebugSessionCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +108,7 @@ func (client *dataFlowDebugSessionClient) createDataFlowDebugSession(ctx context
 }
 
 // createDataFlowDebugSessionCreateRequest creates the CreateDataFlowDebugSession request.
-func (client *dataFlowDebugSessionClient) createDataFlowDebugSessionCreateRequest(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*policy.Request, error) {
+func (client *DataFlowDebugSessionClient) createDataFlowDebugSessionCreateRequest(ctx context.Context, request CreateDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions) (*policy.Request, error) {
 	urlPath := "/createDataFlowDebugSession"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -134,14 +126,14 @@ func (client *dataFlowDebugSessionClient) createDataFlowDebugSessionCreateReques
 //
 // Generated from API version 2019-06-01-preview
 //   - request - Data flow debug session definition for deletion
-//   - options - DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions contains the optional parameters for the dataFlowDebugSessionClient.DeleteDataFlowDebugSession
+//   - options - DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSessionClient.DeleteDataFlowDebugSession
 //     method.
-func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions) (DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse, error) {
+func (client *DataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions) (DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse, error) {
 	req, err := client.deleteDataFlowDebugSessionCreateRequest(ctx, request, options)
 	if err != nil {
 		return DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse{}, err
 	}
@@ -152,7 +144,7 @@ func (client *dataFlowDebugSessionClient) DeleteDataFlowDebugSession(ctx context
 }
 
 // deleteDataFlowDebugSessionCreateRequest creates the DeleteDataFlowDebugSession request.
-func (client *dataFlowDebugSessionClient) deleteDataFlowDebugSessionCreateRequest(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions) (*policy.Request, error) {
+func (client *DataFlowDebugSessionClient) deleteDataFlowDebugSessionCreateRequest(ctx context.Context, request DeleteDataFlowDebugSessionRequest, options *DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions) (*policy.Request, error) {
 	urlPath := "/deleteDataFlowDebugSession"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -170,17 +162,17 @@ func (client *dataFlowDebugSessionClient) deleteDataFlowDebugSessionCreateReques
 //
 // Generated from API version 2019-06-01-preview
 //   - request - Data flow debug command definition.
-//   - options - DataFlowDebugSessionClientBeginExecuteCommandOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginExecuteCommand
+//   - options - DataFlowDebugSessionClientBeginExecuteCommandOptions contains the optional parameters for the DataFlowDebugSessionClient.BeginExecuteCommand
 //     method.
-func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*runtime.Poller[DataFlowDebugSessionClientExecuteCommandResponse], error) {
+func (client *DataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*runtime.Poller[DataFlowDebugSessionClientExecuteCommandResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.executeCommand(ctx, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DataFlowDebugSessionClientExecuteCommandResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DataFlowDebugSessionClientExecuteCommandResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DataFlowDebugSessionClientExecuteCommandResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DataFlowDebugSessionClientExecuteCommandResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -188,12 +180,12 @@ func (client *dataFlowDebugSessionClient) BeginExecuteCommand(ctx context.Contex
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *dataFlowDebugSessionClient) executeCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*http.Response, error) {
+func (client *DataFlowDebugSessionClient) executeCommand(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*http.Response, error) {
 	req, err := client.executeCommandCreateRequest(ctx, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -204,7 +196,7 @@ func (client *dataFlowDebugSessionClient) executeCommand(ctx context.Context, re
 }
 
 // executeCommandCreateRequest creates the ExecuteCommand request.
-func (client *dataFlowDebugSessionClient) executeCommandCreateRequest(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*policy.Request, error) {
+func (client *DataFlowDebugSessionClient) executeCommandCreateRequest(ctx context.Context, request DataFlowDebugCommandRequest, options *DataFlowDebugSessionClientBeginExecuteCommandOptions) (*policy.Request, error) {
 	urlPath := "/executeDataFlowDebugCommand"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -221,8 +213,8 @@ func (client *dataFlowDebugSessionClient) executeCommandCreateRequest(ctx contex
 //
 // Generated from API version 2019-06-01-preview
 //   - options - DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the
-//     dataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager method.
-func (client *dataFlowDebugSessionClient) NewQueryDataFlowDebugSessionsByWorkspacePager(options *DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions) *runtime.Pager[DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse] {
+//     DataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager method.
+func (client *DataFlowDebugSessionClient) NewQueryDataFlowDebugSessionsByWorkspacePager(options *DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions) *runtime.Pager[DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse]{
 		More: func(page DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -238,7 +230,7 @@ func (client *dataFlowDebugSessionClient) NewQueryDataFlowDebugSessionsByWorkspa
 			if err != nil {
 				return DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err
 			}
@@ -251,7 +243,7 @@ func (client *dataFlowDebugSessionClient) NewQueryDataFlowDebugSessionsByWorkspa
 }
 
 // queryDataFlowDebugSessionsByWorkspaceCreateRequest creates the QueryDataFlowDebugSessionsByWorkspace request.
-func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions) (*policy.Request, error) {
+func (client *DataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceCreateRequest(ctx context.Context, options *DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/queryDataFlowDebugSessions"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -265,7 +257,7 @@ func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceC
 }
 
 // queryDataFlowDebugSessionsByWorkspaceHandleResponse handles the QueryDataFlowDebugSessionsByWorkspace response.
-func (client *dataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp *http.Response) (DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
+func (client *DataFlowDebugSessionClient) queryDataFlowDebugSessionsByWorkspaceHandleResponse(resp *http.Response) (DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse, error) {
 	result := DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.QueryDataFlowDebugSessionsResponse); err != nil {
 		return DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_dataset_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_dataset_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type datasetClient struct {
+// DatasetClient contains the methods for the Dataset group.
+// Don't use this type directly, use a constructor function instead.
+type DatasetClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newDatasetClient creates a new instance of datasetClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newDatasetClient(endpoint string, pl runtime.Pipeline) *datasetClient {
-	client := &datasetClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateDataset - Creates or updates a dataset.
@@ -41,17 +33,17 @@ func newDatasetClient(endpoint string, pl runtime.Pipeline) *datasetClient {
 // Generated from API version 2019-06-01-preview
 //   - datasetName - The dataset name.
 //   - dataset - Dataset resource definition.
-//   - options - DatasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the datasetClient.BeginCreateOrUpdateDataset
+//   - options - DatasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the DatasetClient.BeginCreateOrUpdateDataset
 //     method.
-func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*runtime.Poller[DatasetClientCreateOrUpdateDatasetResponse], error) {
+func (client *DatasetClient) BeginCreateOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*runtime.Poller[DatasetClientCreateOrUpdateDatasetResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateDataset(ctx, datasetName, dataset, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DatasetClientCreateOrUpdateDatasetResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DatasetClientCreateOrUpdateDatasetResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DatasetClientCreateOrUpdateDatasetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DatasetClientCreateOrUpdateDatasetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *datasetClient) BeginCreateOrUpdateDataset(ctx context.Context, dat
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *datasetClient) createOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*http.Response, error) {
+func (client *DatasetClient) createOrUpdateDataset(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateDatasetCreateRequest(ctx, datasetName, dataset, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *datasetClient) createOrUpdateDataset(ctx context.Context, datasetN
 }
 
 // createOrUpdateDatasetCreateRequest creates the CreateOrUpdateDataset request.
-func (client *datasetClient) createOrUpdateDatasetCreateRequest(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*policy.Request, error) {
+func (client *DatasetClient) createOrUpdateDatasetCreateRequest(ctx context.Context, datasetName string, dataset DatasetResource, options *DatasetClientBeginCreateOrUpdateDatasetOptions) (*policy.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	if datasetName == "" {
 		return nil, errors.New("parameter datasetName cannot be empty")
@@ -100,17 +92,17 @@ func (client *datasetClient) createOrUpdateDatasetCreateRequest(ctx context.Cont
 //
 // Generated from API version 2019-06-01-preview
 //   - datasetName - The dataset name.
-//   - options - DatasetClientBeginDeleteDatasetOptions contains the optional parameters for the datasetClient.BeginDeleteDataset
+//   - options - DatasetClientBeginDeleteDatasetOptions contains the optional parameters for the DatasetClient.BeginDeleteDataset
 //     method.
-func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*runtime.Poller[DatasetClientDeleteDatasetResponse], error) {
+func (client *DatasetClient) BeginDeleteDataset(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*runtime.Poller[DatasetClientDeleteDatasetResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteDataset(ctx, datasetName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DatasetClientDeleteDatasetResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DatasetClientDeleteDatasetResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DatasetClientDeleteDatasetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DatasetClientDeleteDatasetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *datasetClient) BeginDeleteDataset(ctx context.Context, datasetName
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *datasetClient) deleteDataset(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*http.Response, error) {
+func (client *DatasetClient) deleteDataset(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*http.Response, error) {
 	req, err := client.deleteDatasetCreateRequest(ctx, datasetName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *datasetClient) deleteDataset(ctx context.Context, datasetName stri
 }
 
 // deleteDatasetCreateRequest creates the DeleteDataset request.
-func (client *datasetClient) deleteDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*policy.Request, error) {
+func (client *DatasetClient) deleteDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetClientBeginDeleteDatasetOptions) (*policy.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	if datasetName == "" {
 		return nil, errors.New("parameter datasetName cannot be empty")
@@ -156,13 +148,13 @@ func (client *datasetClient) deleteDatasetCreateRequest(ctx context.Context, dat
 //
 // Generated from API version 2019-06-01-preview
 //   - datasetName - The dataset name.
-//   - options - DatasetClientGetDatasetOptions contains the optional parameters for the datasetClient.GetDataset method.
-func (client *datasetClient) GetDataset(ctx context.Context, datasetName string, options *DatasetClientGetDatasetOptions) (DatasetClientGetDatasetResponse, error) {
+//   - options - DatasetClientGetDatasetOptions contains the optional parameters for the DatasetClient.GetDataset method.
+func (client *DatasetClient) GetDataset(ctx context.Context, datasetName string, options *DatasetClientGetDatasetOptions) (DatasetClientGetDatasetResponse, error) {
 	req, err := client.getDatasetCreateRequest(ctx, datasetName, options)
 	if err != nil {
 		return DatasetClientGetDatasetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return DatasetClientGetDatasetResponse{}, err
 	}
@@ -173,7 +165,7 @@ func (client *datasetClient) GetDataset(ctx context.Context, datasetName string,
 }
 
 // getDatasetCreateRequest creates the GetDataset request.
-func (client *datasetClient) getDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetClientGetDatasetOptions) (*policy.Request, error) {
+func (client *DatasetClient) getDatasetCreateRequest(ctx context.Context, datasetName string, options *DatasetClientGetDatasetOptions) (*policy.Request, error) {
 	urlPath := "/datasets/{datasetName}"
 	if datasetName == "" {
 		return nil, errors.New("parameter datasetName cannot be empty")
@@ -194,7 +186,7 @@ func (client *datasetClient) getDatasetCreateRequest(ctx context.Context, datase
 }
 
 // getDatasetHandleResponse handles the GetDataset response.
-func (client *datasetClient) getDatasetHandleResponse(resp *http.Response) (DatasetClientGetDatasetResponse, error) {
+func (client *DatasetClient) getDatasetHandleResponse(resp *http.Response) (DatasetClientGetDatasetResponse, error) {
 	result := DatasetClientGetDatasetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetResource); err != nil {
 		return DatasetClientGetDatasetResponse{}, err
@@ -205,9 +197,9 @@ func (client *datasetClient) getDatasetHandleResponse(resp *http.Response) (Data
 // NewGetDatasetsByWorkspacePager - Lists datasets.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - DatasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the datasetClient.NewGetDatasetsByWorkspacePager
+//   - options - DatasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the DatasetClient.NewGetDatasetsByWorkspacePager
 //     method.
-func (client *datasetClient) NewGetDatasetsByWorkspacePager(options *DatasetClientGetDatasetsByWorkspaceOptions) *runtime.Pager[DatasetClientGetDatasetsByWorkspaceResponse] {
+func (client *DatasetClient) NewGetDatasetsByWorkspacePager(options *DatasetClientGetDatasetsByWorkspaceOptions) *runtime.Pager[DatasetClientGetDatasetsByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[DatasetClientGetDatasetsByWorkspaceResponse]{
 		More: func(page DatasetClientGetDatasetsByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -223,7 +215,7 @@ func (client *datasetClient) NewGetDatasetsByWorkspacePager(options *DatasetClie
 			if err != nil {
 				return DatasetClientGetDatasetsByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return DatasetClientGetDatasetsByWorkspaceResponse{}, err
 			}
@@ -236,7 +228,7 @@ func (client *datasetClient) NewGetDatasetsByWorkspacePager(options *DatasetClie
 }
 
 // getDatasetsByWorkspaceCreateRequest creates the GetDatasetsByWorkspace request.
-func (client *datasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Context, options *DatasetClientGetDatasetsByWorkspaceOptions) (*policy.Request, error) {
+func (client *DatasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Context, options *DatasetClientGetDatasetsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/datasets"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -250,7 +242,7 @@ func (client *datasetClient) getDatasetsByWorkspaceCreateRequest(ctx context.Con
 }
 
 // getDatasetsByWorkspaceHandleResponse handles the GetDatasetsByWorkspace response.
-func (client *datasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Response) (DatasetClientGetDatasetsByWorkspaceResponse, error) {
+func (client *DatasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Response) (DatasetClientGetDatasetsByWorkspaceResponse, error) {
 	result := DatasetClientGetDatasetsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.DatasetListResponse); err != nil {
 		return DatasetClientGetDatasetsByWorkspaceResponse{}, err
@@ -264,17 +256,17 @@ func (client *datasetClient) getDatasetsByWorkspaceHandleResponse(resp *http.Res
 // Generated from API version 2019-06-01-preview
 //   - datasetName - The dataset name.
 //   - request - proposed new name.
-//   - options - DatasetClientBeginRenameDatasetOptions contains the optional parameters for the datasetClient.BeginRenameDataset
+//   - options - DatasetClientBeginRenameDatasetOptions contains the optional parameters for the DatasetClient.BeginRenameDataset
 //     method.
-func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*runtime.Poller[DatasetClientRenameDatasetResponse], error) {
+func (client *DatasetClient) BeginRenameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*runtime.Poller[DatasetClientRenameDatasetResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameDataset(ctx, datasetName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[DatasetClientRenameDatasetResponse](resp, client.pl, nil)
+		return runtime.NewPoller[DatasetClientRenameDatasetResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[DatasetClientRenameDatasetResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[DatasetClientRenameDatasetResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -282,12 +274,12 @@ func (client *datasetClient) BeginRenameDataset(ctx context.Context, datasetName
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *datasetClient) renameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*http.Response, error) {
+func (client *DatasetClient) renameDataset(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*http.Response, error) {
 	req, err := client.renameDatasetCreateRequest(ctx, datasetName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +290,7 @@ func (client *datasetClient) renameDataset(ctx context.Context, datasetName stri
 }
 
 // renameDatasetCreateRequest creates the RenameDataset request.
-func (client *datasetClient) renameDatasetCreateRequest(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*policy.Request, error) {
+func (client *DatasetClient) renameDatasetCreateRequest(ctx context.Context, datasetName string, request ArtifactRenameRequest, options *DatasetClientBeginRenameDatasetOptions) (*policy.Request, error) {
 	urlPath := "/datasets/{datasetName}/rename"
 	if datasetName == "" {
 		return nil, errors.New("parameter datasetName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_integrationruntimes_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_integrationruntimes_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type integrationRuntimesClient struct {
+// IntegrationRuntimesClient contains the methods for the IntegrationRuntimes group.
+// Don't use this type directly, use a constructor function instead.
+type IntegrationRuntimesClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newIntegrationRuntimesClient creates a new instance of integrationRuntimesClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newIntegrationRuntimesClient(endpoint string, pl runtime.Pipeline) *integrationRuntimesClient {
-	client := &integrationRuntimesClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // Get - Get Integration Runtime
@@ -40,13 +32,13 @@ func newIntegrationRuntimesClient(endpoint string, pl runtime.Pipeline) *integra
 //
 // Generated from API version 2019-06-01-preview
 //   - integrationRuntimeName - The Integration Runtime name
-//   - options - IntegrationRuntimesClientGetOptions contains the optional parameters for the integrationRuntimesClient.Get method.
-func (client *integrationRuntimesClient) Get(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesClientGetOptions) (IntegrationRuntimesClientGetResponse, error) {
+//   - options - IntegrationRuntimesClientGetOptions contains the optional parameters for the IntegrationRuntimesClient.Get method.
+func (client *IntegrationRuntimesClient) Get(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesClientGetOptions) (IntegrationRuntimesClientGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, integrationRuntimeName, options)
 	if err != nil {
 		return IntegrationRuntimesClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntegrationRuntimesClientGetResponse{}, err
 	}
@@ -57,7 +49,7 @@ func (client *integrationRuntimesClient) Get(ctx context.Context, integrationRun
 }
 
 // getCreateRequest creates the Get request.
-func (client *integrationRuntimesClient) getCreateRequest(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesClientGetOptions) (*policy.Request, error) {
+func (client *IntegrationRuntimesClient) getCreateRequest(ctx context.Context, integrationRuntimeName string, options *IntegrationRuntimesClientGetOptions) (*policy.Request, error) {
 	urlPath := "/integrationRuntimes/{integrationRuntimeName}"
 	if integrationRuntimeName == "" {
 		return nil, errors.New("parameter integrationRuntimeName cannot be empty")
@@ -75,7 +67,7 @@ func (client *integrationRuntimesClient) getCreateRequest(ctx context.Context, i
 }
 
 // getHandleResponse handles the Get response.
-func (client *integrationRuntimesClient) getHandleResponse(resp *http.Response) (IntegrationRuntimesClientGetResponse, error) {
+func (client *IntegrationRuntimesClient) getHandleResponse(resp *http.Response) (IntegrationRuntimesClientGetResponse, error) {
 	result := IntegrationRuntimesClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeResource); err != nil {
 		return IntegrationRuntimesClientGetResponse{}, err
@@ -87,14 +79,14 @@ func (client *integrationRuntimesClient) getHandleResponse(resp *http.Response) 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - IntegrationRuntimesClientListOptions contains the optional parameters for the integrationRuntimesClient.List
+//   - options - IntegrationRuntimesClientListOptions contains the optional parameters for the IntegrationRuntimesClient.List
 //     method.
-func (client *integrationRuntimesClient) List(ctx context.Context, options *IntegrationRuntimesClientListOptions) (IntegrationRuntimesClientListResponse, error) {
+func (client *IntegrationRuntimesClient) List(ctx context.Context, options *IntegrationRuntimesClientListOptions) (IntegrationRuntimesClientListResponse, error) {
 	req, err := client.listCreateRequest(ctx, options)
 	if err != nil {
 		return IntegrationRuntimesClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return IntegrationRuntimesClientListResponse{}, err
 	}
@@ -105,7 +97,7 @@ func (client *integrationRuntimesClient) List(ctx context.Context, options *Inte
 }
 
 // listCreateRequest creates the List request.
-func (client *integrationRuntimesClient) listCreateRequest(ctx context.Context, options *IntegrationRuntimesClientListOptions) (*policy.Request, error) {
+func (client *IntegrationRuntimesClient) listCreateRequest(ctx context.Context, options *IntegrationRuntimesClientListOptions) (*policy.Request, error) {
 	urlPath := "/integrationRuntimes"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -119,7 +111,7 @@ func (client *integrationRuntimesClient) listCreateRequest(ctx context.Context, 
 }
 
 // listHandleResponse handles the List response.
-func (client *integrationRuntimesClient) listHandleResponse(resp *http.Response) (IntegrationRuntimesClientListResponse, error) {
+func (client *IntegrationRuntimesClient) listHandleResponse(resp *http.Response) (IntegrationRuntimesClientListResponse, error) {
 	result := IntegrationRuntimesClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.IntegrationRuntimeListResponse); err != nil {
 		return IntegrationRuntimesClientListResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_library_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_library_client.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"io"
@@ -22,20 +23,11 @@ import (
 	"strings"
 )
 
-type libraryClient struct {
+// LibraryClient contains the methods for the Library group.
+// Don't use this type directly, use a constructor function instead.
+type LibraryClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newLibraryClient creates a new instance of libraryClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newLibraryClient(endpoint string, pl runtime.Pipeline) *libraryClient {
-	client := &libraryClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // Append - Append the content to the library resource created using the create operation. The maximum content size is 4MiB.
@@ -45,13 +37,13 @@ func newLibraryClient(endpoint string, pl runtime.Pipeline) *libraryClient {
 // Generated from API version 2019-06-01-preview
 //   - libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
 //   - content - Library file chunk.
-//   - options - LibraryClientAppendOptions contains the optional parameters for the libraryClient.Append method.
-func (client *libraryClient) Append(ctx context.Context, libraryName string, content io.ReadSeekCloser, options *LibraryClientAppendOptions) (LibraryClientAppendResponse, error) {
+//   - options - LibraryClientAppendOptions contains the optional parameters for the LibraryClient.Append method.
+func (client *LibraryClient) Append(ctx context.Context, libraryName string, content io.ReadSeekCloser, options *LibraryClientAppendOptions) (LibraryClientAppendResponse, error) {
 	req, err := client.appendCreateRequest(ctx, libraryName, content, options)
 	if err != nil {
 		return LibraryClientAppendResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LibraryClientAppendResponse{}, err
 	}
@@ -62,7 +54,7 @@ func (client *libraryClient) Append(ctx context.Context, libraryName string, con
 }
 
 // appendCreateRequest creates the Append request.
-func (client *libraryClient) appendCreateRequest(ctx context.Context, libraryName string, content io.ReadSeekCloser, options *LibraryClientAppendOptions) (*policy.Request, error) {
+func (client *LibraryClient) appendCreateRequest(ctx context.Context, libraryName string, content io.ReadSeekCloser, options *LibraryClientAppendOptions) (*policy.Request, error) {
 	urlPath := "/libraries/{libraryName}"
 	if libraryName == "" {
 		return nil, errors.New("parameter libraryName cannot be empty")
@@ -87,16 +79,16 @@ func (client *libraryClient) appendCreateRequest(ctx context.Context, libraryNam
 //
 // Generated from API version 2019-06-01-preview
 //   - libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
-//   - options - LibraryClientBeginCreateOptions contains the optional parameters for the libraryClient.BeginCreate method.
-func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*runtime.Poller[LibraryClientCreateResponse], error) {
+//   - options - LibraryClientBeginCreateOptions contains the optional parameters for the LibraryClient.BeginCreate method.
+func (client *LibraryClient) BeginCreate(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*runtime.Poller[LibraryClientCreateResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.create(ctx, libraryName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LibraryClientCreateResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LibraryClientCreateResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LibraryClientCreateResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LibraryClientCreateResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -104,12 +96,12 @@ func (client *libraryClient) BeginCreate(ctx context.Context, libraryName string
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *libraryClient) create(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*http.Response, error) {
+func (client *LibraryClient) create(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*http.Response, error) {
 	req, err := client.createCreateRequest(ctx, libraryName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +112,7 @@ func (client *libraryClient) create(ctx context.Context, libraryName string, opt
 }
 
 // createCreateRequest creates the Create request.
-func (client *libraryClient) createCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*policy.Request, error) {
+func (client *LibraryClient) createCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginCreateOptions) (*policy.Request, error) {
 	urlPath := "/libraries/{libraryName}"
 	if libraryName == "" {
 		return nil, errors.New("parameter libraryName cannot be empty")
@@ -142,16 +134,16 @@ func (client *libraryClient) createCreateRequest(ctx context.Context, libraryNam
 //
 // Generated from API version 2019-06-01-preview
 //   - libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
-//   - options - LibraryClientBeginDeleteOptions contains the optional parameters for the libraryClient.BeginDelete method.
-func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*runtime.Poller[LibraryClientDeleteResponse], error) {
+//   - options - LibraryClientBeginDeleteOptions contains the optional parameters for the LibraryClient.BeginDelete method.
+func (client *LibraryClient) BeginDelete(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*runtime.Poller[LibraryClientDeleteResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteOperation(ctx, libraryName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LibraryClientDeleteResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LibraryClientDeleteResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LibraryClientDeleteResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LibraryClientDeleteResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -159,12 +151,12 @@ func (client *libraryClient) BeginDelete(ctx context.Context, libraryName string
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *libraryClient) deleteOperation(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*http.Response, error) {
+func (client *LibraryClient) deleteOperation(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*http.Response, error) {
 	req, err := client.deleteCreateRequest(ctx, libraryName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +167,7 @@ func (client *libraryClient) deleteOperation(ctx context.Context, libraryName st
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *libraryClient) deleteCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*policy.Request, error) {
+func (client *LibraryClient) deleteCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/libraries/{libraryName}"
 	if libraryName == "" {
 		return nil, errors.New("parameter libraryName cannot be empty")
@@ -197,16 +189,16 @@ func (client *libraryClient) deleteCreateRequest(ctx context.Context, libraryNam
 //
 // Generated from API version 2019-06-01-preview
 //   - libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
-//   - options - LibraryClientBeginFlushOptions contains the optional parameters for the libraryClient.BeginFlush method.
-func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*runtime.Poller[LibraryClientFlushResponse], error) {
+//   - options - LibraryClientBeginFlushOptions contains the optional parameters for the LibraryClient.BeginFlush method.
+func (client *LibraryClient) BeginFlush(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*runtime.Poller[LibraryClientFlushResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.flush(ctx, libraryName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LibraryClientFlushResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LibraryClientFlushResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LibraryClientFlushResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LibraryClientFlushResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -214,12 +206,12 @@ func (client *libraryClient) BeginFlush(ctx context.Context, libraryName string,
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *libraryClient) flush(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*http.Response, error) {
+func (client *LibraryClient) flush(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*http.Response, error) {
 	req, err := client.flushCreateRequest(ctx, libraryName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +222,7 @@ func (client *libraryClient) flush(ctx context.Context, libraryName string, opti
 }
 
 // flushCreateRequest creates the Flush request.
-func (client *libraryClient) flushCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*policy.Request, error) {
+func (client *LibraryClient) flushCreateRequest(ctx context.Context, libraryName string, options *LibraryClientBeginFlushOptions) (*policy.Request, error) {
 	urlPath := "/libraries/{libraryName}/flush"
 	if libraryName == "" {
 		return nil, errors.New("parameter libraryName cannot be empty")
@@ -252,13 +244,13 @@ func (client *libraryClient) flushCreateRequest(ctx context.Context, libraryName
 //
 // Generated from API version 2019-06-01-preview
 //   - libraryName - file name to upload. Minimum length of the filename should be 1 excluding the extension length.
-//   - options - LibraryClientGetOptions contains the optional parameters for the libraryClient.Get method.
-func (client *libraryClient) Get(ctx context.Context, libraryName string, options *LibraryClientGetOptions) (LibraryClientGetResponse, error) {
+//   - options - LibraryClientGetOptions contains the optional parameters for the LibraryClient.Get method.
+func (client *LibraryClient) Get(ctx context.Context, libraryName string, options *LibraryClientGetOptions) (LibraryClientGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, libraryName, options)
 	if err != nil {
 		return LibraryClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LibraryClientGetResponse{}, err
 	}
@@ -269,7 +261,7 @@ func (client *libraryClient) Get(ctx context.Context, libraryName string, option
 }
 
 // getCreateRequest creates the Get request.
-func (client *libraryClient) getCreateRequest(ctx context.Context, libraryName string, options *LibraryClientGetOptions) (*policy.Request, error) {
+func (client *LibraryClient) getCreateRequest(ctx context.Context, libraryName string, options *LibraryClientGetOptions) (*policy.Request, error) {
 	urlPath := "/libraries/{libraryName}"
 	if libraryName == "" {
 		return nil, errors.New("parameter libraryName cannot be empty")
@@ -287,7 +279,7 @@ func (client *libraryClient) getCreateRequest(ctx context.Context, libraryName s
 }
 
 // getHandleResponse handles the Get response.
-func (client *libraryClient) getHandleResponse(resp *http.Response) (LibraryClientGetResponse, error) {
+func (client *LibraryClient) getHandleResponse(resp *http.Response) (LibraryClientGetResponse, error) {
 	result := LibraryClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryResource); err != nil {
 		return LibraryClientGetResponse{}, err
@@ -300,14 +292,14 @@ func (client *libraryClient) getHandleResponse(resp *http.Response) (LibraryClie
 //
 // Generated from API version 2019-06-01-preview
 //   - operationID - operation id for which status is requested
-//   - options - LibraryClientGetOperationResultOptions contains the optional parameters for the libraryClient.GetOperationResult
+//   - options - LibraryClientGetOperationResultOptions contains the optional parameters for the LibraryClient.GetOperationResult
 //     method.
-func (client *libraryClient) GetOperationResult(ctx context.Context, operationID string, options *LibraryClientGetOperationResultOptions) (LibraryClientGetOperationResultResponse, error) {
+func (client *LibraryClient) GetOperationResult(ctx context.Context, operationID string, options *LibraryClientGetOperationResultOptions) (LibraryClientGetOperationResultResponse, error) {
 	req, err := client.getOperationResultCreateRequest(ctx, operationID, options)
 	if err != nil {
 		return LibraryClientGetOperationResultResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LibraryClientGetOperationResultResponse{}, err
 	}
@@ -318,7 +310,7 @@ func (client *libraryClient) GetOperationResult(ctx context.Context, operationID
 }
 
 // getOperationResultCreateRequest creates the GetOperationResult request.
-func (client *libraryClient) getOperationResultCreateRequest(ctx context.Context, operationID string, options *LibraryClientGetOperationResultOptions) (*policy.Request, error) {
+func (client *LibraryClient) getOperationResultCreateRequest(ctx context.Context, operationID string, options *LibraryClientGetOperationResultOptions) (*policy.Request, error) {
 	urlPath := "/libraryOperationResults/{operationId}"
 	if operationID == "" {
 		return nil, errors.New("parameter operationID cannot be empty")
@@ -336,7 +328,7 @@ func (client *libraryClient) getOperationResultCreateRequest(ctx context.Context
 }
 
 // getOperationResultHandleResponse handles the GetOperationResult response.
-func (client *libraryClient) getOperationResultHandleResponse(resp *http.Response) (LibraryClientGetOperationResultResponse, error) {
+func (client *LibraryClient) getOperationResultHandleResponse(resp *http.Response) (LibraryClientGetOperationResultResponse, error) {
 	result := LibraryClientGetOperationResultResponse{}
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -360,8 +352,8 @@ func (client *libraryClient) getOperationResultHandleResponse(resp *http.Respons
 // NewListPager - Lists Library.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - LibraryClientListOptions contains the optional parameters for the libraryClient.NewListPager method.
-func (client *libraryClient) NewListPager(options *LibraryClientListOptions) *runtime.Pager[LibraryClientListResponse] {
+//   - options - LibraryClientListOptions contains the optional parameters for the LibraryClient.NewListPager method.
+func (client *LibraryClient) NewListPager(options *LibraryClientListOptions) *runtime.Pager[LibraryClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[LibraryClientListResponse]{
 		More: func(page LibraryClientListResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -377,7 +369,7 @@ func (client *libraryClient) NewListPager(options *LibraryClientListOptions) *ru
 			if err != nil {
 				return LibraryClientListResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LibraryClientListResponse{}, err
 			}
@@ -390,7 +382,7 @@ func (client *libraryClient) NewListPager(options *LibraryClientListOptions) *ru
 }
 
 // listCreateRequest creates the List request.
-func (client *libraryClient) listCreateRequest(ctx context.Context, options *LibraryClientListOptions) (*policy.Request, error) {
+func (client *LibraryClient) listCreateRequest(ctx context.Context, options *LibraryClientListOptions) (*policy.Request, error) {
 	urlPath := "/libraries"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -404,7 +396,7 @@ func (client *libraryClient) listCreateRequest(ctx context.Context, options *Lib
 }
 
 // listHandleResponse handles the List response.
-func (client *libraryClient) listHandleResponse(resp *http.Response) (LibraryClientListResponse, error) {
+func (client *LibraryClient) listHandleResponse(resp *http.Response) (LibraryClientListResponse, error) {
 	result := LibraryClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LibraryListResponse); err != nil {
 		return LibraryClientListResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_linkedservice_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_linkedservice_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type linkedServiceClient struct {
+// LinkedServiceClient contains the methods for the LinkedService group.
+// Don't use this type directly, use a constructor function instead.
+type LinkedServiceClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newLinkedServiceClient creates a new instance of linkedServiceClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newLinkedServiceClient(endpoint string, pl runtime.Pipeline) *linkedServiceClient {
-	client := &linkedServiceClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateLinkedService - Creates or updates a linked service.
@@ -41,17 +33,17 @@ func newLinkedServiceClient(endpoint string, pl runtime.Pipeline) *linkedService
 // Generated from API version 2019-06-01-preview
 //   - linkedServiceName - The linked service name.
 //   - linkedService - Linked service resource definition.
-//   - options - LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginCreateOrUpdateLinkedService
+//   - options - LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginCreateOrUpdateLinkedService
 //     method.
-func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientCreateOrUpdateLinkedServiceResponse], error) {
+func (client *LinkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientCreateOrUpdateLinkedServiceResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateLinkedService(ctx, linkedServiceName, linkedService, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LinkedServiceClientCreateOrUpdateLinkedServiceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LinkedServiceClientCreateOrUpdateLinkedServiceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LinkedServiceClientCreateOrUpdateLinkedServiceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LinkedServiceClientCreateOrUpdateLinkedServiceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *linkedServiceClient) BeginCreateOrUpdateLinkedService(ctx context.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *linkedServiceClient) createOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*http.Response, error) {
+func (client *LinkedServiceClient) createOrUpdateLinkedService(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateLinkedServiceCreateRequest(ctx, linkedServiceName, linkedService, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *linkedServiceClient) createOrUpdateLinkedService(ctx context.Conte
 }
 
 // createOrUpdateLinkedServiceCreateRequest creates the CreateOrUpdateLinkedService request.
-func (client *linkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*policy.Request, error) {
+func (client *LinkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, linkedService LinkedServiceResource, options *LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions) (*policy.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	if linkedServiceName == "" {
 		return nil, errors.New("parameter linkedServiceName cannot be empty")
@@ -100,17 +92,17 @@ func (client *linkedServiceClient) createOrUpdateLinkedServiceCreateRequest(ctx 
 //
 // Generated from API version 2019-06-01-preview
 //   - linkedServiceName - The linked service name.
-//   - options - LinkedServiceClientBeginDeleteLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginDeleteLinkedService
+//   - options - LinkedServiceClientBeginDeleteLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginDeleteLinkedService
 //     method.
-func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientDeleteLinkedServiceResponse], error) {
+func (client *LinkedServiceClient) BeginDeleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientDeleteLinkedServiceResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteLinkedService(ctx, linkedServiceName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LinkedServiceClientDeleteLinkedServiceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LinkedServiceClientDeleteLinkedServiceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LinkedServiceClientDeleteLinkedServiceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LinkedServiceClientDeleteLinkedServiceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *linkedServiceClient) BeginDeleteLinkedService(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *linkedServiceClient) deleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*http.Response, error) {
+func (client *LinkedServiceClient) deleteLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*http.Response, error) {
 	req, err := client.deleteLinkedServiceCreateRequest(ctx, linkedServiceName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *linkedServiceClient) deleteLinkedService(ctx context.Context, link
 }
 
 // deleteLinkedServiceCreateRequest creates the DeleteLinkedService request.
-func (client *linkedServiceClient) deleteLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*policy.Request, error) {
+func (client *LinkedServiceClient) deleteLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceClientBeginDeleteLinkedServiceOptions) (*policy.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	if linkedServiceName == "" {
 		return nil, errors.New("parameter linkedServiceName cannot be empty")
@@ -156,14 +148,14 @@ func (client *linkedServiceClient) deleteLinkedServiceCreateRequest(ctx context.
 //
 // Generated from API version 2019-06-01-preview
 //   - linkedServiceName - The linked service name.
-//   - options - LinkedServiceClientGetLinkedServiceOptions contains the optional parameters for the linkedServiceClient.GetLinkedService
+//   - options - LinkedServiceClientGetLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.GetLinkedService
 //     method.
-func (client *linkedServiceClient) GetLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientGetLinkedServiceOptions) (LinkedServiceClientGetLinkedServiceResponse, error) {
+func (client *LinkedServiceClient) GetLinkedService(ctx context.Context, linkedServiceName string, options *LinkedServiceClientGetLinkedServiceOptions) (LinkedServiceClientGetLinkedServiceResponse, error) {
 	req, err := client.getLinkedServiceCreateRequest(ctx, linkedServiceName, options)
 	if err != nil {
 		return LinkedServiceClientGetLinkedServiceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return LinkedServiceClientGetLinkedServiceResponse{}, err
 	}
@@ -174,7 +166,7 @@ func (client *linkedServiceClient) GetLinkedService(ctx context.Context, linkedS
 }
 
 // getLinkedServiceCreateRequest creates the GetLinkedService request.
-func (client *linkedServiceClient) getLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceClientGetLinkedServiceOptions) (*policy.Request, error) {
+func (client *LinkedServiceClient) getLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, options *LinkedServiceClientGetLinkedServiceOptions) (*policy.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}"
 	if linkedServiceName == "" {
 		return nil, errors.New("parameter linkedServiceName cannot be empty")
@@ -195,7 +187,7 @@ func (client *linkedServiceClient) getLinkedServiceCreateRequest(ctx context.Con
 }
 
 // getLinkedServiceHandleResponse handles the GetLinkedService response.
-func (client *linkedServiceClient) getLinkedServiceHandleResponse(resp *http.Response) (LinkedServiceClientGetLinkedServiceResponse, error) {
+func (client *LinkedServiceClient) getLinkedServiceHandleResponse(resp *http.Response) (LinkedServiceClientGetLinkedServiceResponse, error) {
 	result := LinkedServiceClientGetLinkedServiceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceResource); err != nil {
 		return LinkedServiceClientGetLinkedServiceResponse{}, err
@@ -206,9 +198,9 @@ func (client *linkedServiceClient) getLinkedServiceHandleResponse(resp *http.Res
 // NewGetLinkedServicesByWorkspacePager - Lists linked services.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - LinkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the linkedServiceClient.NewGetLinkedServicesByWorkspacePager
+//   - options - LinkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the LinkedServiceClient.NewGetLinkedServicesByWorkspacePager
 //     method.
-func (client *linkedServiceClient) NewGetLinkedServicesByWorkspacePager(options *LinkedServiceClientGetLinkedServicesByWorkspaceOptions) *runtime.Pager[LinkedServiceClientGetLinkedServicesByWorkspaceResponse] {
+func (client *LinkedServiceClient) NewGetLinkedServicesByWorkspacePager(options *LinkedServiceClientGetLinkedServicesByWorkspaceOptions) *runtime.Pager[LinkedServiceClientGetLinkedServicesByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[LinkedServiceClientGetLinkedServicesByWorkspaceResponse]{
 		More: func(page LinkedServiceClientGetLinkedServicesByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -224,7 +216,7 @@ func (client *linkedServiceClient) NewGetLinkedServicesByWorkspacePager(options 
 			if err != nil {
 				return LinkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return LinkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
 			}
@@ -237,7 +229,7 @@ func (client *linkedServiceClient) NewGetLinkedServicesByWorkspacePager(options 
 }
 
 // getLinkedServicesByWorkspaceCreateRequest creates the GetLinkedServicesByWorkspace request.
-func (client *linkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx context.Context, options *LinkedServiceClientGetLinkedServicesByWorkspaceOptions) (*policy.Request, error) {
+func (client *LinkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx context.Context, options *LinkedServiceClientGetLinkedServicesByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/linkedservices"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -251,7 +243,7 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceCreateRequest(ctx
 }
 
 // getLinkedServicesByWorkspaceHandleResponse handles the GetLinkedServicesByWorkspace response.
-func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(resp *http.Response) (LinkedServiceClientGetLinkedServicesByWorkspaceResponse, error) {
+func (client *LinkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(resp *http.Response) (LinkedServiceClientGetLinkedServicesByWorkspaceResponse, error) {
 	result := LinkedServiceClientGetLinkedServicesByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.LinkedServiceListResponse); err != nil {
 		return LinkedServiceClientGetLinkedServicesByWorkspaceResponse{}, err
@@ -265,17 +257,17 @@ func (client *linkedServiceClient) getLinkedServicesByWorkspaceHandleResponse(re
 // Generated from API version 2019-06-01-preview
 //   - linkedServiceName - The linked service name.
 //   - request - proposed new name.
-//   - options - LinkedServiceClientBeginRenameLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginRenameLinkedService
+//   - options - LinkedServiceClientBeginRenameLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginRenameLinkedService
 //     method.
-func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientRenameLinkedServiceResponse], error) {
+func (client *LinkedServiceClient) BeginRenameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*runtime.Poller[LinkedServiceClientRenameLinkedServiceResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameLinkedService(ctx, linkedServiceName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[LinkedServiceClientRenameLinkedServiceResponse](resp, client.pl, nil)
+		return runtime.NewPoller[LinkedServiceClientRenameLinkedServiceResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[LinkedServiceClientRenameLinkedServiceResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[LinkedServiceClientRenameLinkedServiceResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -283,12 +275,12 @@ func (client *linkedServiceClient) BeginRenameLinkedService(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *linkedServiceClient) renameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*http.Response, error) {
+func (client *LinkedServiceClient) renameLinkedService(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*http.Response, error) {
 	req, err := client.renameLinkedServiceCreateRequest(ctx, linkedServiceName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +291,7 @@ func (client *linkedServiceClient) renameLinkedService(ctx context.Context, link
 }
 
 // renameLinkedServiceCreateRequest creates the RenameLinkedService request.
-func (client *linkedServiceClient) renameLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*policy.Request, error) {
+func (client *LinkedServiceClient) renameLinkedServiceCreateRequest(ctx context.Context, linkedServiceName string, request ArtifactRenameRequest, options *LinkedServiceClientBeginRenameLinkedServiceOptions) (*policy.Request, error) {
 	urlPath := "/linkedservices/{linkedServiceName}/rename"
 	if linkedServiceName == "" {
 		return nil, errors.New("parameter linkedServiceName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_models.go
@@ -4219,12 +4219,12 @@ type BigDataPoolResourceProperties struct {
 	LastSucceededTimestamp *time.Time `json:"lastSucceededTimestamp,omitempty" azure:"ro"`
 }
 
-// BigDataPoolsClientGetOptions contains the optional parameters for the bigDataPoolsClient.Get method.
+// BigDataPoolsClientGetOptions contains the optional parameters for the BigDataPoolsClient.Get method.
 type BigDataPoolsClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// BigDataPoolsClientListOptions contains the optional parameters for the bigDataPoolsClient.List method.
+// BigDataPoolsClientListOptions contains the optional parameters for the BigDataPoolsClient.List method.
 type BigDataPoolsClientListOptions struct {
 	// placeholder for future optional parameters
 }
@@ -6232,7 +6232,7 @@ type DataFlow struct {
 // GetDataFlow implements the DataFlowClassification interface for type DataFlow.
 func (d *DataFlow) GetDataFlow() *DataFlow { return d }
 
-// DataFlowClientBeginCreateOrUpdateDataFlowOptions contains the optional parameters for the dataFlowClient.BeginCreateOrUpdateDataFlow
+// DataFlowClientBeginCreateOrUpdateDataFlowOptions contains the optional parameters for the DataFlowClient.BeginCreateOrUpdateDataFlow
 // method.
 type DataFlowClientBeginCreateOrUpdateDataFlowOptions struct {
 	// ETag of the data flow entity. Should only be specified for update, for which it should match existing entity or can be
@@ -6242,26 +6242,26 @@ type DataFlowClientBeginCreateOrUpdateDataFlowOptions struct {
 	ResumeToken string
 }
 
-// DataFlowClientBeginDeleteDataFlowOptions contains the optional parameters for the dataFlowClient.BeginDeleteDataFlow method.
+// DataFlowClientBeginDeleteDataFlowOptions contains the optional parameters for the DataFlowClient.BeginDeleteDataFlow method.
 type DataFlowClientBeginDeleteDataFlowOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DataFlowClientBeginRenameDataFlowOptions contains the optional parameters for the dataFlowClient.BeginRenameDataFlow method.
+// DataFlowClientBeginRenameDataFlowOptions contains the optional parameters for the DataFlowClient.BeginRenameDataFlow method.
 type DataFlowClientBeginRenameDataFlowOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DataFlowClientGetDataFlowOptions contains the optional parameters for the dataFlowClient.GetDataFlow method.
+// DataFlowClientGetDataFlowOptions contains the optional parameters for the DataFlowClient.GetDataFlow method.
 type DataFlowClientGetDataFlowOptions struct {
 	// ETag of the data flow entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
 }
 
-// DataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the dataFlowClient.NewGetDataFlowsByWorkspacePager
+// DataFlowClientGetDataFlowsByWorkspaceOptions contains the optional parameters for the DataFlowClient.NewGetDataFlowsByWorkspacePager
 // method.
 type DataFlowClientGetDataFlowsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -6366,33 +6366,33 @@ type DataFlowDebugResultResponse struct {
 	Status *string `json:"status,omitempty"`
 }
 
-// DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the dataFlowDebugSessionClient.AddDataFlow
+// DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the DataFlowDebugSessionClient.AddDataFlow
 // method.
 type DataFlowDebugSessionClientAddDataFlowOptions struct {
 	// placeholder for future optional parameters
 }
 
-// DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginCreateDataFlowDebugSession
+// DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSessionClient.BeginCreateDataFlowDebugSession
 // method.
 type DataFlowDebugSessionClientBeginCreateDataFlowDebugSessionOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DataFlowDebugSessionClientBeginExecuteCommandOptions contains the optional parameters for the dataFlowDebugSessionClient.BeginExecuteCommand
+// DataFlowDebugSessionClientBeginExecuteCommandOptions contains the optional parameters for the DataFlowDebugSessionClient.BeginExecuteCommand
 // method.
 type DataFlowDebugSessionClientBeginExecuteCommandOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions contains the optional parameters for the dataFlowDebugSessionClient.DeleteDataFlowDebugSession
+// DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions contains the optional parameters for the DataFlowDebugSessionClient.DeleteDataFlowDebugSession
 // method.
 type DataFlowDebugSessionClientDeleteDataFlowDebugSessionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the dataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager
+// DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions contains the optional parameters for the DataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager
 // method.
 type DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -6916,7 +6916,7 @@ func (d *DatasetBZip2Compression) GetDatasetCompression() *DatasetCompression {
 	}
 }
 
-// DatasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the datasetClient.BeginCreateOrUpdateDataset
+// DatasetClientBeginCreateOrUpdateDatasetOptions contains the optional parameters for the DatasetClient.BeginCreateOrUpdateDataset
 // method.
 type DatasetClientBeginCreateOrUpdateDatasetOptions struct {
 	// ETag of the dataset entity. Should only be specified for update, for which it should match existing entity or can be *
@@ -6926,26 +6926,26 @@ type DatasetClientBeginCreateOrUpdateDatasetOptions struct {
 	ResumeToken string
 }
 
-// DatasetClientBeginDeleteDatasetOptions contains the optional parameters for the datasetClient.BeginDeleteDataset method.
+// DatasetClientBeginDeleteDatasetOptions contains the optional parameters for the DatasetClient.BeginDeleteDataset method.
 type DatasetClientBeginDeleteDatasetOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DatasetClientBeginRenameDatasetOptions contains the optional parameters for the datasetClient.BeginRenameDataset method.
+// DatasetClientBeginRenameDatasetOptions contains the optional parameters for the DatasetClient.BeginRenameDataset method.
 type DatasetClientBeginRenameDatasetOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// DatasetClientGetDatasetOptions contains the optional parameters for the datasetClient.GetDataset method.
+// DatasetClientGetDatasetOptions contains the optional parameters for the DatasetClient.GetDataset method.
 type DatasetClientGetDatasetOptions struct {
 	// ETag of the dataset entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
 }
 
-// DatasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the datasetClient.NewGetDatasetsByWorkspacePager
+// DatasetClientGetDatasetsByWorkspaceOptions contains the optional parameters for the DatasetClient.NewGetDatasetsByWorkspacePager
 // method.
 type DatasetClientGetDatasetsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -12499,12 +12499,12 @@ type IntegrationRuntimeVNetProperties struct {
 	VNetID *string `json:"vNetId,omitempty"`
 }
 
-// IntegrationRuntimesClientGetOptions contains the optional parameters for the integrationRuntimesClient.Get method.
+// IntegrationRuntimesClientGetOptions contains the optional parameters for the IntegrationRuntimesClient.Get method.
 type IntegrationRuntimesClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// IntegrationRuntimesClientListOptions contains the optional parameters for the integrationRuntimesClient.List method.
+// IntegrationRuntimesClientListOptions contains the optional parameters for the IntegrationRuntimesClient.List method.
 type IntegrationRuntimesClientListOptions struct {
 	// placeholder for future optional parameters
 }
@@ -12880,7 +12880,7 @@ func (j *JiraSource) GetTabularSource() *TabularSource {
 	}
 }
 
-// LibraryClientAppendOptions contains the optional parameters for the libraryClient.Append method.
+// LibraryClientAppendOptions contains the optional parameters for the LibraryClient.Append method.
 type LibraryClientAppendOptions struct {
 	// Set this header to a byte offset at which the block is expected to be appended. The request succeeds only if the current
 	// offset matches this value. Otherwise, the request fails with the
@@ -12888,35 +12888,35 @@ type LibraryClientAppendOptions struct {
 	XMSBlobConditionAppendpos *int64
 }
 
-// LibraryClientBeginCreateOptions contains the optional parameters for the libraryClient.BeginCreate method.
+// LibraryClientBeginCreateOptions contains the optional parameters for the LibraryClient.BeginCreate method.
 type LibraryClientBeginCreateOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// LibraryClientBeginDeleteOptions contains the optional parameters for the libraryClient.BeginDelete method.
+// LibraryClientBeginDeleteOptions contains the optional parameters for the LibraryClient.BeginDelete method.
 type LibraryClientBeginDeleteOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// LibraryClientBeginFlushOptions contains the optional parameters for the libraryClient.BeginFlush method.
+// LibraryClientBeginFlushOptions contains the optional parameters for the LibraryClient.BeginFlush method.
 type LibraryClientBeginFlushOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// LibraryClientGetOperationResultOptions contains the optional parameters for the libraryClient.GetOperationResult method.
+// LibraryClientGetOperationResultOptions contains the optional parameters for the LibraryClient.GetOperationResult method.
 type LibraryClientGetOperationResultOptions struct {
 	// placeholder for future optional parameters
 }
 
-// LibraryClientGetOptions contains the optional parameters for the libraryClient.Get method.
+// LibraryClientGetOptions contains the optional parameters for the LibraryClient.Get method.
 type LibraryClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// LibraryClientListOptions contains the optional parameters for the libraryClient.NewListPager method.
+// LibraryClientListOptions contains the optional parameters for the LibraryClient.NewListPager method.
 type LibraryClientListOptions struct {
 	// placeholder for future optional parameters
 }
@@ -13142,7 +13142,7 @@ type LinkedService struct {
 // GetLinkedService implements the LinkedServiceClassification interface for type LinkedService.
 func (l *LinkedService) GetLinkedService() *LinkedService { return l }
 
-// LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginCreateOrUpdateLinkedService
+// LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginCreateOrUpdateLinkedService
 // method.
 type LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions struct {
 	// ETag of the linkedService entity. Should only be specified for update, for which it should match existing entity or can
@@ -13152,21 +13152,21 @@ type LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions struct {
 	ResumeToken string
 }
 
-// LinkedServiceClientBeginDeleteLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginDeleteLinkedService
+// LinkedServiceClientBeginDeleteLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginDeleteLinkedService
 // method.
 type LinkedServiceClientBeginDeleteLinkedServiceOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// LinkedServiceClientBeginRenameLinkedServiceOptions contains the optional parameters for the linkedServiceClient.BeginRenameLinkedService
+// LinkedServiceClientBeginRenameLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.BeginRenameLinkedService
 // method.
 type LinkedServiceClientBeginRenameLinkedServiceOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// LinkedServiceClientGetLinkedServiceOptions contains the optional parameters for the linkedServiceClient.GetLinkedService
+// LinkedServiceClientGetLinkedServiceOptions contains the optional parameters for the LinkedServiceClient.GetLinkedService
 // method.
 type LinkedServiceClientGetLinkedServiceOptions struct {
 	// ETag of the linked service entity. Should only be specified for get. If the ETag matches the existing entity tag, or if
@@ -13174,7 +13174,7 @@ type LinkedServiceClientGetLinkedServiceOptions struct {
 	IfNoneMatch *string
 }
 
-// LinkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the linkedServiceClient.NewGetLinkedServicesByWorkspacePager
+// LinkedServiceClientGetLinkedServicesByWorkspaceOptions contains the optional parameters for the LinkedServiceClient.NewGetLinkedServicesByWorkspacePager
 // method.
 type LinkedServiceClientGetLinkedServicesByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -14827,7 +14827,7 @@ type NotebookCellOutputItem struct {
 	Text any `json:"text,omitempty"`
 }
 
-// NotebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the notebookClient.BeginCreateOrUpdateNotebook
+// NotebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the NotebookClient.BeginCreateOrUpdateNotebook
 // method.
 type NotebookClientBeginCreateOrUpdateNotebookOptions struct {
 	// ETag of the Note book entity. Should only be specified for update, for which it should match existing entity or can be
@@ -14837,32 +14837,32 @@ type NotebookClientBeginCreateOrUpdateNotebookOptions struct {
 	ResumeToken string
 }
 
-// NotebookClientBeginDeleteNotebookOptions contains the optional parameters for the notebookClient.BeginDeleteNotebook method.
+// NotebookClientBeginDeleteNotebookOptions contains the optional parameters for the NotebookClient.BeginDeleteNotebook method.
 type NotebookClientBeginDeleteNotebookOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// NotebookClientBeginRenameNotebookOptions contains the optional parameters for the notebookClient.BeginRenameNotebook method.
+// NotebookClientBeginRenameNotebookOptions contains the optional parameters for the NotebookClient.BeginRenameNotebook method.
 type NotebookClientBeginRenameNotebookOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// NotebookClientGetNotebookOptions contains the optional parameters for the notebookClient.GetNotebook method.
+// NotebookClientGetNotebookOptions contains the optional parameters for the NotebookClient.GetNotebook method.
 type NotebookClientGetNotebookOptions struct {
 	// ETag of the Notebook entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
 }
 
-// NotebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the notebookClient.NewGetNotebookSummaryByWorkSpacePager
+// NotebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the NotebookClient.NewGetNotebookSummaryByWorkSpacePager
 // method.
 type NotebookClientGetNotebookSummaryByWorkSpaceOptions struct {
 	// placeholder for future optional parameters
 }
 
-// NotebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the notebookClient.NewGetNotebooksByWorkspacePager
+// NotebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the NotebookClient.NewGetNotebooksByWorkspacePager
 // method.
 type NotebookClientGetNotebooksByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -16550,7 +16550,7 @@ type Pipeline struct {
 	Variables map[string]*VariableSpecification `json:"variables,omitempty"`
 }
 
-// PipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the pipelineClient.BeginCreateOrUpdatePipeline
+// PipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the PipelineClient.BeginCreateOrUpdatePipeline
 // method.
 type PipelineClientBeginCreateOrUpdatePipelineOptions struct {
 	// ETag of the pipeline entity. Should only be specified for update, for which it should match existing entity or can be *
@@ -16560,19 +16560,19 @@ type PipelineClientBeginCreateOrUpdatePipelineOptions struct {
 	ResumeToken string
 }
 
-// PipelineClientBeginDeletePipelineOptions contains the optional parameters for the pipelineClient.BeginDeletePipeline method.
+// PipelineClientBeginDeletePipelineOptions contains the optional parameters for the PipelineClient.BeginDeletePipeline method.
 type PipelineClientBeginDeletePipelineOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// PipelineClientBeginRenamePipelineOptions contains the optional parameters for the pipelineClient.BeginRenamePipeline method.
+// PipelineClientBeginRenamePipelineOptions contains the optional parameters for the PipelineClient.BeginRenamePipeline method.
 type PipelineClientBeginRenamePipelineOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// PipelineClientCreatePipelineRunOptions contains the optional parameters for the pipelineClient.CreatePipelineRun method.
+// PipelineClientCreatePipelineRunOptions contains the optional parameters for the PipelineClient.CreatePipelineRun method.
 type PipelineClientCreatePipelineRunOptions struct {
 	// Recovery mode flag. If recovery mode is set to true, the specified referenced pipeline run and the new run will be grouped
 	// under the same groupId.
@@ -16585,14 +16585,14 @@ type PipelineClientCreatePipelineRunOptions struct {
 	StartActivityName *string
 }
 
-// PipelineClientGetPipelineOptions contains the optional parameters for the pipelineClient.GetPipeline method.
+// PipelineClientGetPipelineOptions contains the optional parameters for the PipelineClient.GetPipeline method.
 type PipelineClientGetPipelineOptions struct {
 	// ETag of the pipeline entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
 }
 
-// PipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the pipelineClient.NewGetPipelinesByWorkspacePager
+// PipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the PipelineClient.NewGetPipelinesByWorkspacePager
 // method.
 type PipelineClientGetPipelinesByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -16688,25 +16688,25 @@ type PipelineRun struct {
 	Status *string `json:"status,omitempty" azure:"ro"`
 }
 
-// PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the pipelineRunClient.CancelPipelineRun
+// PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the PipelineRunClient.CancelPipelineRun
 // method.
 type PipelineRunClientCancelPipelineRunOptions struct {
 	// If true, cancel all the Child pipelines that are triggered by the current pipeline.
 	IsRecursive *bool
 }
 
-// PipelineRunClientGetPipelineRunOptions contains the optional parameters for the pipelineRunClient.GetPipelineRun method.
+// PipelineRunClientGetPipelineRunOptions contains the optional parameters for the PipelineRunClient.GetPipelineRun method.
 type PipelineRunClientGetPipelineRunOptions struct {
 	// placeholder for future optional parameters
 }
 
-// PipelineRunClientQueryActivityRunsOptions contains the optional parameters for the pipelineRunClient.QueryActivityRuns
+// PipelineRunClientQueryActivityRunsOptions contains the optional parameters for the PipelineRunClient.QueryActivityRuns
 // method.
 type PipelineRunClientQueryActivityRunsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// PipelineRunClientQueryPipelineRunsByWorkspaceOptions contains the optional parameters for the pipelineRunClient.QueryPipelineRunsByWorkspace
+// PipelineRunClientQueryPipelineRunsByWorkspaceOptions contains the optional parameters for the PipelineRunClient.QueryPipelineRunsByWorkspace
 // method.
 type PipelineRunClientQueryPipelineRunsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -18357,6 +18357,16 @@ type SQLPoolStoredProcedureActivityTypeProperties struct {
 	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
 }
 
+// SQLPoolsClientGetOptions contains the optional parameters for the SQLPoolsClient.Get method.
+type SQLPoolsClientGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// SQLPoolsClientListOptions contains the optional parameters for the SQLPoolsClient.List method.
+type SQLPoolsClientListOptions struct {
+	// placeholder for future optional parameters
+}
+
 // SQLScript - SQL script.
 type SQLScript struct {
 	// REQUIRED; The content of the SQL script.
@@ -18370,6 +18380,43 @@ type SQLScript struct {
 
 	// The type of the SQL script.
 	Type *SQLScriptType `json:"type,omitempty"`
+}
+
+// SQLScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginCreateOrUpdateSQLScript
+// method.
+type SQLScriptClientBeginCreateOrUpdateSQLScriptOptions struct {
+	// ETag of the SQL script entity. Should only be specified for update, for which it should match existing entity or can be
+	// * for unconditional update.
+	IfMatch *string
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
+// SQLScriptClientBeginDeleteSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginDeleteSQLScript
+// method.
+type SQLScriptClientBeginDeleteSQLScriptOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
+// SQLScriptClientBeginRenameSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginRenameSQLScript
+// method.
+type SQLScriptClientBeginRenameSQLScriptOptions struct {
+	// Resumes the LRO from the provided token.
+	ResumeToken string
+}
+
+// SQLScriptClientGetSQLScriptOptions contains the optional parameters for the SQLScriptClient.GetSQLScript method.
+type SQLScriptClientGetSQLScriptOptions struct {
+	// ETag of the sql compute entity. Should only be specified for get. If the ETag matches the existing entity tag, or if *
+	// was provided, then no content will be returned.
+	IfNoneMatch *string
+}
+
+// SQLScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the SQLScriptClient.NewGetSQLScriptsByWorkspacePager
+// method.
+type SQLScriptClientGetSQLScriptsByWorkspaceOptions struct {
+	// placeholder for future optional parameters
 }
 
 // SQLScriptContent - The content of the SQL script.
@@ -21460,7 +21507,7 @@ type SparkJobDefinition struct {
 	RequiredSparkVersion *string `json:"requiredSparkVersion,omitempty"`
 }
 
-// SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition
+// SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition
 // method.
 type SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions struct {
 	// ETag of the Spark Job Definition entity. Should only be specified for update, for which it should match existing entity
@@ -21470,35 +21517,35 @@ type SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions struct
 	ResumeToken string
 }
 
-// SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDebugSparkJobDefinition
+// SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginDebugSparkJobDefinition
 // method.
 type SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDeleteSparkJobDefinition
+// SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginDeleteSparkJobDefinition
 // method.
 type SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginExecuteSparkJobDefinition
+// SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginExecuteSparkJobDefinition
 // method.
 type SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginRenameSparkJobDefinition
+// SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginRenameSparkJobDefinition
 // method.
 type SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// SparkJobDefinitionClientGetSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.GetSparkJobDefinition
+// SparkJobDefinitionClientGetSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.GetSparkJobDefinition
 // method.
 type SparkJobDefinitionClientGetSparkJobDefinitionOptions struct {
 	// ETag of the Spark Job Definition entity. Should only be specified for get. If the ETag matches the existing entity tag,
@@ -21506,7 +21553,7 @@ type SparkJobDefinitionClientGetSparkJobDefinitionOptions struct {
 	IfNoneMatch *string
 }
 
-// SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the sparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager
+// SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the SparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager
 // method.
 type SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -21806,53 +21853,6 @@ func (s *SparkSource) GetTabularSource() *TabularSource {
 		MaxConcurrentConnections: s.MaxConcurrentConnections,
 		AdditionalProperties:     s.AdditionalProperties,
 	}
-}
-
-// SqlPoolsClientGetOptions contains the optional parameters for the sqlPoolsClient.Get method.
-type SqlPoolsClientGetOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SqlPoolsClientListOptions contains the optional parameters for the sqlPoolsClient.List method.
-type SqlPoolsClientListOptions struct {
-	// placeholder for future optional parameters
-}
-
-// SqlScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginCreateOrUpdateSQLScript
-// method.
-type SqlScriptClientBeginCreateOrUpdateSQLScriptOptions struct {
-	// ETag of the SQL script entity. Should only be specified for update, for which it should match existing entity or can be
-	// * for unconditional update.
-	IfMatch *string
-	// Resumes the LRO from the provided token.
-	ResumeToken string
-}
-
-// SqlScriptClientBeginDeleteSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginDeleteSQLScript
-// method.
-type SqlScriptClientBeginDeleteSQLScriptOptions struct {
-	// Resumes the LRO from the provided token.
-	ResumeToken string
-}
-
-// SqlScriptClientBeginRenameSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginRenameSQLScript
-// method.
-type SqlScriptClientBeginRenameSQLScriptOptions struct {
-	// Resumes the LRO from the provided token.
-	ResumeToken string
-}
-
-// SqlScriptClientGetSQLScriptOptions contains the optional parameters for the sqlScriptClient.GetSQLScript method.
-type SqlScriptClientGetSQLScriptOptions struct {
-	// ETag of the sql compute entity. Should only be specified for get. If the ETag matches the existing entity tag, or if *
-	// was provided, then no content will be returned.
-	IfNoneMatch *string
-}
-
-// SqlScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the sqlScriptClient.NewGetSQLScriptsByWorkspacePager
-// method.
-type SqlScriptClientGetSQLScriptsByWorkspaceOptions struct {
-	// placeholder for future optional parameters
 }
 
 // SquareLinkedService - Square Service linked service.
@@ -22936,7 +22936,7 @@ type Trigger struct {
 // GetTrigger implements the TriggerClassification interface for type Trigger.
 func (t *Trigger) GetTrigger() *Trigger { return t }
 
-// TriggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the triggerClient.BeginCreateOrUpdateTrigger
+// TriggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the TriggerClient.BeginCreateOrUpdateTrigger
 // method.
 type TriggerClientBeginCreateOrUpdateTriggerOptions struct {
 	// ETag of the trigger entity. Should only be specified for update, for which it should match existing entity or can be *
@@ -22946,52 +22946,52 @@ type TriggerClientBeginCreateOrUpdateTriggerOptions struct {
 	ResumeToken string
 }
 
-// TriggerClientBeginDeleteTriggerOptions contains the optional parameters for the triggerClient.BeginDeleteTrigger method.
+// TriggerClientBeginDeleteTriggerOptions contains the optional parameters for the TriggerClient.BeginDeleteTrigger method.
 type TriggerClientBeginDeleteTriggerOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// TriggerClientBeginStartTriggerOptions contains the optional parameters for the triggerClient.BeginStartTrigger method.
+// TriggerClientBeginStartTriggerOptions contains the optional parameters for the TriggerClient.BeginStartTrigger method.
 type TriggerClientBeginStartTriggerOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// TriggerClientBeginStopTriggerOptions contains the optional parameters for the triggerClient.BeginStopTrigger method.
+// TriggerClientBeginStopTriggerOptions contains the optional parameters for the TriggerClient.BeginStopTrigger method.
 type TriggerClientBeginStopTriggerOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// TriggerClientBeginSubscribeTriggerToEventsOptions contains the optional parameters for the triggerClient.BeginSubscribeTriggerToEvents
+// TriggerClientBeginSubscribeTriggerToEventsOptions contains the optional parameters for the TriggerClient.BeginSubscribeTriggerToEvents
 // method.
 type TriggerClientBeginSubscribeTriggerToEventsOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// TriggerClientBeginUnsubscribeTriggerFromEventsOptions contains the optional parameters for the triggerClient.BeginUnsubscribeTriggerFromEvents
+// TriggerClientBeginUnsubscribeTriggerFromEventsOptions contains the optional parameters for the TriggerClient.BeginUnsubscribeTriggerFromEvents
 // method.
 type TriggerClientBeginUnsubscribeTriggerFromEventsOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// TriggerClientGetEventSubscriptionStatusOptions contains the optional parameters for the triggerClient.GetEventSubscriptionStatus
+// TriggerClientGetEventSubscriptionStatusOptions contains the optional parameters for the TriggerClient.GetEventSubscriptionStatus
 // method.
 type TriggerClientGetEventSubscriptionStatusOptions struct {
 	// placeholder for future optional parameters
 }
 
-// TriggerClientGetTriggerOptions contains the optional parameters for the triggerClient.GetTrigger method.
+// TriggerClientGetTriggerOptions contains the optional parameters for the TriggerClient.GetTrigger method.
 type TriggerClientGetTriggerOptions struct {
 	// ETag of the trigger entity. Should only be specified for get. If the ETag matches the existing entity tag, or if * was
 	// provided, then no content will be returned.
 	IfNoneMatch *string
 }
 
-// TriggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the triggerClient.NewGetTriggersByWorkspacePager
+// TriggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the TriggerClient.NewGetTriggersByWorkspacePager
 // method.
 type TriggerClientGetTriggersByWorkspaceOptions struct {
 	// placeholder for future optional parameters
@@ -23112,19 +23112,19 @@ type TriggerRun struct {
 	TriggeredPipelines map[string]*string `json:"triggeredPipelines,omitempty" azure:"ro"`
 }
 
-// TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the triggerRunClient.CancelTriggerInstance
+// TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.CancelTriggerInstance
 // method.
 type TriggerRunClientCancelTriggerInstanceOptions struct {
 	// placeholder for future optional parameters
 }
 
-// TriggerRunClientQueryTriggerRunsByWorkspaceOptions contains the optional parameters for the triggerRunClient.QueryTriggerRunsByWorkspace
+// TriggerRunClientQueryTriggerRunsByWorkspaceOptions contains the optional parameters for the TriggerRunClient.QueryTriggerRunsByWorkspace
 // method.
 type TriggerRunClientQueryTriggerRunsByWorkspaceOptions struct {
 	// placeholder for future optional parameters
 }
 
-// TriggerRunClientRerunTriggerInstanceOptions contains the optional parameters for the triggerRunClient.RerunTriggerInstance
+// TriggerRunClientRerunTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.RerunTriggerInstance
 // method.
 type TriggerRunClientRerunTriggerInstanceOptions struct {
 	// placeholder for future optional parameters
@@ -24038,12 +24038,12 @@ type Workspace struct {
 	Type *string `json:"type,omitempty" azure:"ro"`
 }
 
-// WorkspaceClientGetOptions contains the optional parameters for the workspaceClient.Get method.
+// WorkspaceClientGetOptions contains the optional parameters for the WorkspaceClient.Get method.
 type WorkspaceClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions contains the optional parameters for the workspaceGitRepoManagementClient.GetGitHubAccessToken
+// WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions contains the optional parameters for the WorkspaceGitRepoManagementClient.GetGitHubAccessToken
 // method.
 type WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions struct {
 	// Can provide a guid, which is helpful for debugging and to provide better customer support

--- a/test/synapse/2019-06-01/azartifacts/zz_notebook_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_notebook_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type notebookClient struct {
+// NotebookClient contains the methods for the Notebook group.
+// Don't use this type directly, use a constructor function instead.
+type NotebookClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newNotebookClient creates a new instance of notebookClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newNotebookClient(endpoint string, pl runtime.Pipeline) *notebookClient {
-	client := &notebookClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateNotebook - Creates or updates a Note Book.
@@ -41,17 +33,17 @@ func newNotebookClient(endpoint string, pl runtime.Pipeline) *notebookClient {
 // Generated from API version 2019-06-01-preview
 //   - notebookName - The notebook name.
 //   - notebook - Note book resource definition.
-//   - options - NotebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the notebookClient.BeginCreateOrUpdateNotebook
+//   - options - NotebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the NotebookClient.BeginCreateOrUpdateNotebook
 //     method.
-func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*runtime.Poller[NotebookClientCreateOrUpdateNotebookResponse], error) {
+func (client *NotebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*runtime.Poller[NotebookClientCreateOrUpdateNotebookResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateNotebook(ctx, notebookName, notebook, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[NotebookClientCreateOrUpdateNotebookResponse](resp, client.pl, nil)
+		return runtime.NewPoller[NotebookClientCreateOrUpdateNotebookResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[NotebookClientCreateOrUpdateNotebookResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[NotebookClientCreateOrUpdateNotebookResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *notebookClient) BeginCreateOrUpdateNotebook(ctx context.Context, n
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *notebookClient) createOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*http.Response, error) {
+func (client *NotebookClient) createOrUpdateNotebook(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateNotebookCreateRequest(ctx, notebookName, notebook, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *notebookClient) createOrUpdateNotebook(ctx context.Context, notebo
 }
 
 // createOrUpdateNotebookCreateRequest creates the CreateOrUpdateNotebook request.
-func (client *notebookClient) createOrUpdateNotebookCreateRequest(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*policy.Request, error) {
+func (client *NotebookClient) createOrUpdateNotebookCreateRequest(ctx context.Context, notebookName string, notebook NotebookResource, options *NotebookClientBeginCreateOrUpdateNotebookOptions) (*policy.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	if notebookName == "" {
 		return nil, errors.New("parameter notebookName cannot be empty")
@@ -100,17 +92,17 @@ func (client *notebookClient) createOrUpdateNotebookCreateRequest(ctx context.Co
 //
 // Generated from API version 2019-06-01-preview
 //   - notebookName - The notebook name.
-//   - options - NotebookClientBeginDeleteNotebookOptions contains the optional parameters for the notebookClient.BeginDeleteNotebook
+//   - options - NotebookClientBeginDeleteNotebookOptions contains the optional parameters for the NotebookClient.BeginDeleteNotebook
 //     method.
-func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*runtime.Poller[NotebookClientDeleteNotebookResponse], error) {
+func (client *NotebookClient) BeginDeleteNotebook(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*runtime.Poller[NotebookClientDeleteNotebookResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteNotebook(ctx, notebookName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[NotebookClientDeleteNotebookResponse](resp, client.pl, nil)
+		return runtime.NewPoller[NotebookClientDeleteNotebookResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[NotebookClientDeleteNotebookResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[NotebookClientDeleteNotebookResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *notebookClient) BeginDeleteNotebook(ctx context.Context, notebookN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *notebookClient) deleteNotebook(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*http.Response, error) {
+func (client *NotebookClient) deleteNotebook(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*http.Response, error) {
 	req, err := client.deleteNotebookCreateRequest(ctx, notebookName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *notebookClient) deleteNotebook(ctx context.Context, notebookName s
 }
 
 // deleteNotebookCreateRequest creates the DeleteNotebook request.
-func (client *notebookClient) deleteNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*policy.Request, error) {
+func (client *NotebookClient) deleteNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookClientBeginDeleteNotebookOptions) (*policy.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	if notebookName == "" {
 		return nil, errors.New("parameter notebookName cannot be empty")
@@ -156,13 +148,13 @@ func (client *notebookClient) deleteNotebookCreateRequest(ctx context.Context, n
 //
 // Generated from API version 2019-06-01-preview
 //   - notebookName - The notebook name.
-//   - options - NotebookClientGetNotebookOptions contains the optional parameters for the notebookClient.GetNotebook method.
-func (client *notebookClient) GetNotebook(ctx context.Context, notebookName string, options *NotebookClientGetNotebookOptions) (NotebookClientGetNotebookResponse, error) {
+//   - options - NotebookClientGetNotebookOptions contains the optional parameters for the NotebookClient.GetNotebook method.
+func (client *NotebookClient) GetNotebook(ctx context.Context, notebookName string, options *NotebookClientGetNotebookOptions) (NotebookClientGetNotebookResponse, error) {
 	req, err := client.getNotebookCreateRequest(ctx, notebookName, options)
 	if err != nil {
 		return NotebookClientGetNotebookResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return NotebookClientGetNotebookResponse{}, err
 	}
@@ -173,7 +165,7 @@ func (client *notebookClient) GetNotebook(ctx context.Context, notebookName stri
 }
 
 // getNotebookCreateRequest creates the GetNotebook request.
-func (client *notebookClient) getNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookClientGetNotebookOptions) (*policy.Request, error) {
+func (client *NotebookClient) getNotebookCreateRequest(ctx context.Context, notebookName string, options *NotebookClientGetNotebookOptions) (*policy.Request, error) {
 	urlPath := "/notebooks/{notebookName}"
 	if notebookName == "" {
 		return nil, errors.New("parameter notebookName cannot be empty")
@@ -194,7 +186,7 @@ func (client *notebookClient) getNotebookCreateRequest(ctx context.Context, note
 }
 
 // getNotebookHandleResponse handles the GetNotebook response.
-func (client *notebookClient) getNotebookHandleResponse(resp *http.Response) (NotebookClientGetNotebookResponse, error) {
+func (client *NotebookClient) getNotebookHandleResponse(resp *http.Response) (NotebookClientGetNotebookResponse, error) {
 	result := NotebookClientGetNotebookResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookResource); err != nil {
 		return NotebookClientGetNotebookResponse{}, err
@@ -205,9 +197,9 @@ func (client *notebookClient) getNotebookHandleResponse(resp *http.Response) (No
 // NewGetNotebookSummaryByWorkSpacePager - Lists a summary of Notebooks.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - NotebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the notebookClient.NewGetNotebookSummaryByWorkSpacePager
+//   - options - NotebookClientGetNotebookSummaryByWorkSpaceOptions contains the optional parameters for the NotebookClient.NewGetNotebookSummaryByWorkSpacePager
 //     method.
-func (client *notebookClient) NewGetNotebookSummaryByWorkSpacePager(options *NotebookClientGetNotebookSummaryByWorkSpaceOptions) *runtime.Pager[NotebookClientGetNotebookSummaryByWorkSpaceResponse] {
+func (client *NotebookClient) NewGetNotebookSummaryByWorkSpacePager(options *NotebookClientGetNotebookSummaryByWorkSpaceOptions) *runtime.Pager[NotebookClientGetNotebookSummaryByWorkSpaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[NotebookClientGetNotebookSummaryByWorkSpaceResponse]{
 		More: func(page NotebookClientGetNotebookSummaryByWorkSpaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -223,7 +215,7 @@ func (client *notebookClient) NewGetNotebookSummaryByWorkSpacePager(options *Not
 			if err != nil {
 				return NotebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return NotebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
 			}
@@ -236,7 +228,7 @@ func (client *notebookClient) NewGetNotebookSummaryByWorkSpacePager(options *Not
 }
 
 // getNotebookSummaryByWorkSpaceCreateRequest creates the GetNotebookSummaryByWorkSpace request.
-func (client *notebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx context.Context, options *NotebookClientGetNotebookSummaryByWorkSpaceOptions) (*policy.Request, error) {
+func (client *NotebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx context.Context, options *NotebookClientGetNotebookSummaryByWorkSpaceOptions) (*policy.Request, error) {
 	urlPath := "/notebooks/summary"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -250,7 +242,7 @@ func (client *notebookClient) getNotebookSummaryByWorkSpaceCreateRequest(ctx con
 }
 
 // getNotebookSummaryByWorkSpaceHandleResponse handles the GetNotebookSummaryByWorkSpace response.
-func (client *notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *http.Response) (NotebookClientGetNotebookSummaryByWorkSpaceResponse, error) {
+func (client *NotebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *http.Response) (NotebookClientGetNotebookSummaryByWorkSpaceResponse, error) {
 	result := NotebookClientGetNotebookSummaryByWorkSpaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
 		return NotebookClientGetNotebookSummaryByWorkSpaceResponse{}, err
@@ -261,9 +253,9 @@ func (client *notebookClient) getNotebookSummaryByWorkSpaceHandleResponse(resp *
 // NewGetNotebooksByWorkspacePager - Lists Notebooks.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - NotebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the notebookClient.NewGetNotebooksByWorkspacePager
+//   - options - NotebookClientGetNotebooksByWorkspaceOptions contains the optional parameters for the NotebookClient.NewGetNotebooksByWorkspacePager
 //     method.
-func (client *notebookClient) NewGetNotebooksByWorkspacePager(options *NotebookClientGetNotebooksByWorkspaceOptions) *runtime.Pager[NotebookClientGetNotebooksByWorkspaceResponse] {
+func (client *NotebookClient) NewGetNotebooksByWorkspacePager(options *NotebookClientGetNotebooksByWorkspaceOptions) *runtime.Pager[NotebookClientGetNotebooksByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[NotebookClientGetNotebooksByWorkspaceResponse]{
 		More: func(page NotebookClientGetNotebooksByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -279,7 +271,7 @@ func (client *notebookClient) NewGetNotebooksByWorkspacePager(options *NotebookC
 			if err != nil {
 				return NotebookClientGetNotebooksByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return NotebookClientGetNotebooksByWorkspaceResponse{}, err
 			}
@@ -292,7 +284,7 @@ func (client *notebookClient) NewGetNotebooksByWorkspacePager(options *NotebookC
 }
 
 // getNotebooksByWorkspaceCreateRequest creates the GetNotebooksByWorkspace request.
-func (client *notebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.Context, options *NotebookClientGetNotebooksByWorkspaceOptions) (*policy.Request, error) {
+func (client *NotebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.Context, options *NotebookClientGetNotebooksByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/notebooks"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -306,7 +298,7 @@ func (client *notebookClient) getNotebooksByWorkspaceCreateRequest(ctx context.C
 }
 
 // getNotebooksByWorkspaceHandleResponse handles the GetNotebooksByWorkspace response.
-func (client *notebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.Response) (NotebookClientGetNotebooksByWorkspaceResponse, error) {
+func (client *NotebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.Response) (NotebookClientGetNotebooksByWorkspaceResponse, error) {
 	result := NotebookClientGetNotebooksByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.NotebookListResponse); err != nil {
 		return NotebookClientGetNotebooksByWorkspaceResponse{}, err
@@ -320,17 +312,17 @@ func (client *notebookClient) getNotebooksByWorkspaceHandleResponse(resp *http.R
 // Generated from API version 2019-06-01-preview
 //   - notebookName - The notebook name.
 //   - request - proposed new name.
-//   - options - NotebookClientBeginRenameNotebookOptions contains the optional parameters for the notebookClient.BeginRenameNotebook
+//   - options - NotebookClientBeginRenameNotebookOptions contains the optional parameters for the NotebookClient.BeginRenameNotebook
 //     method.
-func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*runtime.Poller[NotebookClientRenameNotebookResponse], error) {
+func (client *NotebookClient) BeginRenameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*runtime.Poller[NotebookClientRenameNotebookResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameNotebook(ctx, notebookName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[NotebookClientRenameNotebookResponse](resp, client.pl, nil)
+		return runtime.NewPoller[NotebookClientRenameNotebookResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[NotebookClientRenameNotebookResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[NotebookClientRenameNotebookResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -338,12 +330,12 @@ func (client *notebookClient) BeginRenameNotebook(ctx context.Context, notebookN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *notebookClient) renameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*http.Response, error) {
+func (client *NotebookClient) renameNotebook(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*http.Response, error) {
 	req, err := client.renameNotebookCreateRequest(ctx, notebookName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -354,7 +346,7 @@ func (client *notebookClient) renameNotebook(ctx context.Context, notebookName s
 }
 
 // renameNotebookCreateRequest creates the RenameNotebook request.
-func (client *notebookClient) renameNotebookCreateRequest(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*policy.Request, error) {
+func (client *NotebookClient) renameNotebookCreateRequest(ctx context.Context, notebookName string, request ArtifactRenameRequest, options *NotebookClientBeginRenameNotebookOptions) (*policy.Request, error) {
 	urlPath := "/notebooks/{notebookName}/rename"
 	if notebookName == "" {
 		return nil, errors.New("parameter notebookName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_pipeline_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_pipeline_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,20 +21,11 @@ import (
 	"strings"
 )
 
-type pipelineClient struct {
+// PipelineClient contains the methods for the Pipeline group.
+// Don't use this type directly, use a constructor function instead.
+type PipelineClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newPipelineClient creates a new instance of pipelineClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newPipelineClient(endpoint string, pl runtime.Pipeline) *pipelineClient {
-	client := &pipelineClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdatePipeline - Creates or updates a pipeline.
@@ -42,17 +34,17 @@ func newPipelineClient(endpoint string, pl runtime.Pipeline) *pipelineClient {
 // Generated from API version 2019-06-01-preview
 //   - pipelineName - The pipeline name.
 //   - pipeline - Pipeline resource definition.
-//   - options - PipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the pipelineClient.BeginCreateOrUpdatePipeline
+//   - options - PipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the PipelineClient.BeginCreateOrUpdatePipeline
 //     method.
-func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*runtime.Poller[PipelineClientCreateOrUpdatePipelineResponse], error) {
+func (client *PipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*runtime.Poller[PipelineClientCreateOrUpdatePipelineResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdatePipeline(ctx, pipelineName, pipeline, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[PipelineClientCreateOrUpdatePipelineResponse](resp, client.pl, nil)
+		return runtime.NewPoller[PipelineClientCreateOrUpdatePipelineResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[PipelineClientCreateOrUpdatePipelineResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PipelineClientCreateOrUpdatePipelineResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -60,12 +52,12 @@ func (client *pipelineClient) BeginCreateOrUpdatePipeline(ctx context.Context, p
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *pipelineClient) createOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*http.Response, error) {
+func (client *PipelineClient) createOrUpdatePipeline(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*http.Response, error) {
 	req, err := client.createOrUpdatePipelineCreateRequest(ctx, pipelineName, pipeline, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +68,7 @@ func (client *pipelineClient) createOrUpdatePipeline(ctx context.Context, pipeli
 }
 
 // createOrUpdatePipelineCreateRequest creates the CreateOrUpdatePipeline request.
-func (client *pipelineClient) createOrUpdatePipelineCreateRequest(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*policy.Request, error) {
+func (client *PipelineClient) createOrUpdatePipelineCreateRequest(ctx context.Context, pipelineName string, pipeline PipelineResource, options *PipelineClientBeginCreateOrUpdatePipelineOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")
@@ -101,14 +93,14 @@ func (client *pipelineClient) createOrUpdatePipelineCreateRequest(ctx context.Co
 //
 // Generated from API version 2019-06-01-preview
 //   - pipelineName - The pipeline name.
-//   - options - PipelineClientCreatePipelineRunOptions contains the optional parameters for the pipelineClient.CreatePipelineRun
+//   - options - PipelineClientCreatePipelineRunOptions contains the optional parameters for the PipelineClient.CreatePipelineRun
 //     method.
-func (client *pipelineClient) CreatePipelineRun(ctx context.Context, pipelineName string, options *PipelineClientCreatePipelineRunOptions) (PipelineClientCreatePipelineRunResponse, error) {
+func (client *PipelineClient) CreatePipelineRun(ctx context.Context, pipelineName string, options *PipelineClientCreatePipelineRunOptions) (PipelineClientCreatePipelineRunResponse, error) {
 	req, err := client.createPipelineRunCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return PipelineClientCreatePipelineRunResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineClientCreatePipelineRunResponse{}, err
 	}
@@ -119,7 +111,7 @@ func (client *pipelineClient) CreatePipelineRun(ctx context.Context, pipelineNam
 }
 
 // createPipelineRunCreateRequest creates the CreatePipelineRun request.
-func (client *pipelineClient) createPipelineRunCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientCreatePipelineRunOptions) (*policy.Request, error) {
+func (client *PipelineClient) createPipelineRunCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientCreatePipelineRunOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}/createRun"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")
@@ -149,7 +141,7 @@ func (client *pipelineClient) createPipelineRunCreateRequest(ctx context.Context
 }
 
 // createPipelineRunHandleResponse handles the CreatePipelineRun response.
-func (client *pipelineClient) createPipelineRunHandleResponse(resp *http.Response) (PipelineClientCreatePipelineRunResponse, error) {
+func (client *PipelineClient) createPipelineRunHandleResponse(resp *http.Response) (PipelineClientCreatePipelineRunResponse, error) {
 	result := PipelineClientCreatePipelineRunResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.CreateRunResponse); err != nil {
 		return PipelineClientCreatePipelineRunResponse{}, err
@@ -162,17 +154,17 @@ func (client *pipelineClient) createPipelineRunHandleResponse(resp *http.Respons
 //
 // Generated from API version 2019-06-01-preview
 //   - pipelineName - The pipeline name.
-//   - options - PipelineClientBeginDeletePipelineOptions contains the optional parameters for the pipelineClient.BeginDeletePipeline
+//   - options - PipelineClientBeginDeletePipelineOptions contains the optional parameters for the PipelineClient.BeginDeletePipeline
 //     method.
-func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*runtime.Poller[PipelineClientDeletePipelineResponse], error) {
+func (client *PipelineClient) BeginDeletePipeline(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*runtime.Poller[PipelineClientDeletePipelineResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deletePipeline(ctx, pipelineName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[PipelineClientDeletePipelineResponse](resp, client.pl, nil)
+		return runtime.NewPoller[PipelineClientDeletePipelineResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[PipelineClientDeletePipelineResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PipelineClientDeletePipelineResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -180,12 +172,12 @@ func (client *pipelineClient) BeginDeletePipeline(ctx context.Context, pipelineN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *pipelineClient) deletePipeline(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*http.Response, error) {
+func (client *PipelineClient) deletePipeline(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*http.Response, error) {
 	req, err := client.deletePipelineCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +188,7 @@ func (client *pipelineClient) deletePipeline(ctx context.Context, pipelineName s
 }
 
 // deletePipelineCreateRequest creates the DeletePipeline request.
-func (client *pipelineClient) deletePipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*policy.Request, error) {
+func (client *PipelineClient) deletePipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientBeginDeletePipelineOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")
@@ -218,13 +210,13 @@ func (client *pipelineClient) deletePipelineCreateRequest(ctx context.Context, p
 //
 // Generated from API version 2019-06-01-preview
 //   - pipelineName - The pipeline name.
-//   - options - PipelineClientGetPipelineOptions contains the optional parameters for the pipelineClient.GetPipeline method.
-func (client *pipelineClient) GetPipeline(ctx context.Context, pipelineName string, options *PipelineClientGetPipelineOptions) (PipelineClientGetPipelineResponse, error) {
+//   - options - PipelineClientGetPipelineOptions contains the optional parameters for the PipelineClient.GetPipeline method.
+func (client *PipelineClient) GetPipeline(ctx context.Context, pipelineName string, options *PipelineClientGetPipelineOptions) (PipelineClientGetPipelineResponse, error) {
 	req, err := client.getPipelineCreateRequest(ctx, pipelineName, options)
 	if err != nil {
 		return PipelineClientGetPipelineResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineClientGetPipelineResponse{}, err
 	}
@@ -235,7 +227,7 @@ func (client *pipelineClient) GetPipeline(ctx context.Context, pipelineName stri
 }
 
 // getPipelineCreateRequest creates the GetPipeline request.
-func (client *pipelineClient) getPipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientGetPipelineOptions) (*policy.Request, error) {
+func (client *PipelineClient) getPipelineCreateRequest(ctx context.Context, pipelineName string, options *PipelineClientGetPipelineOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")
@@ -256,7 +248,7 @@ func (client *pipelineClient) getPipelineCreateRequest(ctx context.Context, pipe
 }
 
 // getPipelineHandleResponse handles the GetPipeline response.
-func (client *pipelineClient) getPipelineHandleResponse(resp *http.Response) (PipelineClientGetPipelineResponse, error) {
+func (client *PipelineClient) getPipelineHandleResponse(resp *http.Response) (PipelineClientGetPipelineResponse, error) {
 	result := PipelineClientGetPipelineResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineResource); err != nil {
 		return PipelineClientGetPipelineResponse{}, err
@@ -267,9 +259,9 @@ func (client *pipelineClient) getPipelineHandleResponse(resp *http.Response) (Pi
 // NewGetPipelinesByWorkspacePager - Lists pipelines.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - PipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the pipelineClient.NewGetPipelinesByWorkspacePager
+//   - options - PipelineClientGetPipelinesByWorkspaceOptions contains the optional parameters for the PipelineClient.NewGetPipelinesByWorkspacePager
 //     method.
-func (client *pipelineClient) NewGetPipelinesByWorkspacePager(options *PipelineClientGetPipelinesByWorkspaceOptions) *runtime.Pager[PipelineClientGetPipelinesByWorkspaceResponse] {
+func (client *PipelineClient) NewGetPipelinesByWorkspacePager(options *PipelineClientGetPipelinesByWorkspaceOptions) *runtime.Pager[PipelineClientGetPipelinesByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[PipelineClientGetPipelinesByWorkspaceResponse]{
 		More: func(page PipelineClientGetPipelinesByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -285,7 +277,7 @@ func (client *pipelineClient) NewGetPipelinesByWorkspacePager(options *PipelineC
 			if err != nil {
 				return PipelineClientGetPipelinesByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PipelineClientGetPipelinesByWorkspaceResponse{}, err
 			}
@@ -298,7 +290,7 @@ func (client *pipelineClient) NewGetPipelinesByWorkspacePager(options *PipelineC
 }
 
 // getPipelinesByWorkspaceCreateRequest creates the GetPipelinesByWorkspace request.
-func (client *pipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.Context, options *PipelineClientGetPipelinesByWorkspaceOptions) (*policy.Request, error) {
+func (client *PipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.Context, options *PipelineClientGetPipelinesByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/pipelines"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -312,7 +304,7 @@ func (client *pipelineClient) getPipelinesByWorkspaceCreateRequest(ctx context.C
 }
 
 // getPipelinesByWorkspaceHandleResponse handles the GetPipelinesByWorkspace response.
-func (client *pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.Response) (PipelineClientGetPipelinesByWorkspaceResponse, error) {
+func (client *PipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.Response) (PipelineClientGetPipelinesByWorkspaceResponse, error) {
 	result := PipelineClientGetPipelinesByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineListResponse); err != nil {
 		return PipelineClientGetPipelinesByWorkspaceResponse{}, err
@@ -326,17 +318,17 @@ func (client *pipelineClient) getPipelinesByWorkspaceHandleResponse(resp *http.R
 // Generated from API version 2019-06-01-preview
 //   - pipelineName - The pipeline name.
 //   - request - proposed new name.
-//   - options - PipelineClientBeginRenamePipelineOptions contains the optional parameters for the pipelineClient.BeginRenamePipeline
+//   - options - PipelineClientBeginRenamePipelineOptions contains the optional parameters for the PipelineClient.BeginRenamePipeline
 //     method.
-func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*runtime.Poller[PipelineClientRenamePipelineResponse], error) {
+func (client *PipelineClient) BeginRenamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*runtime.Poller[PipelineClientRenamePipelineResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renamePipeline(ctx, pipelineName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[PipelineClientRenamePipelineResponse](resp, client.pl, nil)
+		return runtime.NewPoller[PipelineClientRenamePipelineResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[PipelineClientRenamePipelineResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[PipelineClientRenamePipelineResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -344,12 +336,12 @@ func (client *pipelineClient) BeginRenamePipeline(ctx context.Context, pipelineN
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *pipelineClient) renamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*http.Response, error) {
+func (client *PipelineClient) renamePipeline(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*http.Response, error) {
 	req, err := client.renamePipelineCreateRequest(ctx, pipelineName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +352,7 @@ func (client *pipelineClient) renamePipeline(ctx context.Context, pipelineName s
 }
 
 // renamePipelineCreateRequest creates the RenamePipeline request.
-func (client *pipelineClient) renamePipelineCreateRequest(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*policy.Request, error) {
+func (client *PipelineClient) renamePipelineCreateRequest(ctx context.Context, pipelineName string, request ArtifactRenameRequest, options *PipelineClientBeginRenamePipelineOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}/rename"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_pipelinerun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_pipelinerun_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -20,20 +21,11 @@ import (
 	"strings"
 )
 
-type pipelineRunClient struct {
+// PipelineRunClient contains the methods for the PipelineRun group.
+// Don't use this type directly, use a constructor function instead.
+type PipelineRunClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newPipelineRunClient creates a new instance of pipelineRunClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newPipelineRunClient(endpoint string, pl runtime.Pipeline) *pipelineRunClient {
-	client := &pipelineRunClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // CancelPipelineRun - Cancel a pipeline run by its run ID.
@@ -41,14 +33,14 @@ func newPipelineRunClient(endpoint string, pl runtime.Pipeline) *pipelineRunClie
 //
 // Generated from API version 2019-06-01-preview
 //   - runID - The pipeline run identifier.
-//   - options - PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the pipelineRunClient.CancelPipelineRun
+//   - options - PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the PipelineRunClient.CancelPipelineRun
 //     method.
-func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runID string, options *PipelineRunClientCancelPipelineRunOptions) (PipelineRunClientCancelPipelineRunResponse, error) {
+func (client *PipelineRunClient) CancelPipelineRun(ctx context.Context, runID string, options *PipelineRunClientCancelPipelineRunOptions) (PipelineRunClientCancelPipelineRunResponse, error) {
 	req, err := client.cancelPipelineRunCreateRequest(ctx, runID, options)
 	if err != nil {
 		return PipelineRunClientCancelPipelineRunResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineRunClientCancelPipelineRunResponse{}, err
 	}
@@ -59,7 +51,7 @@ func (client *pipelineRunClient) CancelPipelineRun(ctx context.Context, runID st
 }
 
 // cancelPipelineRunCreateRequest creates the CancelPipelineRun request.
-func (client *pipelineRunClient) cancelPipelineRunCreateRequest(ctx context.Context, runID string, options *PipelineRunClientCancelPipelineRunOptions) (*policy.Request, error) {
+func (client *PipelineRunClient) cancelPipelineRunCreateRequest(ctx context.Context, runID string, options *PipelineRunClientCancelPipelineRunOptions) (*policy.Request, error) {
 	urlPath := "/pipelineruns/{runId}/cancel"
 	if runID == "" {
 		return nil, errors.New("parameter runID cannot be empty")
@@ -84,14 +76,14 @@ func (client *pipelineRunClient) cancelPipelineRunCreateRequest(ctx context.Cont
 //
 // Generated from API version 2019-06-01-preview
 //   - runID - The pipeline run identifier.
-//   - options - PipelineRunClientGetPipelineRunOptions contains the optional parameters for the pipelineRunClient.GetPipelineRun
+//   - options - PipelineRunClientGetPipelineRunOptions contains the optional parameters for the PipelineRunClient.GetPipelineRun
 //     method.
-func (client *pipelineRunClient) GetPipelineRun(ctx context.Context, runID string, options *PipelineRunClientGetPipelineRunOptions) (PipelineRunClientGetPipelineRunResponse, error) {
+func (client *PipelineRunClient) GetPipelineRun(ctx context.Context, runID string, options *PipelineRunClientGetPipelineRunOptions) (PipelineRunClientGetPipelineRunResponse, error) {
 	req, err := client.getPipelineRunCreateRequest(ctx, runID, options)
 	if err != nil {
 		return PipelineRunClientGetPipelineRunResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineRunClientGetPipelineRunResponse{}, err
 	}
@@ -102,7 +94,7 @@ func (client *pipelineRunClient) GetPipelineRun(ctx context.Context, runID strin
 }
 
 // getPipelineRunCreateRequest creates the GetPipelineRun request.
-func (client *pipelineRunClient) getPipelineRunCreateRequest(ctx context.Context, runID string, options *PipelineRunClientGetPipelineRunOptions) (*policy.Request, error) {
+func (client *PipelineRunClient) getPipelineRunCreateRequest(ctx context.Context, runID string, options *PipelineRunClientGetPipelineRunOptions) (*policy.Request, error) {
 	urlPath := "/pipelineruns/{runId}"
 	if runID == "" {
 		return nil, errors.New("parameter runID cannot be empty")
@@ -120,7 +112,7 @@ func (client *pipelineRunClient) getPipelineRunCreateRequest(ctx context.Context
 }
 
 // getPipelineRunHandleResponse handles the GetPipelineRun response.
-func (client *pipelineRunClient) getPipelineRunHandleResponse(resp *http.Response) (PipelineRunClientGetPipelineRunResponse, error) {
+func (client *PipelineRunClient) getPipelineRunHandleResponse(resp *http.Response) (PipelineRunClientGetPipelineRunResponse, error) {
 	result := PipelineRunClientGetPipelineRunResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRun); err != nil {
 		return PipelineRunClientGetPipelineRunResponse{}, err
@@ -135,14 +127,14 @@ func (client *pipelineRunClient) getPipelineRunHandleResponse(resp *http.Respons
 //   - pipelineName - The pipeline name.
 //   - runID - The pipeline run identifier.
 //   - filterParameters - Parameters to filter the activity runs.
-//   - options - PipelineRunClientQueryActivityRunsOptions contains the optional parameters for the pipelineRunClient.QueryActivityRuns
+//   - options - PipelineRunClientQueryActivityRunsOptions contains the optional parameters for the PipelineRunClient.QueryActivityRuns
 //     method.
-func (client *pipelineRunClient) QueryActivityRuns(ctx context.Context, pipelineName string, runID string, filterParameters RunFilterParameters, options *PipelineRunClientQueryActivityRunsOptions) (PipelineRunClientQueryActivityRunsResponse, error) {
+func (client *PipelineRunClient) QueryActivityRuns(ctx context.Context, pipelineName string, runID string, filterParameters RunFilterParameters, options *PipelineRunClientQueryActivityRunsOptions) (PipelineRunClientQueryActivityRunsResponse, error) {
 	req, err := client.queryActivityRunsCreateRequest(ctx, pipelineName, runID, filterParameters, options)
 	if err != nil {
 		return PipelineRunClientQueryActivityRunsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineRunClientQueryActivityRunsResponse{}, err
 	}
@@ -153,7 +145,7 @@ func (client *pipelineRunClient) QueryActivityRuns(ctx context.Context, pipeline
 }
 
 // queryActivityRunsCreateRequest creates the QueryActivityRuns request.
-func (client *pipelineRunClient) queryActivityRunsCreateRequest(ctx context.Context, pipelineName string, runID string, filterParameters RunFilterParameters, options *PipelineRunClientQueryActivityRunsOptions) (*policy.Request, error) {
+func (client *PipelineRunClient) queryActivityRunsCreateRequest(ctx context.Context, pipelineName string, runID string, filterParameters RunFilterParameters, options *PipelineRunClientQueryActivityRunsOptions) (*policy.Request, error) {
 	urlPath := "/pipelines/{pipelineName}/pipelineruns/{runId}/queryActivityruns"
 	if pipelineName == "" {
 		return nil, errors.New("parameter pipelineName cannot be empty")
@@ -175,7 +167,7 @@ func (client *pipelineRunClient) queryActivityRunsCreateRequest(ctx context.Cont
 }
 
 // queryActivityRunsHandleResponse handles the QueryActivityRuns response.
-func (client *pipelineRunClient) queryActivityRunsHandleResponse(resp *http.Response) (PipelineRunClientQueryActivityRunsResponse, error) {
+func (client *PipelineRunClient) queryActivityRunsHandleResponse(resp *http.Response) (PipelineRunClientQueryActivityRunsResponse, error) {
 	result := PipelineRunClientQueryActivityRunsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ActivityRunsQueryResponse); err != nil {
 		return PipelineRunClientQueryActivityRunsResponse{}, err
@@ -188,14 +180,14 @@ func (client *pipelineRunClient) queryActivityRunsHandleResponse(resp *http.Resp
 //
 // Generated from API version 2019-06-01-preview
 //   - filterParameters - Parameters to filter the pipeline run.
-//   - options - PipelineRunClientQueryPipelineRunsByWorkspaceOptions contains the optional parameters for the pipelineRunClient.QueryPipelineRunsByWorkspace
+//   - options - PipelineRunClientQueryPipelineRunsByWorkspaceOptions contains the optional parameters for the PipelineRunClient.QueryPipelineRunsByWorkspace
 //     method.
-func (client *pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunClientQueryPipelineRunsByWorkspaceOptions) (PipelineRunClientQueryPipelineRunsByWorkspaceResponse, error) {
+func (client *PipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunClientQueryPipelineRunsByWorkspaceOptions) (PipelineRunClientQueryPipelineRunsByWorkspaceResponse, error) {
 	req, err := client.queryPipelineRunsByWorkspaceCreateRequest(ctx, filterParameters, options)
 	if err != nil {
 		return PipelineRunClientQueryPipelineRunsByWorkspaceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return PipelineRunClientQueryPipelineRunsByWorkspaceResponse{}, err
 	}
@@ -206,7 +198,7 @@ func (client *pipelineRunClient) QueryPipelineRunsByWorkspace(ctx context.Contex
 }
 
 // queryPipelineRunsByWorkspaceCreateRequest creates the QueryPipelineRunsByWorkspace request.
-func (client *pipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunClientQueryPipelineRunsByWorkspaceOptions) (*policy.Request, error) {
+func (client *PipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *PipelineRunClientQueryPipelineRunsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/queryPipelineRuns"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -220,7 +212,7 @@ func (client *pipelineRunClient) queryPipelineRunsByWorkspaceCreateRequest(ctx c
 }
 
 // queryPipelineRunsByWorkspaceHandleResponse handles the QueryPipelineRunsByWorkspace response.
-func (client *pipelineRunClient) queryPipelineRunsByWorkspaceHandleResponse(resp *http.Response) (PipelineRunClientQueryPipelineRunsByWorkspaceResponse, error) {
+func (client *PipelineRunClient) queryPipelineRunsByWorkspaceHandleResponse(resp *http.Response) (PipelineRunClientQueryPipelineRunsByWorkspaceResponse, error) {
 	result := PipelineRunClientQueryPipelineRunsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PipelineRunsQueryResponse); err != nil {
 		return PipelineRunClientQueryPipelineRunsByWorkspaceResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_response_types.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_response_types.go
@@ -9,378 +9,378 @@
 
 package azartifacts
 
-// BigDataPoolsClientGetResponse contains the response from method bigDataPoolsClient.Get.
+// BigDataPoolsClientGetResponse contains the response from method BigDataPoolsClient.Get.
 type BigDataPoolsClientGetResponse struct {
 	BigDataPoolResourceInfo
 }
 
-// BigDataPoolsClientListResponse contains the response from method bigDataPoolsClient.List.
+// BigDataPoolsClientListResponse contains the response from method BigDataPoolsClient.List.
 type BigDataPoolsClientListResponse struct {
 	BigDataPoolResourceInfoListResult
 }
 
-// DataFlowClientCreateOrUpdateDataFlowResponse contains the response from method dataFlowClient.BeginCreateOrUpdateDataFlow.
+// DataFlowClientCreateOrUpdateDataFlowResponse contains the response from method DataFlowClient.BeginCreateOrUpdateDataFlow.
 type DataFlowClientCreateOrUpdateDataFlowResponse struct {
 	DataFlowResource
 }
 
-// DataFlowClientDeleteDataFlowResponse contains the response from method dataFlowClient.BeginDeleteDataFlow.
+// DataFlowClientDeleteDataFlowResponse contains the response from method DataFlowClient.BeginDeleteDataFlow.
 type DataFlowClientDeleteDataFlowResponse struct {
 	// placeholder for future response values
 }
 
-// DataFlowClientGetDataFlowResponse contains the response from method dataFlowClient.GetDataFlow.
+// DataFlowClientGetDataFlowResponse contains the response from method DataFlowClient.GetDataFlow.
 type DataFlowClientGetDataFlowResponse struct {
 	DataFlowResource
 }
 
-// DataFlowClientGetDataFlowsByWorkspaceResponse contains the response from method dataFlowClient.NewGetDataFlowsByWorkspacePager.
+// DataFlowClientGetDataFlowsByWorkspaceResponse contains the response from method DataFlowClient.NewGetDataFlowsByWorkspacePager.
 type DataFlowClientGetDataFlowsByWorkspaceResponse struct {
 	DataFlowListResponse
 }
 
-// DataFlowClientRenameDataFlowResponse contains the response from method dataFlowClient.BeginRenameDataFlow.
+// DataFlowClientRenameDataFlowResponse contains the response from method DataFlowClient.BeginRenameDataFlow.
 type DataFlowClientRenameDataFlowResponse struct {
 	// placeholder for future response values
 }
 
-// DataFlowDebugSessionClientAddDataFlowResponse contains the response from method dataFlowDebugSessionClient.AddDataFlow.
+// DataFlowDebugSessionClientAddDataFlowResponse contains the response from method DataFlowDebugSessionClient.AddDataFlow.
 type DataFlowDebugSessionClientAddDataFlowResponse struct {
 	AddDataFlowToDebugSessionResponse
 }
 
-// DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.BeginCreateDataFlowDebugSession.
+// DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse contains the response from method DataFlowDebugSessionClient.BeginCreateDataFlowDebugSession.
 type DataFlowDebugSessionClientCreateDataFlowDebugSessionResponse struct {
 	CreateDataFlowDebugSessionResponse
 }
 
-// DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse contains the response from method dataFlowDebugSessionClient.DeleteDataFlowDebugSession.
+// DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse contains the response from method DataFlowDebugSessionClient.DeleteDataFlowDebugSession.
 type DataFlowDebugSessionClientDeleteDataFlowDebugSessionResponse struct {
 	// placeholder for future response values
 }
 
-// DataFlowDebugSessionClientExecuteCommandResponse contains the response from method dataFlowDebugSessionClient.BeginExecuteCommand.
+// DataFlowDebugSessionClientExecuteCommandResponse contains the response from method DataFlowDebugSessionClient.BeginExecuteCommand.
 type DataFlowDebugSessionClientExecuteCommandResponse struct {
 	DataFlowDebugCommandResponse
 }
 
-// DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse contains the response from method dataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager.
+// DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse contains the response from method DataFlowDebugSessionClient.NewQueryDataFlowDebugSessionsByWorkspacePager.
 type DataFlowDebugSessionClientQueryDataFlowDebugSessionsByWorkspaceResponse struct {
 	QueryDataFlowDebugSessionsResponse
 }
 
-// DatasetClientCreateOrUpdateDatasetResponse contains the response from method datasetClient.BeginCreateOrUpdateDataset.
+// DatasetClientCreateOrUpdateDatasetResponse contains the response from method DatasetClient.BeginCreateOrUpdateDataset.
 type DatasetClientCreateOrUpdateDatasetResponse struct {
 	DatasetResource
 }
 
-// DatasetClientDeleteDatasetResponse contains the response from method datasetClient.BeginDeleteDataset.
+// DatasetClientDeleteDatasetResponse contains the response from method DatasetClient.BeginDeleteDataset.
 type DatasetClientDeleteDatasetResponse struct {
 	// placeholder for future response values
 }
 
-// DatasetClientGetDatasetResponse contains the response from method datasetClient.GetDataset.
+// DatasetClientGetDatasetResponse contains the response from method DatasetClient.GetDataset.
 type DatasetClientGetDatasetResponse struct {
 	DatasetResource
 }
 
-// DatasetClientGetDatasetsByWorkspaceResponse contains the response from method datasetClient.NewGetDatasetsByWorkspacePager.
+// DatasetClientGetDatasetsByWorkspaceResponse contains the response from method DatasetClient.NewGetDatasetsByWorkspacePager.
 type DatasetClientGetDatasetsByWorkspaceResponse struct {
 	DatasetListResponse
 }
 
-// DatasetClientRenameDatasetResponse contains the response from method datasetClient.BeginRenameDataset.
+// DatasetClientRenameDatasetResponse contains the response from method DatasetClient.BeginRenameDataset.
 type DatasetClientRenameDatasetResponse struct {
 	// placeholder for future response values
 }
 
-// IntegrationRuntimesClientGetResponse contains the response from method integrationRuntimesClient.Get.
+// IntegrationRuntimesClientGetResponse contains the response from method IntegrationRuntimesClient.Get.
 type IntegrationRuntimesClientGetResponse struct {
 	IntegrationRuntimeResource
 }
 
-// IntegrationRuntimesClientListResponse contains the response from method integrationRuntimesClient.List.
+// IntegrationRuntimesClientListResponse contains the response from method IntegrationRuntimesClient.List.
 type IntegrationRuntimesClientListResponse struct {
 	IntegrationRuntimeListResponse
 }
 
-// LibraryClientAppendResponse contains the response from method libraryClient.Append.
+// LibraryClientAppendResponse contains the response from method LibraryClient.Append.
 type LibraryClientAppendResponse struct {
 	// placeholder for future response values
 }
 
-// LibraryClientCreateResponse contains the response from method libraryClient.BeginCreate.
+// LibraryClientCreateResponse contains the response from method LibraryClient.BeginCreate.
 type LibraryClientCreateResponse struct {
 	LibraryResourceInfo
 }
 
-// LibraryClientDeleteResponse contains the response from method libraryClient.BeginDelete.
+// LibraryClientDeleteResponse contains the response from method LibraryClient.BeginDelete.
 type LibraryClientDeleteResponse struct {
 	LibraryResourceInfo
 }
 
-// LibraryClientFlushResponse contains the response from method libraryClient.BeginFlush.
+// LibraryClientFlushResponse contains the response from method LibraryClient.BeginFlush.
 type LibraryClientFlushResponse struct {
 	LibraryResourceInfo
 }
 
-// LibraryClientGetOperationResultResponse contains the response from method libraryClient.GetOperationResult.
+// LibraryClientGetOperationResultResponse contains the response from method LibraryClient.GetOperationResult.
 type LibraryClientGetOperationResultResponse struct {
 	// Possible types are LibraryResource, OperationResult
 	Value any
 }
 
-// LibraryClientGetResponse contains the response from method libraryClient.Get.
+// LibraryClientGetResponse contains the response from method LibraryClient.Get.
 type LibraryClientGetResponse struct {
 	LibraryResource
 }
 
-// LibraryClientListResponse contains the response from method libraryClient.NewListPager.
+// LibraryClientListResponse contains the response from method LibraryClient.NewListPager.
 type LibraryClientListResponse struct {
 	LibraryListResponse
 }
 
-// LinkedServiceClientCreateOrUpdateLinkedServiceResponse contains the response from method linkedServiceClient.BeginCreateOrUpdateLinkedService.
+// LinkedServiceClientCreateOrUpdateLinkedServiceResponse contains the response from method LinkedServiceClient.BeginCreateOrUpdateLinkedService.
 type LinkedServiceClientCreateOrUpdateLinkedServiceResponse struct {
 	LinkedServiceResource
 }
 
-// LinkedServiceClientDeleteLinkedServiceResponse contains the response from method linkedServiceClient.BeginDeleteLinkedService.
+// LinkedServiceClientDeleteLinkedServiceResponse contains the response from method LinkedServiceClient.BeginDeleteLinkedService.
 type LinkedServiceClientDeleteLinkedServiceResponse struct {
 	// placeholder for future response values
 }
 
-// LinkedServiceClientGetLinkedServiceResponse contains the response from method linkedServiceClient.GetLinkedService.
+// LinkedServiceClientGetLinkedServiceResponse contains the response from method LinkedServiceClient.GetLinkedService.
 type LinkedServiceClientGetLinkedServiceResponse struct {
 	LinkedServiceResource
 }
 
-// LinkedServiceClientGetLinkedServicesByWorkspaceResponse contains the response from method linkedServiceClient.NewGetLinkedServicesByWorkspacePager.
+// LinkedServiceClientGetLinkedServicesByWorkspaceResponse contains the response from method LinkedServiceClient.NewGetLinkedServicesByWorkspacePager.
 type LinkedServiceClientGetLinkedServicesByWorkspaceResponse struct {
 	LinkedServiceListResponse
 }
 
-// LinkedServiceClientRenameLinkedServiceResponse contains the response from method linkedServiceClient.BeginRenameLinkedService.
+// LinkedServiceClientRenameLinkedServiceResponse contains the response from method LinkedServiceClient.BeginRenameLinkedService.
 type LinkedServiceClientRenameLinkedServiceResponse struct {
 	// placeholder for future response values
 }
 
-// NotebookClientCreateOrUpdateNotebookResponse contains the response from method notebookClient.BeginCreateOrUpdateNotebook.
+// NotebookClientCreateOrUpdateNotebookResponse contains the response from method NotebookClient.BeginCreateOrUpdateNotebook.
 type NotebookClientCreateOrUpdateNotebookResponse struct {
 	NotebookResource
 }
 
-// NotebookClientDeleteNotebookResponse contains the response from method notebookClient.BeginDeleteNotebook.
+// NotebookClientDeleteNotebookResponse contains the response from method NotebookClient.BeginDeleteNotebook.
 type NotebookClientDeleteNotebookResponse struct {
 	// placeholder for future response values
 }
 
-// NotebookClientGetNotebookResponse contains the response from method notebookClient.GetNotebook.
+// NotebookClientGetNotebookResponse contains the response from method NotebookClient.GetNotebook.
 type NotebookClientGetNotebookResponse struct {
 	NotebookResource
 }
 
-// NotebookClientGetNotebookSummaryByWorkSpaceResponse contains the response from method notebookClient.NewGetNotebookSummaryByWorkSpacePager.
+// NotebookClientGetNotebookSummaryByWorkSpaceResponse contains the response from method NotebookClient.NewGetNotebookSummaryByWorkSpacePager.
 type NotebookClientGetNotebookSummaryByWorkSpaceResponse struct {
 	NotebookListResponse
 }
 
-// NotebookClientGetNotebooksByWorkspaceResponse contains the response from method notebookClient.NewGetNotebooksByWorkspacePager.
+// NotebookClientGetNotebooksByWorkspaceResponse contains the response from method NotebookClient.NewGetNotebooksByWorkspacePager.
 type NotebookClientGetNotebooksByWorkspaceResponse struct {
 	NotebookListResponse
 }
 
-// NotebookClientRenameNotebookResponse contains the response from method notebookClient.BeginRenameNotebook.
+// NotebookClientRenameNotebookResponse contains the response from method NotebookClient.BeginRenameNotebook.
 type NotebookClientRenameNotebookResponse struct {
 	// placeholder for future response values
 }
 
-// PipelineClientCreateOrUpdatePipelineResponse contains the response from method pipelineClient.BeginCreateOrUpdatePipeline.
+// PipelineClientCreateOrUpdatePipelineResponse contains the response from method PipelineClient.BeginCreateOrUpdatePipeline.
 type PipelineClientCreateOrUpdatePipelineResponse struct {
 	PipelineResource
 }
 
-// PipelineClientCreatePipelineRunResponse contains the response from method pipelineClient.CreatePipelineRun.
+// PipelineClientCreatePipelineRunResponse contains the response from method PipelineClient.CreatePipelineRun.
 type PipelineClientCreatePipelineRunResponse struct {
 	CreateRunResponse
 }
 
-// PipelineClientDeletePipelineResponse contains the response from method pipelineClient.BeginDeletePipeline.
+// PipelineClientDeletePipelineResponse contains the response from method PipelineClient.BeginDeletePipeline.
 type PipelineClientDeletePipelineResponse struct {
 	// placeholder for future response values
 }
 
-// PipelineClientGetPipelineResponse contains the response from method pipelineClient.GetPipeline.
+// PipelineClientGetPipelineResponse contains the response from method PipelineClient.GetPipeline.
 type PipelineClientGetPipelineResponse struct {
 	PipelineResource
 }
 
-// PipelineClientGetPipelinesByWorkspaceResponse contains the response from method pipelineClient.NewGetPipelinesByWorkspacePager.
+// PipelineClientGetPipelinesByWorkspaceResponse contains the response from method PipelineClient.NewGetPipelinesByWorkspacePager.
 type PipelineClientGetPipelinesByWorkspaceResponse struct {
 	PipelineListResponse
 }
 
-// PipelineClientRenamePipelineResponse contains the response from method pipelineClient.BeginRenamePipeline.
+// PipelineClientRenamePipelineResponse contains the response from method PipelineClient.BeginRenamePipeline.
 type PipelineClientRenamePipelineResponse struct {
 	// placeholder for future response values
 }
 
-// PipelineRunClientCancelPipelineRunResponse contains the response from method pipelineRunClient.CancelPipelineRun.
+// PipelineRunClientCancelPipelineRunResponse contains the response from method PipelineRunClient.CancelPipelineRun.
 type PipelineRunClientCancelPipelineRunResponse struct {
 	// placeholder for future response values
 }
 
-// PipelineRunClientGetPipelineRunResponse contains the response from method pipelineRunClient.GetPipelineRun.
+// PipelineRunClientGetPipelineRunResponse contains the response from method PipelineRunClient.GetPipelineRun.
 type PipelineRunClientGetPipelineRunResponse struct {
 	PipelineRun
 }
 
-// PipelineRunClientQueryActivityRunsResponse contains the response from method pipelineRunClient.QueryActivityRuns.
+// PipelineRunClientQueryActivityRunsResponse contains the response from method PipelineRunClient.QueryActivityRuns.
 type PipelineRunClientQueryActivityRunsResponse struct {
 	ActivityRunsQueryResponse
 }
 
-// PipelineRunClientQueryPipelineRunsByWorkspaceResponse contains the response from method pipelineRunClient.QueryPipelineRunsByWorkspace.
+// PipelineRunClientQueryPipelineRunsByWorkspaceResponse contains the response from method PipelineRunClient.QueryPipelineRunsByWorkspace.
 type PipelineRunClientQueryPipelineRunsByWorkspaceResponse struct {
 	PipelineRunsQueryResponse
 }
 
-// SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition.
+// SQLPoolsClientGetResponse contains the response from method SQLPoolsClient.Get.
+type SQLPoolsClientGetResponse struct {
+	SQLPool
+}
+
+// SQLPoolsClientListResponse contains the response from method SQLPoolsClient.List.
+type SQLPoolsClientListResponse struct {
+	SQLPoolInfoListResult
+}
+
+// SQLScriptClientCreateOrUpdateSQLScriptResponse contains the response from method SQLScriptClient.BeginCreateOrUpdateSQLScript.
+type SQLScriptClientCreateOrUpdateSQLScriptResponse struct {
+	SQLScriptResource
+}
+
+// SQLScriptClientDeleteSQLScriptResponse contains the response from method SQLScriptClient.BeginDeleteSQLScript.
+type SQLScriptClientDeleteSQLScriptResponse struct {
+	// placeholder for future response values
+}
+
+// SQLScriptClientGetSQLScriptResponse contains the response from method SQLScriptClient.GetSQLScript.
+type SQLScriptClientGetSQLScriptResponse struct {
+	SQLScriptResource
+}
+
+// SQLScriptClientGetSQLScriptsByWorkspaceResponse contains the response from method SQLScriptClient.NewGetSQLScriptsByWorkspacePager.
+type SQLScriptClientGetSQLScriptsByWorkspaceResponse struct {
+	SQLScriptsListResponse
+}
+
+// SQLScriptClientRenameSQLScriptResponse contains the response from method SQLScriptClient.BeginRenameSQLScript.
+type SQLScriptClientRenameSQLScriptResponse struct {
+	// placeholder for future response values
+}
+
+// SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition.
 type SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse struct {
 	SparkJobDefinitionResource
 }
 
-// SparkJobDefinitionClientDebugSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.BeginDebugSparkJobDefinition.
+// SparkJobDefinitionClientDebugSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.BeginDebugSparkJobDefinition.
 type SparkJobDefinitionClientDebugSparkJobDefinitionResponse struct {
 	SparkBatchJob
 }
 
-// SparkJobDefinitionClientDeleteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.BeginDeleteSparkJobDefinition.
+// SparkJobDefinitionClientDeleteSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.BeginDeleteSparkJobDefinition.
 type SparkJobDefinitionClientDeleteSparkJobDefinitionResponse struct {
 	// placeholder for future response values
 }
 
-// SparkJobDefinitionClientExecuteSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.BeginExecuteSparkJobDefinition.
+// SparkJobDefinitionClientExecuteSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.BeginExecuteSparkJobDefinition.
 type SparkJobDefinitionClientExecuteSparkJobDefinitionResponse struct {
 	SparkBatchJob
 }
 
-// SparkJobDefinitionClientGetSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.GetSparkJobDefinition.
+// SparkJobDefinitionClientGetSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.GetSparkJobDefinition.
 type SparkJobDefinitionClientGetSparkJobDefinitionResponse struct {
 	SparkJobDefinitionResource
 }
 
-// SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse contains the response from method sparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager.
+// SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse contains the response from method SparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager.
 type SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse struct {
 	SparkJobDefinitionsListResponse
 }
 
-// SparkJobDefinitionClientRenameSparkJobDefinitionResponse contains the response from method sparkJobDefinitionClient.BeginRenameSparkJobDefinition.
+// SparkJobDefinitionClientRenameSparkJobDefinitionResponse contains the response from method SparkJobDefinitionClient.BeginRenameSparkJobDefinition.
 type SparkJobDefinitionClientRenameSparkJobDefinitionResponse struct {
 	// placeholder for future response values
 }
 
-// SqlPoolsClientGetResponse contains the response from method sqlPoolsClient.Get.
-type SqlPoolsClientGetResponse struct {
-	SQLPool
-}
-
-// SqlPoolsClientListResponse contains the response from method sqlPoolsClient.List.
-type SqlPoolsClientListResponse struct {
-	SQLPoolInfoListResult
-}
-
-// SqlScriptClientCreateOrUpdateSQLScriptResponse contains the response from method sqlScriptClient.BeginCreateOrUpdateSQLScript.
-type SqlScriptClientCreateOrUpdateSQLScriptResponse struct {
-	SQLScriptResource
-}
-
-// SqlScriptClientDeleteSQLScriptResponse contains the response from method sqlScriptClient.BeginDeleteSQLScript.
-type SqlScriptClientDeleteSQLScriptResponse struct {
-	// placeholder for future response values
-}
-
-// SqlScriptClientGetSQLScriptResponse contains the response from method sqlScriptClient.GetSQLScript.
-type SqlScriptClientGetSQLScriptResponse struct {
-	SQLScriptResource
-}
-
-// SqlScriptClientGetSQLScriptsByWorkspaceResponse contains the response from method sqlScriptClient.NewGetSQLScriptsByWorkspacePager.
-type SqlScriptClientGetSQLScriptsByWorkspaceResponse struct {
-	SQLScriptsListResponse
-}
-
-// SqlScriptClientRenameSQLScriptResponse contains the response from method sqlScriptClient.BeginRenameSQLScript.
-type SqlScriptClientRenameSQLScriptResponse struct {
-	// placeholder for future response values
-}
-
-// TriggerClientCreateOrUpdateTriggerResponse contains the response from method triggerClient.BeginCreateOrUpdateTrigger.
+// TriggerClientCreateOrUpdateTriggerResponse contains the response from method TriggerClient.BeginCreateOrUpdateTrigger.
 type TriggerClientCreateOrUpdateTriggerResponse struct {
 	TriggerResource
 }
 
-// TriggerClientDeleteTriggerResponse contains the response from method triggerClient.BeginDeleteTrigger.
+// TriggerClientDeleteTriggerResponse contains the response from method TriggerClient.BeginDeleteTrigger.
 type TriggerClientDeleteTriggerResponse struct {
 	// placeholder for future response values
 }
 
-// TriggerClientGetEventSubscriptionStatusResponse contains the response from method triggerClient.GetEventSubscriptionStatus.
+// TriggerClientGetEventSubscriptionStatusResponse contains the response from method TriggerClient.GetEventSubscriptionStatus.
 type TriggerClientGetEventSubscriptionStatusResponse struct {
 	TriggerSubscriptionOperationStatus
 }
 
-// TriggerClientGetTriggerResponse contains the response from method triggerClient.GetTrigger.
+// TriggerClientGetTriggerResponse contains the response from method TriggerClient.GetTrigger.
 type TriggerClientGetTriggerResponse struct {
 	TriggerResource
 }
 
-// TriggerClientGetTriggersByWorkspaceResponse contains the response from method triggerClient.NewGetTriggersByWorkspacePager.
+// TriggerClientGetTriggersByWorkspaceResponse contains the response from method TriggerClient.NewGetTriggersByWorkspacePager.
 type TriggerClientGetTriggersByWorkspaceResponse struct {
 	TriggerListResponse
 }
 
-// TriggerClientStartTriggerResponse contains the response from method triggerClient.BeginStartTrigger.
+// TriggerClientStartTriggerResponse contains the response from method TriggerClient.BeginStartTrigger.
 type TriggerClientStartTriggerResponse struct {
 	// placeholder for future response values
 }
 
-// TriggerClientStopTriggerResponse contains the response from method triggerClient.BeginStopTrigger.
+// TriggerClientStopTriggerResponse contains the response from method TriggerClient.BeginStopTrigger.
 type TriggerClientStopTriggerResponse struct {
 	// placeholder for future response values
 }
 
-// TriggerClientSubscribeTriggerToEventsResponse contains the response from method triggerClient.BeginSubscribeTriggerToEvents.
+// TriggerClientSubscribeTriggerToEventsResponse contains the response from method TriggerClient.BeginSubscribeTriggerToEvents.
 type TriggerClientSubscribeTriggerToEventsResponse struct {
 	TriggerSubscriptionOperationStatus
 }
 
-// TriggerClientUnsubscribeTriggerFromEventsResponse contains the response from method triggerClient.BeginUnsubscribeTriggerFromEvents.
+// TriggerClientUnsubscribeTriggerFromEventsResponse contains the response from method TriggerClient.BeginUnsubscribeTriggerFromEvents.
 type TriggerClientUnsubscribeTriggerFromEventsResponse struct {
 	TriggerSubscriptionOperationStatus
 }
 
-// TriggerRunClientCancelTriggerInstanceResponse contains the response from method triggerRunClient.CancelTriggerInstance.
+// TriggerRunClientCancelTriggerInstanceResponse contains the response from method TriggerRunClient.CancelTriggerInstance.
 type TriggerRunClientCancelTriggerInstanceResponse struct {
 	// placeholder for future response values
 }
 
-// TriggerRunClientQueryTriggerRunsByWorkspaceResponse contains the response from method triggerRunClient.QueryTriggerRunsByWorkspace.
+// TriggerRunClientQueryTriggerRunsByWorkspaceResponse contains the response from method TriggerRunClient.QueryTriggerRunsByWorkspace.
 type TriggerRunClientQueryTriggerRunsByWorkspaceResponse struct {
 	TriggerRunsQueryResponse
 }
 
-// TriggerRunClientRerunTriggerInstanceResponse contains the response from method triggerRunClient.RerunTriggerInstance.
+// TriggerRunClientRerunTriggerInstanceResponse contains the response from method TriggerRunClient.RerunTriggerInstance.
 type TriggerRunClientRerunTriggerInstanceResponse struct {
 	// placeholder for future response values
 }
 
-// WorkspaceClientGetResponse contains the response from method workspaceClient.Get.
+// WorkspaceClientGetResponse contains the response from method WorkspaceClient.Get.
 type WorkspaceClientGetResponse struct {
 	Workspace
 }
 
-// WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse contains the response from method workspaceGitRepoManagementClient.GetGitHubAccessToken.
+// WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse contains the response from method WorkspaceGitRepoManagementClient.GetGitHubAccessToken.
 type WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse struct {
 	GitHubAccessTokenResponse
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_sparkjobdefinition_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_sparkjobdefinition_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type sparkJobDefinitionClient struct {
+// SparkJobDefinitionClient contains the methods for the SparkJobDefinition group.
+// Don't use this type directly, use a constructor function instead.
+type SparkJobDefinitionClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newSparkJobDefinitionClient creates a new instance of sparkJobDefinitionClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newSparkJobDefinitionClient(endpoint string, pl runtime.Pipeline) *sparkJobDefinitionClient {
-	client := &sparkJobDefinitionClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateSparkJobDefinition - Creates or updates a Spark Job Definition.
@@ -42,16 +34,16 @@ func newSparkJobDefinitionClient(endpoint string, pl runtime.Pipeline) *sparkJob
 //   - sparkJobDefinitionName - The spark job definition name.
 //   - sparkJobDefinition - Spark Job Definition resource definition.
 //   - options - SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the
-//     sparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition method.
-func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse], error) {
+//     SparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition method.
+func (client *SparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateSparkJobDefinition(ctx, sparkJobDefinitionName, sparkJobDefinition, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientCreateOrUpdateSparkJobDefinitionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *sparkJobDefinitionClient) BeginCreateOrUpdateSparkJobDefinition(ct
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*http.Response, error) {
+func (client *SparkJobDefinitionClient) createOrUpdateSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, sparkJobDefinition, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinition(ctx con
 }
 
 // createOrUpdateSparkJobDefinitionCreateRequest creates the CreateOrUpdateSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, sparkJobDefinition SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	if sparkJobDefinitionName == "" {
 		return nil, errors.New("parameter sparkJobDefinitionName cannot be empty")
@@ -100,19 +92,19 @@ func (client *sparkJobDefinitionClient) createOrUpdateSparkJobDefinitionCreateRe
 //
 // Generated from API version 2019-06-01-preview
 //   - sparkJobDefinitionAzureResource - Spark Job Definition resource definition.
-//   - options - SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDebugSparkJobDefinition
+//   - options - SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginDebugSparkJobDefinition
 //     method.
-func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientDebugSparkJobDefinitionResponse], error) {
+func (client *SparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientDebugSparkJobDefinitionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.debugSparkJobDefinition(ctx, sparkJobDefinitionAzureResource, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SparkJobDefinitionClientDebugSparkJobDefinitionResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SparkJobDefinitionClientDebugSparkJobDefinitionResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientDebugSparkJobDefinitionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientDebugSparkJobDefinitionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -120,12 +112,12 @@ func (client *sparkJobDefinitionClient) BeginDebugSparkJobDefinition(ctx context
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sparkJobDefinitionClient) debugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*http.Response, error) {
+func (client *SparkJobDefinitionClient) debugSparkJobDefinition(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*http.Response, error) {
 	req, err := client.debugSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionAzureResource, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +128,7 @@ func (client *sparkJobDefinitionClient) debugSparkJobDefinition(ctx context.Cont
 }
 
 // debugSparkJobDefinitionCreateRequest creates the DebugSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionAzureResource SparkJobDefinitionResource, options *SparkJobDefinitionClientBeginDebugSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/debugSparkJobDefinition"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -154,17 +146,17 @@ func (client *sparkJobDefinitionClient) debugSparkJobDefinitionCreateRequest(ctx
 //
 // Generated from API version 2019-06-01-preview
 //   - sparkJobDefinitionName - The spark job definition name.
-//   - options - SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginDeleteSparkJobDefinition
+//   - options - SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginDeleteSparkJobDefinition
 //     method.
-func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse], error) {
+func (client *SparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteSparkJobDefinition(ctx, sparkJobDefinitionName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientDeleteSparkJobDefinitionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -172,12 +164,12 @@ func (client *sparkJobDefinitionClient) BeginDeleteSparkJobDefinition(ctx contex
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sparkJobDefinitionClient) deleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*http.Response, error) {
+func (client *SparkJobDefinitionClient) deleteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*http.Response, error) {
 	req, err := client.deleteSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +180,7 @@ func (client *sparkJobDefinitionClient) deleteSparkJobDefinition(ctx context.Con
 }
 
 // deleteSparkJobDefinitionCreateRequest creates the DeleteSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) deleteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) deleteSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginDeleteSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	if sparkJobDefinitionName == "" {
 		return nil, errors.New("parameter sparkJobDefinitionName cannot be empty")
@@ -210,19 +202,19 @@ func (client *sparkJobDefinitionClient) deleteSparkJobDefinitionCreateRequest(ct
 //
 // Generated from API version 2019-06-01-preview
 //   - sparkJobDefinitionName - The spark job definition name.
-//   - options - SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginExecuteSparkJobDefinition
+//   - options - SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginExecuteSparkJobDefinition
 //     method.
-func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse], error) {
+func (client *SparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.executeSparkJobDefinition(ctx, sparkJobDefinitionName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller(resp, client.pl, &runtime.NewPollerOptions[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse]{
+		return runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse]{
 			FinalStateVia: runtime.FinalStateViaLocation,
 		})
 	} else {
-		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientExecuteSparkJobDefinitionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -230,12 +222,12 @@ func (client *sparkJobDefinitionClient) BeginExecuteSparkJobDefinition(ctx conte
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sparkJobDefinitionClient) executeSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*http.Response, error) {
+func (client *SparkJobDefinitionClient) executeSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*http.Response, error) {
 	req, err := client.executeSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +238,7 @@ func (client *sparkJobDefinitionClient) executeSparkJobDefinition(ctx context.Co
 }
 
 // executeSparkJobDefinitionCreateRequest creates the ExecuteSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) executeSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) executeSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientBeginExecuteSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}/execute"
 	if sparkJobDefinitionName == "" {
 		return nil, errors.New("parameter sparkJobDefinitionName cannot be empty")
@@ -268,14 +260,14 @@ func (client *sparkJobDefinitionClient) executeSparkJobDefinitionCreateRequest(c
 //
 // Generated from API version 2019-06-01-preview
 //   - sparkJobDefinitionName - The spark job definition name.
-//   - options - SparkJobDefinitionClientGetSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.GetSparkJobDefinition
+//   - options - SparkJobDefinitionClientGetSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.GetSparkJobDefinition
 //     method.
-func (client *sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientGetSparkJobDefinitionOptions) (SparkJobDefinitionClientGetSparkJobDefinitionResponse, error) {
+func (client *SparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientGetSparkJobDefinitionOptions) (SparkJobDefinitionClientGetSparkJobDefinitionResponse, error) {
 	req, err := client.getSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, options)
 	if err != nil {
 		return SparkJobDefinitionClientGetSparkJobDefinitionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SparkJobDefinitionClientGetSparkJobDefinitionResponse{}, err
 	}
@@ -286,7 +278,7 @@ func (client *sparkJobDefinitionClient) GetSparkJobDefinition(ctx context.Contex
 }
 
 // getSparkJobDefinitionCreateRequest creates the GetSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientGetSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, options *SparkJobDefinitionClientGetSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}"
 	if sparkJobDefinitionName == "" {
 		return nil, errors.New("parameter sparkJobDefinitionName cannot be empty")
@@ -307,7 +299,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionCreateRequest(ctx c
 }
 
 // getSparkJobDefinitionHandleResponse handles the GetSparkJobDefinition response.
-func (client *sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp *http.Response) (SparkJobDefinitionClientGetSparkJobDefinitionResponse, error) {
+func (client *SparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp *http.Response) (SparkJobDefinitionClientGetSparkJobDefinitionResponse, error) {
 	result := SparkJobDefinitionClientGetSparkJobDefinitionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionResource); err != nil {
 		return SparkJobDefinitionClientGetSparkJobDefinitionResponse{}, err
@@ -318,9 +310,9 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionHandleResponse(resp
 // NewGetSparkJobDefinitionsByWorkspacePager - Lists spark job definitions.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the sparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager
+//   - options - SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions contains the optional parameters for the SparkJobDefinitionClient.NewGetSparkJobDefinitionsByWorkspacePager
 //     method.
-func (client *sparkJobDefinitionClient) NewGetSparkJobDefinitionsByWorkspacePager(options *SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions) *runtime.Pager[SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse] {
+func (client *SparkJobDefinitionClient) NewGetSparkJobDefinitionsByWorkspacePager(options *SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions) *runtime.Pager[SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse]{
 		More: func(page SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -336,7 +328,7 @@ func (client *sparkJobDefinitionClient) NewGetSparkJobDefinitionsByWorkspacePage
 			if err != nil {
 				return SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
 			}
@@ -349,7 +341,7 @@ func (client *sparkJobDefinitionClient) NewGetSparkJobDefinitionsByWorkspacePage
 }
 
 // getSparkJobDefinitionsByWorkspaceCreateRequest creates the GetSparkJobDefinitionsByWorkspace request.
-func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateRequest(ctx context.Context, options *SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateRequest(ctx context.Context, options *SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -363,7 +355,7 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceCreateR
 }
 
 // getSparkJobDefinitionsByWorkspaceHandleResponse handles the GetSparkJobDefinitionsByWorkspace response.
-func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleResponse(resp *http.Response) (SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse, error) {
+func (client *SparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleResponse(resp *http.Response) (SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse, error) {
 	result := SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SparkJobDefinitionsListResponse); err != nil {
 		return SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceResponse{}, err
@@ -377,17 +369,17 @@ func (client *sparkJobDefinitionClient) getSparkJobDefinitionsByWorkspaceHandleR
 // Generated from API version 2019-06-01-preview
 //   - sparkJobDefinitionName - The spark job definition name.
 //   - request - proposed new name.
-//   - options - SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions contains the optional parameters for the sparkJobDefinitionClient.BeginRenameSparkJobDefinition
+//   - options - SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginRenameSparkJobDefinition
 //     method.
-func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientRenameSparkJobDefinitionResponse], error) {
+func (client *SparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*runtime.Poller[SparkJobDefinitionClientRenameSparkJobDefinitionResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameSparkJobDefinition(ctx, sparkJobDefinitionName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SparkJobDefinitionClientRenameSparkJobDefinitionResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SparkJobDefinitionClientRenameSparkJobDefinitionResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientRenameSparkJobDefinitionResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SparkJobDefinitionClientRenameSparkJobDefinitionResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -395,12 +387,12 @@ func (client *sparkJobDefinitionClient) BeginRenameSparkJobDefinition(ctx contex
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sparkJobDefinitionClient) renameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*http.Response, error) {
+func (client *SparkJobDefinitionClient) renameSparkJobDefinition(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*http.Response, error) {
 	req, err := client.renameSparkJobDefinitionCreateRequest(ctx, sparkJobDefinitionName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +403,7 @@ func (client *sparkJobDefinitionClient) renameSparkJobDefinition(ctx context.Con
 }
 
 // renameSparkJobDefinitionCreateRequest creates the RenameSparkJobDefinition request.
-func (client *sparkJobDefinitionClient) renameSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*policy.Request, error) {
+func (client *SparkJobDefinitionClient) renameSparkJobDefinitionCreateRequest(ctx context.Context, sparkJobDefinitionName string, request ArtifactRenameRequest, options *SparkJobDefinitionClientBeginRenameSparkJobDefinitionOptions) (*policy.Request, error) {
 	urlPath := "/sparkJobDefinitions/{sparkJobDefinitionName}/rename"
 	if sparkJobDefinitionName == "" {
 		return nil, errors.New("parameter sparkJobDefinitionName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_sqlpools_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_sqlpools_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type sqlPoolsClient struct {
+// SQLPoolsClient contains the methods for the SQLPools group.
+// Don't use this type directly, use a constructor function instead.
+type SQLPoolsClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newSQLPoolsClient creates a new instance of sqlPoolsClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newSQLPoolsClient(endpoint string, pl runtime.Pipeline) *sqlPoolsClient {
-	client := &sqlPoolsClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // Get - Get Sql Pool
@@ -40,24 +32,24 @@ func newSQLPoolsClient(endpoint string, pl runtime.Pipeline) *sqlPoolsClient {
 //
 // Generated from API version 2019-06-01-preview
 //   - sqlPoolName - The Sql Pool name
-//   - options - SqlPoolsClientGetOptions contains the optional parameters for the sqlPoolsClient.Get method.
-func (client *sqlPoolsClient) Get(ctx context.Context, sqlPoolName string, options *SqlPoolsClientGetOptions) (SqlPoolsClientGetResponse, error) {
+//   - options - SQLPoolsClientGetOptions contains the optional parameters for the SQLPoolsClient.Get method.
+func (client *SQLPoolsClient) Get(ctx context.Context, sqlPoolName string, options *SQLPoolsClientGetOptions) (SQLPoolsClientGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, sqlPoolName, options)
 	if err != nil {
-		return SqlPoolsClientGetResponse{}, err
+		return SQLPoolsClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return SqlPoolsClientGetResponse{}, err
+		return SQLPoolsClientGetResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return SqlPoolsClientGetResponse{}, runtime.NewResponseError(resp)
+		return SQLPoolsClientGetResponse{}, runtime.NewResponseError(resp)
 	}
 	return client.getHandleResponse(resp)
 }
 
 // getCreateRequest creates the Get request.
-func (client *sqlPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName string, options *SqlPoolsClientGetOptions) (*policy.Request, error) {
+func (client *SQLPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName string, options *SQLPoolsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/sqlPools/{sqlPoolName}"
 	if sqlPoolName == "" {
 		return nil, errors.New("parameter sqlPoolName cannot be empty")
@@ -75,10 +67,10 @@ func (client *sqlPoolsClient) getCreateRequest(ctx context.Context, sqlPoolName 
 }
 
 // getHandleResponse handles the Get response.
-func (client *sqlPoolsClient) getHandleResponse(resp *http.Response) (SqlPoolsClientGetResponse, error) {
-	result := SqlPoolsClientGetResponse{}
+func (client *SQLPoolsClient) getHandleResponse(resp *http.Response) (SQLPoolsClientGetResponse, error) {
+	result := SQLPoolsClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPool); err != nil {
-		return SqlPoolsClientGetResponse{}, err
+		return SQLPoolsClientGetResponse{}, err
 	}
 	return result, nil
 }
@@ -87,24 +79,24 @@ func (client *sqlPoolsClient) getHandleResponse(resp *http.Response) (SqlPoolsCl
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - SqlPoolsClientListOptions contains the optional parameters for the sqlPoolsClient.List method.
-func (client *sqlPoolsClient) List(ctx context.Context, options *SqlPoolsClientListOptions) (SqlPoolsClientListResponse, error) {
+//   - options - SQLPoolsClientListOptions contains the optional parameters for the SQLPoolsClient.List method.
+func (client *SQLPoolsClient) List(ctx context.Context, options *SQLPoolsClientListOptions) (SQLPoolsClientListResponse, error) {
 	req, err := client.listCreateRequest(ctx, options)
 	if err != nil {
-		return SqlPoolsClientListResponse{}, err
+		return SQLPoolsClientListResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return SqlPoolsClientListResponse{}, err
+		return SQLPoolsClientListResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK) {
-		return SqlPoolsClientListResponse{}, runtime.NewResponseError(resp)
+		return SQLPoolsClientListResponse{}, runtime.NewResponseError(resp)
 	}
 	return client.listHandleResponse(resp)
 }
 
 // listCreateRequest creates the List request.
-func (client *sqlPoolsClient) listCreateRequest(ctx context.Context, options *SqlPoolsClientListOptions) (*policy.Request, error) {
+func (client *SQLPoolsClient) listCreateRequest(ctx context.Context, options *SQLPoolsClientListOptions) (*policy.Request, error) {
 	urlPath := "/sqlPools"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -118,10 +110,10 @@ func (client *sqlPoolsClient) listCreateRequest(ctx context.Context, options *Sq
 }
 
 // listHandleResponse handles the List response.
-func (client *sqlPoolsClient) listHandleResponse(resp *http.Response) (SqlPoolsClientListResponse, error) {
-	result := SqlPoolsClientListResponse{}
+func (client *SQLPoolsClient) listHandleResponse(resp *http.Response) (SQLPoolsClientListResponse, error) {
+	result := SQLPoolsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLPoolInfoListResult); err != nil {
-		return SqlPoolsClientListResponse{}, err
+		return SQLPoolsClientListResponse{}, err
 	}
 	return result, nil
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_sqlscript_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_sqlscript_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type sqlScriptClient struct {
+// SQLScriptClient contains the methods for the SQLScript group.
+// Don't use this type directly, use a constructor function instead.
+type SQLScriptClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newSQLScriptClient creates a new instance of sqlScriptClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newSQLScriptClient(endpoint string, pl runtime.Pipeline) *sqlScriptClient {
-	client := &sqlScriptClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateSQLScript - Creates or updates a Sql Script.
@@ -41,17 +33,17 @@ func newSQLScriptClient(endpoint string, pl runtime.Pipeline) *sqlScriptClient {
 // Generated from API version 2019-06-01-preview
 //   - sqlScriptName - The sql script name.
 //   - sqlScript - Sql Script resource definition.
-//   - options - SqlScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginCreateOrUpdateSQLScript
+//   - options - SQLScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginCreateOrUpdateSQLScript
 //     method.
-func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SqlScriptClientBeginCreateOrUpdateSQLScriptOptions) (*runtime.Poller[SqlScriptClientCreateOrUpdateSQLScriptResponse], error) {
+func (client *SQLScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptClientBeginCreateOrUpdateSQLScriptOptions) (*runtime.Poller[SQLScriptClientCreateOrUpdateSQLScriptResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateSQLScript(ctx, sqlScriptName, sqlScript, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SqlScriptClientCreateOrUpdateSQLScriptResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SQLScriptClientCreateOrUpdateSQLScriptResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SqlScriptClientCreateOrUpdateSQLScriptResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SQLScriptClientCreateOrUpdateSQLScriptResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *sqlScriptClient) BeginCreateOrUpdateSQLScript(ctx context.Context,
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sqlScriptClient) createOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SqlScriptClientBeginCreateOrUpdateSQLScriptOptions) (*http.Response, error) {
+func (client *SQLScriptClient) createOrUpdateSQLScript(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptClientBeginCreateOrUpdateSQLScriptOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateSQLScriptCreateRequest(ctx, sqlScriptName, sqlScript, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *sqlScriptClient) createOrUpdateSQLScript(ctx context.Context, sqlS
 }
 
 // createOrUpdateSQLScriptCreateRequest creates the CreateOrUpdateSQLScript request.
-func (client *sqlScriptClient) createOrUpdateSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SqlScriptClientBeginCreateOrUpdateSQLScriptOptions) (*policy.Request, error) {
+func (client *SQLScriptClient) createOrUpdateSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, sqlScript SQLScriptResource, options *SQLScriptClientBeginCreateOrUpdateSQLScriptOptions) (*policy.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	if sqlScriptName == "" {
 		return nil, errors.New("parameter sqlScriptName cannot be empty")
@@ -100,17 +92,17 @@ func (client *sqlScriptClient) createOrUpdateSQLScriptCreateRequest(ctx context.
 //
 // Generated from API version 2019-06-01-preview
 //   - sqlScriptName - The sql script name.
-//   - options - SqlScriptClientBeginDeleteSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginDeleteSQLScript
+//   - options - SQLScriptClientBeginDeleteSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginDeleteSQLScript
 //     method.
-func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScriptName string, options *SqlScriptClientBeginDeleteSQLScriptOptions) (*runtime.Poller[SqlScriptClientDeleteSQLScriptResponse], error) {
+func (client *SQLScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptClientBeginDeleteSQLScriptOptions) (*runtime.Poller[SQLScriptClientDeleteSQLScriptResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteSQLScript(ctx, sqlScriptName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SqlScriptClientDeleteSQLScriptResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SQLScriptClientDeleteSQLScriptResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SqlScriptClientDeleteSQLScriptResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SQLScriptClientDeleteSQLScriptResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *sqlScriptClient) BeginDeleteSQLScript(ctx context.Context, sqlScri
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sqlScriptClient) deleteSQLScript(ctx context.Context, sqlScriptName string, options *SqlScriptClientBeginDeleteSQLScriptOptions) (*http.Response, error) {
+func (client *SQLScriptClient) deleteSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptClientBeginDeleteSQLScriptOptions) (*http.Response, error) {
 	req, err := client.deleteSQLScriptCreateRequest(ctx, sqlScriptName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *sqlScriptClient) deleteSQLScript(ctx context.Context, sqlScriptNam
 }
 
 // deleteSQLScriptCreateRequest creates the DeleteSQLScript request.
-func (client *sqlScriptClient) deleteSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SqlScriptClientBeginDeleteSQLScriptOptions) (*policy.Request, error) {
+func (client *SQLScriptClient) deleteSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SQLScriptClientBeginDeleteSQLScriptOptions) (*policy.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	if sqlScriptName == "" {
 		return nil, errors.New("parameter sqlScriptName cannot be empty")
@@ -156,24 +148,24 @@ func (client *sqlScriptClient) deleteSQLScriptCreateRequest(ctx context.Context,
 //
 // Generated from API version 2019-06-01-preview
 //   - sqlScriptName - The sql script name.
-//   - options - SqlScriptClientGetSQLScriptOptions contains the optional parameters for the sqlScriptClient.GetSQLScript method.
-func (client *sqlScriptClient) GetSQLScript(ctx context.Context, sqlScriptName string, options *SqlScriptClientGetSQLScriptOptions) (SqlScriptClientGetSQLScriptResponse, error) {
+//   - options - SQLScriptClientGetSQLScriptOptions contains the optional parameters for the SQLScriptClient.GetSQLScript method.
+func (client *SQLScriptClient) GetSQLScript(ctx context.Context, sqlScriptName string, options *SQLScriptClientGetSQLScriptOptions) (SQLScriptClientGetSQLScriptResponse, error) {
 	req, err := client.getSQLScriptCreateRequest(ctx, sqlScriptName, options)
 	if err != nil {
-		return SqlScriptClientGetSQLScriptResponse{}, err
+		return SQLScriptClientGetSQLScriptResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return SqlScriptClientGetSQLScriptResponse{}, err
+		return SQLScriptClientGetSQLScriptResponse{}, err
 	}
 	if !runtime.HasStatusCode(resp, http.StatusOK, http.StatusNotModified) {
-		return SqlScriptClientGetSQLScriptResponse{}, runtime.NewResponseError(resp)
+		return SQLScriptClientGetSQLScriptResponse{}, runtime.NewResponseError(resp)
 	}
 	return client.getSQLScriptHandleResponse(resp)
 }
 
 // getSQLScriptCreateRequest creates the GetSQLScript request.
-func (client *sqlScriptClient) getSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SqlScriptClientGetSQLScriptOptions) (*policy.Request, error) {
+func (client *SQLScriptClient) getSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, options *SQLScriptClientGetSQLScriptOptions) (*policy.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}"
 	if sqlScriptName == "" {
 		return nil, errors.New("parameter sqlScriptName cannot be empty")
@@ -194,10 +186,10 @@ func (client *sqlScriptClient) getSQLScriptCreateRequest(ctx context.Context, sq
 }
 
 // getSQLScriptHandleResponse handles the GetSQLScript response.
-func (client *sqlScriptClient) getSQLScriptHandleResponse(resp *http.Response) (SqlScriptClientGetSQLScriptResponse, error) {
-	result := SqlScriptClientGetSQLScriptResponse{}
+func (client *SQLScriptClient) getSQLScriptHandleResponse(resp *http.Response) (SQLScriptClientGetSQLScriptResponse, error) {
+	result := SQLScriptClientGetSQLScriptResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptResource); err != nil {
-		return SqlScriptClientGetSQLScriptResponse{}, err
+		return SQLScriptClientGetSQLScriptResponse{}, err
 	}
 	return result, nil
 }
@@ -205,14 +197,14 @@ func (client *sqlScriptClient) getSQLScriptHandleResponse(resp *http.Response) (
 // NewGetSQLScriptsByWorkspacePager - Lists sql scripts.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - SqlScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the sqlScriptClient.NewGetSQLScriptsByWorkspacePager
+//   - options - SQLScriptClientGetSQLScriptsByWorkspaceOptions contains the optional parameters for the SQLScriptClient.NewGetSQLScriptsByWorkspacePager
 //     method.
-func (client *sqlScriptClient) NewGetSQLScriptsByWorkspacePager(options *SqlScriptClientGetSQLScriptsByWorkspaceOptions) *runtime.Pager[SqlScriptClientGetSQLScriptsByWorkspaceResponse] {
-	return runtime.NewPager(runtime.PagingHandler[SqlScriptClientGetSQLScriptsByWorkspaceResponse]{
-		More: func(page SqlScriptClientGetSQLScriptsByWorkspaceResponse) bool {
+func (client *SQLScriptClient) NewGetSQLScriptsByWorkspacePager(options *SQLScriptClientGetSQLScriptsByWorkspaceOptions) *runtime.Pager[SQLScriptClientGetSQLScriptsByWorkspaceResponse] {
+	return runtime.NewPager(runtime.PagingHandler[SQLScriptClientGetSQLScriptsByWorkspaceResponse]{
+		More: func(page SQLScriptClientGetSQLScriptsByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *SqlScriptClientGetSQLScriptsByWorkspaceResponse) (SqlScriptClientGetSQLScriptsByWorkspaceResponse, error) {
+		Fetcher: func(ctx context.Context, page *SQLScriptClientGetSQLScriptsByWorkspaceResponse) (SQLScriptClientGetSQLScriptsByWorkspaceResponse, error) {
 			var req *policy.Request
 			var err error
 			if page == nil {
@@ -221,14 +213,14 @@ func (client *sqlScriptClient) NewGetSQLScriptsByWorkspacePager(options *SqlScri
 				req, err = runtime.NewRequest(ctx, http.MethodGet, *page.NextLink)
 			}
 			if err != nil {
-				return SqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
+				return SQLScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
-				return SqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
+				return SQLScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 			}
 			if !runtime.HasStatusCode(resp, http.StatusOK) {
-				return SqlScriptClientGetSQLScriptsByWorkspaceResponse{}, runtime.NewResponseError(resp)
+				return SQLScriptClientGetSQLScriptsByWorkspaceResponse{}, runtime.NewResponseError(resp)
 			}
 			return client.getSQLScriptsByWorkspaceHandleResponse(resp)
 		},
@@ -236,7 +228,7 @@ func (client *sqlScriptClient) NewGetSQLScriptsByWorkspacePager(options *SqlScri
 }
 
 // getSQLScriptsByWorkspaceCreateRequest creates the GetSQLScriptsByWorkspace request.
-func (client *sqlScriptClient) getSQLScriptsByWorkspaceCreateRequest(ctx context.Context, options *SqlScriptClientGetSQLScriptsByWorkspaceOptions) (*policy.Request, error) {
+func (client *SQLScriptClient) getSQLScriptsByWorkspaceCreateRequest(ctx context.Context, options *SQLScriptClientGetSQLScriptsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/sqlScripts"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -250,10 +242,10 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceCreateRequest(ctx context
 }
 
 // getSQLScriptsByWorkspaceHandleResponse handles the GetSQLScriptsByWorkspace response.
-func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http.Response) (SqlScriptClientGetSQLScriptsByWorkspaceResponse, error) {
-	result := SqlScriptClientGetSQLScriptsByWorkspaceResponse{}
+func (client *SQLScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http.Response) (SQLScriptClientGetSQLScriptsByWorkspaceResponse, error) {
+	result := SQLScriptClientGetSQLScriptsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SQLScriptsListResponse); err != nil {
-		return SqlScriptClientGetSQLScriptsByWorkspaceResponse{}, err
+		return SQLScriptClientGetSQLScriptsByWorkspaceResponse{}, err
 	}
 	return result, nil
 }
@@ -264,17 +256,17 @@ func (client *sqlScriptClient) getSQLScriptsByWorkspaceHandleResponse(resp *http
 // Generated from API version 2019-06-01-preview
 //   - sqlScriptName - The sql script name.
 //   - request - proposed new name.
-//   - options - SqlScriptClientBeginRenameSQLScriptOptions contains the optional parameters for the sqlScriptClient.BeginRenameSQLScript
+//   - options - SQLScriptClientBeginRenameSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginRenameSQLScript
 //     method.
-func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SqlScriptClientBeginRenameSQLScriptOptions) (*runtime.Poller[SqlScriptClientRenameSQLScriptResponse], error) {
+func (client *SQLScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SQLScriptClientBeginRenameSQLScriptOptions) (*runtime.Poller[SQLScriptClientRenameSQLScriptResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.renameSQLScript(ctx, sqlScriptName, request, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[SqlScriptClientRenameSQLScriptResponse](resp, client.pl, nil)
+		return runtime.NewPoller[SQLScriptClientRenameSQLScriptResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[SqlScriptClientRenameSQLScriptResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[SQLScriptClientRenameSQLScriptResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -282,12 +274,12 @@ func (client *sqlScriptClient) BeginRenameSQLScript(ctx context.Context, sqlScri
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *sqlScriptClient) renameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SqlScriptClientBeginRenameSQLScriptOptions) (*http.Response, error) {
+func (client *SQLScriptClient) renameSQLScript(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SQLScriptClientBeginRenameSQLScriptOptions) (*http.Response, error) {
 	req, err := client.renameSQLScriptCreateRequest(ctx, sqlScriptName, request, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +290,7 @@ func (client *sqlScriptClient) renameSQLScript(ctx context.Context, sqlScriptNam
 }
 
 // renameSQLScriptCreateRequest creates the RenameSQLScript request.
-func (client *sqlScriptClient) renameSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SqlScriptClientBeginRenameSQLScriptOptions) (*policy.Request, error) {
+func (client *SQLScriptClient) renameSQLScriptCreateRequest(ctx context.Context, sqlScriptName string, request ArtifactRenameRequest, options *SQLScriptClientBeginRenameSQLScriptOptions) (*policy.Request, error) {
 	urlPath := "/sqlScripts/{sqlScriptName}/rename"
 	if sqlScriptName == "" {
 		return nil, errors.New("parameter sqlScriptName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_trigger_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_trigger_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type triggerClient struct {
+// TriggerClient contains the methods for the Trigger group.
+// Don't use this type directly, use a constructor function instead.
+type TriggerClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newTriggerClient creates a new instance of triggerClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newTriggerClient(endpoint string, pl runtime.Pipeline) *triggerClient {
-	client := &triggerClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // BeginCreateOrUpdateTrigger - Creates or updates a trigger.
@@ -41,17 +33,17 @@ func newTriggerClient(endpoint string, pl runtime.Pipeline) *triggerClient {
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
 //   - trigger - Trigger resource definition.
-//   - options - TriggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the triggerClient.BeginCreateOrUpdateTrigger
+//   - options - TriggerClientBeginCreateOrUpdateTriggerOptions contains the optional parameters for the TriggerClient.BeginCreateOrUpdateTrigger
 //     method.
-func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*runtime.Poller[TriggerClientCreateOrUpdateTriggerResponse], error) {
+func (client *TriggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*runtime.Poller[TriggerClientCreateOrUpdateTriggerResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrUpdateTrigger(ctx, triggerName, trigger, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientCreateOrUpdateTriggerResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientCreateOrUpdateTriggerResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientCreateOrUpdateTriggerResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientCreateOrUpdateTriggerResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -59,12 +51,12 @@ func (client *triggerClient) BeginCreateOrUpdateTrigger(ctx context.Context, tri
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) createOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*http.Response, error) {
+func (client *TriggerClient) createOrUpdateTrigger(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*http.Response, error) {
 	req, err := client.createOrUpdateTriggerCreateRequest(ctx, triggerName, trigger, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +67,7 @@ func (client *triggerClient) createOrUpdateTrigger(ctx context.Context, triggerN
 }
 
 // createOrUpdateTriggerCreateRequest creates the CreateOrUpdateTrigger request.
-func (client *triggerClient) createOrUpdateTriggerCreateRequest(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*policy.Request, error) {
+func (client *TriggerClient) createOrUpdateTriggerCreateRequest(ctx context.Context, triggerName string, trigger TriggerResource, options *TriggerClientBeginCreateOrUpdateTriggerOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -100,17 +92,17 @@ func (client *triggerClient) createOrUpdateTriggerCreateRequest(ctx context.Cont
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientBeginDeleteTriggerOptions contains the optional parameters for the triggerClient.BeginDeleteTrigger
+//   - options - TriggerClientBeginDeleteTriggerOptions contains the optional parameters for the TriggerClient.BeginDeleteTrigger
 //     method.
-func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*runtime.Poller[TriggerClientDeleteTriggerResponse], error) {
+func (client *TriggerClient) BeginDeleteTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*runtime.Poller[TriggerClientDeleteTriggerResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteTrigger(ctx, triggerName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientDeleteTriggerResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientDeleteTriggerResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientDeleteTriggerResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientDeleteTriggerResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -118,12 +110,12 @@ func (client *triggerClient) BeginDeleteTrigger(ctx context.Context, triggerName
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) deleteTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*http.Response, error) {
+func (client *TriggerClient) deleteTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*http.Response, error) {
 	req, err := client.deleteTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (client *triggerClient) deleteTrigger(ctx context.Context, triggerName stri
 }
 
 // deleteTriggerCreateRequest creates the DeleteTrigger request.
-func (client *triggerClient) deleteTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*policy.Request, error) {
+func (client *TriggerClient) deleteTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginDeleteTriggerOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -156,14 +148,14 @@ func (client *triggerClient) deleteTriggerCreateRequest(ctx context.Context, tri
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientGetEventSubscriptionStatusOptions contains the optional parameters for the triggerClient.GetEventSubscriptionStatus
+//   - options - TriggerClientGetEventSubscriptionStatusOptions contains the optional parameters for the TriggerClient.GetEventSubscriptionStatus
 //     method.
-func (client *triggerClient) GetEventSubscriptionStatus(ctx context.Context, triggerName string, options *TriggerClientGetEventSubscriptionStatusOptions) (TriggerClientGetEventSubscriptionStatusResponse, error) {
+func (client *TriggerClient) GetEventSubscriptionStatus(ctx context.Context, triggerName string, options *TriggerClientGetEventSubscriptionStatusOptions) (TriggerClientGetEventSubscriptionStatusResponse, error) {
 	req, err := client.getEventSubscriptionStatusCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return TriggerClientGetEventSubscriptionStatusResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return TriggerClientGetEventSubscriptionStatusResponse{}, err
 	}
@@ -174,7 +166,7 @@ func (client *triggerClient) GetEventSubscriptionStatus(ctx context.Context, tri
 }
 
 // getEventSubscriptionStatusCreateRequest creates the GetEventSubscriptionStatus request.
-func (client *triggerClient) getEventSubscriptionStatusCreateRequest(ctx context.Context, triggerName string, options *TriggerClientGetEventSubscriptionStatusOptions) (*policy.Request, error) {
+func (client *TriggerClient) getEventSubscriptionStatusCreateRequest(ctx context.Context, triggerName string, options *TriggerClientGetEventSubscriptionStatusOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/getEventSubscriptionStatus"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -192,7 +184,7 @@ func (client *triggerClient) getEventSubscriptionStatusCreateRequest(ctx context
 }
 
 // getEventSubscriptionStatusHandleResponse handles the GetEventSubscriptionStatus response.
-func (client *triggerClient) getEventSubscriptionStatusHandleResponse(resp *http.Response) (TriggerClientGetEventSubscriptionStatusResponse, error) {
+func (client *TriggerClient) getEventSubscriptionStatusHandleResponse(resp *http.Response) (TriggerClientGetEventSubscriptionStatusResponse, error) {
 	result := TriggerClientGetEventSubscriptionStatusResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerSubscriptionOperationStatus); err != nil {
 		return TriggerClientGetEventSubscriptionStatusResponse{}, err
@@ -205,13 +197,13 @@ func (client *triggerClient) getEventSubscriptionStatusHandleResponse(resp *http
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientGetTriggerOptions contains the optional parameters for the triggerClient.GetTrigger method.
-func (client *triggerClient) GetTrigger(ctx context.Context, triggerName string, options *TriggerClientGetTriggerOptions) (TriggerClientGetTriggerResponse, error) {
+//   - options - TriggerClientGetTriggerOptions contains the optional parameters for the TriggerClient.GetTrigger method.
+func (client *TriggerClient) GetTrigger(ctx context.Context, triggerName string, options *TriggerClientGetTriggerOptions) (TriggerClientGetTriggerResponse, error) {
 	req, err := client.getTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return TriggerClientGetTriggerResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return TriggerClientGetTriggerResponse{}, err
 	}
@@ -222,7 +214,7 @@ func (client *triggerClient) GetTrigger(ctx context.Context, triggerName string,
 }
 
 // getTriggerCreateRequest creates the GetTrigger request.
-func (client *triggerClient) getTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientGetTriggerOptions) (*policy.Request, error) {
+func (client *TriggerClient) getTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientGetTriggerOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -243,7 +235,7 @@ func (client *triggerClient) getTriggerCreateRequest(ctx context.Context, trigge
 }
 
 // getTriggerHandleResponse handles the GetTrigger response.
-func (client *triggerClient) getTriggerHandleResponse(resp *http.Response) (TriggerClientGetTriggerResponse, error) {
+func (client *TriggerClient) getTriggerHandleResponse(resp *http.Response) (TriggerClientGetTriggerResponse, error) {
 	result := TriggerClientGetTriggerResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerResource); err != nil {
 		return TriggerClientGetTriggerResponse{}, err
@@ -254,9 +246,9 @@ func (client *triggerClient) getTriggerHandleResponse(resp *http.Response) (Trig
 // NewGetTriggersByWorkspacePager - Lists triggers.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - TriggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the triggerClient.NewGetTriggersByWorkspacePager
+//   - options - TriggerClientGetTriggersByWorkspaceOptions contains the optional parameters for the TriggerClient.NewGetTriggersByWorkspacePager
 //     method.
-func (client *triggerClient) NewGetTriggersByWorkspacePager(options *TriggerClientGetTriggersByWorkspaceOptions) *runtime.Pager[TriggerClientGetTriggersByWorkspaceResponse] {
+func (client *TriggerClient) NewGetTriggersByWorkspacePager(options *TriggerClientGetTriggersByWorkspaceOptions) *runtime.Pager[TriggerClientGetTriggersByWorkspaceResponse] {
 	return runtime.NewPager(runtime.PagingHandler[TriggerClientGetTriggersByWorkspaceResponse]{
 		More: func(page TriggerClientGetTriggersByWorkspaceResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
@@ -272,7 +264,7 @@ func (client *triggerClient) NewGetTriggersByWorkspacePager(options *TriggerClie
 			if err != nil {
 				return TriggerClientGetTriggersByWorkspaceResponse{}, err
 			}
-			resp, err := client.pl.Do(req)
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return TriggerClientGetTriggersByWorkspaceResponse{}, err
 			}
@@ -285,7 +277,7 @@ func (client *triggerClient) NewGetTriggersByWorkspacePager(options *TriggerClie
 }
 
 // getTriggersByWorkspaceCreateRequest creates the GetTriggersByWorkspace request.
-func (client *triggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Context, options *TriggerClientGetTriggersByWorkspaceOptions) (*policy.Request, error) {
+func (client *TriggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Context, options *TriggerClientGetTriggersByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/triggers"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -299,7 +291,7 @@ func (client *triggerClient) getTriggersByWorkspaceCreateRequest(ctx context.Con
 }
 
 // getTriggersByWorkspaceHandleResponse handles the GetTriggersByWorkspace response.
-func (client *triggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Response) (TriggerClientGetTriggersByWorkspaceResponse, error) {
+func (client *TriggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Response) (TriggerClientGetTriggersByWorkspaceResponse, error) {
 	result := TriggerClientGetTriggersByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerListResponse); err != nil {
 		return TriggerClientGetTriggersByWorkspaceResponse{}, err
@@ -312,17 +304,17 @@ func (client *triggerClient) getTriggersByWorkspaceHandleResponse(resp *http.Res
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientBeginStartTriggerOptions contains the optional parameters for the triggerClient.BeginStartTrigger
+//   - options - TriggerClientBeginStartTriggerOptions contains the optional parameters for the TriggerClient.BeginStartTrigger
 //     method.
-func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*runtime.Poller[TriggerClientStartTriggerResponse], error) {
+func (client *TriggerClient) BeginStartTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*runtime.Poller[TriggerClientStartTriggerResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.startTrigger(ctx, triggerName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientStartTriggerResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientStartTriggerResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientStartTriggerResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientStartTriggerResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -330,12 +322,12 @@ func (client *triggerClient) BeginStartTrigger(ctx context.Context, triggerName 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) startTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*http.Response, error) {
+func (client *TriggerClient) startTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*http.Response, error) {
 	req, err := client.startTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -346,7 +338,7 @@ func (client *triggerClient) startTrigger(ctx context.Context, triggerName strin
 }
 
 // startTriggerCreateRequest creates the StartTrigger request.
-func (client *triggerClient) startTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*policy.Request, error) {
+func (client *TriggerClient) startTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginStartTriggerOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/start"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -368,17 +360,17 @@ func (client *triggerClient) startTriggerCreateRequest(ctx context.Context, trig
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientBeginStopTriggerOptions contains the optional parameters for the triggerClient.BeginStopTrigger
+//   - options - TriggerClientBeginStopTriggerOptions contains the optional parameters for the TriggerClient.BeginStopTrigger
 //     method.
-func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*runtime.Poller[TriggerClientStopTriggerResponse], error) {
+func (client *TriggerClient) BeginStopTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*runtime.Poller[TriggerClientStopTriggerResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.stopTrigger(ctx, triggerName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientStopTriggerResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientStopTriggerResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientStopTriggerResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientStopTriggerResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -386,12 +378,12 @@ func (client *triggerClient) BeginStopTrigger(ctx context.Context, triggerName s
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) stopTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*http.Response, error) {
+func (client *TriggerClient) stopTrigger(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*http.Response, error) {
 	req, err := client.stopTriggerCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +394,7 @@ func (client *triggerClient) stopTrigger(ctx context.Context, triggerName string
 }
 
 // stopTriggerCreateRequest creates the StopTrigger request.
-func (client *triggerClient) stopTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*policy.Request, error) {
+func (client *TriggerClient) stopTriggerCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginStopTriggerOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/stop"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -424,17 +416,17 @@ func (client *triggerClient) stopTriggerCreateRequest(ctx context.Context, trigg
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientBeginSubscribeTriggerToEventsOptions contains the optional parameters for the triggerClient.BeginSubscribeTriggerToEvents
+//   - options - TriggerClientBeginSubscribeTriggerToEventsOptions contains the optional parameters for the TriggerClient.BeginSubscribeTriggerToEvents
 //     method.
-func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*runtime.Poller[TriggerClientSubscribeTriggerToEventsResponse], error) {
+func (client *TriggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*runtime.Poller[TriggerClientSubscribeTriggerToEventsResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.subscribeTriggerToEvents(ctx, triggerName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientSubscribeTriggerToEventsResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientSubscribeTriggerToEventsResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientSubscribeTriggerToEventsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientSubscribeTriggerToEventsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -442,12 +434,12 @@ func (client *triggerClient) BeginSubscribeTriggerToEvents(ctx context.Context, 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) subscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*http.Response, error) {
+func (client *TriggerClient) subscribeTriggerToEvents(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*http.Response, error) {
 	req, err := client.subscribeTriggerToEventsCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -458,7 +450,7 @@ func (client *triggerClient) subscribeTriggerToEvents(ctx context.Context, trigg
 }
 
 // subscribeTriggerToEventsCreateRequest creates the SubscribeTriggerToEvents request.
-func (client *triggerClient) subscribeTriggerToEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*policy.Request, error) {
+func (client *TriggerClient) subscribeTriggerToEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginSubscribeTriggerToEventsOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/subscribeToEvents"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -480,17 +472,17 @@ func (client *triggerClient) subscribeTriggerToEventsCreateRequest(ctx context.C
 //
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
-//   - options - TriggerClientBeginUnsubscribeTriggerFromEventsOptions contains the optional parameters for the triggerClient.BeginUnsubscribeTriggerFromEvents
+//   - options - TriggerClientBeginUnsubscribeTriggerFromEventsOptions contains the optional parameters for the TriggerClient.BeginUnsubscribeTriggerFromEvents
 //     method.
-func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*runtime.Poller[TriggerClientUnsubscribeTriggerFromEventsResponse], error) {
+func (client *TriggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*runtime.Poller[TriggerClientUnsubscribeTriggerFromEventsResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.unsubscribeTriggerFromEvents(ctx, triggerName, options)
 		if err != nil {
 			return nil, err
 		}
-		return runtime.NewPoller[TriggerClientUnsubscribeTriggerFromEventsResponse](resp, client.pl, nil)
+		return runtime.NewPoller[TriggerClientUnsubscribeTriggerFromEventsResponse](resp, client.internal.Pipeline(), nil)
 	} else {
-		return runtime.NewPollerFromResumeToken[TriggerClientUnsubscribeTriggerFromEventsResponse](options.ResumeToken, client.pl, nil)
+		return runtime.NewPollerFromResumeToken[TriggerClientUnsubscribeTriggerFromEventsResponse](options.ResumeToken, client.internal.Pipeline(), nil)
 	}
 }
 
@@ -498,12 +490,12 @@ func (client *triggerClient) BeginUnsubscribeTriggerFromEvents(ctx context.Conte
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-func (client *triggerClient) unsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*http.Response, error) {
+func (client *TriggerClient) unsubscribeTriggerFromEvents(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*http.Response, error) {
 	req, err := client.unsubscribeTriggerFromEventsCreateRequest(ctx, triggerName, options)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -514,7 +506,7 @@ func (client *triggerClient) unsubscribeTriggerFromEvents(ctx context.Context, t
 }
 
 // unsubscribeTriggerFromEventsCreateRequest creates the UnsubscribeTriggerFromEvents request.
-func (client *triggerClient) unsubscribeTriggerFromEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*policy.Request, error) {
+func (client *TriggerClient) unsubscribeTriggerFromEventsCreateRequest(ctx context.Context, triggerName string, options *TriggerClientBeginUnsubscribeTriggerFromEventsOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/unsubscribeFromEvents"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_triggerrun_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_triggerrun_client.go
@@ -12,6 +12,7 @@ package azartifacts
 import (
 	"context"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,20 +20,11 @@ import (
 	"strings"
 )
 
-type triggerRunClient struct {
+// TriggerRunClient contains the methods for the TriggerRun group.
+// Don't use this type directly, use a constructor function instead.
+type TriggerRunClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newTriggerRunClient creates a new instance of triggerRunClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newTriggerRunClient(endpoint string, pl runtime.Pipeline) *triggerRunClient {
-	client := &triggerRunClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // CancelTriggerInstance - Cancel single trigger instance by runId.
@@ -41,14 +33,14 @@ func newTriggerRunClient(endpoint string, pl runtime.Pipeline) *triggerRunClient
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
 //   - runID - The pipeline run identifier.
-//   - options - TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the triggerRunClient.CancelTriggerInstance
+//   - options - TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.CancelTriggerInstance
 //     method.
-func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, triggerName string, runID string, options *TriggerRunClientCancelTriggerInstanceOptions) (TriggerRunClientCancelTriggerInstanceResponse, error) {
+func (client *TriggerRunClient) CancelTriggerInstance(ctx context.Context, triggerName string, runID string, options *TriggerRunClientCancelTriggerInstanceOptions) (TriggerRunClientCancelTriggerInstanceResponse, error) {
 	req, err := client.cancelTriggerInstanceCreateRequest(ctx, triggerName, runID, options)
 	if err != nil {
 		return TriggerRunClientCancelTriggerInstanceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return TriggerRunClientCancelTriggerInstanceResponse{}, err
 	}
@@ -59,7 +51,7 @@ func (client *triggerRunClient) CancelTriggerInstance(ctx context.Context, trigg
 }
 
 // cancelTriggerInstanceCreateRequest creates the CancelTriggerInstance request.
-func (client *triggerRunClient) cancelTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runID string, options *TriggerRunClientCancelTriggerInstanceOptions) (*policy.Request, error) {
+func (client *TriggerRunClient) cancelTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runID string, options *TriggerRunClientCancelTriggerInstanceOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/triggerRuns/{runId}/cancel"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")
@@ -85,14 +77,14 @@ func (client *triggerRunClient) cancelTriggerInstanceCreateRequest(ctx context.C
 //
 // Generated from API version 2019-06-01-preview
 //   - filterParameters - Parameters to filter the pipeline run.
-//   - options - TriggerRunClientQueryTriggerRunsByWorkspaceOptions contains the optional parameters for the triggerRunClient.QueryTriggerRunsByWorkspace
+//   - options - TriggerRunClientQueryTriggerRunsByWorkspaceOptions contains the optional parameters for the TriggerRunClient.QueryTriggerRunsByWorkspace
 //     method.
-func (client *triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunClientQueryTriggerRunsByWorkspaceOptions) (TriggerRunClientQueryTriggerRunsByWorkspaceResponse, error) {
+func (client *TriggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunClientQueryTriggerRunsByWorkspaceOptions) (TriggerRunClientQueryTriggerRunsByWorkspaceResponse, error) {
 	req, err := client.queryTriggerRunsByWorkspaceCreateRequest(ctx, filterParameters, options)
 	if err != nil {
 		return TriggerRunClientQueryTriggerRunsByWorkspaceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return TriggerRunClientQueryTriggerRunsByWorkspaceResponse{}, err
 	}
@@ -103,7 +95,7 @@ func (client *triggerRunClient) QueryTriggerRunsByWorkspace(ctx context.Context,
 }
 
 // queryTriggerRunsByWorkspaceCreateRequest creates the QueryTriggerRunsByWorkspace request.
-func (client *triggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunClientQueryTriggerRunsByWorkspaceOptions) (*policy.Request, error) {
+func (client *TriggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx context.Context, filterParameters RunFilterParameters, options *TriggerRunClientQueryTriggerRunsByWorkspaceOptions) (*policy.Request, error) {
 	urlPath := "/queryTriggerRuns"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -117,7 +109,7 @@ func (client *triggerRunClient) queryTriggerRunsByWorkspaceCreateRequest(ctx con
 }
 
 // queryTriggerRunsByWorkspaceHandleResponse handles the QueryTriggerRunsByWorkspace response.
-func (client *triggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *http.Response) (TriggerRunClientQueryTriggerRunsByWorkspaceResponse, error) {
+func (client *TriggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *http.Response) (TriggerRunClientQueryTriggerRunsByWorkspaceResponse, error) {
 	result := TriggerRunClientQueryTriggerRunsByWorkspaceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.TriggerRunsQueryResponse); err != nil {
 		return TriggerRunClientQueryTriggerRunsByWorkspaceResponse{}, err
@@ -131,14 +123,14 @@ func (client *triggerRunClient) queryTriggerRunsByWorkspaceHandleResponse(resp *
 // Generated from API version 2019-06-01-preview
 //   - triggerName - The trigger name.
 //   - runID - The pipeline run identifier.
-//   - options - TriggerRunClientRerunTriggerInstanceOptions contains the optional parameters for the triggerRunClient.RerunTriggerInstance
+//   - options - TriggerRunClientRerunTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.RerunTriggerInstance
 //     method.
-func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, triggerName string, runID string, options *TriggerRunClientRerunTriggerInstanceOptions) (TriggerRunClientRerunTriggerInstanceResponse, error) {
+func (client *TriggerRunClient) RerunTriggerInstance(ctx context.Context, triggerName string, runID string, options *TriggerRunClientRerunTriggerInstanceOptions) (TriggerRunClientRerunTriggerInstanceResponse, error) {
 	req, err := client.rerunTriggerInstanceCreateRequest(ctx, triggerName, runID, options)
 	if err != nil {
 		return TriggerRunClientRerunTriggerInstanceResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return TriggerRunClientRerunTriggerInstanceResponse{}, err
 	}
@@ -149,7 +141,7 @@ func (client *triggerRunClient) RerunTriggerInstance(ctx context.Context, trigge
 }
 
 // rerunTriggerInstanceCreateRequest creates the RerunTriggerInstance request.
-func (client *triggerRunClient) rerunTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runID string, options *TriggerRunClientRerunTriggerInstanceOptions) (*policy.Request, error) {
+func (client *TriggerRunClient) rerunTriggerInstanceCreateRequest(ctx context.Context, triggerName string, runID string, options *TriggerRunClientRerunTriggerInstanceOptions) (*policy.Request, error) {
 	urlPath := "/triggers/{triggerName}/triggerRuns/{runId}/rerun"
 	if triggerName == "" {
 		return nil, errors.New("parameter triggerName cannot be empty")

--- a/test/synapse/2019-06-01/azartifacts/zz_workspace_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_workspace_client.go
@@ -11,38 +11,30 @@ package azartifacts
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
-type workspaceClient struct {
+// WorkspaceClient contains the methods for the Workspace group.
+// Don't use this type directly, use a constructor function instead.
+type WorkspaceClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newWorkspaceClient creates a new instance of workspaceClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newWorkspaceClient(endpoint string, pl runtime.Pipeline) *workspaceClient {
-	client := &workspaceClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // Get - Get Workspace
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - WorkspaceClientGetOptions contains the optional parameters for the workspaceClient.Get method.
-func (client *workspaceClient) Get(ctx context.Context, options *WorkspaceClientGetOptions) (WorkspaceClientGetResponse, error) {
+//   - options - WorkspaceClientGetOptions contains the optional parameters for the WorkspaceClient.Get method.
+func (client *WorkspaceClient) Get(ctx context.Context, options *WorkspaceClientGetOptions) (WorkspaceClientGetResponse, error) {
 	req, err := client.getCreateRequest(ctx, options)
 	if err != nil {
 		return WorkspaceClientGetResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WorkspaceClientGetResponse{}, err
 	}
@@ -53,7 +45,7 @@ func (client *workspaceClient) Get(ctx context.Context, options *WorkspaceClient
 }
 
 // getCreateRequest creates the Get request.
-func (client *workspaceClient) getCreateRequest(ctx context.Context, options *WorkspaceClientGetOptions) (*policy.Request, error) {
+func (client *WorkspaceClient) getCreateRequest(ctx context.Context, options *WorkspaceClientGetOptions) (*policy.Request, error) {
 	urlPath := "/workspace"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -67,7 +59,7 @@ func (client *workspaceClient) getCreateRequest(ctx context.Context, options *Wo
 }
 
 // getHandleResponse handles the Get response.
-func (client *workspaceClient) getHandleResponse(resp *http.Response) (WorkspaceClientGetResponse, error) {
+func (client *WorkspaceClient) getHandleResponse(resp *http.Response) (WorkspaceClientGetResponse, error) {
 	result := WorkspaceClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Workspace); err != nil {
 		return WorkspaceClientGetResponse{}, err

--- a/test/synapse/2019-06-01/azartifacts/zz_workspacegitrepomanagement_client.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_workspacegitrepomanagement_client.go
@@ -11,39 +11,31 @@ package azartifacts
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 )
 
-type workspaceGitRepoManagementClient struct {
+// WorkspaceGitRepoManagementClient contains the methods for the WorkspaceGitRepoManagement group.
+// Don't use this type directly, use a constructor function instead.
+type WorkspaceGitRepoManagementClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newWorkspaceGitRepoManagementClient creates a new instance of workspaceGitRepoManagementClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newWorkspaceGitRepoManagementClient(endpoint string, pl runtime.Pipeline) *workspaceGitRepoManagementClient {
-	client := &workspaceGitRepoManagementClient{
-		endpoint: endpoint,
-		pl:       pl,
-	}
-	return client
 }
 
 // GetGitHubAccessToken - Get the GitHub access token.
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-06-01-preview
-//   - options - WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions contains the optional parameters for the workspaceGitRepoManagementClient.GetGitHubAccessToken
+//   - options - WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions contains the optional parameters for the WorkspaceGitRepoManagementClient.GetGitHubAccessToken
 //     method.
-func (client *workspaceGitRepoManagementClient) GetGitHubAccessToken(ctx context.Context, gitHubAccessTokenRequest GitHubAccessTokenRequest, options *WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions) (WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse, error) {
+func (client *WorkspaceGitRepoManagementClient) GetGitHubAccessToken(ctx context.Context, gitHubAccessTokenRequest GitHubAccessTokenRequest, options *WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions) (WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse, error) {
 	req, err := client.getGitHubAccessTokenCreateRequest(ctx, gitHubAccessTokenRequest, options)
 	if err != nil {
 		return WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}, err
 	}
@@ -54,7 +46,7 @@ func (client *workspaceGitRepoManagementClient) GetGitHubAccessToken(ctx context
 }
 
 // getGitHubAccessTokenCreateRequest creates the GetGitHubAccessToken request.
-func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenCreateRequest(ctx context.Context, gitHubAccessTokenRequest GitHubAccessTokenRequest, options *WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions) (*policy.Request, error) {
+func (client *WorkspaceGitRepoManagementClient) getGitHubAccessTokenCreateRequest(ctx context.Context, gitHubAccessTokenRequest GitHubAccessTokenRequest, options *WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions) (*policy.Request, error) {
 	urlPath := "/getGitHubAccessToken"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -71,7 +63,7 @@ func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenCreateReques
 }
 
 // getGitHubAccessTokenHandleResponse handles the GetGitHubAccessToken response.
-func (client *workspaceGitRepoManagementClient) getGitHubAccessTokenHandleResponse(resp *http.Response) (WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse, error) {
+func (client *WorkspaceGitRepoManagementClient) getGitHubAccessTokenHandleResponse(resp *http.Response) (WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse, error) {
 	result := WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.GitHubAccessTokenResponse); err != nil {
 		return WorkspaceGitRepoManagementClientGetGitHubAccessTokenResponse{}, err

--- a/test/synapse/2019-06-01/azspark/go.mod
+++ b/test/synapse/2019-06-01/azspark/go.mod
@@ -2,10 +2,10 @@ module azspark
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/synapse/2019-06-01/azspark/go.sum
+++ b/test/synapse/2019-06-01/azspark/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/synapse/2019-06-01/azspark/zz_batch_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_batch_client.go
@@ -11,6 +11,7 @@ package azspark
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,30 +20,11 @@ import (
 	"strings"
 )
 
-type batchClient struct {
+// BatchClient contains the methods for the SparkBatch group.
+// Don't use this type directly, use a constructor function instead.
+type BatchClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newBatchClient creates a new instance of batchClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - livyAPIVersion - Valid api-version for the request.
-//   - sparkPoolName - Name of the spark pool.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *batchClient {
-	hostURL := "{endpoint}/livyApi/versions/{livyApiVersion}/sparkPools/{sparkPoolName}"
-	hostURL = strings.ReplaceAll(hostURL, "{endpoint}", endpoint)
-	if livyAPIVersion == nil {
-		defaultValue := "2019-11-01-preview"
-		livyAPIVersion = &defaultValue
-	}
-	hostURL = strings.ReplaceAll(hostURL, "{livyApiVersion}", *livyAPIVersion)
-	hostURL = strings.ReplaceAll(hostURL, "{sparkPoolName}", sparkPoolName)
-	client := &batchClient{
-		endpoint: hostURL,
-		pl:       pl,
-	}
-	return client
 }
 
 // CancelSparkBatchJob - Cancels a running spark batch job.
@@ -50,14 +32,14 @@ func newBatchClient(endpoint string, livyAPIVersion *string, sparkPoolName strin
 //
 // Generated from API version 2019-11-01-preview
 //   - batchID - Identifier for the batch job.
-//   - options - BatchClientCancelSparkBatchJobOptions contains the optional parameters for the batchClient.CancelSparkBatchJob
+//   - options - BatchClientCancelSparkBatchJobOptions contains the optional parameters for the BatchClient.CancelSparkBatchJob
 //     method.
-func (client *batchClient) CancelSparkBatchJob(ctx context.Context, batchID int32, options *BatchClientCancelSparkBatchJobOptions) (BatchClientCancelSparkBatchJobResponse, error) {
+func (client *BatchClient) CancelSparkBatchJob(ctx context.Context, batchID int32, options *BatchClientCancelSparkBatchJobOptions) (BatchClientCancelSparkBatchJobResponse, error) {
 	req, err := client.cancelSparkBatchJobCreateRequest(ctx, batchID, options)
 	if err != nil {
 		return BatchClientCancelSparkBatchJobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BatchClientCancelSparkBatchJobResponse{}, err
 	}
@@ -68,7 +50,7 @@ func (client *batchClient) CancelSparkBatchJob(ctx context.Context, batchID int3
 }
 
 // cancelSparkBatchJobCreateRequest creates the CancelSparkBatchJob request.
-func (client *batchClient) cancelSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *BatchClientCancelSparkBatchJobOptions) (*policy.Request, error) {
+func (client *BatchClient) cancelSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *BatchClientCancelSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -83,14 +65,14 @@ func (client *batchClient) cancelSparkBatchJobCreateRequest(ctx context.Context,
 //
 // Generated from API version 2019-11-01-preview
 //   - sparkBatchJobOptions - Livy compatible batch job request payload.
-//   - options - BatchClientCreateSparkBatchJobOptions contains the optional parameters for the batchClient.CreateSparkBatchJob
+//   - options - BatchClientCreateSparkBatchJobOptions contains the optional parameters for the BatchClient.CreateSparkBatchJob
 //     method.
-func (client *batchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *BatchClientCreateSparkBatchJobOptions) (BatchClientCreateSparkBatchJobResponse, error) {
+func (client *BatchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *BatchClientCreateSparkBatchJobOptions) (BatchClientCreateSparkBatchJobResponse, error) {
 	req, err := client.createSparkBatchJobCreateRequest(ctx, sparkBatchJobOptions, options)
 	if err != nil {
 		return BatchClientCreateSparkBatchJobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BatchClientCreateSparkBatchJobResponse{}, err
 	}
@@ -101,7 +83,7 @@ func (client *batchClient) CreateSparkBatchJob(ctx context.Context, sparkBatchJo
 }
 
 // createSparkBatchJobCreateRequest creates the CreateSparkBatchJob request.
-func (client *batchClient) createSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *BatchClientCreateSparkBatchJobOptions) (*policy.Request, error) {
+func (client *BatchClient) createSparkBatchJobCreateRequest(ctx context.Context, sparkBatchJobOptions BatchJobOptions, options *BatchClientCreateSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -117,7 +99,7 @@ func (client *batchClient) createSparkBatchJobCreateRequest(ctx context.Context,
 }
 
 // createSparkBatchJobHandleResponse handles the CreateSparkBatchJob response.
-func (client *batchClient) createSparkBatchJobHandleResponse(resp *http.Response) (BatchClientCreateSparkBatchJobResponse, error) {
+func (client *BatchClient) createSparkBatchJobHandleResponse(resp *http.Response) (BatchClientCreateSparkBatchJobResponse, error) {
 	result := BatchClientCreateSparkBatchJobResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return BatchClientCreateSparkBatchJobResponse{}, err
@@ -130,13 +112,13 @@ func (client *batchClient) createSparkBatchJobHandleResponse(resp *http.Response
 //
 // Generated from API version 2019-11-01-preview
 //   - batchID - Identifier for the batch job.
-//   - options - BatchClientGetSparkBatchJobOptions contains the optional parameters for the batchClient.GetSparkBatchJob method.
-func (client *batchClient) GetSparkBatchJob(ctx context.Context, batchID int32, options *BatchClientGetSparkBatchJobOptions) (BatchClientGetSparkBatchJobResponse, error) {
+//   - options - BatchClientGetSparkBatchJobOptions contains the optional parameters for the BatchClient.GetSparkBatchJob method.
+func (client *BatchClient) GetSparkBatchJob(ctx context.Context, batchID int32, options *BatchClientGetSparkBatchJobOptions) (BatchClientGetSparkBatchJobResponse, error) {
 	req, err := client.getSparkBatchJobCreateRequest(ctx, batchID, options)
 	if err != nil {
 		return BatchClientGetSparkBatchJobResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BatchClientGetSparkBatchJobResponse{}, err
 	}
@@ -147,7 +129,7 @@ func (client *batchClient) GetSparkBatchJob(ctx context.Context, batchID int32, 
 }
 
 // getSparkBatchJobCreateRequest creates the GetSparkBatchJob request.
-func (client *batchClient) getSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *BatchClientGetSparkBatchJobOptions) (*policy.Request, error) {
+func (client *BatchClient) getSparkBatchJobCreateRequest(ctx context.Context, batchID int32, options *BatchClientGetSparkBatchJobOptions) (*policy.Request, error) {
 	urlPath := "/batches/{batchId}"
 	urlPath = strings.ReplaceAll(urlPath, "{batchId}", url.PathEscape(strconv.FormatInt(int64(batchID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -164,7 +146,7 @@ func (client *batchClient) getSparkBatchJobCreateRequest(ctx context.Context, ba
 }
 
 // getSparkBatchJobHandleResponse handles the GetSparkBatchJob response.
-func (client *batchClient) getSparkBatchJobHandleResponse(resp *http.Response) (BatchClientGetSparkBatchJobResponse, error) {
+func (client *BatchClient) getSparkBatchJobHandleResponse(resp *http.Response) (BatchClientGetSparkBatchJobResponse, error) {
 	result := BatchClientGetSparkBatchJobResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJob); err != nil {
 		return BatchClientGetSparkBatchJobResponse{}, err
@@ -176,13 +158,13 @@ func (client *batchClient) getSparkBatchJobHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-11-01-preview
-//   - options - BatchClientGetSparkBatchJobsOptions contains the optional parameters for the batchClient.GetSparkBatchJobs method.
-func (client *batchClient) GetSparkBatchJobs(ctx context.Context, options *BatchClientGetSparkBatchJobsOptions) (BatchClientGetSparkBatchJobsResponse, error) {
+//   - options - BatchClientGetSparkBatchJobsOptions contains the optional parameters for the BatchClient.GetSparkBatchJobs method.
+func (client *BatchClient) GetSparkBatchJobs(ctx context.Context, options *BatchClientGetSparkBatchJobsOptions) (BatchClientGetSparkBatchJobsResponse, error) {
 	req, err := client.getSparkBatchJobsCreateRequest(ctx, options)
 	if err != nil {
 		return BatchClientGetSparkBatchJobsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return BatchClientGetSparkBatchJobsResponse{}, err
 	}
@@ -193,7 +175,7 @@ func (client *batchClient) GetSparkBatchJobs(ctx context.Context, options *Batch
 }
 
 // getSparkBatchJobsCreateRequest creates the GetSparkBatchJobs request.
-func (client *batchClient) getSparkBatchJobsCreateRequest(ctx context.Context, options *BatchClientGetSparkBatchJobsOptions) (*policy.Request, error) {
+func (client *BatchClient) getSparkBatchJobsCreateRequest(ctx context.Context, options *BatchClientGetSparkBatchJobsOptions) (*policy.Request, error) {
 	urlPath := "/batches"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -215,7 +197,7 @@ func (client *batchClient) getSparkBatchJobsCreateRequest(ctx context.Context, o
 }
 
 // getSparkBatchJobsHandleResponse handles the GetSparkBatchJobs response.
-func (client *batchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (BatchClientGetSparkBatchJobsResponse, error) {
+func (client *BatchClient) getSparkBatchJobsHandleResponse(resp *http.Response) (BatchClientGetSparkBatchJobsResponse, error) {
 	result := BatchClientGetSparkBatchJobsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.BatchJobCollection); err != nil {
 		return BatchClientGetSparkBatchJobsResponse{}, err

--- a/test/synapse/2019-06-01/azspark/zz_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_models.go
@@ -11,24 +11,24 @@ package azspark
 
 import "time"
 
-// BatchClientCancelSparkBatchJobOptions contains the optional parameters for the batchClient.CancelSparkBatchJob method.
+// BatchClientCancelSparkBatchJobOptions contains the optional parameters for the BatchClient.CancelSparkBatchJob method.
 type BatchClientCancelSparkBatchJobOptions struct {
 	// placeholder for future optional parameters
 }
 
-// BatchClientCreateSparkBatchJobOptions contains the optional parameters for the batchClient.CreateSparkBatchJob method.
+// BatchClientCreateSparkBatchJobOptions contains the optional parameters for the BatchClient.CreateSparkBatchJob method.
 type BatchClientCreateSparkBatchJobOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
 }
 
-// BatchClientGetSparkBatchJobOptions contains the optional parameters for the batchClient.GetSparkBatchJob method.
+// BatchClientGetSparkBatchJobOptions contains the optional parameters for the BatchClient.GetSparkBatchJob method.
 type BatchClientGetSparkBatchJobOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
 }
 
-// BatchClientGetSparkBatchJobsOptions contains the optional parameters for the batchClient.GetSparkBatchJobs method.
+// BatchClientGetSparkBatchJobsOptions contains the optional parameters for the BatchClient.GetSparkBatchJobs method.
 type BatchClientGetSparkBatchJobsOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
@@ -229,34 +229,34 @@ type Session struct {
 	WorkspaceName *string            `json:"workspaceName,omitempty"`
 }
 
-// SessionClientCancelSparkSessionOptions contains the optional parameters for the sessionClient.CancelSparkSession method.
+// SessionClientCancelSparkSessionOptions contains the optional parameters for the SessionClient.CancelSparkSession method.
 type SessionClientCancelSparkSessionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SessionClientCancelSparkStatementOptions contains the optional parameters for the sessionClient.CancelSparkStatement method.
+// SessionClientCancelSparkStatementOptions contains the optional parameters for the SessionClient.CancelSparkStatement method.
 type SessionClientCancelSparkStatementOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SessionClientCreateSparkSessionOptions contains the optional parameters for the sessionClient.CreateSparkSession method.
+// SessionClientCreateSparkSessionOptions contains the optional parameters for the SessionClient.CreateSparkSession method.
 type SessionClientCreateSparkSessionOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
 }
 
-// SessionClientCreateSparkStatementOptions contains the optional parameters for the sessionClient.CreateSparkStatement method.
+// SessionClientCreateSparkStatementOptions contains the optional parameters for the SessionClient.CreateSparkStatement method.
 type SessionClientCreateSparkStatementOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SessionClientGetSparkSessionOptions contains the optional parameters for the sessionClient.GetSparkSession method.
+// SessionClientGetSparkSessionOptions contains the optional parameters for the SessionClient.GetSparkSession method.
 type SessionClientGetSparkSessionOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
 }
 
-// SessionClientGetSparkSessionsOptions contains the optional parameters for the sessionClient.GetSparkSessions method.
+// SessionClientGetSparkSessionsOptions contains the optional parameters for the SessionClient.GetSparkSessions method.
 type SessionClientGetSparkSessionsOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
@@ -266,17 +266,17 @@ type SessionClientGetSparkSessionsOptions struct {
 	Size *int32
 }
 
-// SessionClientGetSparkStatementOptions contains the optional parameters for the sessionClient.GetSparkStatement method.
+// SessionClientGetSparkStatementOptions contains the optional parameters for the SessionClient.GetSparkStatement method.
 type SessionClientGetSparkStatementOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SessionClientGetSparkStatementsOptions contains the optional parameters for the sessionClient.GetSparkStatements method.
+// SessionClientGetSparkStatementsOptions contains the optional parameters for the SessionClient.GetSparkStatements method.
 type SessionClientGetSparkStatementsOptions struct {
 	// placeholder for future optional parameters
 }
 
-// SessionClientResetSparkSessionTimeoutOptions contains the optional parameters for the sessionClient.ResetSparkSessionTimeout
+// SessionClientResetSparkSessionTimeoutOptions contains the optional parameters for the SessionClient.ResetSparkSessionTimeout
 // method.
 type SessionClientResetSparkSessionTimeoutOptions struct {
 	// placeholder for future optional parameters

--- a/test/synapse/2019-06-01/azspark/zz_response_types.go
+++ b/test/synapse/2019-06-01/azspark/zz_response_types.go
@@ -9,67 +9,67 @@
 
 package azspark
 
-// BatchClientCancelSparkBatchJobResponse contains the response from method batchClient.CancelSparkBatchJob.
+// BatchClientCancelSparkBatchJobResponse contains the response from method BatchClient.CancelSparkBatchJob.
 type BatchClientCancelSparkBatchJobResponse struct {
 	// placeholder for future response values
 }
 
-// BatchClientCreateSparkBatchJobResponse contains the response from method batchClient.CreateSparkBatchJob.
+// BatchClientCreateSparkBatchJobResponse contains the response from method BatchClient.CreateSparkBatchJob.
 type BatchClientCreateSparkBatchJobResponse struct {
 	BatchJob
 }
 
-// BatchClientGetSparkBatchJobResponse contains the response from method batchClient.GetSparkBatchJob.
+// BatchClientGetSparkBatchJobResponse contains the response from method BatchClient.GetSparkBatchJob.
 type BatchClientGetSparkBatchJobResponse struct {
 	BatchJob
 }
 
-// BatchClientGetSparkBatchJobsResponse contains the response from method batchClient.GetSparkBatchJobs.
+// BatchClientGetSparkBatchJobsResponse contains the response from method BatchClient.GetSparkBatchJobs.
 type BatchClientGetSparkBatchJobsResponse struct {
 	BatchJobCollection
 }
 
-// SessionClientCancelSparkSessionResponse contains the response from method sessionClient.CancelSparkSession.
+// SessionClientCancelSparkSessionResponse contains the response from method SessionClient.CancelSparkSession.
 type SessionClientCancelSparkSessionResponse struct {
 	// placeholder for future response values
 }
 
-// SessionClientCancelSparkStatementResponse contains the response from method sessionClient.CancelSparkStatement.
+// SessionClientCancelSparkStatementResponse contains the response from method SessionClient.CancelSparkStatement.
 type SessionClientCancelSparkStatementResponse struct {
 	StatementCancellationResult
 }
 
-// SessionClientCreateSparkSessionResponse contains the response from method sessionClient.CreateSparkSession.
+// SessionClientCreateSparkSessionResponse contains the response from method SessionClient.CreateSparkSession.
 type SessionClientCreateSparkSessionResponse struct {
 	Session
 }
 
-// SessionClientCreateSparkStatementResponse contains the response from method sessionClient.CreateSparkStatement.
+// SessionClientCreateSparkStatementResponse contains the response from method SessionClient.CreateSparkStatement.
 type SessionClientCreateSparkStatementResponse struct {
 	Statement
 }
 
-// SessionClientGetSparkSessionResponse contains the response from method sessionClient.GetSparkSession.
+// SessionClientGetSparkSessionResponse contains the response from method SessionClient.GetSparkSession.
 type SessionClientGetSparkSessionResponse struct {
 	Session
 }
 
-// SessionClientGetSparkSessionsResponse contains the response from method sessionClient.GetSparkSessions.
+// SessionClientGetSparkSessionsResponse contains the response from method SessionClient.GetSparkSessions.
 type SessionClientGetSparkSessionsResponse struct {
 	SessionCollection
 }
 
-// SessionClientGetSparkStatementResponse contains the response from method sessionClient.GetSparkStatement.
+// SessionClientGetSparkStatementResponse contains the response from method SessionClient.GetSparkStatement.
 type SessionClientGetSparkStatementResponse struct {
 	Statement
 }
 
-// SessionClientGetSparkStatementsResponse contains the response from method sessionClient.GetSparkStatements.
+// SessionClientGetSparkStatementsResponse contains the response from method SessionClient.GetSparkStatements.
 type SessionClientGetSparkStatementsResponse struct {
 	StatementCollection
 }
 
-// SessionClientResetSparkSessionTimeoutResponse contains the response from method sessionClient.ResetSparkSessionTimeout.
+// SessionClientResetSparkSessionTimeoutResponse contains the response from method SessionClient.ResetSparkSessionTimeout.
 type SessionClientResetSparkSessionTimeoutResponse struct {
 	// placeholder for future response values
 }

--- a/test/synapse/2019-06-01/azspark/zz_session_client.go
+++ b/test/synapse/2019-06-01/azspark/zz_session_client.go
@@ -11,6 +11,7 @@ package azspark
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,30 +20,11 @@ import (
 	"strings"
 )
 
-type sessionClient struct {
+// SessionClient contains the methods for the SparkSession group.
+// Don't use this type directly, use a constructor function instead.
+type SessionClient struct {
+	internal *azcore.Client
 	endpoint string
-	pl       runtime.Pipeline
-}
-
-// newSessionClient creates a new instance of sessionClient with the specified values.
-//   - endpoint - The workspace development endpoint, for example https://myworkspace.dev.azuresynapse.net.
-//   - livyAPIVersion - Valid api-version for the request.
-//   - sparkPoolName - Name of the spark pool.
-//   - pl - the pipeline used for sending requests and handling responses.
-func newSessionClient(endpoint string, livyAPIVersion *string, sparkPoolName string, pl runtime.Pipeline) *sessionClient {
-	hostURL := "{endpoint}/livyApi/versions/{livyApiVersion}/sparkPools/{sparkPoolName}"
-	hostURL = strings.ReplaceAll(hostURL, "{endpoint}", endpoint)
-	if livyAPIVersion == nil {
-		defaultValue := "2019-11-01-preview"
-		livyAPIVersion = &defaultValue
-	}
-	hostURL = strings.ReplaceAll(hostURL, "{livyApiVersion}", *livyAPIVersion)
-	hostURL = strings.ReplaceAll(hostURL, "{sparkPoolName}", sparkPoolName)
-	client := &sessionClient{
-		endpoint: hostURL,
-		pl:       pl,
-	}
-	return client
 }
 
 // CancelSparkSession - Cancels a running spark session.
@@ -50,14 +32,14 @@ func newSessionClient(endpoint string, livyAPIVersion *string, sparkPoolName str
 //
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
-//   - options - SessionClientCancelSparkSessionOptions contains the optional parameters for the sessionClient.CancelSparkSession
+//   - options - SessionClientCancelSparkSessionOptions contains the optional parameters for the SessionClient.CancelSparkSession
 //     method.
-func (client *sessionClient) CancelSparkSession(ctx context.Context, sessionID int32, options *SessionClientCancelSparkSessionOptions) (SessionClientCancelSparkSessionResponse, error) {
+func (client *SessionClient) CancelSparkSession(ctx context.Context, sessionID int32, options *SessionClientCancelSparkSessionOptions) (SessionClientCancelSparkSessionResponse, error) {
 	req, err := client.cancelSparkSessionCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SessionClientCancelSparkSessionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientCancelSparkSessionResponse{}, err
 	}
@@ -68,7 +50,7 @@ func (client *sessionClient) CancelSparkSession(ctx context.Context, sessionID i
 }
 
 // cancelSparkSessionCreateRequest creates the CancelSparkSession request.
-func (client *sessionClient) cancelSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SessionClientCancelSparkSessionOptions) (*policy.Request, error) {
+func (client *SessionClient) cancelSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SessionClientCancelSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodDelete, runtime.JoinPaths(client.endpoint, urlPath))
@@ -84,14 +66,14 @@ func (client *sessionClient) cancelSparkSessionCreateRequest(ctx context.Context
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
 //   - statementID - Identifier for the statement.
-//   - options - SessionClientCancelSparkStatementOptions contains the optional parameters for the sessionClient.CancelSparkStatement
+//   - options - SessionClientCancelSparkStatementOptions contains the optional parameters for the SessionClient.CancelSparkStatement
 //     method.
-func (client *sessionClient) CancelSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SessionClientCancelSparkStatementOptions) (SessionClientCancelSparkStatementResponse, error) {
+func (client *SessionClient) CancelSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SessionClientCancelSparkStatementOptions) (SessionClientCancelSparkStatementResponse, error) {
 	req, err := client.cancelSparkStatementCreateRequest(ctx, sessionID, statementID, options)
 	if err != nil {
 		return SessionClientCancelSparkStatementResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientCancelSparkStatementResponse{}, err
 	}
@@ -102,7 +84,7 @@ func (client *sessionClient) CancelSparkStatement(ctx context.Context, sessionID
 }
 
 // cancelSparkStatementCreateRequest creates the CancelSparkStatement request.
-func (client *sessionClient) cancelSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SessionClientCancelSparkStatementOptions) (*policy.Request, error) {
+func (client *SessionClient) cancelSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SessionClientCancelSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}/cancel"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementID), 10)))
@@ -115,7 +97,7 @@ func (client *sessionClient) cancelSparkStatementCreateRequest(ctx context.Conte
 }
 
 // cancelSparkStatementHandleResponse handles the CancelSparkStatement response.
-func (client *sessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (SessionClientCancelSparkStatementResponse, error) {
+func (client *SessionClient) cancelSparkStatementHandleResponse(resp *http.Response) (SessionClientCancelSparkStatementResponse, error) {
 	result := SessionClientCancelSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCancellationResult); err != nil {
 		return SessionClientCancelSparkStatementResponse{}, err
@@ -128,14 +110,14 @@ func (client *sessionClient) cancelSparkStatementHandleResponse(resp *http.Respo
 //
 // Generated from API version 2019-11-01-preview
 //   - sparkSessionOptions - Livy compatible batch job request payload.
-//   - options - SessionClientCreateSparkSessionOptions contains the optional parameters for the sessionClient.CreateSparkSession
+//   - options - SessionClientCreateSparkSessionOptions contains the optional parameters for the SessionClient.CreateSparkSession
 //     method.
-func (client *sessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SessionOptions, options *SessionClientCreateSparkSessionOptions) (SessionClientCreateSparkSessionResponse, error) {
+func (client *SessionClient) CreateSparkSession(ctx context.Context, sparkSessionOptions SessionOptions, options *SessionClientCreateSparkSessionOptions) (SessionClientCreateSparkSessionResponse, error) {
 	req, err := client.createSparkSessionCreateRequest(ctx, sparkSessionOptions, options)
 	if err != nil {
 		return SessionClientCreateSparkSessionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientCreateSparkSessionResponse{}, err
 	}
@@ -146,7 +128,7 @@ func (client *sessionClient) CreateSparkSession(ctx context.Context, sparkSessio
 }
 
 // createSparkSessionCreateRequest creates the CreateSparkSession request.
-func (client *sessionClient) createSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SessionOptions, options *SessionClientCreateSparkSessionOptions) (*policy.Request, error) {
+func (client *SessionClient) createSparkSessionCreateRequest(ctx context.Context, sparkSessionOptions SessionOptions, options *SessionClientCreateSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -162,7 +144,7 @@ func (client *sessionClient) createSparkSessionCreateRequest(ctx context.Context
 }
 
 // createSparkSessionHandleResponse handles the CreateSparkSession response.
-func (client *sessionClient) createSparkSessionHandleResponse(resp *http.Response) (SessionClientCreateSparkSessionResponse, error) {
+func (client *SessionClient) createSparkSessionHandleResponse(resp *http.Response) (SessionClientCreateSparkSessionResponse, error) {
 	result := SessionClientCreateSparkSessionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return SessionClientCreateSparkSessionResponse{}, err
@@ -176,14 +158,14 @@ func (client *sessionClient) createSparkSessionHandleResponse(resp *http.Respons
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
 //   - sparkStatementOptions - Livy compatible batch job request payload.
-//   - options - SessionClientCreateSparkStatementOptions contains the optional parameters for the sessionClient.CreateSparkStatement
+//   - options - SessionClientCreateSparkStatementOptions contains the optional parameters for the SessionClient.CreateSparkStatement
 //     method.
-func (client *sessionClient) CreateSparkStatement(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SessionClientCreateSparkStatementOptions) (SessionClientCreateSparkStatementResponse, error) {
+func (client *SessionClient) CreateSparkStatement(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SessionClientCreateSparkStatementOptions) (SessionClientCreateSparkStatementResponse, error) {
 	req, err := client.createSparkStatementCreateRequest(ctx, sessionID, sparkStatementOptions, options)
 	if err != nil {
 		return SessionClientCreateSparkStatementResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientCreateSparkStatementResponse{}, err
 	}
@@ -194,7 +176,7 @@ func (client *sessionClient) CreateSparkStatement(ctx context.Context, sessionID
 }
 
 // createSparkStatementCreateRequest creates the CreateSparkStatement request.
-func (client *sessionClient) createSparkStatementCreateRequest(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SessionClientCreateSparkStatementOptions) (*policy.Request, error) {
+func (client *SessionClient) createSparkStatementCreateRequest(ctx context.Context, sessionID int32, sparkStatementOptions StatementOptions, options *SessionClientCreateSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
@@ -206,7 +188,7 @@ func (client *sessionClient) createSparkStatementCreateRequest(ctx context.Conte
 }
 
 // createSparkStatementHandleResponse handles the CreateSparkStatement response.
-func (client *sessionClient) createSparkStatementHandleResponse(resp *http.Response) (SessionClientCreateSparkStatementResponse, error) {
+func (client *SessionClient) createSparkStatementHandleResponse(resp *http.Response) (SessionClientCreateSparkStatementResponse, error) {
 	result := SessionClientCreateSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return SessionClientCreateSparkStatementResponse{}, err
@@ -219,13 +201,13 @@ func (client *sessionClient) createSparkStatementHandleResponse(resp *http.Respo
 //
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
-//   - options - SessionClientGetSparkSessionOptions contains the optional parameters for the sessionClient.GetSparkSession method.
-func (client *sessionClient) GetSparkSession(ctx context.Context, sessionID int32, options *SessionClientGetSparkSessionOptions) (SessionClientGetSparkSessionResponse, error) {
+//   - options - SessionClientGetSparkSessionOptions contains the optional parameters for the SessionClient.GetSparkSession method.
+func (client *SessionClient) GetSparkSession(ctx context.Context, sessionID int32, options *SessionClientGetSparkSessionOptions) (SessionClientGetSparkSessionResponse, error) {
 	req, err := client.getSparkSessionCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SessionClientGetSparkSessionResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientGetSparkSessionResponse{}, err
 	}
@@ -236,7 +218,7 @@ func (client *sessionClient) GetSparkSession(ctx context.Context, sessionID int3
 }
 
 // getSparkSessionCreateRequest creates the GetSparkSession request.
-func (client *sessionClient) getSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SessionClientGetSparkSessionOptions) (*policy.Request, error) {
+func (client *SessionClient) getSparkSessionCreateRequest(ctx context.Context, sessionID int32, options *SessionClientGetSparkSessionOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -253,7 +235,7 @@ func (client *sessionClient) getSparkSessionCreateRequest(ctx context.Context, s
 }
 
 // getSparkSessionHandleResponse handles the GetSparkSession response.
-func (client *sessionClient) getSparkSessionHandleResponse(resp *http.Response) (SessionClientGetSparkSessionResponse, error) {
+func (client *SessionClient) getSparkSessionHandleResponse(resp *http.Response) (SessionClientGetSparkSessionResponse, error) {
 	result := SessionClientGetSparkSessionResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Session); err != nil {
 		return SessionClientGetSparkSessionResponse{}, err
@@ -265,14 +247,14 @@ func (client *sessionClient) getSparkSessionHandleResponse(resp *http.Response) 
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2019-11-01-preview
-//   - options - SessionClientGetSparkSessionsOptions contains the optional parameters for the sessionClient.GetSparkSessions
+//   - options - SessionClientGetSparkSessionsOptions contains the optional parameters for the SessionClient.GetSparkSessions
 //     method.
-func (client *sessionClient) GetSparkSessions(ctx context.Context, options *SessionClientGetSparkSessionsOptions) (SessionClientGetSparkSessionsResponse, error) {
+func (client *SessionClient) GetSparkSessions(ctx context.Context, options *SessionClientGetSparkSessionsOptions) (SessionClientGetSparkSessionsResponse, error) {
 	req, err := client.getSparkSessionsCreateRequest(ctx, options)
 	if err != nil {
 		return SessionClientGetSparkSessionsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientGetSparkSessionsResponse{}, err
 	}
@@ -283,7 +265,7 @@ func (client *sessionClient) GetSparkSessions(ctx context.Context, options *Sess
 }
 
 // getSparkSessionsCreateRequest creates the GetSparkSessions request.
-func (client *sessionClient) getSparkSessionsCreateRequest(ctx context.Context, options *SessionClientGetSparkSessionsOptions) (*policy.Request, error) {
+func (client *SessionClient) getSparkSessionsCreateRequest(ctx context.Context, options *SessionClientGetSparkSessionsOptions) (*policy.Request, error) {
 	urlPath := "/sessions"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -305,7 +287,7 @@ func (client *sessionClient) getSparkSessionsCreateRequest(ctx context.Context, 
 }
 
 // getSparkSessionsHandleResponse handles the GetSparkSessions response.
-func (client *sessionClient) getSparkSessionsHandleResponse(resp *http.Response) (SessionClientGetSparkSessionsResponse, error) {
+func (client *SessionClient) getSparkSessionsHandleResponse(resp *http.Response) (SessionClientGetSparkSessionsResponse, error) {
 	result := SessionClientGetSparkSessionsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.SessionCollection); err != nil {
 		return SessionClientGetSparkSessionsResponse{}, err
@@ -319,14 +301,14 @@ func (client *sessionClient) getSparkSessionsHandleResponse(resp *http.Response)
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
 //   - statementID - Identifier for the statement.
-//   - options - SessionClientGetSparkStatementOptions contains the optional parameters for the sessionClient.GetSparkStatement
+//   - options - SessionClientGetSparkStatementOptions contains the optional parameters for the SessionClient.GetSparkStatement
 //     method.
-func (client *sessionClient) GetSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SessionClientGetSparkStatementOptions) (SessionClientGetSparkStatementResponse, error) {
+func (client *SessionClient) GetSparkStatement(ctx context.Context, sessionID int32, statementID int32, options *SessionClientGetSparkStatementOptions) (SessionClientGetSparkStatementResponse, error) {
 	req, err := client.getSparkStatementCreateRequest(ctx, sessionID, statementID, options)
 	if err != nil {
 		return SessionClientGetSparkStatementResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientGetSparkStatementResponse{}, err
 	}
@@ -337,7 +319,7 @@ func (client *sessionClient) GetSparkStatement(ctx context.Context, sessionID in
 }
 
 // getSparkStatementCreateRequest creates the GetSparkStatement request.
-func (client *sessionClient) getSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SessionClientGetSparkStatementOptions) (*policy.Request, error) {
+func (client *SessionClient) getSparkStatementCreateRequest(ctx context.Context, sessionID int32, statementID int32, options *SessionClientGetSparkStatementOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements/{statementId}"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	urlPath = strings.ReplaceAll(urlPath, "{statementId}", url.PathEscape(strconv.FormatInt(int64(statementID), 10)))
@@ -350,7 +332,7 @@ func (client *sessionClient) getSparkStatementCreateRequest(ctx context.Context,
 }
 
 // getSparkStatementHandleResponse handles the GetSparkStatement response.
-func (client *sessionClient) getSparkStatementHandleResponse(resp *http.Response) (SessionClientGetSparkStatementResponse, error) {
+func (client *SessionClient) getSparkStatementHandleResponse(resp *http.Response) (SessionClientGetSparkStatementResponse, error) {
 	result := SessionClientGetSparkStatementResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Statement); err != nil {
 		return SessionClientGetSparkStatementResponse{}, err
@@ -363,14 +345,14 @@ func (client *sessionClient) getSparkStatementHandleResponse(resp *http.Response
 //
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
-//   - options - SessionClientGetSparkStatementsOptions contains the optional parameters for the sessionClient.GetSparkStatements
+//   - options - SessionClientGetSparkStatementsOptions contains the optional parameters for the SessionClient.GetSparkStatements
 //     method.
-func (client *sessionClient) GetSparkStatements(ctx context.Context, sessionID int32, options *SessionClientGetSparkStatementsOptions) (SessionClientGetSparkStatementsResponse, error) {
+func (client *SessionClient) GetSparkStatements(ctx context.Context, sessionID int32, options *SessionClientGetSparkStatementsOptions) (SessionClientGetSparkStatementsResponse, error) {
 	req, err := client.getSparkStatementsCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SessionClientGetSparkStatementsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientGetSparkStatementsResponse{}, err
 	}
@@ -381,7 +363,7 @@ func (client *sessionClient) GetSparkStatements(ctx context.Context, sessionID i
 }
 
 // getSparkStatementsCreateRequest creates the GetSparkStatements request.
-func (client *sessionClient) getSparkStatementsCreateRequest(ctx context.Context, sessionID int32, options *SessionClientGetSparkStatementsOptions) (*policy.Request, error) {
+func (client *SessionClient) getSparkStatementsCreateRequest(ctx context.Context, sessionID int32, options *SessionClientGetSparkStatementsOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/statements"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
@@ -393,7 +375,7 @@ func (client *sessionClient) getSparkStatementsCreateRequest(ctx context.Context
 }
 
 // getSparkStatementsHandleResponse handles the GetSparkStatements response.
-func (client *sessionClient) getSparkStatementsHandleResponse(resp *http.Response) (SessionClientGetSparkStatementsResponse, error) {
+func (client *SessionClient) getSparkStatementsHandleResponse(resp *http.Response) (SessionClientGetSparkStatementsResponse, error) {
 	result := SessionClientGetSparkStatementsResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.StatementCollection); err != nil {
 		return SessionClientGetSparkStatementsResponse{}, err
@@ -406,14 +388,14 @@ func (client *sessionClient) getSparkStatementsHandleResponse(resp *http.Respons
 //
 // Generated from API version 2019-11-01-preview
 //   - sessionID - Identifier for the session.
-//   - options - SessionClientResetSparkSessionTimeoutOptions contains the optional parameters for the sessionClient.ResetSparkSessionTimeout
+//   - options - SessionClientResetSparkSessionTimeoutOptions contains the optional parameters for the SessionClient.ResetSparkSessionTimeout
 //     method.
-func (client *sessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionID int32, options *SessionClientResetSparkSessionTimeoutOptions) (SessionClientResetSparkSessionTimeoutResponse, error) {
+func (client *SessionClient) ResetSparkSessionTimeout(ctx context.Context, sessionID int32, options *SessionClientResetSparkSessionTimeoutOptions) (SessionClientResetSparkSessionTimeoutResponse, error) {
 	req, err := client.resetSparkSessionTimeoutCreateRequest(ctx, sessionID, options)
 	if err != nil {
 		return SessionClientResetSparkSessionTimeoutResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return SessionClientResetSparkSessionTimeoutResponse{}, err
 	}
@@ -424,7 +406,7 @@ func (client *sessionClient) ResetSparkSessionTimeout(ctx context.Context, sessi
 }
 
 // resetSparkSessionTimeoutCreateRequest creates the ResetSparkSessionTimeout request.
-func (client *sessionClient) resetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionID int32, options *SessionClientResetSparkSessionTimeoutOptions) (*policy.Request, error) {
+func (client *SessionClient) resetSparkSessionTimeoutCreateRequest(ctx context.Context, sessionID int32, options *SessionClientResetSparkSessionTimeoutOptions) (*policy.Request, error) {
 	urlPath := "/sessions/{sessionId}/reset-timeout"
 	urlPath = strings.ReplaceAll(urlPath, "{sessionId}", url.PathEscape(strconv.FormatInt(int64(sessionID), 10)))
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))

--- a/test/tables/2019-02-02/aztables/go.mod
+++ b/test/tables/2019-02-02/aztables/go.mod
@@ -2,10 +2,10 @@ module aztables
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0
 
 require (
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/test/tables/2019-02-02/aztables/go.sum
+++ b/test/tables/2019-02-02/aztables/go.sum
@@ -1,7 +1,7 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0 h1:sVPhtT2qjO86rTUaWMr4WoES4TkjGnzcioXcnHV9s5k=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.0.0/go.mod h1:uGG2W01BaETf0Ozp+QxxKJdMBNRWPdstHG0Fmdwn1/U=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0 h1:jp0dGvZ7ZK0mgqnTSClMxa5xuRL7NZgHameVYF6BurY=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.0.0/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 h1:VuHAcMq8pU1IWNT/m5yRaGqbK0BiQKHT8X4DTp9CHdI=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0/go.mod h1:tZoQYdDZNOiIjdSn0dVWVfl0NEPGOJqVLzSrcFk4Is0=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1 h1:Oj853U9kG+RLTCQXpjvOnrv0WaZHxgmZz1TlLywgOPY=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.1/go.mod h1:eWRD7oawr1Mu1sLCawqVc0CUiF43ia3qQMxLscsKQ9w=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=

--- a/test/tables/2019-02-02/aztables/zz_client.go
+++ b/test/tables/2019-02-02/aztables/zz_client.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/xml"
 	"errors"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -23,24 +24,11 @@ import (
 )
 
 // Client contains the methods for the Table group.
-// Don't use this type directly, use NewClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type Client struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum0
-	pl       runtime.Pipeline
-}
-
-// NewClient creates a new instance of Client with the specified values.
-//   - endpoint - The URL of the service account or table that is the target of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewClient(endpoint string, version Enum0, pl runtime.Pipeline) *Client {
-	client := &Client{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // Create - Creates a new table under the given account.
@@ -55,7 +43,7 @@ func (client *Client) Create(ctx context.Context, dataServiceVersion Enum1, tabl
 	if err != nil {
 		return ClientCreateResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientCreateResponse{}, err
 	}
@@ -128,7 +116,7 @@ func (client *Client) Delete(ctx context.Context, table string, options *ClientD
 	if err != nil {
 		return ClientDeleteResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteResponse{}, err
 	}
@@ -195,7 +183,7 @@ func (client *Client) DeleteEntity(ctx context.Context, dataServiceVersion Enum1
 	if err != nil {
 		return ClientDeleteEntityResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientDeleteEntityResponse{}, err
 	}
@@ -277,7 +265,7 @@ func (client *Client) GetAccessPolicy(ctx context.Context, table string, comp En
 	if err != nil {
 		return ClientGetAccessPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientGetAccessPolicyResponse{}, err
 	}
@@ -349,7 +337,7 @@ func (client *Client) InsertEntity(ctx context.Context, dataServiceVersion Enum1
 	if err != nil {
 		return ClientInsertEntityResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientInsertEntityResponse{}, err
 	}
@@ -442,7 +430,7 @@ func (client *Client) MergeEntity(ctx context.Context, dataServiceVersion Enum1,
 	if err != nil {
 		return ClientMergeEntityResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientMergeEntityResponse{}, err
 	}
@@ -527,7 +515,7 @@ func (client *Client) Query(ctx context.Context, dataServiceVersion Enum1, optio
 	if err != nil {
 		return ClientQueryResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientQueryResponse{}, err
 	}
@@ -610,7 +598,7 @@ func (client *Client) QueryEntities(ctx context.Context, dataServiceVersion Enum
 	if err != nil {
 		return ClientQueryEntitiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientQueryEntitiesResponse{}, err
 	}
@@ -709,7 +697,7 @@ func (client *Client) QueryEntityWithPartitionAndRowKey(ctx context.Context, dat
 	if err != nil {
 		return ClientQueryEntityWithPartitionAndRowKeyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientQueryEntityWithPartitionAndRowKeyResponse{}, err
 	}
@@ -808,7 +796,7 @@ func (client *Client) SetAccessPolicy(ctx context.Context, table string, comp En
 	if err != nil {
 		return ClientSetAccessPolicyResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientSetAccessPolicyResponse{}, err
 	}
@@ -884,7 +872,7 @@ func (client *Client) UpdateEntity(ctx context.Context, dataServiceVersion Enum1
 	if err != nil {
 		return ClientUpdateEntityResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ClientUpdateEntityResponse{}, err
 	}

--- a/test/tables/2019-02-02/aztables/zz_service_client.go
+++ b/test/tables/2019-02-02/aztables/zz_service_client.go
@@ -11,6 +11,7 @@ package aztables
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
@@ -19,24 +20,11 @@ import (
 )
 
 // ServiceClient contains the methods for the Service group.
-// Don't use this type directly, use NewServiceClient() instead.
+// Don't use this type directly, use a constructor function instead.
 type ServiceClient struct {
+	internal *azcore.Client
 	endpoint string
 	version  Enum0
-	pl       runtime.Pipeline
-}
-
-// NewServiceClient creates a new instance of ServiceClient with the specified values.
-//   - endpoint - The URL of the service account or table that is the target of the desired operation.
-//   - version - Specifies the version of the operation to use for this request.
-//   - pl - the pipeline used for sending requests and handling responses.
-func NewServiceClient(endpoint string, version Enum0, pl runtime.Pipeline) *ServiceClient {
-	client := &ServiceClient{
-		endpoint: endpoint,
-		version:  version,
-		pl:       pl,
-	}
-	return client
 }
 
 // GetProperties - Gets the properties of an account's Table service, including properties for Analytics and CORS (Cross-Origin
@@ -52,7 +40,7 @@ func (client *ServiceClient) GetProperties(ctx context.Context, restype Enum5, c
 	if err != nil {
 		return ServiceClientGetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetPropertiesResponse{}, err
 	}
@@ -114,7 +102,7 @@ func (client *ServiceClient) GetStatistics(ctx context.Context, restype Enum5, c
 	if err != nil {
 		return ServiceClientGetStatisticsResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientGetStatisticsResponse{}, err
 	}
@@ -184,7 +172,7 @@ func (client *ServiceClient) SetProperties(ctx context.Context, restype Enum5, c
 	if err != nil {
 		return ServiceClientSetPropertiesResponse{}, err
 	}
-	resp, err := client.pl.Do(req)
+	resp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
 		return ServiceClientSetPropertiesResponse{}, err
 	}


### PR DESCRIPTION
Generated clients now contain an internal client from azcore. Removed client constructors for non-ARM targets.
Error on optional client parameters for ARM.
Exporting clients is now on by default.