### PR TITLE
Fix for the preview.46

### DIFF
--- a/src/generator/clientFactory.ts
+++ b/src/generator/clientFactory.ts
@@ -56,7 +56,7 @@ export async function generateClientFactory(session: Session<CodeModel>): Promis
     result += `${formatCommentAsBulletItem('credential - used to authorize requests. Usually a credential from azidentity.')}\n`;
     result += `${formatCommentAsBulletItem('options - pass nil to accept the default values.')}\n`;
 
-    result += `func NewClientFactory(${allClientParams.map(p => {return `${p.language.go!.name} ${formatParameterTypeName(p)}`;}).join(', ')}, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
+    result += `func NewClientFactory(${allClientParams.map(p => {return `${p.language.go!.name} ${formatParameterTypeName(p)}`;}).join(', ')}${allClientParams.length>0 ? ',' : ''} credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
     result += '\t_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)\n';
     result += '\tif err != nil {\n';
     result += '\t\treturn nil, err\n';

--- a/src/generator/clientFactory.ts
+++ b/src/generator/clientFactory.ts
@@ -57,7 +57,7 @@ export async function generateClientFactory(session: Session<CodeModel>): Promis
     result += `${formatCommentAsBulletItem('options - pass nil to accept the default values.')}\n`;
 
     result += `func NewClientFactory(${allClientParams.map(p => {return `${p.language.go!.name} ${formatParameterTypeName(p)}`;}).join(', ')}${allClientParams.length>0 ? ',' : ''} credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
-    result += '\t_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)\n';
+    result += '\t_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)\n';
     result += '\tif err != nil {\n';
     result += '\t\treturn nil, err\n';
     result += '\t}\n';

--- a/src/generator/operations.ts
+++ b/src/generator/operations.ts
@@ -141,7 +141,7 @@ export async function generateOperations(session: Session<CodeModel>): Promise<O
       }
 
       clientText += `func ${group.language.go!.clientCtorName}(${methodParams.join(', ')}) (*${clientName}, error) {\n`;
-      clientText += `\tcl, err := ${clientPkg}.NewClient("${session.model.language.go!.packageName}.${clientName}", moduleVersion, credential, options)\n`;
+      clientText += `\tcl, err := ${clientPkg}.NewClient(moduleName+".${clientName}", moduleVersion, credential, options)\n`;
       clientText += "\tif err != nil {\n"
       clientText += '\t\treturn nil, err\n';
       clientText += '\t}\n';

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.46",
+  "version": "4.0.0-preview.47",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/test/compute/2019-12-01/armcompute/zz_availabilitysets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_availabilitysets_client.go
@@ -34,7 +34,7 @@ type AvailabilitySetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailabilitySetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailabilitySetsClient, error) {
-	cl, err := arm.NewClient("armcompute.AvailabilitySetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailabilitySetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_client_factory.go
+++ b/test/compute/2019-12-01/armcompute/zz_client_factory.go
@@ -29,7 +29,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_containerservices_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_containerservices_client.go
@@ -34,7 +34,7 @@ type ContainerServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewContainerServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ContainerServicesClient, error) {
-	cl, err := arm.NewClient("armcompute.ContainerServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ContainerServicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_dedicatedhostgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_dedicatedhostgroups_client.go
@@ -34,7 +34,7 @@ type DedicatedHostGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDedicatedHostGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostGroupsClient, error) {
-	cl, err := arm.NewClient("armcompute.DedicatedHostGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DedicatedHostGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_dedicatedhosts_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_dedicatedhosts_client.go
@@ -34,7 +34,7 @@ type DedicatedHostsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDedicatedHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostsClient, error) {
-	cl, err := arm.NewClient("armcompute.DedicatedHostsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DedicatedHostsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_diskencryptionsets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_diskencryptionsets_client.go
@@ -34,7 +34,7 @@ type DiskEncryptionSetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiskEncryptionSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskEncryptionSetsClient, error) {
-	cl, err := arm.NewClient("armcompute.DiskEncryptionSetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DiskEncryptionSetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_disks_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_disks_client.go
@@ -34,7 +34,7 @@ type DisksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDisksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DisksClient, error) {
-	cl, err := arm.NewClient("armcompute.DisksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DisksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_galleries_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_galleries_client.go
@@ -34,7 +34,7 @@ type GalleriesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleriesClient, error) {
-	cl, err := arm.NewClient("armcompute.GalleriesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".GalleriesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_galleryapplications_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_galleryapplications_client.go
@@ -34,7 +34,7 @@ type GalleryApplicationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryApplicationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationsClient, error) {
-	cl, err := arm.NewClient("armcompute.GalleryApplicationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".GalleryApplicationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_galleryapplicationversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_galleryapplicationversions_client.go
@@ -34,7 +34,7 @@ type GalleryApplicationVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryApplicationVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationVersionsClient, error) {
-	cl, err := arm.NewClient("armcompute.GalleryApplicationVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".GalleryApplicationVersionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_galleryimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_galleryimages_client.go
@@ -34,7 +34,7 @@ type GalleryImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImagesClient, error) {
-	cl, err := arm.NewClient("armcompute.GalleryImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".GalleryImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_galleryimageversions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_galleryimageversions_client.go
@@ -34,7 +34,7 @@ type GalleryImageVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImageVersionsClient, error) {
-	cl, err := arm.NewClient("armcompute.GalleryImageVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".GalleryImageVersionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_images_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_images_client.go
@@ -34,7 +34,7 @@ type ImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ImagesClient, error) {
-	cl, err := arm.NewClient("armcompute.ImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_loganalytics_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_loganalytics_client.go
@@ -34,7 +34,7 @@ type LogAnalyticsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLogAnalyticsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LogAnalyticsClient, error) {
-	cl, err := arm.NewClient("armcompute.LogAnalyticsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LogAnalyticsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_operations_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_operations_client.go
@@ -28,7 +28,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient("armcompute.OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_proximityplacementgroups_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_proximityplacementgroups_client.go
@@ -34,7 +34,7 @@ type ProximityPlacementGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProximityPlacementGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProximityPlacementGroupsClient, error) {
-	cl, err := arm.NewClient("armcompute.ProximityPlacementGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ProximityPlacementGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_resourceskus_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_resourceskus_client.go
@@ -34,7 +34,7 @@ type ResourceSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceSKUsClient, error) {
-	cl, err := arm.NewClient("armcompute.ResourceSKUsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ResourceSKUsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_snapshots_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_snapshots_client.go
@@ -34,7 +34,7 @@ type SnapshotsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSnapshotsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SnapshotsClient, error) {
-	cl, err := arm.NewClient("armcompute.SnapshotsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SnapshotsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_sshpublickeys_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_sshpublickeys_client.go
@@ -34,7 +34,7 @@ type SSHPublicKeysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSSHPublicKeysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SSHPublicKeysClient, error) {
-	cl, err := arm.NewClient("armcompute.SSHPublicKeysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SSHPublicKeysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_usage_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_usage_client.go
@@ -34,7 +34,7 @@ type UsageClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageClient, error) {
-	cl, err := arm.NewClient("armcompute.UsageClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".UsageClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineextensionimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineextensionimages_client.go
@@ -35,7 +35,7 @@ type VirtualMachineExtensionImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineExtensionImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionImagesClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineExtensionImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineExtensionImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineextensions_client.go
@@ -34,7 +34,7 @@ type VirtualMachineExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineExtensionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineimages_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineimages_client.go
@@ -35,7 +35,7 @@ type VirtualMachineImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineImagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachineruncommands_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachineruncommands_client.go
@@ -34,7 +34,7 @@ type VirtualMachineRunCommandsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineRunCommandsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineRunCommandsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineRunCommandsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachines_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachines_client.go
@@ -35,7 +35,7 @@ type VirtualMachinesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachinesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachinesClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachinesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachinesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetextensions_client.go
@@ -34,7 +34,7 @@ type VirtualMachineScaleSetExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetExtensionsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetExtensionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
@@ -34,7 +34,7 @@ type VirtualMachineScaleSetRollingUpgradesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetRollingUpgradesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetRollingUpgradesClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetRollingUpgradesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetRollingUpgradesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesets_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesets_client.go
@@ -35,7 +35,7 @@ type VirtualMachineScaleSetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetvmextensions_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetvmextensions_client.go
@@ -34,7 +34,7 @@ type VirtualMachineScaleSetVMExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMExtensionsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetVMExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetVMExtensionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetvms_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinescalesetvms_client.go
@@ -35,7 +35,7 @@ type VirtualMachineScaleSetVMsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMsClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineScaleSetVMsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetVMsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/compute/2019-12-01/armcompute/zz_virtualmachinesizes_client.go
+++ b/test/compute/2019-12-01/armcompute/zz_virtualmachinesizes_client.go
@@ -34,7 +34,7 @@ type VirtualMachineSizesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
-	cl, err := arm.NewClient("armcompute.VirtualMachineSizesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualMachineSizesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_aggregatedcost_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_aggregatedcost_client.go
@@ -31,7 +31,7 @@ type AggregatedCostClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAggregatedCostClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*AggregatedCostClient, error) {
-	cl, err := arm.NewClient("armconsumption.AggregatedCostClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AggregatedCostClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_balances_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_balances_client.go
@@ -31,7 +31,7 @@ type BalancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBalancesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BalancesClient, error) {
-	cl, err := arm.NewClient("armconsumption.BalancesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".BalancesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_budgets_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_budgets_client.go
@@ -31,7 +31,7 @@ type BudgetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBudgetsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BudgetsClient, error) {
-	cl, err := arm.NewClient("armconsumption.BudgetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".BudgetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_charges_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_charges_client.go
@@ -29,7 +29,7 @@ type ChargesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewChargesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ChargesClient, error) {
-	cl, err := arm.NewClient("armconsumption.ChargesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ChargesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_client_factory.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_client_factory.go
@@ -28,7 +28,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_credits_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_credits_client.go
@@ -29,7 +29,7 @@ type CreditsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCreditsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*CreditsClient, error) {
-	cl, err := arm.NewClient("armconsumption.CreditsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".CreditsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_events_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_events_client.go
@@ -29,7 +29,7 @@ type EventsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewEventsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*EventsClient, error) {
-	cl, err := arm.NewClient("armconsumption.EventsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".EventsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_forecasts_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_forecasts_client.go
@@ -33,7 +33,7 @@ type ForecastsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewForecastsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ForecastsClient, error) {
-	cl, err := arm.NewClient("armconsumption.ForecastsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ForecastsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_lots_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_lots_client.go
@@ -29,7 +29,7 @@ type LotsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLotsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*LotsClient, error) {
-	cl, err := arm.NewClient("armconsumption.LotsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LotsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_marketplaces_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_marketplaces_client.go
@@ -30,7 +30,7 @@ type MarketplacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewMarketplacesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*MarketplacesClient, error) {
-	cl, err := arm.NewClient("armconsumption.MarketplacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".MarketplacesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_operations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_operations_client.go
@@ -28,7 +28,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient("armconsumption.OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_pricesheet_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_pricesheet_client.go
@@ -34,7 +34,7 @@ type PriceSheetClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPriceSheetClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PriceSheetClient, error) {
-	cl, err := arm.NewClient("armconsumption.PriceSheetClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PriceSheetClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendationdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendationdetails_client.go
@@ -29,7 +29,7 @@ type ReservationRecommendationDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationDetailsClient, error) {
-	cl, err := arm.NewClient("armconsumption.ReservationRecommendationDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ReservationRecommendationDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendations_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationrecommendations_client.go
@@ -29,7 +29,7 @@ type ReservationRecommendationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationsClient, error) {
-	cl, err := arm.NewClient("armconsumption.ReservationRecommendationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ReservationRecommendationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationsdetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationsdetails_client.go
@@ -31,7 +31,7 @@ type ReservationsDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsDetailsClient, error) {
-	cl, err := arm.NewClient("armconsumption.ReservationsDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ReservationsDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationssummaries_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationssummaries_client.go
@@ -31,7 +31,7 @@ type ReservationsSummariesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsSummariesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsSummariesClient, error) {
-	cl, err := arm.NewClient("armconsumption.ReservationsSummariesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ReservationsSummariesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_reservationtransactions_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_reservationtransactions_client.go
@@ -31,7 +31,7 @@ type ReservationTransactionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationTransactionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationTransactionsClient, error) {
-	cl, err := arm.NewClient("armconsumption.ReservationTransactionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ReservationTransactionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_tags_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_tags_client.go
@@ -29,7 +29,7 @@ type TagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewTagsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*TagsClient, error) {
-	cl, err := arm.NewClient("armconsumption.TagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".TagsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/consumption/2019-10-01/armconsumption/zz_usagedetails_client.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_usagedetails_client.go
@@ -30,7 +30,7 @@ type UsageDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageDetailsClient, error) {
-	cl, err := arm.NewClient("armconsumption.UsageDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".UsageDetailsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_addons_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_addons_client.go
@@ -33,7 +33,7 @@ type AddonsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAddonsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AddonsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.AddonsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AddonsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_alerts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_alerts_client.go
@@ -33,7 +33,7 @@ type AlertsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAlertsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AlertsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.AlertsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AlertsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_availableskus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_availableskus_client.go
@@ -33,7 +33,7 @@ type AvailableSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableSKUsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.AvailableSKUsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailableSKUsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_bandwidthschedules_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_bandwidthschedules_client.go
@@ -33,7 +33,7 @@ type BandwidthSchedulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBandwidthSchedulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BandwidthSchedulesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.BandwidthSchedulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".BandwidthSchedulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_client_factory.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_client_factory.go
@@ -28,7 +28,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_containers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_containers_client.go
@@ -33,7 +33,7 @@ type ContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ContainersClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.ContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ContainersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_devices_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_devices_client.go
@@ -33,7 +33,7 @@ type DevicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDevicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DevicesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.DevicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DevicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_diagnosticsettings_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_diagnosticsettings_client.go
@@ -33,7 +33,7 @@ type DiagnosticSettingsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiagnosticSettingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiagnosticSettingsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.DiagnosticSettingsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DiagnosticSettingsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_jobs_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_jobs_client.go
@@ -33,7 +33,7 @@ type JobsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.JobsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".JobsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_monitoringconfig_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_monitoringconfig_client.go
@@ -33,7 +33,7 @@ type MonitoringConfigClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewMonitoringConfigClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*MonitoringConfigClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.MonitoringConfigClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".MonitoringConfigClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_nodes_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_nodes_client.go
@@ -33,7 +33,7 @@ type NodesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNodesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NodesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.NodesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".NodesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_operations_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_operations_client.go
@@ -28,7 +28,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_operationsstatus_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_operationsstatus_client.go
@@ -33,7 +33,7 @@ type OperationsStatusClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsStatusClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.OperationsStatusClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OperationsStatusClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_orders_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_orders_client.go
@@ -33,7 +33,7 @@ type OrdersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOrdersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OrdersClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.OrdersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OrdersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_roles_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_roles_client.go
@@ -33,7 +33,7 @@ type RolesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRolesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RolesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.RolesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".RolesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_shares_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_shares_client.go
@@ -33,7 +33,7 @@ type SharesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSharesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.SharesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SharesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_storageaccountcredentials_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_storageaccountcredentials_client.go
@@ -33,7 +33,7 @@ type StorageAccountCredentialsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewStorageAccountCredentialsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountCredentialsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.StorageAccountCredentialsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".StorageAccountCredentialsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_storageaccounts_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_storageaccounts_client.go
@@ -33,7 +33,7 @@ type StorageAccountsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewStorageAccountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountsClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.StorageAccountsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".StorageAccountsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_supportpackages_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_supportpackages_client.go
@@ -33,7 +33,7 @@ type SupportPackagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSupportPackagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SupportPackagesClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.SupportPackagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SupportPackagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_triggers_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_triggers_client.go
@@ -33,7 +33,7 @@ type TriggersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewTriggersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*TriggersClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.TriggersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".TriggersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_users_client.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_users_client.go
@@ -33,7 +33,7 @@ type UsersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsersClient, error) {
-	cl, err := arm.NewClient("armdataboxedge.UsersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".UsersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_applicationgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_applicationgateways_client.go
@@ -34,7 +34,7 @@ type ApplicationGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.ApplicationGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ApplicationGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_applicationsecuritygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_applicationsecuritygroups_client.go
@@ -34,7 +34,7 @@ type ApplicationSecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationSecurityGroupsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ApplicationSecurityGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ApplicationSecurityGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availabledelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availabledelegations_client.go
@@ -34,7 +34,7 @@ type AvailableDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableDelegationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.AvailableDelegationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailableDelegationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableendpointservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableendpointservices_client.go
@@ -34,7 +34,7 @@ type AvailableEndpointServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableEndpointServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableEndpointServicesClient, error) {
-	cl, err := arm.NewClient("armnetwork.AvailableEndpointServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailableEndpointServicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableprivateendpointtypes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableprivateendpointtypes_client.go
@@ -34,7 +34,7 @@ type AvailablePrivateEndpointTypesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailablePrivateEndpointTypesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailablePrivateEndpointTypesClient, error) {
-	cl, err := arm.NewClient("armnetwork.AvailablePrivateEndpointTypesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailablePrivateEndpointTypesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableresourcegroupdelegations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableresourcegroupdelegations_client.go
@@ -34,7 +34,7 @@ type AvailableResourceGroupDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableResourceGroupDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableResourceGroupDelegationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.AvailableResourceGroupDelegationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailableResourceGroupDelegationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_availableservicealiases_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_availableservicealiases_client.go
@@ -34,7 +34,7 @@ type AvailableServiceAliasesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableServiceAliasesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableServiceAliasesClient, error) {
-	cl, err := arm.NewClient("armnetwork.AvailableServiceAliasesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AvailableServiceAliasesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_azurefirewallfqdntags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_azurefirewallfqdntags_client.go
@@ -34,7 +34,7 @@ type AzureFirewallFqdnTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallFqdnTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallFqdnTagsClient, error) {
-	cl, err := arm.NewClient("armnetwork.AzureFirewallFqdnTagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AzureFirewallFqdnTagsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_azurefirewalls_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_azurefirewalls_client.go
@@ -34,7 +34,7 @@ type AzureFirewallsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallsClient, error) {
-	cl, err := arm.NewClient("armnetwork.AzureFirewallsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".AzureFirewallsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_bastionhosts_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_bastionhosts_client.go
@@ -34,7 +34,7 @@ type BastionHostsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBastionHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BastionHostsClient, error) {
-	cl, err := arm.NewClient("armnetwork.BastionHostsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".BastionHostsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_bgpservicecommunities_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_bgpservicecommunities_client.go
@@ -34,7 +34,7 @@ type BgpServiceCommunitiesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBgpServiceCommunitiesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BgpServiceCommunitiesClient, error) {
-	cl, err := arm.NewClient("armnetwork.BgpServiceCommunitiesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".BgpServiceCommunitiesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_client_factory.go
+++ b/test/network/2020-03-01/armnetwork/zz_client_factory.go
@@ -29,7 +29,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient("armcompute.ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_connectionmonitors_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_connectionmonitors_client.go
@@ -34,7 +34,7 @@ type ConnectionMonitorsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewConnectionMonitorsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConnectionMonitorsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ConnectionMonitorsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ConnectionMonitorsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ddoscustompolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ddoscustompolicies_client.go
@@ -34,7 +34,7 @@ type DdosCustomPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosCustomPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosCustomPoliciesClient, error) {
-	cl, err := arm.NewClient("armnetwork.DdosCustomPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DdosCustomPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ddosprotectionplans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ddosprotectionplans_client.go
@@ -34,7 +34,7 @@ type DdosProtectionPlansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosProtectionPlansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosProtectionPlansClient, error) {
-	cl, err := arm.NewClient("armnetwork.DdosProtectionPlansClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DdosProtectionPlansClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_defaultsecurityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_defaultsecurityrules_client.go
@@ -34,7 +34,7 @@ type DefaultSecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDefaultSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DefaultSecurityRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.DefaultSecurityRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".DefaultSecurityRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitauthorizations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitauthorizations_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCircuitAuthorizationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitAuthorizationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitAuthorizationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitAuthorizationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitconnections_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuitpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuitpeerings_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCircuitPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitPeeringsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecircuits_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecircuits_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCircuitsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCircuitsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteconnections_client.go
@@ -34,7 +34,7 @@ type ExpressRouteConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCrossConnectionPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionPeeringsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCrossConnectionPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCrossConnectionPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutecrossconnections_client.go
@@ -34,7 +34,7 @@ type ExpressRouteCrossConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteCrossConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteCrossConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutegateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutegateways_client.go
@@ -34,7 +34,7 @@ type ExpressRouteGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressroutelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressroutelinks_client.go
@@ -34,7 +34,7 @@ type ExpressRouteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteLinksClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteports_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteports_client.go
@@ -34,7 +34,7 @@ type ExpressRoutePortsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRoutePortsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRoutePortsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteportslocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteportslocations_client.go
@@ -34,7 +34,7 @@ type ExpressRoutePortsLocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsLocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsLocationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRoutePortsLocationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRoutePortsLocationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_expressrouteserviceproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_expressrouteserviceproviders_client.go
@@ -34,7 +34,7 @@ type ExpressRouteServiceProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteServiceProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteServiceProvidersClient, error) {
-	cl, err := arm.NewClient("armnetwork.ExpressRouteServiceProvidersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ExpressRouteServiceProvidersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_firewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_firewallpolicies_client.go
@@ -34,7 +34,7 @@ type FirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPoliciesClient, error) {
-	cl, err := arm.NewClient("armnetwork.FirewallPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".FirewallPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_firewallpolicyrulegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_firewallpolicyrulegroups_client.go
@@ -34,7 +34,7 @@ type FirewallPolicyRuleGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPolicyRuleGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyRuleGroupsClient, error) {
-	cl, err := arm.NewClient("armnetwork.FirewallPolicyRuleGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".FirewallPolicyRuleGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_flowlogs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_flowlogs_client.go
@@ -34,7 +34,7 @@ type FlowLogsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFlowLogsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FlowLogsClient, error) {
-	cl, err := arm.NewClient("armnetwork.FlowLogsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".FlowLogsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_hubvirtualnetworkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_hubvirtualnetworkconnections_client.go
@@ -34,7 +34,7 @@ type HubVirtualNetworkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewHubVirtualNetworkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubVirtualNetworkConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.HubVirtualNetworkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".HubVirtualNetworkConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_inboundnatrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_inboundnatrules_client.go
@@ -34,7 +34,7 @@ type InboundNatRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInboundNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundNatRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.InboundNatRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".InboundNatRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfaceipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfaceipconfigurations_client.go
@@ -34,7 +34,7 @@ type InterfaceIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceIPConfigurationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.InterfaceIPConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".InterfaceIPConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfaceloadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfaceloadbalancers_client.go
@@ -34,7 +34,7 @@ type InterfaceLoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceLoadBalancersClient, error) {
-	cl, err := arm.NewClient("armnetwork.InterfaceLoadBalancersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".InterfaceLoadBalancersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfaces_client.go
@@ -34,7 +34,7 @@ type InterfacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfacesClient, error) {
-	cl, err := arm.NewClient("armnetwork.InterfacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".InterfacesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_interfacetapconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_interfacetapconfigurations_client.go
@@ -34,7 +34,7 @@ type InterfaceTapConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceTapConfigurationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.InterfaceTapConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".InterfaceTapConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ipallocations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ipallocations_client.go
@@ -34,7 +34,7 @@ type IPAllocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPAllocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPAllocationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.IPAllocationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".IPAllocationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_ipgroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_ipgroups_client.go
@@ -34,7 +34,7 @@ type IPGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPGroupsClient, error) {
-	cl, err := arm.NewClient("armnetwork.IPGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".IPGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerbackendaddresspools_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerbackendaddresspools_client.go
@@ -34,7 +34,7 @@ type LoadBalancerBackendAddressPoolsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerBackendAddressPoolsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerBackendAddressPoolsClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerBackendAddressPoolsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerBackendAddressPoolsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
@@ -34,7 +34,7 @@ type LoadBalancerFrontendIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerFrontendIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerFrontendIPConfigurationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerFrontendIPConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerFrontendIPConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerloadbalancingrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerloadbalancingrules_client.go
@@ -34,7 +34,7 @@ type LoadBalancerLoadBalancingRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerLoadBalancingRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerLoadBalancingRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerLoadBalancingRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerLoadBalancingRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancernetworkinterfaces_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancernetworkinterfaces_client.go
@@ -34,7 +34,7 @@ type LoadBalancerNetworkInterfacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerNetworkInterfacesClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerNetworkInterfacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerNetworkInterfacesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalanceroutboundrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalanceroutboundrules_client.go
@@ -34,7 +34,7 @@ type LoadBalancerOutboundRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerOutboundRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerOutboundRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerOutboundRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerOutboundRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancerprobes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancerprobes_client.go
@@ -34,7 +34,7 @@ type LoadBalancerProbesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerProbesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerProbesClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancerProbesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancerProbesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_loadbalancers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_loadbalancers_client.go
@@ -34,7 +34,7 @@ type LoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancersClient, error) {
-	cl, err := arm.NewClient("armnetwork.LoadBalancersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LoadBalancersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_localnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_localnetworkgateways_client.go
@@ -34,7 +34,7 @@ type LocalNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLocalNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LocalNetworkGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.LocalNetworkGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".LocalNetworkGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_management_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_management_client.go
@@ -34,7 +34,7 @@ type ManagementClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementClient, error) {
-	cl, err := arm.NewClient("armnetwork.ManagementClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ManagementClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_natgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_natgateways_client.go
@@ -34,7 +34,7 @@ type NatGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNatGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.NatGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".NatGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_operations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_operations_client.go
@@ -28,7 +28,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_p2svpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_p2svpngateways_client.go
@@ -34,7 +34,7 @@ type P2SVPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewP2SVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*P2SVPNGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.P2SVPNGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".P2SVPNGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_packetcaptures_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_packetcaptures_client.go
@@ -34,7 +34,7 @@ type PacketCapturesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPacketCapturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PacketCapturesClient, error) {
-	cl, err := arm.NewClient("armnetwork.PacketCapturesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PacketCapturesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_peerexpressroutecircuitconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_peerexpressroutecircuitconnections_client.go
@@ -34,7 +34,7 @@ type PeerExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPeerExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PeerExpressRouteCircuitConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.PeerExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PeerExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privatednszonegroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privatednszonegroups_client.go
@@ -34,7 +34,7 @@ type PrivateDNSZoneGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateDNSZoneGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateDNSZoneGroupsClient, error) {
-	cl, err := arm.NewClient("armnetwork.PrivateDNSZoneGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PrivateDNSZoneGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privateendpoints_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privateendpoints_client.go
@@ -34,7 +34,7 @@ type PrivateEndpointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointsClient, error) {
-	cl, err := arm.NewClient("armnetwork.PrivateEndpointsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PrivateEndpointsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_privatelinkservices_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_privatelinkservices_client.go
@@ -34,7 +34,7 @@ type PrivateLinkServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateLinkServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkServicesClient, error) {
-	cl, err := arm.NewClient("armnetwork.PrivateLinkServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PrivateLinkServicesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_profiles_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_profiles_client.go
@@ -34,7 +34,7 @@ type ProfilesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProfilesClient, error) {
-	cl, err := arm.NewClient("armnetwork.ProfilesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ProfilesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_publicipaddresses_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_publicipaddresses_client.go
@@ -34,7 +34,7 @@ type PublicIPAddressesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPAddressesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPAddressesClient, error) {
-	cl, err := arm.NewClient("armnetwork.PublicIPAddressesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PublicIPAddressesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_publicipprefixes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_publicipprefixes_client.go
@@ -34,7 +34,7 @@ type PublicIPPrefixesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPPrefixesClient, error) {
-	cl, err := arm.NewClient("armnetwork.PublicIPPrefixesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".PublicIPPrefixesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_resourcenavigationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_resourcenavigationlinks_client.go
@@ -34,7 +34,7 @@ type ResourceNavigationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceNavigationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceNavigationLinksClient, error) {
-	cl, err := arm.NewClient("armnetwork.ResourceNavigationLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ResourceNavigationLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routefilterrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routefilterrules_client.go
@@ -34,7 +34,7 @@ type RouteFilterRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFilterRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFilterRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.RouteFilterRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".RouteFilterRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routefilters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routefilters_client.go
@@ -34,7 +34,7 @@ type RouteFiltersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFiltersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFiltersClient, error) {
-	cl, err := arm.NewClient("armnetwork.RouteFiltersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".RouteFiltersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routes_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routes_client.go
@@ -34,7 +34,7 @@ type RoutesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRoutesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutesClient, error) {
-	cl, err := arm.NewClient("armnetwork.RoutesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".RoutesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_routetables_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_routetables_client.go
@@ -34,7 +34,7 @@ type RouteTablesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteTablesClient, error) {
-	cl, err := arm.NewClient("armnetwork.RouteTablesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".RouteTablesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securitygroups_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securitygroups_client.go
@@ -34,7 +34,7 @@ type SecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityGroupsClient, error) {
-	cl, err := arm.NewClient("armnetwork.SecurityGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SecurityGroupsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securitypartnerproviders_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securitypartnerproviders_client.go
@@ -34,7 +34,7 @@ type SecurityPartnerProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityPartnerProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityPartnerProvidersClient, error) {
-	cl, err := arm.NewClient("armnetwork.SecurityPartnerProvidersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SecurityPartnerProvidersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_securityrules_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_securityrules_client.go
@@ -34,7 +34,7 @@ type SecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityRulesClient, error) {
-	cl, err := arm.NewClient("armnetwork.SecurityRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SecurityRulesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceassociationlinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceassociationlinks_client.go
@@ -34,7 +34,7 @@ type ServiceAssociationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceAssociationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceAssociationLinksClient, error) {
-	cl, err := arm.NewClient("armnetwork.ServiceAssociationLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ServiceAssociationLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicies_client.go
@@ -34,7 +34,7 @@ type ServiceEndpointPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPoliciesClient, error) {
-	cl, err := arm.NewClient("armnetwork.ServiceEndpointPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ServiceEndpointPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicydefinitions_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_serviceendpointpolicydefinitions_client.go
@@ -34,7 +34,7 @@ type ServiceEndpointPolicyDefinitionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPolicyDefinitionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPolicyDefinitionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ServiceEndpointPolicyDefinitionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ServiceEndpointPolicyDefinitionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_servicetags_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_servicetags_client.go
@@ -34,7 +34,7 @@ type ServiceTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagsClient, error) {
-	cl, err := arm.NewClient("armnetwork.ServiceTagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".ServiceTagsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_subnets_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_subnets_client.go
@@ -34,7 +34,7 @@ type SubnetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubnetsClient, error) {
-	cl, err := arm.NewClient("armnetwork.SubnetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".SubnetsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_usages_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_usages_client.go
@@ -34,7 +34,7 @@ type UsagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
-	cl, err := arm.NewClient("armnetwork.UsagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".UsagesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualappliances_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualappliances_client.go
@@ -34,7 +34,7 @@ type VirtualAppliancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualAppliancesClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualAppliancesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualAppliancesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualhubroutetablev2s_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualhubroutetablev2s_client.go
@@ -34,7 +34,7 @@ type VirtualHubRouteTableV2SClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubRouteTableV2SClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubRouteTableV2SClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualHubRouteTableV2SClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualHubRouteTableV2SClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualhubs_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualhubs_client.go
@@ -34,7 +34,7 @@ type VirtualHubsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualHubsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualHubsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkgatewayconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkgatewayconnections_client.go
@@ -34,7 +34,7 @@ type VirtualNetworkGatewayConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewayConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualNetworkGatewayConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualNetworkGatewayConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkgateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkgateways_client.go
@@ -34,7 +34,7 @@ type VirtualNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualNetworkGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualNetworkGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworkpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworkpeerings_client.go
@@ -34,7 +34,7 @@ type VirtualNetworkPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkPeeringsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualNetworkPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualNetworkPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworks_client.go
@@ -34,7 +34,7 @@ type VirtualNetworksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworksClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualNetworksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualNetworksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualnetworktaps_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualnetworktaps_client.go
@@ -34,7 +34,7 @@ type VirtualNetworkTapsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkTapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkTapsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualNetworkTapsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualNetworkTapsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualrouterpeerings_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualrouterpeerings_client.go
@@ -34,7 +34,7 @@ type VirtualRouterPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRouterPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRouterPeeringsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualRouterPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualRouterPeeringsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualrouters_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualrouters_client.go
@@ -34,7 +34,7 @@ type VirtualRoutersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRoutersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRoutersClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualRoutersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualRoutersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_virtualwans_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_virtualwans_client.go
@@ -34,7 +34,7 @@ type VirtualWansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualWansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualWansClient, error) {
-	cl, err := arm.NewClient("armnetwork.VirtualWansClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VirtualWansClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnconnections_client.go
@@ -34,7 +34,7 @@ type VPNConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpngateways_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpngateways_client.go
@@ -34,7 +34,7 @@ type VPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNGatewaysClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNGatewaysClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnlinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnlinkconnections_client.go
@@ -34,7 +34,7 @@ type VPNLinkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNLinkConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNLinkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNLinkConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurations_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurations_client.go
@@ -34,7 +34,7 @@ type VPNServerConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNServerConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNServerConfigurationsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -34,7 +34,7 @@ type VPNServerConfigurationsAssociatedWithVirtualWanClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsAssociatedWithVirtualWanClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsAssociatedWithVirtualWanClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNServerConfigurationsAssociatedWithVirtualWanClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitelinkconnections_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitelinkconnections_client.go
@@ -34,7 +34,7 @@ type VPNSiteLinkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinkConnectionsClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNSiteLinkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNSiteLinkConnectionsClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitelinks_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitelinks_client.go
@@ -34,7 +34,7 @@ type VPNSiteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinksClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNSiteLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNSiteLinksClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsites_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsites_client.go
@@ -34,7 +34,7 @@ type VPNSitesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNSitesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNSitesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_vpnsitesconfiguration_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_vpnsitesconfiguration_client.go
@@ -34,7 +34,7 @@ type VPNSitesConfigurationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesConfigurationClient, error) {
-	cl, err := arm.NewClient("armnetwork.VPNSitesConfigurationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".VPNSitesConfigurationClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_watchers_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_watchers_client.go
@@ -34,7 +34,7 @@ type WatchersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WatchersClient, error) {
-	cl, err := arm.NewClient("armnetwork.WatchersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".WatchersClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/test/network/2020-03-01/armnetwork/zz_webapplicationfirewallpolicies_client.go
+++ b/test/network/2020-03-01/armnetwork/zz_webapplicationfirewallpolicies_client.go
@@ -34,7 +34,7 @@ type WebApplicationFirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWebApplicationFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebApplicationFirewallPoliciesClient, error) {
-	cl, err := arm.NewClient("armnetwork.WebApplicationFirewallPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName+".WebApplicationFirewallPoliciesClient", moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. Remove redundant comma when no client params for client factory.
2. Use `moduleName` instead of hard code pkg name in `NewClient` for arm.
3. Pump version to preview.47.