### PR TITLE
Omit tags for JSON marshalling/unmarshalling

### DIFF
--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -99,12 +99,10 @@ export class StructDef {
       if (prop.readOnly) {
         readOnly = ` azure:"ro"`;
       }
-      let tag = ` \`${this.Language.marshallingFormat}:"${serialization}"${readOnly}\``;
-      // if this is a response type then omit the tag IFF the marshalling format is
-      // JSON, or it's a header.  XML marshalling needs a tag.
-      // also omit the tag for additionalProperties
-      if ((this.Language.responseType === true && (this.Language.marshallingFormat !== 'xml')) || prop.language.go!.isAdditionalProperties) {
-        tag = '';
+      let tag = '';
+      // only emit tags for XML; JSON uses custom marshallers/unmarshallers
+      if (this.Language.marshallingFormat === 'xml' && !prop.language.go!.isAdditionalProperties) {
+        tag = ` \`${this.Language.marshallingFormat}:"${serialization}"${readOnly}\``;
       }
       let pointer = '*';
       if (prop.language.go!.byValue === true) {

--- a/test/acr/2021-07-01/azacr/zz_models.go
+++ b/test/acr/2021-07-01/azacr/zz_models.go
@@ -13,7 +13,7 @@ import "time"
 
 type AccessToken struct {
 	// The access token for performing authenticated requests
-	AccessToken *string `json:"access_token,omitempty"`
+	AccessToken *string
 }
 
 // Annotations - Additional information provided through arbitrary metadata.
@@ -22,77 +22,77 @@ type Annotations struct {
 	AdditionalProperties map[string]any
 
 	// Contact details of the people or organization responsible for the image.
-	Authors *string `json:"org.opencontainers.image.authors,omitempty"`
+	Authors *string
 
 	// Date and time on which the image was built (string, date-time as defined by https://tools.ietf.org/html/rfc3339#section-5.6)
-	Created *time.Time `json:"org.opencontainers.image.created,omitempty"`
+	Created *time.Time
 
 	// Human-readable description of the software packaged in the image
-	Description *string `json:"org.opencontainers.image.description,omitempty"`
+	Description *string
 
 	// URL to get documentation on the image.
-	Documentation *string `json:"org.opencontainers.image.documentation,omitempty"`
+	Documentation *string
 
 	// License(s) under which contained software is distributed as an SPDX License Expression.
-	Licenses *string `json:"org.opencontainers.image.licenses,omitempty"`
+	Licenses *string
 
 	// Name of the reference for a target.
-	Name *string `json:"org.opencontainers.image.ref.name,omitempty"`
+	Name *string
 
 	// Source control revision identifier for the packaged software.
-	Revision *string `json:"org.opencontainers.image.revision,omitempty"`
+	Revision *string
 
 	// URL to get source code for building the image.
-	Source *string `json:"org.opencontainers.image.source,omitempty"`
+	Source *string
 
 	// Human-readable title of the image
-	Title *string `json:"org.opencontainers.image.title,omitempty"`
+	Title *string
 
 	// URL to find more information on the image.
-	URL *string `json:"org.opencontainers.image.url,omitempty"`
+	URL *string
 
 	// Name of the distributing entity, organization or individual.
-	Vendor *string `json:"org.opencontainers.image.vendor,omitempty"`
+	Vendor *string
 
 	// Version of the packaged software. The version MAY match a label or tag in the source code repository, may also be Semantic
 	// versioning-compatible
-	Version *string `json:"org.opencontainers.image.version,omitempty"`
+	Version *string
 }
 
 // ArtifactManifestPlatform - The artifact's platform, consisting of operating system and architecture.
 type ArtifactManifestPlatform struct {
 	// READ-ONLY; Manifest digest
-	Digest *string `json:"digest,omitempty" azure:"ro"`
+	Digest *string
 
 	// READ-ONLY; CPU architecture
-	Architecture *ArtifactArchitecture `json:"architecture,omitempty" azure:"ro"`
+	Architecture *ArtifactArchitecture
 
 	// READ-ONLY; Operating system
-	OperatingSystem *ArtifactOperatingSystem `json:"os,omitempty" azure:"ro"`
+	OperatingSystem *ArtifactOperatingSystem
 }
 
 // ArtifactManifestProperties - Manifest attributes details
 type ArtifactManifestProperties struct {
 	// READ-ONLY; Manifest attributes
-	Manifest *ManifestAttributesBase `json:"manifest,omitempty" azure:"ro"`
+	Manifest *ManifestAttributesBase
 
 	// READ-ONLY; Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
-	RegistryLoginServer *string `json:"registry,omitempty" azure:"ro"`
+	RegistryLoginServer *string
 
 	// READ-ONLY; Repository name
-	RepositoryName *string `json:"imageName,omitempty" azure:"ro"`
+	RepositoryName *string
 }
 
 // ArtifactTagProperties - Tag attributes
 type ArtifactTagProperties struct {
 	// READ-ONLY; Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
-	RegistryLoginServer *string `json:"registry,omitempty" azure:"ro"`
+	RegistryLoginServer *string
 
 	// READ-ONLY; Image name
-	RepositoryName *string `json:"imageName,omitempty" azure:"ro"`
+	RepositoryName *string
 
 	// READ-ONLY; List of tag attribute details
-	Tag *TagAttributesBase `json:"tag,omitempty" azure:"ro"`
+	Tag *TagAttributesBase
 }
 
 // AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions contains the optional parameters for the AuthenticationClient.ExchangeAADAccessTokenForAcrRefreshToken
@@ -293,323 +293,323 @@ type ContainerRegistryClientUpdateTagAttributesOptions struct {
 // ContainerRepositoryProperties - Properties of this repository.
 type ContainerRepositoryProperties struct {
 	// REQUIRED; Writeable properties of the resource
-	ChangeableAttributes *RepositoryWriteableProperties `json:"changeableAttributes,omitempty"`
+	ChangeableAttributes *RepositoryWriteableProperties
 
 	// READ-ONLY; Image created time
-	CreatedOn *time.Time `json:"createdTime,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// READ-ONLY; Image last update time
-	LastUpdatedOn *time.Time `json:"lastUpdateTime,omitempty" azure:"ro"`
+	LastUpdatedOn *time.Time
 
 	// READ-ONLY; Number of the manifests
-	ManifestCount *int32 `json:"manifestCount,omitempty" azure:"ro"`
+	ManifestCount *int32
 
 	// READ-ONLY; Image name
-	Name *string `json:"imageName,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
-	RegistryLoginServer *string `json:"registry,omitempty" azure:"ro"`
+	RegistryLoginServer *string
 
 	// READ-ONLY; Number of the tags
-	TagCount *int32 `json:"tagCount,omitempty" azure:"ro"`
+	TagCount *int32
 }
 
 // DeleteRepositoryResult - Deleted repository
 type DeleteRepositoryResult struct {
 	// READ-ONLY; SHA of the deleted image
-	DeletedManifests []*string `json:"manifestsDeleted,omitempty" azure:"ro"`
+	DeletedManifests []*string
 
 	// READ-ONLY; Tag of the deleted image
-	DeletedTags []*string `json:"tagsDeleted,omitempty" azure:"ro"`
+	DeletedTags []*string
 }
 
 // Descriptor - Docker V2 image layer descriptor including config and layers
 type Descriptor struct {
 	// Additional information provided through arbitrary metadata.
-	Annotations *Annotations `json:"annotations,omitempty"`
+	Annotations *Annotations
 
 	// Layer digest
-	Digest *string `json:"digest,omitempty"`
+	Digest *string
 
 	// Layer media type
-	MediaType *string `json:"mediaType,omitempty"`
+	MediaType *string
 
 	// Layer size
-	Size *int64 `json:"size,omitempty"`
+	Size *int64
 
 	// Specifies a list of URIs from which this object may be downloaded.
-	Urls []*string `json:"urls,omitempty"`
+	Urls []*string
 }
 
 // ErrorInfo - Error information
 type ErrorInfo struct {
 	// Error code
-	Code *string `json:"code,omitempty"`
+	Code *string
 
 	// Error details
-	Detail []byte `json:"detail,omitempty"`
+	Detail []byte
 
 	// Error message
-	Message *string `json:"message,omitempty"`
+	Message *string
 }
 
 // Errors - Acr error response describing why the operation failed
 type Errors struct {
 	// Array of detailed error
-	Errors []*ErrorInfo `json:"errors,omitempty"`
+	Errors []*ErrorInfo
 }
 
 // FsLayer - Image layer information
 type FsLayer struct {
 	// SHA of an image layer
-	BlobSum *string `json:"blobSum,omitempty"`
+	BlobSum *string
 }
 
 // History - A list of unstructured historical data for v1 compatibility
 type History struct {
 	// The raw v1 compatibility information
-	V1Compatibility *string `json:"v1Compatibility,omitempty"`
+	V1Compatibility *string
 }
 
 // ImageSignature - Signature of a signed manifest
 type ImageSignature struct {
 	// A JSON web signature
-	Header *JWK `json:"header,omitempty"`
+	Header *JWK
 
 	// The signed protected header
-	Protected *string `json:"protected,omitempty"`
+	Protected *string
 
 	// A signature for the image manifest, signed by a libtrust private key
-	Signature *string `json:"signature,omitempty"`
+	Signature *string
 }
 
 // JWK - A JSON web signature
 type JWK struct {
 	// The algorithm used to sign or encrypt the JWT
-	Alg *string `json:"alg,omitempty"`
+	Alg *string
 
 	// JSON web key parameter
-	Jwk *JWKHeader `json:"jwk,omitempty"`
+	Jwk *JWKHeader
 }
 
 // JWKHeader - JSON web key parameter
 type JWKHeader struct {
 	// crv value
-	Crv *string `json:"crv,omitempty"`
+	Crv *string
 
 	// kid value
-	Kid *string `json:"kid,omitempty"`
+	Kid *string
 
 	// kty value
-	Kty *string `json:"kty,omitempty"`
+	Kty *string
 
 	// x value
-	X *string `json:"x,omitempty"`
+	X *string
 
 	// y value
-	Y *string `json:"y,omitempty"`
+	Y *string
 }
 
 // Manifest - Returns the requested manifest file
 type Manifest struct {
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 }
 
 // ManifestAttributesBase - Manifest details
 type ManifestAttributesBase struct {
 	// READ-ONLY; Created time
-	CreatedOn *time.Time `json:"createdTime,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// READ-ONLY; Manifest
-	Digest *string `json:"digest,omitempty" azure:"ro"`
+	Digest *string
 
 	// READ-ONLY; Last update time
-	LastUpdatedOn *time.Time `json:"lastUpdateTime,omitempty" azure:"ro"`
+	LastUpdatedOn *time.Time
 
 	// Writeable properties of the resource
-	ChangeableAttributes *ManifestWriteableProperties `json:"changeableAttributes,omitempty"`
+	ChangeableAttributes *ManifestWriteableProperties
 
 	// Config blob media type
-	ConfigMediaType *string `json:"configMediaType,omitempty"`
+	ConfigMediaType *string
 
 	// READ-ONLY; CPU architecture
-	Architecture *ArtifactArchitecture `json:"architecture,omitempty" azure:"ro"`
+	Architecture *ArtifactArchitecture
 
 	// READ-ONLY; Operating system
-	OperatingSystem *ArtifactOperatingSystem `json:"os,omitempty" azure:"ro"`
+	OperatingSystem *ArtifactOperatingSystem
 
 	// READ-ONLY; List of artifacts that are referenced by this manifest list, with information about the platform each supports.
 	// This list will be empty if this is a leaf manifest and not a manifest list.
-	RelatedArtifacts []*ArtifactManifestPlatform `json:"references,omitempty" azure:"ro"`
+	RelatedArtifacts []*ArtifactManifestPlatform
 
 	// READ-ONLY; Image size
-	Size *int64 `json:"imageSize,omitempty" azure:"ro"`
+	Size *int64
 
 	// READ-ONLY; List of tags
-	Tags []*string `json:"tags,omitempty" azure:"ro"`
+	Tags []*string
 }
 
 // ManifestAttributesManifest - List of manifest attributes
 type ManifestAttributesManifest struct {
 	// List of manifest attributes details
-	References []*ArtifactManifestPlatform `json:"references,omitempty"`
+	References []*ArtifactManifestPlatform
 }
 
 // ManifestList - Returns the requested Docker multi-arch-manifest file
 type ManifestList struct {
 	// List of V2 image layer information
-	Manifests []*ManifestListAttributes `json:"manifests,omitempty"`
+	Manifests []*ManifestListAttributes
 
 	// Media type for this Manifest
-	MediaType *string `json:"mediaType,omitempty"`
+	MediaType *string
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 }
 
 type ManifestListAttributes struct {
 	// The digest of the content, as defined by the Registry V2 HTTP API Specification
-	Digest *string `json:"digest,omitempty"`
+	Digest *string
 
 	// The MIME type of the referenced object. This will generally be application/vnd.docker.image.manifest.v2+json, but it could
 	// also be application/vnd.docker.image.manifest.v1+json
-	MediaType *string `json:"mediaType,omitempty"`
+	MediaType *string
 
 	// The platform object describes the platform which the image in the manifest runs on. A full list of valid operating system
 	// and architecture values are listed in the Go language documentation for $GOOS
 	// and $GOARCH
-	Platform *Platform `json:"platform,omitempty"`
+	Platform *Platform
 
 	// The size in bytes of the object
-	Size *int64 `json:"size,omitempty"`
+	Size *int64
 }
 
 // ManifestWrapper - Returns the requested manifest file
 type ManifestWrapper struct {
 	// (OCI, OCIIndex) Additional metadata
-	Annotations *Annotations `json:"annotations,omitempty"`
+	Annotations *Annotations
 
 	// (V1) CPU architecture
-	Architecture *string `json:"architecture,omitempty"`
+	Architecture *string
 
 	// (V2, OCI) Image config descriptor
-	Config *Descriptor `json:"config,omitempty"`
+	Config *Descriptor
 
 	// (V1) List of layer information
-	FsLayers []*FsLayer `json:"fsLayers,omitempty"`
+	FsLayers []*FsLayer
 
 	// (V1) Image history
-	History []*History `json:"history,omitempty"`
+	History []*History
 
 	// (V2, OCI) List of V2 image layer information
-	Layers []*Descriptor `json:"layers,omitempty"`
+	Layers []*Descriptor
 
 	// (ManifestList, OCIIndex) List of V2 image layer information
-	Manifests []*ManifestListAttributes `json:"manifests,omitempty"`
+	Manifests []*ManifestListAttributes
 
 	// Media type for this Manifest
-	MediaType *string `json:"mediaType,omitempty"`
+	MediaType *string
 
 	// (V1) Image name
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 
 	// (V1) Image signature
-	Signatures []*ImageSignature `json:"signatures,omitempty"`
+	Signatures []*ImageSignature
 
 	// (V1) Image tag
-	Tag *string `json:"tag,omitempty"`
+	Tag *string
 }
 
 // ManifestWriteableProperties - Changeable attributes
 type ManifestWriteableProperties struct {
 	// Delete enabled
-	CanDelete *bool `json:"deleteEnabled,omitempty"`
+	CanDelete *bool
 
 	// List enabled
-	CanList *bool `json:"listEnabled,omitempty"`
+	CanList *bool
 
 	// Read enabled
-	CanRead *bool `json:"readEnabled,omitempty"`
+	CanRead *bool
 
 	// Write enabled
-	CanWrite *bool `json:"writeEnabled,omitempty"`
+	CanWrite *bool
 }
 
 // Manifests - Manifest attributes
 type Manifests struct {
-	Link *string `json:"link,omitempty"`
+	Link *string
 
 	// List of manifests
-	Manifests []*ManifestAttributesBase `json:"manifests,omitempty"`
+	Manifests []*ManifestAttributesBase
 
 	// Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
-	RegistryLoginServer *string `json:"registry,omitempty"`
+	RegistryLoginServer *string
 
 	// Image name
-	Repository *string `json:"imageName,omitempty"`
+	Repository *string
 }
 
 // OCIIndex - Returns the requested OCI index file
 type OCIIndex struct {
 	// Additional information provided through arbitrary metadata.
-	Annotations *Annotations `json:"annotations,omitempty"`
+	Annotations *Annotations
 
 	// List of OCI image layer information
-	Manifests []*ManifestListAttributes `json:"manifests,omitempty"`
+	Manifests []*ManifestListAttributes
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 }
 
 // OCIManifest - Returns the requested OCI Manifest file
 type OCIManifest struct {
 	// Additional information provided through arbitrary metadata.
-	Annotations *Annotations `json:"annotations,omitempty"`
+	Annotations *Annotations
 
 	// V2 image config descriptor
-	Config *Descriptor `json:"config,omitempty"`
+	Config *Descriptor
 
 	// List of V2 image layer information
-	Layers []*Descriptor `json:"layers,omitempty"`
+	Layers []*Descriptor
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 }
 
 type Paths108HwamOauth2ExchangePostRequestbodyContentApplicationXWwwFormUrlencodedSchema struct {
 	// REQUIRED; Can take a value of accesstokenrefreshtoken, or accesstoken, or refresh_token
-	GrantType *PostContentSchemaGrantType `json:"grant_type,omitempty"`
+	GrantType *PostContentSchemaGrantType
 
 	// REQUIRED; Indicates the name of your Azure container registry.
-	Service *string `json:"service,omitempty"`
+	Service *string
 
 	// AAD access token, mandatory when granttype is accesstokenrefreshtoken or access_token.
-	AADAccessToken *string `json:"access_token,omitempty"`
+	AADAccessToken *string
 
 	// AAD refresh token, mandatory when granttype is accesstokenrefreshtoken or refresh_token
-	RefreshToken *string `json:"refresh_token,omitempty"`
+	RefreshToken *string
 
 	// AAD tenant associated to the AAD credentials.
-	Tenant *string `json:"tenant,omitempty"`
+	Tenant *string
 }
 
 type PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema struct {
 	// REQUIRED; Must be a valid ACR refresh token
-	AcrRefreshToken *string `json:"refresh_token,omitempty"`
+	AcrRefreshToken *string
 
 	// REQUIRED; Grant type is expected to be refresh_token
-	GrantType *TokenGrantType `json:"grant_type,omitempty"`
+	GrantType *TokenGrantType
 
 	// REQUIRED; Which is expected to be a valid scope, and can be specified more than once for multiple scope requests. You obtained
 	// this from the Www-Authenticate response header from the challenge.
-	Scope *string `json:"scope,omitempty"`
+	Scope *string
 
 	// REQUIRED; Indicates the name of your Azure container registry.
-	Service *string `json:"service,omitempty"`
+	Service *string
 }
 
 // Platform - The platform object describes the platform which the image in the manifest runs on. A full list of valid operating
@@ -617,153 +617,153 @@ type PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSc
 // and $GOARCH
 type Platform struct {
 	// Specifies the CPU architecture, for example amd64 or ppc64le.
-	Architecture *string `json:"architecture,omitempty"`
+	Architecture *string
 
 	// The optional features field specifies an array of strings, each listing a required CPU feature (for example sse4 or aes
-	Features []*string `json:"features,omitempty"`
+	Features []*string
 
 	// The os field specifies the operating system, for example linux or windows.
-	OS *string `json:"os,omitempty"`
+	OS *string
 
 	// The optional os.features field specifies an array of strings, each listing a required OS feature (for example on Windows
 	// win32k
-	OSFeatures []*string `json:"os.features,omitempty"`
+	OSFeatures []*string
 
 	// The optional os.version field specifies the operating system version, for example 10.0.10586.
-	OSVersion *string `json:"os.version,omitempty"`
+	OSVersion *string
 
 	// The optional variant field specifies a variant of the CPU, for example armv6l to specify a particular CPU variant of the
 	// ARM CPU.
-	Variant *string `json:"variant,omitempty"`
+	Variant *string
 }
 
 type RefreshToken struct {
 	// The refresh token to be used for generating access tokens
-	RefreshToken *string `json:"refresh_token,omitempty"`
+	RefreshToken *string
 }
 
 // Repositories - List of repositories
 type Repositories struct {
-	Link *string `json:"link,omitempty"`
+	Link *string
 
 	// Repository names
-	Repositories []*string `json:"repositories,omitempty"`
+	Repositories []*string
 }
 
 // RepositoryTags - Result of the request to list tags of the image
 type RepositoryTags struct {
 	// Name of the image
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// List of tags
-	Tags []*string `json:"tags,omitempty"`
+	Tags []*string
 }
 
 // RepositoryWriteableProperties - Changeable attributes for Repository
 type RepositoryWriteableProperties struct {
 	// Delete enabled
-	CanDelete *bool `json:"deleteEnabled,omitempty"`
+	CanDelete *bool
 
 	// List enabled
-	CanList *bool `json:"listEnabled,omitempty"`
+	CanList *bool
 
 	// Read enabled
-	CanRead *bool `json:"readEnabled,omitempty"`
+	CanRead *bool
 
 	// Write enabled
-	CanWrite *bool `json:"writeEnabled,omitempty"`
+	CanWrite *bool
 }
 
 // TagAttributesBase - Tag attribute details
 type TagAttributesBase struct {
 	// REQUIRED; Writeable properties of the resource
-	ChangeableAttributes *TagWriteableProperties `json:"changeableAttributes,omitempty"`
+	ChangeableAttributes *TagWriteableProperties
 
 	// Is signed
-	Signed *bool `json:"signed,omitempty"`
+	Signed *bool
 
 	// READ-ONLY; Tag created time
-	CreatedOn *time.Time `json:"createdTime,omitempty" azure:"ro"`
+	CreatedOn *time.Time
 
 	// READ-ONLY; Tag digest
-	Digest *string `json:"digest,omitempty" azure:"ro"`
+	Digest *string
 
 	// READ-ONLY; Tag last update time
-	LastUpdatedOn *time.Time `json:"lastUpdateTime,omitempty" azure:"ro"`
+	LastUpdatedOn *time.Time
 
 	// READ-ONLY; Tag name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 }
 
 // TagAttributesTag - Tag
 type TagAttributesTag struct {
 	// SignatureRecord value
-	SignatureRecord *string `json:"signatureRecord,omitempty"`
+	SignatureRecord *string
 }
 
 // TagList - List of tag details
 type TagList struct {
 	// REQUIRED; Registry login server name. This is likely to be similar to {registry-name}.azurecr.io.
-	RegistryLoginServer *string `json:"registry,omitempty"`
+	RegistryLoginServer *string
 
 	// REQUIRED; Image name
-	Repository *string `json:"imageName,omitempty"`
+	Repository *string
 
 	// REQUIRED; List of tag attribute details
-	TagAttributeBases []*TagAttributesBase `json:"tags,omitempty"`
-	Link              *string              `json:"link,omitempty"`
+	TagAttributeBases []*TagAttributesBase
+	Link              *string
 }
 
 // TagWriteableProperties - Changeable attributes
 type TagWriteableProperties struct {
 	// Delete enabled
-	CanDelete *bool `json:"deleteEnabled,omitempty"`
+	CanDelete *bool
 
 	// List enabled
-	CanList *bool `json:"listEnabled,omitempty"`
+	CanList *bool
 
 	// Read enabled
-	CanRead *bool `json:"readEnabled,omitempty"`
+	CanRead *bool
 
 	// Write enabled
-	CanWrite *bool `json:"writeEnabled,omitempty"`
+	CanWrite *bool
 }
 
 // V1Manifest - Returns the requested V1 manifest file
 type V1Manifest struct {
 	// CPU architecture
-	Architecture *string `json:"architecture,omitempty"`
+	Architecture *string
 
 	// List of layer information
-	FsLayers []*FsLayer `json:"fsLayers,omitempty"`
+	FsLayers []*FsLayer
 
 	// Image history
-	History []*History `json:"history,omitempty"`
+	History []*History
 
 	// Image name
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 
 	// Image signature
-	Signatures []*ImageSignature `json:"signatures,omitempty"`
+	Signatures []*ImageSignature
 
 	// Image tag
-	Tag *string `json:"tag,omitempty"`
+	Tag *string
 }
 
 // V2Manifest - Returns the requested Docker V2 Manifest file
 type V2Manifest struct {
 	// V2 image config descriptor
-	Config *Descriptor `json:"config,omitempty"`
+	Config *Descriptor
 
 	// List of V2 image layer information
-	Layers []*Descriptor `json:"layers,omitempty"`
+	Layers []*Descriptor
 
 	// Media type for this Manifest
-	MediaType *string `json:"mediaType,omitempty"`
+	MediaType *string
 
 	// Schema version
-	SchemaVersion *int32 `json:"schemaVersion,omitempty"`
+	SchemaVersion *int32
 }

--- a/test/autorest/additionalpropsgroup/zz_models.go
+++ b/test/autorest/additionalpropsgroup/zz_models.go
@@ -11,81 +11,81 @@ package additionalpropsgroup
 
 type CatAPTrue struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
-	Friendly             *bool   `json:"friendly,omitempty"`
-	Name                 *string `json:"name,omitempty"`
+	Friendly             *bool
+	Name                 *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 type PetAPInProperties struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// Dictionary of
-	AdditionalProperties map[string]*float32 `json:"additionalProperties,omitempty"`
-	Name                 *string             `json:"name,omitempty"`
+	AdditionalProperties map[string]*float32
+	Name                 *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 type PetAPInPropertiesWithAPString struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// REQUIRED
-	ODataLocation *string `json:"@odata.location,omitempty"`
+	ODataLocation *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]*string
 
 	// Dictionary of
-	AdditionalProperties1 map[string]*float32 `json:"additionalProperties,omitempty"`
-	Name                  *string             `json:"name,omitempty"`
+	AdditionalProperties1 map[string]*float32
+	Name                  *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 type PetAPObject struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
-	Name                 *string `json:"name,omitempty"`
+	Name                 *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 type PetAPString struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]*string
-	Name                 *string `json:"name,omitempty"`
+	Name                 *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 type PetAPTrue struct {
 	// REQUIRED
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
-	Name                 *string `json:"name,omitempty"`
+	Name                 *string
 
 	// READ-ONLY
-	Status *bool `json:"status,omitempty" azure:"ro"`
+	Status *bool
 }
 
 // PetsClientCreateAPInPropertiesOptions contains the optional parameters for the PetsClient.CreateAPInProperties method.

--- a/test/autorest/arraygroup/zz_models.go
+++ b/test/autorest/arraygroup/zz_models.go
@@ -359,6 +359,6 @@ type ArrayClientPutUUIDValidOptions struct {
 }
 
 type Product struct {
-	Integer *int32  `json:"integer,omitempty"`
-	String  *string `json:"string,omitempty"`
+	Integer *int32
+	String  *string
 }

--- a/test/autorest/azurespecialsgroup/zz_models.go
+++ b/test/autorest/azurespecialsgroup/zz_models.go
@@ -93,8 +93,8 @@ type ODataClientGetWithFilterOptions struct {
 }
 
 type ODataFilter struct {
-	ID   *int32  `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	ID   *int32
+	Name *string
 }
 
 // SkipURLEncodingClientGetMethodPathValidOptions contains the optional parameters for the SkipURLEncodingClient.GetMethodPathValid

--- a/test/autorest/complexgroup/zz_models.go
+++ b/test/autorest/complexgroup/zz_models.go
@@ -37,17 +37,17 @@ type ArrayClientPutValidOptions struct {
 }
 
 type ArrayWrapper struct {
-	Array []*string `json:"array,omitempty"`
+	Array []*string
 }
 
 type Basic struct {
-	Color *CMYKColors `json:"color,omitempty"`
+	Color *CMYKColors
 
 	// Basic Id
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// Name property with a very long description that does not fit on a single line and a line break.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // BasicClientGetEmptyOptions contains the optional parameters for the BasicClient.GetEmpty method.
@@ -81,26 +81,26 @@ type BasicClientPutValidOptions struct {
 }
 
 type BooleanWrapper struct {
-	FieldFalse *bool `json:"field_false,omitempty"`
-	FieldTrue  *bool `json:"field_true,omitempty"`
+	FieldFalse *bool
+	FieldTrue  *bool
 }
 
 type ByteWrapper struct {
-	Field []byte `json:"field,omitempty"`
+	Field []byte
 }
 
 type Cookiecuttershark struct {
 	// REQUIRED
-	Birthday *time.Time `json:"birthday,omitempty"`
+	Birthday *time.Time
 
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length   *float32             `json:"length,omitempty"`
-	Age      *int32               `json:"age,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Length   *float32
+	Age      *int32
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Cookiecuttershark.
@@ -126,18 +126,18 @@ func (c *Cookiecuttershark) GetShark() *Shark {
 }
 
 type DateWrapper struct {
-	Field *time.Time `json:"field,omitempty"`
-	Leap  *time.Time `json:"leap,omitempty"`
+	Field *time.Time
+	Leap  *time.Time
 }
 
 type DatetimeWrapper struct {
-	Field *time.Time `json:"field,omitempty"`
-	Now   *time.Time `json:"now,omitempty"`
+	Field *time.Time
+	Now   *time.Time
 }
 
 type Datetimerfc1123Wrapper struct {
-	Field *time.Time `json:"field,omitempty"`
-	Now   *time.Time `json:"now,omitempty"`
+	Field *time.Time
+	Now   *time.Time
 }
 
 // DictionaryClientGetEmptyOptions contains the optional parameters for the DictionaryClient.GetEmpty method.
@@ -172,13 +172,13 @@ type DictionaryClientPutValidOptions struct {
 
 type DictionaryWrapper struct {
 	// Dictionary of
-	DefaultProgram map[string]*string `json:"defaultProgram,omitempty"`
+	DefaultProgram map[string]*string
 }
 
 type Dog struct {
-	Food *string `json:"food,omitempty"`
-	ID   *int32  `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	Food *string
+	ID   *int32
+	Name *string
 }
 
 // DotFishClassification provides polymorphic access to related types.
@@ -192,26 +192,26 @@ type DotFishClassification interface {
 
 type DotFish struct {
 	// REQUIRED
-	FishType *string `json:"fish.type,omitempty"`
-	Species  *string `json:"species,omitempty"`
+	FishType *string
+	Species  *string
 }
 
 // GetDotFish implements the DotFishClassification interface for type DotFish.
 func (d *DotFish) GetDotFish() *DotFish { return d }
 
 type DotFishMarket struct {
-	Fishes       []DotFishClassification `json:"fishes,omitempty"`
-	Salmons      []*DotSalmon            `json:"salmons,omitempty"`
-	SampleFish   DotFishClassification   `json:"sampleFish,omitempty"`
-	SampleSalmon *DotSalmon              `json:"sampleSalmon,omitempty"`
+	Fishes       []DotFishClassification
+	Salmons      []*DotSalmon
+	SampleFish   DotFishClassification
+	SampleSalmon *DotSalmon
 }
 
 type DotSalmon struct {
 	// REQUIRED
-	FishType *string `json:"fish.type,omitempty"`
-	Iswild   *bool   `json:"iswild,omitempty"`
-	Location *string `json:"location,omitempty"`
-	Species  *string `json:"species,omitempty"`
+	FishType *string
+	Iswild   *bool
+	Location *string
+	Species  *string
 }
 
 // GetDotFish implements the DotFishClassification interface for type DotSalmon.
@@ -223,12 +223,12 @@ func (d *DotSalmon) GetDotFish() *DotFish {
 }
 
 type DoubleWrapper struct {
-	Field1                                                                          *float64 `json:"field1,omitempty"`
-	Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose *float64 `json:"field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose,omitempty"`
+	Field1                                                                          *float64
+	Field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose *float64
 }
 
 type DurationWrapper struct {
-	Field *string `json:"field,omitempty"`
+	Field *string
 }
 
 // FishClassification provides polymorphic access to related types.
@@ -242,12 +242,12 @@ type FishClassification interface {
 
 type Fish struct {
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length   *float32             `json:"length,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Length   *float32
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Fish.
@@ -259,26 +259,26 @@ type FlattencomplexClientGetValidOptions struct {
 }
 
 type FloatWrapper struct {
-	Field1 *float32 `json:"field1,omitempty"`
-	Field2 *float32 `json:"field2,omitempty"`
+	Field1 *float32
+	Field2 *float32
 }
 
 type Goblinshark struct {
 	// REQUIRED
-	Birthday *time.Time `json:"birthday,omitempty"`
+	Birthday *time.Time
 
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length *float32 `json:"length,omitempty"`
-	Age    *int32   `json:"age,omitempty"`
+	Length *float32
+	Age    *int32
 
 	// Colors possible
-	Color    *GoblinSharkColor    `json:"color,omitempty"`
-	Jawsize  *int32               `json:"jawsize,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Color    *GoblinSharkColor
+	Jawsize  *int32
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Goblinshark.
@@ -314,17 +314,17 @@ type InheritanceClientPutValidOptions struct {
 }
 
 type IntWrapper struct {
-	Field1 *int32 `json:"field1,omitempty"`
-	Field2 *int32 `json:"field2,omitempty"`
+	Field1 *int32
+	Field2 *int32
 }
 
 type LongWrapper struct {
-	Field1 *int64 `json:"field1,omitempty"`
-	Field2 *int64 `json:"field2,omitempty"`
+	Field1 *int64
+	Field2 *int64
 }
 
 type MyBaseHelperType struct {
-	PropBH1 *string `json:"propBH1,omitempty"`
+	PropBH1 *string
 }
 
 // MyBaseTypeClassification provides polymorphic access to related types.
@@ -338,9 +338,9 @@ type MyBaseTypeClassification interface {
 
 type MyBaseType struct {
 	// REQUIRED
-	Kind   *MyKind           `json:"kind,omitempty"`
-	Helper *MyBaseHelperType `json:"helper,omitempty"`
-	PropB1 *string           `json:"propB1,omitempty"`
+	Kind   *MyKind
+	Helper *MyBaseHelperType
+	PropB1 *string
 }
 
 // GetMyBaseType implements the MyBaseTypeClassification interface for type MyBaseType.
@@ -348,10 +348,10 @@ func (m *MyBaseType) GetMyBaseType() *MyBaseType { return m }
 
 type MyDerivedType struct {
 	// REQUIRED
-	Kind   *MyKind           `json:"kind,omitempty"`
-	Helper *MyBaseHelperType `json:"helper,omitempty"`
-	PropB1 *string           `json:"propB1,omitempty"`
-	PropD1 *string           `json:"propD1,omitempty"`
+	Kind   *MyKind
+	Helper *MyBaseHelperType
+	PropB1 *string
+	PropD1 *string
 }
 
 // GetMyBaseType implements the MyBaseTypeClassification interface for type MyDerivedType.
@@ -535,10 +535,10 @@ type PrimitiveClientPutStringOptions struct {
 }
 
 type ReadonlyObj struct {
-	Size *int32 `json:"size,omitempty"`
+	Size *int32
 
 	// READ-ONLY
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // ReadonlypropertyClientGetValidOptions contains the optional parameters for the ReadonlypropertyClient.GetValid method.
@@ -563,14 +563,14 @@ type SalmonClassification interface {
 
 type Salmon struct {
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length   *float32             `json:"length,omitempty"`
-	Iswild   *bool                `json:"iswild,omitempty"`
-	Location *string              `json:"location,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Length   *float32
+	Iswild   *bool
+	Location *string
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Salmon.
@@ -588,17 +588,17 @@ func (s *Salmon) GetSalmon() *Salmon { return s }
 
 type Sawshark struct {
 	// REQUIRED
-	Birthday *time.Time `json:"birthday,omitempty"`
+	Birthday *time.Time
 
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length   *float32             `json:"length,omitempty"`
-	Age      *int32               `json:"age,omitempty"`
-	Picture  []byte               `json:"picture,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Length   *float32
+	Age      *int32
+	Picture  []byte
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Sawshark.
@@ -635,16 +635,16 @@ type SharkClassification interface {
 
 type Shark struct {
 	// REQUIRED
-	Birthday *time.Time `json:"birthday,omitempty"`
+	Birthday *time.Time
 
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length   *float32             `json:"length,omitempty"`
-	Age      *int32               `json:"age,omitempty"`
-	Siblings []FishClassification `json:"siblings,omitempty"`
-	Species  *string              `json:"species,omitempty"`
+	Length   *float32
+	Age      *int32
+	Siblings []FishClassification
+	Species  *string
 }
 
 // GetFish implements the FishClassification interface for type Shark.
@@ -661,27 +661,27 @@ func (s *Shark) GetFish() *Fish {
 func (s *Shark) GetShark() *Shark { return s }
 
 type Siamese struct {
-	Breed *string `json:"breed,omitempty"`
-	Color *string `json:"color,omitempty"`
-	Hates []*Dog  `json:"hates,omitempty"`
-	ID    *int32  `json:"id,omitempty"`
-	Name  *string `json:"name,omitempty"`
+	Breed *string
+	Color *string
+	Hates []*Dog
+	ID    *int32
+	Name  *string
 }
 
 type SmartSalmon struct {
 	// REQUIRED
-	Fishtype *string `json:"fishtype,omitempty"`
+	Fishtype *string
 
 	// REQUIRED
-	Length *float32 `json:"length,omitempty"`
+	Length *float32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
-	CollegeDegree        *string              `json:"college_degree,omitempty"`
-	Iswild               *bool                `json:"iswild,omitempty"`
-	Location             *string              `json:"location,omitempty"`
-	Siblings             []FishClassification `json:"siblings,omitempty"`
-	Species              *string              `json:"species,omitempty"`
+	CollegeDegree        *string
+	Iswild               *bool
+	Location             *string
+	Siblings             []FishClassification
+	Species              *string
 }
 
 // GetFish implements the FishClassification interface for type SmartSalmon.
@@ -707,7 +707,7 @@ func (s *SmartSalmon) GetSalmon() *Salmon {
 }
 
 type StringWrapper struct {
-	Empty *string `json:"empty,omitempty"`
-	Field *string `json:"field,omitempty"`
-	Null  *string `json:"null,omitempty"`
+	Empty *string
+	Field *string
+	Null  *string
 }

--- a/test/autorest/complexmodelgroup/zz_models.go
+++ b/test/autorest/complexmodelgroup/zz_models.go
@@ -11,22 +11,22 @@ package complexmodelgroup
 
 type CatalogArray struct {
 	// Array of products
-	ProductArray []*Product `json:"productArray,omitempty"`
+	ProductArray []*Product
 }
 
 type CatalogArrayOfDictionary struct {
 	// Array of dictionary of products
-	ProductArrayOfDictionary []map[string]*Product `json:"productArrayOfDictionary,omitempty"`
+	ProductArrayOfDictionary []map[string]*Product
 }
 
 type CatalogDictionary struct {
 	// Dictionary of products
-	ProductDictionary map[string]*Product `json:"productDictionary,omitempty"`
+	ProductDictionary map[string]*Product
 }
 
 type CatalogDictionaryOfArray struct {
 	// Dictionary of Array of product
-	ProductDictionaryOfArray map[string][]*Product `json:"productDictionaryOfArray,omitempty"`
+	ProductDictionaryOfArray map[string][]*Product
 }
 
 // ComplexModelClientCreateOptions contains the optional parameters for the ComplexModelClient.Create method.
@@ -47,18 +47,18 @@ type ComplexModelClientUpdateOptions struct {
 // Product - The product documentation.
 type Product struct {
 	// Capacity of product. For example, 4 people.
-	Capacity *string `json:"capacity,omitempty"`
+	Capacity *string
 
 	// Description of product.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Display name of product.
-	DisplayName *string `json:"display_name,omitempty"`
+	DisplayName *string
 
 	// Image URL representing the product.
-	Image *string `json:"image,omitempty"`
+	Image *string
 
 	// Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco
 	// will have a different product_id than uberX in Los Angeles.
-	ProductID *string `json:"product_id,omitempty"`
+	ProductID *string
 }

--- a/test/autorest/dictionarygroup/zz_models.go
+++ b/test/autorest/dictionarygroup/zz_models.go
@@ -359,6 +359,6 @@ type DictionaryClientPutStringValidOptions struct {
 }
 
 type Widget struct {
-	Integer *int32  `json:"integer,omitempty"`
-	String  *string `json:"string,omitempty"`
+	Integer *int32
+	String  *string
 }

--- a/test/autorest/errorsgroup/zz_models.go
+++ b/test/autorest/errorsgroup/zz_models.go
@@ -10,15 +10,15 @@
 package errorsgroup
 
 type Pet struct {
-	AniType *string `json:"aniType,omitempty"`
+	AniType *string
 
 	// READ-ONLY; Gets the Pet by id.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 }
 
 type PetAction struct {
 	// action feedback
-	ActionResponse *string `json:"actionResponse,omitempty"`
+	ActionResponse *string
 }
 
 // PetClientDoSomethingOptions contains the optional parameters for the PetClient.DoSomething method.

--- a/test/autorest/extenumsgroup/zz_models.go
+++ b/test/autorest/extenumsgroup/zz_models.go
@@ -11,13 +11,13 @@ package extenumsgroup
 
 type Pet struct {
 	// REQUIRED
-	IntEnum *IntEnum `json:"IntEnum,omitempty"`
+	IntEnum *IntEnum
 
 	// Type of Pet
-	DaysOfWeek *DaysOfWeekExtensibleEnum `json:"DaysOfWeek,omitempty"`
+	DaysOfWeek *DaysOfWeekExtensibleEnum
 
 	// name
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // PetClientAddPetOptions contains the optional parameters for the PetClient.AddPet method.

--- a/test/autorest/httpinfrastructuregroup/zz_models.go
+++ b/test/autorest/httpinfrastructuregroup/zz_models.go
@@ -10,16 +10,16 @@
 package httpinfrastructuregroup
 
 type B struct {
-	StatusCode     *string `json:"statusCode,omitempty"`
-	TextStatusCode *string `json:"textStatusCode,omitempty"`
+	StatusCode     *string
+	TextStatusCode *string
 }
 
 type C struct {
-	HTTPCode *string `json:"httpCode,omitempty"`
+	HTTPCode *string
 }
 
 type D struct {
-	HTTPStatusCode *string `json:"httpStatusCode,omitempty"`
+	HTTPStatusCode *string
 }
 
 // HTTPClientFailureClientDelete400Options contains the optional parameters for the HTTPClientFailureClient.Delete400 method.
@@ -612,5 +612,5 @@ type MultipleResponsesClientGetDefaultNone400NoneOptions struct {
 }
 
 type MyException struct {
-	StatusCode *string `json:"statusCode,omitempty"`
+	StatusCode *string
 }

--- a/test/autorest/lrogroup/zz_models.go
+++ b/test/autorest/lrogroup/zz_models.go
@@ -600,44 +600,44 @@ type LROsCustomHeaderClientBeginPutAsyncRetrySucceededOptions struct {
 
 type Product struct {
 	// Resource Location
-	Location   *string            `json:"location,omitempty"`
-	Properties *ProductProperties `json:"properties,omitempty"`
+	Location   *string
+	Properties *ProductProperties
 
 	// Dictionary of
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource Name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource Type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 type ProductProperties struct {
-	ProvisioningState *string `json:"provisioningState,omitempty"`
+	ProvisioningState *string
 
 	// READ-ONLY
-	ProvisioningStateValues *ProductPropertiesProvisioningStateValues `json:"provisioningStateValues,omitempty" azure:"ro"`
+	ProvisioningStateValues *ProductPropertiesProvisioningStateValues
 }
 
 type SKU struct {
-	ID   *string `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	ID   *string
+	Name *string
 }
 
 type SubProduct struct {
-	Properties *SubProductProperties `json:"properties,omitempty"`
+	Properties *SubProductProperties
 
 	// READ-ONLY; Sub Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 type SubProductProperties struct {
-	ProvisioningState *string `json:"provisioningState,omitempty"`
+	ProvisioningState *string
 
 	// READ-ONLY
-	ProvisioningStateValues *SubProductPropertiesProvisioningStateValues `json:"provisioningStateValues,omitempty" azure:"ro"`
+	ProvisioningStateValues *SubProductPropertiesProvisioningStateValues
 }

--- a/test/autorest/mediatypesgroup/zz_models.go
+++ b/test/autorest/mediatypesgroup/zz_models.go
@@ -66,5 +66,5 @@ type MediaTypesClientPutTextAndJSONBodyOptions struct {
 // SourcePath - Uri or local path to source data.
 type SourcePath struct {
 	// File source path.
-	Source *string `json:"source,omitempty"`
+	Source *string
 }

--- a/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_models.go
+++ b/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_models.go
@@ -66,5 +66,5 @@ type MediaTypesClientPutTextAndJSONBodyWithTextOptions struct {
 // SourcePath - Uri or local path to source data.
 type SourcePath struct {
 	// File source path.
-	Source *string `json:"source,omitempty"`
+	Source *string
 }

--- a/test/autorest/migroup/zz_models.go
+++ b/test/autorest/migroup/zz_models.go
@@ -11,30 +11,30 @@ package migroup
 
 type Cat struct {
 	// REQUIRED
-	Name      *string `json:"name,omitempty"`
-	Hisses    *bool   `json:"hisses,omitempty"`
-	LikesMilk *bool   `json:"likesMilk,omitempty"`
-	Meows     *bool   `json:"meows,omitempty"`
+	Name      *string
+	Hisses    *bool
+	LikesMilk *bool
+	Meows     *bool
 }
 
 type Feline struct {
-	Hisses *bool `json:"hisses,omitempty"`
-	Meows  *bool `json:"meows,omitempty"`
+	Hisses *bool
+	Meows  *bool
 }
 
 type Horse struct {
 	// REQUIRED
-	Name         *string `json:"name,omitempty"`
-	IsAShowHorse *bool   `json:"isAShowHorse,omitempty"`
+	Name         *string
+	IsAShowHorse *bool
 }
 
 type Kitten struct {
 	// REQUIRED
-	Name        *string `json:"name,omitempty"`
-	EatsMiceYet *bool   `json:"eatsMiceYet,omitempty"`
-	Hisses      *bool   `json:"hisses,omitempty"`
-	LikesMilk   *bool   `json:"likesMilk,omitempty"`
-	Meows       *bool   `json:"meows,omitempty"`
+	Name        *string
+	EatsMiceYet *bool
+	Hisses      *bool
+	LikesMilk   *bool
+	Meows       *bool
 }
 
 // MultipleInheritanceServiceClientGetCatOptions contains the optional parameters for the MultipleInheritanceServiceClient.GetCat
@@ -99,5 +99,5 @@ type MultipleInheritanceServiceClientPutPetOptions struct {
 
 type Pet struct {
 	// REQUIRED
-	Name *string `json:"name,omitempty"`
+	Name *string
 }

--- a/test/autorest/noopsgroup/zz_models.go
+++ b/test/autorest/noopsgroup/zz_models.go
@@ -10,6 +10,6 @@
 package noopsgroup
 
 type Error struct {
-	Message *string `json:"message,omitempty"`
-	Status  *int32  `json:"status,omitempty"`
+	Message *string
+	Status  *int32
 }

--- a/test/autorest/optionalgroup/zz_models.go
+++ b/test/autorest/optionalgroup/zz_models.go
@@ -10,21 +10,21 @@
 package optionalgroup
 
 type ArrayOptionalWrapper struct {
-	Value []*string `json:"value,omitempty"`
+	Value []*string
 }
 
 type ArrayWrapper struct {
 	// REQUIRED
-	Value []*string `json:"value,omitempty"`
+	Value []*string
 }
 
 type ClassOptionalWrapper struct {
-	Value *Product `json:"value,omitempty"`
+	Value *Product
 }
 
 type ClassWrapper struct {
 	// REQUIRED
-	Value *Product `json:"value,omitempty"`
+	Value *Product
 }
 
 // ExplicitClientPostOptionalArrayHeaderOptions contains the optional parameters for the ExplicitClient.PostOptionalArrayHeader
@@ -215,25 +215,25 @@ type ImplicitClientPutOptionalQueryOptions struct {
 }
 
 type IntOptionalWrapper struct {
-	Value *int32 `json:"value,omitempty"`
+	Value *int32
 }
 
 type IntWrapper struct {
 	// REQUIRED
-	Value *int32 `json:"value,omitempty"`
+	Value *int32
 }
 
 type Product struct {
 	// REQUIRED
-	ID   *int32  `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	ID   *int32
+	Name *string
 }
 
 type StringOptionalWrapper struct {
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 type StringWrapper struct {
 	// REQUIRED
-	Value *string `json:"value,omitempty"`
+	Value *string
 }

--- a/test/autorest/paginggroup/zz_models.go
+++ b/test/autorest/paginggroup/zz_models.go
@@ -18,8 +18,8 @@ type CustomParameterGroup struct {
 }
 
 type ODataProductResult struct {
-	ODataNextLink *string    `json:"odata.nextLink,omitempty"`
-	Values        []*Product `json:"values,omitempty"`
+	ODataNextLink *string
+	Values        []*Product
 }
 
 // PagingClientBeginGetMultiplePagesLROOptions contains the optional parameters for the PagingClient.BeginGetMultiplePagesLRO
@@ -149,25 +149,25 @@ type PagingClientGetWithQueryParamsOptions struct {
 }
 
 type Product struct {
-	Properties *ProductProperties `json:"properties,omitempty"`
+	Properties *ProductProperties
 }
 
 type ProductProperties struct {
-	ID   *int32  `json:"id,omitempty"`
-	Name *string `json:"name,omitempty"`
+	ID   *int32
+	Name *string
 }
 
 type ProductResult struct {
-	NextLink *string    `json:"nextLink,omitempty"`
-	Values   []*Product `json:"values,omitempty"`
+	NextLink *string
+	Values   []*Product
 }
 
 type ProductResultValue struct {
-	NextLink *string    `json:"nextLink,omitempty"`
-	Value    []*Product `json:"value,omitempty"`
+	NextLink *string
+	Value    []*Product
 }
 
 type ProductResultValueWithXMSClientName struct {
-	Indexes  []*Product `json:"values,omitempty"`
-	NextLink *string    `json:"nextLink,omitempty"`
+	Indexes  []*Product
+	NextLink *string
 }

--- a/test/autorest/stringgroup/zz_models.go
+++ b/test/autorest/stringgroup/zz_models.go
@@ -42,10 +42,10 @@ type EnumClientPutReferencedOptions struct {
 type RefColorConstant struct {
 	// CONSTANT; Referenced Color Constant Description.
 	// Field has constant value "green-color", any specified value is ignored.
-	ColorConstant *string `json:"ColorConstant,omitempty"`
+	ColorConstant *string
 
 	// Sample string.
-	Field1 *string `json:"field1,omitempty"`
+	Field1 *string
 }
 
 // StringClientGetBase64EncodedOptions contains the optional parameters for the StringClient.GetBase64Encoded method.

--- a/test/autorest/validationgroup/zz_models.go
+++ b/test/autorest/validationgroup/zz_models.go
@@ -37,48 +37,48 @@ type AutoRestValidationTestClientValidationOfMethodParametersOptions struct {
 type ChildProduct struct {
 	// CONSTANT; Constant string
 	// Field has constant value "constant", any specified value is ignored.
-	ConstProperty *string `json:"constProperty,omitempty"`
+	ConstProperty *string
 
 	// Count
-	Count *int32 `json:"count,omitempty"`
+	Count *int32
 }
 
 // ConstantProduct - The product documentation.
 type ConstantProduct struct {
 	// CONSTANT; Constant string
 	// Field has constant value "constant", any specified value is ignored.
-	ConstProperty *string `json:"constProperty,omitempty"`
+	ConstProperty *string
 
 	// CONSTANT; Constant string2
 	// Field has constant value "constant2", any specified value is ignored.
-	ConstProperty2 *string `json:"constProperty2,omitempty"`
+	ConstProperty2 *string
 }
 
 // Product - The product documentation.
 type Product struct {
 	// REQUIRED; The product documentation.
-	Child *ChildProduct `json:"child,omitempty"`
+	Child *ChildProduct
 
 	// REQUIRED; The product documentation.
-	ConstChild *ConstantProduct `json:"constChild,omitempty"`
+	ConstChild *ConstantProduct
 
 	// CONSTANT; Constant int
 	// Field has constant value 0, any specified value is ignored.
-	ConstInt *int32 `json:"constInt,omitempty"`
+	ConstInt *int32
 
 	// CONSTANT; Constant string
 	// Field has constant value "constant", any specified value is ignored.
-	ConstString *string `json:"constString,omitempty"`
+	ConstString *string
 
 	// Non required int betwen 0 and 100 exclusive.
-	Capacity *int32 `json:"capacity,omitempty"`
+	Capacity *int32
 
 	// Constant string as Enum
-	ConstStringAsEnum *string `json:"constStringAsEnum,omitempty"`
+	ConstStringAsEnum *string
 
 	// Non required array of unique items from 0 to 6 elements.
-	DisplayNames []*string `json:"display_names,omitempty"`
+	DisplayNames []*string
 
 	// Image URL representing the product.
-	Image *string `json:"image,omitempty"`
+	Image *string
 }

--- a/test/autorest/xmlgroup/zz_models.go
+++ b/test/autorest/xmlgroup/zz_models.go
@@ -165,11 +165,11 @@ type CorsRule struct {
 }
 
 type JSONInput struct {
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 }
 
 type JSONOutput struct {
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 }
 
 // ListBlobsResponse - An enumeration of blobs

--- a/test/compute/2019-12-01/armcompute/zz_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_models.go
@@ -14,43 +14,43 @@ import "time"
 // APIEntityReference - The API entity reference.
 type APIEntityReference struct {
 	// The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/…
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // APIError - Api error.
 type APIError struct {
 	// The error code.
-	Code *string `json:"code,omitempty"`
+	Code *string
 
 	// The Api error details
-	Details []*APIErrorBase `json:"details,omitempty"`
+	Details []*APIErrorBase
 
 	// The Api inner error
-	Innererror *InnerError `json:"innererror,omitempty"`
+	Innererror *InnerError
 
 	// The error message.
-	Message *string `json:"message,omitempty"`
+	Message *string
 
 	// The target of the particular error.
-	Target *string `json:"target,omitempty"`
+	Target *string
 }
 
 // APIErrorBase - Api error base.
 type APIErrorBase struct {
 	// The error code.
-	Code *string `json:"code,omitempty"`
+	Code *string
 
 	// The error message.
-	Message *string `json:"message,omitempty"`
+	Message *string
 
 	// The target of the particular error.
-	Target *string `json:"target,omitempty"`
+	Target *string
 }
 
 // AccessURI - A disk access SAS uri.
 type AccessURI struct {
 	// READ-ONLY; A SAS uri for accessing a disk.
-	AccessSAS *string `json:"accessSAS,omitempty" azure:"ro"`
+	AccessSAS *string
 }
 
 // AdditionalCapabilities - Enables or disables a capability on the virtual machine or virtual machine scale set.
@@ -58,7 +58,7 @@ type AdditionalCapabilities struct {
 	// The flag that enables or disables a capability to have one or more managed data disks with UltraSSDLRS storage account
 	// type on the VM or VMSS. Managed disks with storage account type UltraSSDLRS can
 	// be added to a virtual machine or virtual machine scale set only if this property is enabled.
-	UltraSSDEnabled *bool `json:"ultraSSDEnabled,omitempty"`
+	UltraSSDEnabled *bool
 }
 
 // AdditionalUnattendContent - Specifies additional XML formatted information that can be included in the Unattend.xml file,
@@ -66,50 +66,50 @@ type AdditionalCapabilities struct {
 // which the content is applied.
 type AdditionalUnattendContent struct {
 	// The component name. Currently, the only allowable value is Microsoft-Windows-Shell-Setup.
-	ComponentName *string `json:"componentName,omitempty"`
+	ComponentName *string
 
 	// Specifies the XML formatted content that is added to the unattend.xml file for the specified path and component. The XML
 	// must be less than 4KB and must include the root element for the setting or
 	// feature that is being inserted.
-	Content *string `json:"content,omitempty"`
+	Content *string
 
 	// The pass name. Currently, the only allowable value is OobeSystem.
-	PassName *string `json:"passName,omitempty"`
+	PassName *string
 
 	// Specifies the name of the setting to which the content applies. Possible values are: FirstLogonCommands and AutoLogon.
-	SettingName *SettingNames `json:"settingName,omitempty"`
+	SettingName *SettingNames
 }
 
 // AutomaticOSUpgradePolicy - The configuration parameters used for performing automatic OS upgrade.
 type AutomaticOSUpgradePolicy struct {
 	// Whether OS image rollback feature should be disabled. Default value is false.
-	DisableAutomaticRollback *bool `json:"disableAutomaticRollback,omitempty"`
+	DisableAutomaticRollback *bool
 
 	// Indicates whether OS upgrades should automatically be applied to scale set instances in a rolling fashion when a newer
 	// version of the OS image becomes available. Default value is false.
 	// If this is set to true for Windows based scale sets, enableAutomaticUpdates
 	// [https://docs.microsoft.com/dotnet/api/microsoft.azure.management.compute.models.windowsconfiguration.enableautomaticupdates?view=azure-dotnet]
 	// is automatically set to false and cannot be set to true.
-	EnableAutomaticOSUpgrade *bool `json:"enableAutomaticOSUpgrade,omitempty"`
+	EnableAutomaticOSUpgrade *bool
 }
 
 // AutomaticOSUpgradeProperties - Describes automatic OS upgrade properties on the image.
 type AutomaticOSUpgradeProperties struct {
 	// REQUIRED; Specifies whether automatic OS upgrade is supported on the image.
-	AutomaticOSUpgradeSupported *bool `json:"automaticOSUpgradeSupported,omitempty"`
+	AutomaticOSUpgradeSupported *bool
 }
 
 // AutomaticRepairsPolicy - Specifies the configuration parameters for automatic repairs on the virtual machine scale set.
 type AutomaticRepairsPolicy struct {
 	// Specifies whether automatic repairs should be enabled on the virtual machine scale set. The default value is false.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// The amount of time for which automatic repairs are suspended due to a state change on VM. The grace time starts after the
 	// state change has completed. This helps avoid premature or accidental repairs.
 	// The time duration should be specified in ISO 8601 format. The minimum allowed grace period is 30 minutes (PT30M), which
 	// is also the default value. The maximum allowed grace period is 90 minutes
 	// (PT90M).
-	GracePeriod *string `json:"gracePeriod,omitempty"`
+	GracePeriod *string
 }
 
 // AvailabilitySet - Specifies information about the availability set that the virtual machine should be assigned to. Virtual
@@ -122,68 +122,68 @@ type AutomaticRepairsPolicy struct {
 // set.
 type AvailabilitySet struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The instance view of a resource.
-	Properties *AvailabilitySetProperties `json:"properties,omitempty"`
+	Properties *AvailabilitySetProperties
 
 	// Sku of the availability set, only name is required to be set. See AvailabilitySetSkuTypes for possible set of values. Use
 	// 'Aligned' for virtual machines with managed disks and 'Classic' for virtual
 	// machines with unmanaged disks. Default value is 'Classic'.
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AvailabilitySetListResult - The List Availability Set operation response.
 type AvailabilitySetListResult struct {
 	// REQUIRED; The list of availability sets
-	Value []*AvailabilitySet `json:"value,omitempty"`
+	Value []*AvailabilitySet
 
 	// The URI to fetch the next page of AvailabilitySets. Call ListNext() with this URI to fetch the next page of AvailabilitySets.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // AvailabilitySetProperties - The instance view of a resource.
 type AvailabilitySetProperties struct {
 	// Fault Domain count.
-	PlatformFaultDomainCount *int32 `json:"platformFaultDomainCount,omitempty"`
+	PlatformFaultDomainCount *int32
 
 	// Update Domain count.
-	PlatformUpdateDomainCount *int32 `json:"platformUpdateDomainCount,omitempty"`
+	PlatformUpdateDomainCount *int32
 
 	// Specifies information about the proximity placement group that the availability set should be assigned to.
 	// Minimum api-version: 2018-04-01.
-	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
+	ProximityPlacementGroup *SubResource
 
 	// A list of references to all virtual machines in the availability set.
-	VirtualMachines []*SubResource `json:"virtualMachines,omitempty"`
+	VirtualMachines []*SubResource
 
 	// READ-ONLY; The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty" azure:"ro"`
+	Statuses []*InstanceViewStatus
 }
 
 // AvailabilitySetUpdate - Specifies information about the availability set that the virtual machine should be assigned to.
 // Only tags may be updated.
 type AvailabilitySetUpdate struct {
 	// The instance view of a resource.
-	Properties *AvailabilitySetProperties `json:"properties,omitempty"`
+	Properties *AvailabilitySetProperties
 
 	// Sku of the availability set
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // AvailabilitySetsClientCreateOrUpdateOptions contains the optional parameters for the AvailabilitySetsClient.CreateOrUpdate
@@ -240,7 +240,7 @@ type BillingProfile struct {
 	// You can set the maxPrice to -1 to indicate that the Azure Spot VM/VMSS should not be evicted for price reasons. Also, the
 	// default max price is -1 if it is not provided by you.
 	// Minimum api-version: 2019-03-01.
-	MaxPrice *float64 `json:"maxPrice,omitempty"`
+	MaxPrice *float64
 }
 
 // BootDiagnostics - Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose
@@ -249,181 +249,181 @@ type BillingProfile struct {
 // Azure also enables you to see a screenshot of the VM from the hypervisor.
 type BootDiagnostics struct {
 	// Whether boot diagnostics should be enabled on the Virtual Machine.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Uri of the storage account to use for placing the console output and screenshot.
-	StorageURI *string `json:"storageUri,omitempty"`
+	StorageURI *string
 }
 
 // BootDiagnosticsInstanceView - The instance view of a virtual machine boot diagnostics.
 type BootDiagnosticsInstanceView struct {
 	// READ-ONLY; The console screenshot blob URI.
-	ConsoleScreenshotBlobURI *string `json:"consoleScreenshotBlobUri,omitempty" azure:"ro"`
+	ConsoleScreenshotBlobURI *string
 
 	// READ-ONLY; The Linux serial console log blob Uri.
-	SerialConsoleLogBlobURI *string `json:"serialConsoleLogBlobUri,omitempty" azure:"ro"`
+	SerialConsoleLogBlobURI *string
 
 	// READ-ONLY; The boot diagnostics status information for the VM.
 	// NOTE: It will be set only if there are errors encountered in enabling boot diagnostics.
-	Status *InstanceViewStatus `json:"status,omitempty" azure:"ro"`
+	Status *InstanceViewStatus
 }
 
 // ContainerService - Container service.
 type ContainerService struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the container service.
-	Properties *ContainerServiceProperties `json:"properties,omitempty"`
+	Properties *ContainerServiceProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ContainerServiceAgentPoolProfile - Profile for the container service agent pool.
 type ContainerServiceAgentPoolProfile struct {
 	// REQUIRED; Number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive).
 	// The default value is 1.
-	Count *int32 `json:"count,omitempty"`
+	Count *int32
 
 	// REQUIRED; DNS prefix to be used to create the FQDN for the agent pool.
-	DNSPrefix *string `json:"dnsPrefix,omitempty"`
+	DNSPrefix *string
 
 	// REQUIRED; Unique name of the agent pool profile in the context of the subscription and resource group.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Size of agent VMs.
-	VMSize *ContainerServiceVMSizeTypes `json:"vmSize,omitempty"`
+	VMSize *ContainerServiceVMSizeTypes
 
 	// READ-ONLY; FQDN for the agent pool.
-	Fqdn *string `json:"fqdn,omitempty" azure:"ro"`
+	Fqdn *string
 }
 
 // ContainerServiceCustomProfile - Properties to configure a custom container service cluster.
 type ContainerServiceCustomProfile struct {
 	// REQUIRED; The name of the custom orchestrator to use.
-	Orchestrator *string `json:"orchestrator,omitempty"`
+	Orchestrator *string
 }
 
 type ContainerServiceDiagnosticsProfile struct {
 	// REQUIRED; Profile for the container service VM diagnostic agent.
-	VMDiagnostics *ContainerServiceVMDiagnostics `json:"vmDiagnostics,omitempty"`
+	VMDiagnostics *ContainerServiceVMDiagnostics
 }
 
 // ContainerServiceLinuxProfile - Profile for Linux VMs in the container service cluster.
 type ContainerServiceLinuxProfile struct {
 	// REQUIRED; The administrator username to use for Linux VMs.
-	AdminUsername *string `json:"adminUsername,omitempty"`
+	AdminUsername *string
 
 	// REQUIRED; The ssh key configuration for Linux VMs.
-	SSH *ContainerServiceSSHConfiguration `json:"ssh,omitempty"`
+	SSH *ContainerServiceSSHConfiguration
 }
 
 // ContainerServiceListResult - The response from the List Container Services operation.
 type ContainerServiceListResult struct {
 	// The URL to get the next set of container service results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// the list of container services.
-	Value []*ContainerService `json:"value,omitempty"`
+	Value []*ContainerService
 }
 
 // ContainerServiceMasterProfile - Profile for the container service master.
 type ContainerServiceMasterProfile struct {
 	// REQUIRED; DNS prefix to be used to create the FQDN for master.
-	DNSPrefix *string `json:"dnsPrefix,omitempty"`
+	DNSPrefix *string
 
 	// Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1.
-	Count *ContainerServiceMasterProfileCount `json:"count,omitempty"`
+	Count *ContainerServiceMasterProfileCount
 
 	// READ-ONLY; FQDN for the master.
-	Fqdn *string `json:"fqdn,omitempty" azure:"ro"`
+	Fqdn *string
 }
 
 // ContainerServiceOrchestratorProfile - Profile for the container service orchestrator.
 type ContainerServiceOrchestratorProfile struct {
 	// REQUIRED; The orchestrator to use to manage container service cluster resources. Valid values are Swarm, DCOS, and Custom.
-	OrchestratorType *ContainerServiceOrchestratorTypes `json:"orchestratorType,omitempty"`
+	OrchestratorType *ContainerServiceOrchestratorTypes
 }
 
 // ContainerServicePrincipalProfile - Information about a service principal identity for the cluster to use for manipulating
 // Azure APIs.
 type ContainerServicePrincipalProfile struct {
 	// REQUIRED; The ID for the service principal.
-	ClientID *string `json:"clientId,omitempty"`
+	ClientID *string
 
 	// REQUIRED; The secret password associated with the service principal.
-	Secret *string `json:"secret,omitempty"`
+	Secret *string
 }
 
 // ContainerServiceProperties - Properties of the container service.
 type ContainerServiceProperties struct {
 	// REQUIRED; Properties of the agent pool.
-	AgentPoolProfiles []*ContainerServiceAgentPoolProfile `json:"agentPoolProfiles,omitempty"`
+	AgentPoolProfiles []*ContainerServiceAgentPoolProfile
 
 	// REQUIRED; Properties of Linux VMs.
-	LinuxProfile *ContainerServiceLinuxProfile `json:"linuxProfile,omitempty"`
+	LinuxProfile *ContainerServiceLinuxProfile
 
 	// REQUIRED; Properties of master agents.
-	MasterProfile *ContainerServiceMasterProfile `json:"masterProfile,omitempty"`
+	MasterProfile *ContainerServiceMasterProfile
 
 	// Properties for custom clusters.
-	CustomProfile *ContainerServiceCustomProfile `json:"customProfile,omitempty"`
+	CustomProfile *ContainerServiceCustomProfile
 
 	// Properties of the diagnostic agent.
-	DiagnosticsProfile *ContainerServiceDiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *ContainerServiceDiagnosticsProfile
 
 	// Properties of the orchestrator.
-	OrchestratorProfile *ContainerServiceOrchestratorProfile `json:"orchestratorProfile,omitempty"`
+	OrchestratorProfile *ContainerServiceOrchestratorProfile
 
 	// Properties for cluster service principals.
-	ServicePrincipalProfile *ContainerServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+	ServicePrincipalProfile *ContainerServicePrincipalProfile
 
 	// Properties of Windows VMs.
-	WindowsProfile *ContainerServiceWindowsProfile `json:"windowsProfile,omitempty"`
+	WindowsProfile *ContainerServiceWindowsProfile
 
 	// READ-ONLY; the current deployment or provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // ContainerServiceSSHConfiguration - SSH configuration for Linux-based VMs running on Azure.
 type ContainerServiceSSHConfiguration struct {
 	// REQUIRED; the list of SSH public keys used to authenticate with Linux-based VMs.
-	PublicKeys []*ContainerServiceSSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys []*ContainerServiceSSHPublicKey
 }
 
 // ContainerServiceSSHPublicKey - Contains information about SSH certificate public key data.
 type ContainerServiceSSHPublicKey struct {
 	// REQUIRED; Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with
 	// or without headers.
-	KeyData *string `json:"keyData,omitempty"`
+	KeyData *string
 }
 
 // ContainerServiceVMDiagnostics - Profile for diagnostics on the container service VMs.
 type ContainerServiceVMDiagnostics struct {
 	// REQUIRED; Whether the VM diagnostic agent is provisioned on the VM.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// READ-ONLY; The URI of the storage account where diagnostics are stored.
-	StorageURI *string `json:"storageUri,omitempty" azure:"ro"`
+	StorageURI *string
 }
 
 // ContainerServiceWindowsProfile - Profile for Windows VMs in the container service cluster.
 type ContainerServiceWindowsProfile struct {
 	// REQUIRED; The administrator password to use for Windows VMs.
-	AdminPassword *string `json:"adminPassword,omitempty"`
+	AdminPassword *string
 
 	// REQUIRED; The administrator username to use for Windows VMs.
-	AdminUsername *string `json:"adminUsername,omitempty"`
+	AdminUsername *string
 }
 
 // ContainerServicesClientBeginCreateOrUpdateOptions contains the optional parameters for the ContainerServicesClient.BeginCreateOrUpdate
@@ -459,32 +459,32 @@ type ContainerServicesClientListOptions struct {
 // CreationData - Data used when creating a disk.
 type CreationData struct {
 	// REQUIRED; This enumerates the possible sources of a disk's creation.
-	CreateOption *DiskCreateOption `json:"createOption,omitempty"`
+	CreateOption *DiskCreateOption
 
 	// Required if creating from a Gallery Image. The id of the ImageDiskReference will be the ARM id of the shared galley image
 	// version from which to create a disk.
-	GalleryImageReference *ImageDiskReference `json:"galleryImageReference,omitempty"`
+	GalleryImageReference *ImageDiskReference
 
 	// Disk source information.
-	ImageReference *ImageDiskReference `json:"imageReference,omitempty"`
+	ImageReference *ImageDiskReference
 
 	// If createOption is Copy, this is the ARM id of the source snapshot or disk.
-	SourceResourceID *string `json:"sourceResourceId,omitempty"`
+	SourceResourceID *string
 
 	// If createOption is Import, this is the URI of a blob to be imported into a managed disk.
-	SourceURI *string `json:"sourceUri,omitempty"`
+	SourceURI *string
 
 	// Required if createOption is Import. The Azure Resource Manager identifier of the storage account containing the blob to
 	// import as a disk.
-	StorageAccountID *string `json:"storageAccountId,omitempty"`
+	StorageAccountID *string
 
 	// If createOption is Upload, this is the size of the contents of the upload including the VHD footer. This value should be
 	// between 20972032 (20 MiB + 512 bytes for the VHD footer) and 35183298347520
 	// bytes (32 TiB + 512 bytes for the VHD footer).
-	UploadSizeBytes *int64 `json:"uploadSizeBytes,omitempty"`
+	UploadSizeBytes *int64
 
 	// READ-ONLY; If this field is set, this is the unique id identifying the source of this resource.
-	SourceUniqueID *string `json:"sourceUniqueId,omitempty" azure:"ro"`
+	SourceUniqueID *string
 }
 
 // DataDisk - Describes a data disk.
@@ -495,11 +495,11 @@ type DataDisk struct {
 	// FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform
 	// image, you also use the imageReference element described above. If you are
 	// using a marketplace image, you also use the plan element previously described.
-	CreateOption *DiskCreateOptionTypes `json:"createOption,omitempty"`
+	CreateOption *DiskCreateOptionTypes
 
 	// REQUIRED; Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -507,49 +507,49 @@ type DataDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the size of an empty data disk in gigabytes. This element can be used to overwrite the size of the disk in a
 	// virtual machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual machine.
 	// If SourceImage is provided, the destination virtual hard drive must not
 	// exist.
-	Image *VirtualHardDisk `json:"image,omitempty"`
+	Image *VirtualHardDisk
 
 	// The managed disk parameters.
-	ManagedDisk *ManagedDiskParameters `json:"managedDisk,omitempty"`
+	ManagedDisk *ManagedDiskParameters
 
 	// The disk name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Specifies whether the data disk is in process of detachment from the VirtualMachine/VirtualMachineScaleset
-	ToBeDetached *bool `json:"toBeDetached,omitempty"`
+	ToBeDetached *bool
 
 	// The virtual hard disk.
-	Vhd *VirtualHardDisk `json:"vhd,omitempty"`
+	Vhd *VirtualHardDisk
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
-	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+	WriteAcceleratorEnabled *bool
 
 	// READ-ONLY; Specifies the Read-Write IOPS for the managed disk when StorageAccountType is UltraSSD_LRS. Returned only for
 	// VirtualMachine ScaleSet VM disks. Can be updated only via updates to the VirtualMachine
 	// Scale Set.
-	DiskIOPSReadWrite *int64 `json:"diskIOPSReadWrite,omitempty" azure:"ro"`
+	DiskIOPSReadWrite *int64
 
 	// READ-ONLY; Specifies the bandwidth in MB per second for the managed disk when StorageAccountType is UltraSSD_LRS. Returned
 	// only for VirtualMachine ScaleSet VM disks. Can be updated only via updates to the
 	// VirtualMachine Scale Set.
-	DiskMBpsReadWrite *int64 `json:"diskMBpsReadWrite,omitempty" azure:"ro"`
+	DiskMBpsReadWrite *int64
 }
 
 // DataDiskImage - Contains the data disk images information.
 type DataDiskImage struct {
 	// READ-ONLY; Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM
 	// and therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty" azure:"ro"`
+	Lun *int32
 }
 
 // DataDiskImageEncryption - Contains encryption settings for a data disk image.
@@ -557,51 +557,51 @@ type DataDiskImageEncryption struct {
 	// REQUIRED; This property specifies the logical unit number of the data disk. This value is used to identify data disks within
 	// the Virtual Machine and therefore must be unique for each data disk attached to the
 	// Virtual Machine.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 
 	// A relative URI containing the resource ID of the disk encryption set.
-	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
+	DiskEncryptionSetID *string
 }
 
 // DedicatedHost - Specifies information about the Dedicated host.
 type DedicatedHost struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// REQUIRED; SKU of the dedicated host for Hardware Generation and VM family. Only name is required to be set. List Microsoft.Compute
 	// SKUs for a list of possible values.
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Properties of the dedicated host.
-	Properties *DedicatedHostProperties `json:"properties,omitempty"`
+	Properties *DedicatedHostProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DedicatedHostAllocatableVM - Represents the dedicated host unutilized capacity in terms of a specific VM size.
 type DedicatedHostAllocatableVM struct {
 	// Maximum number of VMs of size vmSize that can fit in the dedicated host's remaining capacity.
-	Count *float64 `json:"count,omitempty"`
+	Count *float64
 
 	// VM size in terms of which the unutilized capacity is represented.
-	VMSize *string `json:"vmSize,omitempty"`
+	VMSize *string
 }
 
 // DedicatedHostAvailableCapacity - Dedicated host unutilized capacity.
 type DedicatedHostAvailableCapacity struct {
 	// The unutilized capacity of the dedicated host represented in terms of each VM size that is allowed to be deployed to the
 	// dedicated host.
-	AllocatableVMs []*DedicatedHostAllocatableVM `json:"allocatableVMs,omitempty"`
+	AllocatableVMs []*DedicatedHostAllocatableVM
 }
 
 // DedicatedHostGroup - Specifies information about the dedicated host group that the dedicated hosts should be assigned to.
@@ -609,61 +609,61 @@ type DedicatedHostAvailableCapacity struct {
 // be added to another dedicated host group.
 type DedicatedHostGroup struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Dedicated Host Group Properties.
-	Properties *DedicatedHostGroupProperties `json:"properties,omitempty"`
+	Properties *DedicatedHostGroupProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation.
 	// If not provided, the group supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DedicatedHostGroupListResult - The List Dedicated Host Group with resource group response.
 type DedicatedHostGroupListResult struct {
 	// REQUIRED; The list of dedicated host groups
-	Value []*DedicatedHostGroup `json:"value,omitempty"`
+	Value []*DedicatedHostGroup
 
 	// The URI to fetch the next page of Dedicated Host Groups. Call ListNext() with this URI to fetch the next page of Dedicated
 	// Host Groups.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DedicatedHostGroupProperties - Dedicated Host Group Properties.
 type DedicatedHostGroupProperties struct {
 	// REQUIRED; Number of fault domains that the host group can span.
-	PlatformFaultDomainCount *int32 `json:"platformFaultDomainCount,omitempty"`
+	PlatformFaultDomainCount *int32
 
 	// READ-ONLY; A list of references to all dedicated hosts in the dedicated host group.
-	Hosts []*SubResourceReadOnly `json:"hosts,omitempty" azure:"ro"`
+	Hosts []*SubResourceReadOnly
 }
 
 // DedicatedHostGroupUpdate - Specifies information about the dedicated host group that the dedicated host should be assigned
 // to. Only tags may be updated.
 type DedicatedHostGroupUpdate struct {
 	// Dedicated Host Group Properties.
-	Properties *DedicatedHostGroupProperties `json:"properties,omitempty"`
+	Properties *DedicatedHostGroupProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation.
 	// If not provided, the group supports all zones in the region. If provided,
 	// enforces each host in the group to be in the same zone.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 }
 
 // DedicatedHostGroupsClientCreateOrUpdateOptions contains the optional parameters for the DedicatedHostGroupsClient.CreateOrUpdate
@@ -702,29 +702,29 @@ type DedicatedHostGroupsClientUpdateOptions struct {
 // DedicatedHostInstanceView - The instance view of a dedicated host.
 type DedicatedHostInstanceView struct {
 	// Unutilized capacity of the dedicated host.
-	AvailableCapacity *DedicatedHostAvailableCapacity `json:"availableCapacity,omitempty"`
+	AvailableCapacity *DedicatedHostAvailableCapacity
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// READ-ONLY; Specifies the unique id of the dedicated physical machine on which the dedicated host resides.
-	AssetID *string `json:"assetId,omitempty" azure:"ro"`
+	AssetID *string
 }
 
 // DedicatedHostListResult - The list dedicated host operation response.
 type DedicatedHostListResult struct {
 	// REQUIRED; The list of dedicated hosts
-	Value []*DedicatedHost `json:"value,omitempty"`
+	Value []*DedicatedHost
 
 	// The URI to fetch the next page of dedicated hosts. Call ListNext() with this URI to fetch the next page of dedicated hosts.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DedicatedHostProperties - Properties of the dedicated host.
 type DedicatedHostProperties struct {
 	// Specifies whether the dedicated host should be replaced automatically in case of a failure. The value is defaulted to 'true'
 	// when not provided.
-	AutoReplaceOnFailure *bool `json:"autoReplaceOnFailure,omitempty"`
+	AutoReplaceOnFailure *bool
 
 	// Specifies the software license type that will be applied to the VMs deployed on the dedicated host.
 	// Possible values are:
@@ -732,36 +732,36 @@ type DedicatedHostProperties struct {
 	// WindowsServerHybrid
 	// WindowsServerPerpetual
 	// Default: None
-	LicenseType *DedicatedHostLicenseTypes `json:"licenseType,omitempty"`
+	LicenseType *DedicatedHostLicenseTypes
 
 	// Fault domain of the dedicated host within a dedicated host group.
-	PlatformFaultDomain *int32 `json:"platformFaultDomain,omitempty"`
+	PlatformFaultDomain *int32
 
 	// READ-ONLY; A unique id generated and assigned to the dedicated host by the platform.
 	// Does not change throughout the lifetime of the host.
-	HostID *string `json:"hostId,omitempty" azure:"ro"`
+	HostID *string
 
 	// READ-ONLY; The dedicated host instance view.
-	InstanceView *DedicatedHostInstanceView `json:"instanceView,omitempty" azure:"ro"`
+	InstanceView *DedicatedHostInstanceView
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; The date when the host was first provisioned.
-	ProvisioningTime *time.Time `json:"provisioningTime,omitempty" azure:"ro"`
+	ProvisioningTime *time.Time
 
 	// READ-ONLY; A list of references to all virtual machines in the Dedicated Host.
-	VirtualMachines []*SubResourceReadOnly `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines []*SubResourceReadOnly
 }
 
 // DedicatedHostUpdate - Specifies information about the dedicated host. Only tags, autoReplaceOnFailure and licenseType may
 // be updated.
 type DedicatedHostUpdate struct {
 	// Properties of the dedicated host.
-	Properties *DedicatedHostProperties `json:"properties,omitempty"`
+	Properties *DedicatedHostProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // DedicatedHostsClientBeginCreateOrUpdateOptions contains the optional parameters for the DedicatedHostsClient.BeginCreateOrUpdate
@@ -801,14 +801,14 @@ type DiagnosticsProfile struct {
 	// Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status.
 	// You can easily view the output of your console log.
 	// Azure also enables you to see a screenshot of the VM from the hypervisor.
-	BootDiagnostics *BootDiagnostics `json:"bootDiagnostics,omitempty"`
+	BootDiagnostics *BootDiagnostics
 }
 
 // DiffDiskSettings - Describes the parameters of ephemeral disk settings that can be specified for operating system disk.
 // NOTE: The ephemeral disk settings can only be specified for managed disk.
 type DiffDiskSettings struct {
 	// Specifies the ephemeral disk settings for operating system disk.
-	Option *DiffDiskOptions `json:"option,omitempty"`
+	Option *DiffDiskOptions
 
 	// Specifies the ephemeral disk placement for operating system disk.
 	// Possible values are:
@@ -818,80 +818,80 @@ type DiffDiskSettings struct {
 	// Refer to VM size documentation for Windows VM at https://docs.microsoft.com/en-us/azure/virtual-machines/windows/sizes
 	// and Linux VM at
 	// https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes to check which VM sizes exposes a cache disk.
-	Placement *DiffDiskPlacement `json:"placement,omitempty"`
+	Placement *DiffDiskPlacement
 }
 
 // Disallowed - Describes the disallowed disk types.
 type Disallowed struct {
 	// A list of disk types.
-	DiskTypes []*string `json:"diskTypes,omitempty"`
+	DiskTypes []*string
 }
 
 // Disk resource.
 type Disk struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Disk resource properties.
-	Properties *DiskProperties `json:"properties,omitempty"`
+	Properties *DiskProperties
 
 	// The disks sku name. Can be StandardLRS, PremiumLRS, StandardSSDLRS, or UltraSSDLRS.
-	SKU *DiskSKU `json:"sku,omitempty"`
+	SKU *DiskSKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The Logical zone list for Disk.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; A relative URI containing the ID of the VM that has the disk attached.
-	ManagedBy *string `json:"managedBy,omitempty" azure:"ro"`
+	ManagedBy *string
 
 	// READ-ONLY; List of relative URIs containing the IDs of the VMs that have the disk attached. maxShares should be set to
 	// a value greater than one for disks to allow attaching them to multiple VMs.
-	ManagedByExtended []*string `json:"managedByExtended,omitempty" azure:"ro"`
+	ManagedByExtended []*string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DiskEncryptionSet - disk encryption set resource.
 type DiskEncryptionSet struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used
 	// to encrypt disks.
-	Identity   *EncryptionSetIdentity   `json:"identity,omitempty"`
-	Properties *EncryptionSetProperties `json:"properties,omitempty"`
+	Identity   *EncryptionSetIdentity
+	Properties *EncryptionSetProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DiskEncryptionSetList - The List disk encryption set operation response.
 type DiskEncryptionSetList struct {
 	// REQUIRED; A list of disk encryption sets.
-	Value []*DiskEncryptionSet `json:"value,omitempty"`
+	Value []*DiskEncryptionSet
 
 	// The uri to fetch the next page of disk encryption sets. Call ListNext() with this to fetch the next page of disk encryption
 	// sets.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DiskEncryptionSetParameters - Describes the parameter of customer managed disk encryption set resource id that can be specified
@@ -900,22 +900,22 @@ type DiskEncryptionSetList struct {
 // for more details.
 type DiskEncryptionSetParameters struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // DiskEncryptionSetUpdate - disk encryption set update resource.
 type DiskEncryptionSetUpdate struct {
 	// disk encryption set resource update properties.
-	Properties *DiskEncryptionSetUpdateProperties `json:"properties,omitempty"`
+	Properties *DiskEncryptionSetUpdateProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // DiskEncryptionSetUpdateProperties - disk encryption set resource update properties.
 type DiskEncryptionSetUpdateProperties struct {
 	// Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the encryptionKey
-	ActiveKey *KeyVaultAndKeyReference `json:"activeKey,omitempty"`
+	ActiveKey *KeyVaultAndKeyReference
 }
 
 // DiskEncryptionSetsClientBeginCreateOrUpdateOptions contains the optional parameters for the DiskEncryptionSetsClient.BeginCreateOrUpdate
@@ -958,155 +958,155 @@ type DiskEncryptionSetsClientListOptions struct {
 // DiskEncryptionSettings - Describes a Encryption Settings for a Disk
 type DiskEncryptionSettings struct {
 	// Specifies the location of the disk encryption key, which is a Key Vault Secret.
-	DiskEncryptionKey *KeyVaultSecretReference `json:"diskEncryptionKey,omitempty"`
+	DiskEncryptionKey *KeyVaultSecretReference
 
 	// Specifies whether disk encryption should be enabled on the virtual machine.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Specifies the location of the key encryption key in Key Vault.
-	KeyEncryptionKey *KeyVaultKeyReference `json:"keyEncryptionKey,omitempty"`
+	KeyEncryptionKey *KeyVaultKeyReference
 }
 
 // DiskInstanceView - The instance view of the disk.
 type DiskInstanceView struct {
 	// Specifies the encryption settings for the OS Disk.
 	// Minimum api-version: 2015-06-15
-	EncryptionSettings []*DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	EncryptionSettings []*DiskEncryptionSettings
 
 	// The disk name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 }
 
 // DiskList - The List Disks operation response.
 type DiskList struct {
 	// REQUIRED; A list of disks.
-	Value []*Disk `json:"value,omitempty"`
+	Value []*Disk
 
 	// The uri to fetch the next page of disks. Call ListNext() with this to fetch the next page of disks.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DiskProperties - Disk resource properties.
 type DiskProperties struct {
 	// REQUIRED; Disk source information. CreationData information cannot be changed after the disk has been created.
-	CreationData *CreationData `json:"creationData,omitempty"`
+	CreationData *CreationData
 
 	// The total number of IOPS that will be allowed across all VMs mounting the shared disk as ReadOnly. One operation can transfer
 	// between 4k and 256k bytes.
-	DiskIOPSReadOnly *int64 `json:"diskIOPSReadOnly,omitempty"`
+	DiskIOPSReadOnly *int64
 
 	// The number of IOPS allowed for this disk; only settable for UltraSSD disks. One operation can transfer between 4k and 256k
 	// bytes.
-	DiskIOPSReadWrite *int64 `json:"diskIOPSReadWrite,omitempty"`
+	DiskIOPSReadWrite *int64
 
 	// The total throughput (MBps) that will be allowed across all VMs mounting the shared disk as ReadOnly. MBps means millions
 	// of bytes per second - MB here uses the ISO notation, of powers of 10.
-	DiskMBpsReadOnly *int64 `json:"diskMBpsReadOnly,omitempty"`
+	DiskMBpsReadOnly *int64
 
 	// The bandwidth allowed for this disk; only settable for UltraSSD disks. MBps means millions of bytes per second - MB here
 	// uses the ISO notation, of powers of 10.
-	DiskMBpsReadWrite *int64 `json:"diskMBpsReadWrite,omitempty"`
+	DiskMBpsReadWrite *int64
 
 	// If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to create. If this
 	// field is present for updates or creation with other options, it indicates a
 	// resize. Resizes are only allowed if the disk is not attached to a running VM, and can only increase the disk's size.
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Encryption property can be used to encrypt data at rest with customer managed keys or platform managed keys.
-	Encryption *Encryption `json:"encryption,omitempty"`
+	Encryption *Encryption
 
 	// Encryption settings collection used for Azure Disk Encryption, can contain multiple encryption settings per disk or snapshot.
-	EncryptionSettingsCollection *EncryptionSettingsCollection `json:"encryptionSettingsCollection,omitempty"`
+	EncryptionSettingsCollection *EncryptionSettingsCollection
 
 	// The hypervisor generation of the Virtual Machine. Applicable to OS disks only.
-	HyperVGeneration *HyperVGeneration `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGeneration
 
 	// The maximum number of VMs that can attach to the disk at the same time. Value greater than one indicates a disk that can
 	// be mounted on multiple VMs at the same time.
-	MaxShares *int32 `json:"maxShares,omitempty"`
+	MaxShares *int32
 
 	// The Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// READ-ONLY; The size of the disk in bytes. This field is read only.
-	DiskSizeBytes *int64 `json:"diskSizeBytes,omitempty" azure:"ro"`
+	DiskSizeBytes *int64
 
 	// READ-ONLY; The state of the disk.
-	DiskState *DiskState `json:"diskState,omitempty" azure:"ro"`
+	DiskState *DiskState
 
 	// READ-ONLY; The disk provisioning state.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; Details of the list of all VMs that have the disk attached. maxShares should be set to a value greater than
 	// one for disks to allow attaching them to multiple VMs.
-	ShareInfo []*ShareInfoElement `json:"shareInfo,omitempty" azure:"ro"`
+	ShareInfo []*ShareInfoElement
 
 	// READ-ONLY; The time when the disk was created.
-	TimeCreated *time.Time `json:"timeCreated,omitempty" azure:"ro"`
+	TimeCreated *time.Time
 
 	// READ-ONLY; Unique Guid identifying the resource.
-	UniqueID *string `json:"uniqueId,omitempty" azure:"ro"`
+	UniqueID *string
 }
 
 // DiskSKU - The disks sku name. Can be StandardLRS, PremiumLRS, StandardSSDLRS, or UltraSSDLRS.
 type DiskSKU struct {
 	// The sku name.
-	Name *DiskStorageAccountTypes `json:"name,omitempty"`
+	Name *DiskStorageAccountTypes
 
 	// READ-ONLY; The sku tier.
-	Tier *string `json:"tier,omitempty" azure:"ro"`
+	Tier *string
 }
 
 // DiskUpdate - Disk update resource.
 type DiskUpdate struct {
 	// Disk resource update properties.
-	Properties *DiskUpdateProperties `json:"properties,omitempty"`
+	Properties *DiskUpdateProperties
 
 	// The disks sku name. Can be StandardLRS, PremiumLRS, StandardSSDLRS, or UltraSSDLRS.
-	SKU *DiskSKU `json:"sku,omitempty"`
+	SKU *DiskSKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // DiskUpdateProperties - Disk resource update properties.
 type DiskUpdateProperties struct {
 	// The total number of IOPS that will be allowed across all VMs mounting the shared disk as ReadOnly. One operation can transfer
 	// between 4k and 256k bytes.
-	DiskIOPSReadOnly *int64 `json:"diskIOPSReadOnly,omitempty"`
+	DiskIOPSReadOnly *int64
 
 	// The number of IOPS allowed for this disk; only settable for UltraSSD disks. One operation can transfer between 4k and 256k
 	// bytes.
-	DiskIOPSReadWrite *int64 `json:"diskIOPSReadWrite,omitempty"`
+	DiskIOPSReadWrite *int64
 
 	// The total throughput (MBps) that will be allowed across all VMs mounting the shared disk as ReadOnly. MBps means millions
 	// of bytes per second - MB here uses the ISO notation, of powers of 10.
-	DiskMBpsReadOnly *int64 `json:"diskMBpsReadOnly,omitempty"`
+	DiskMBpsReadOnly *int64
 
 	// The bandwidth allowed for this disk; only settable for UltraSSD disks. MBps means millions of bytes per second - MB here
 	// uses the ISO notation, of powers of 10.
-	DiskMBpsReadWrite *int64 `json:"diskMBpsReadWrite,omitempty"`
+	DiskMBpsReadWrite *int64
 
 	// If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to create. If this
 	// field is present for updates or creation with other options, it indicates a
 	// resize. Resizes are only allowed if the disk is not attached to a running VM, and can only increase the disk's size.
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Encryption property can be used to encrypt data at rest with customer managed keys or platform managed keys.
-	Encryption *Encryption `json:"encryption,omitempty"`
+	Encryption *Encryption
 
 	// Encryption settings collection used be Azure Disk Encryption, can contain multiple encryption settings per disk or snapshot.
-	EncryptionSettingsCollection *EncryptionSettingsCollection `json:"encryptionSettingsCollection,omitempty"`
+	EncryptionSettingsCollection *EncryptionSettingsCollection
 
 	// The maximum number of VMs that can attach to the disk at the same time. Value greater than one indicates a disk that can
 	// be mounted on multiple VMs at the same time.
-	MaxShares *int32 `json:"maxShares,omitempty"`
+	MaxShares *int32
 
 	// the Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 }
 
 // DisksClientBeginCreateOrUpdateOptions contains the optional parameters for the DisksClient.BeginCreateOrUpdate method.
@@ -1158,48 +1158,48 @@ type DisksClientListOptions struct {
 // Encryption at rest settings for disk or snapshot
 type Encryption struct {
 	// ResourceId of the disk encryption set to use for enabling encryption at rest.
-	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
+	DiskEncryptionSetID *string
 
 	// The type of key used to encrypt the data of the disk.
-	Type *EncryptionType `json:"type,omitempty"`
+	Type *EncryptionType
 }
 
 // EncryptionImages - Optional. Allows users to provide customer managed keys for encrypting the OS and data disks in the
 // gallery artifact.
 type EncryptionImages struct {
 	// A list of encryption specifications for data disk images.
-	DataDiskImages []*DataDiskImageEncryption `json:"dataDiskImages,omitempty"`
+	DataDiskImages []*DataDiskImageEncryption
 
 	// Contains encryption settings for an OS disk image.
-	OSDiskImage *OSDiskImageEncryption `json:"osDiskImage,omitempty"`
+	OSDiskImage *OSDiskImageEncryption
 }
 
 // EncryptionSetIdentity - The managed identity for the disk encryption set. It should be given permission on the key vault
 // before it can be used to encrypt disks.
 type EncryptionSetIdentity struct {
 	// The type of Managed Identity used by the DiskEncryptionSet. Only SystemAssigned is supported.
-	Type *DiskEncryptionSetIdentityType `json:"type,omitempty"`
+	Type *DiskEncryptionSetIdentityType
 
 	// READ-ONLY; The object id of the Managed Identity Resource. This will be sent to the RP from ARM via the x-ms-identity-principal-id
 	// header in the PUT request if the resource has a systemAssigned(implicit)
 	// identity
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The tenant id of the Managed Identity Resource. This will be sent to the RP from ARM via the x-ms-client-tenant-id
 	// header in the PUT request if the resource has a systemAssigned(implicit) identity
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 type EncryptionSetProperties struct {
 	// The key vault key which is currently used by this disk encryption set.
-	ActiveKey *KeyVaultAndKeyReference `json:"activeKey,omitempty"`
+	ActiveKey *KeyVaultAndKeyReference
 
 	// READ-ONLY; A readonly collection of key vault keys previously used by this disk encryption set while a key rotation is
 	// in progress. It will be empty if there is no ongoing key rotation.
-	PreviousKeys []*KeyVaultAndKeyReference `json:"previousKeys,omitempty" azure:"ro"`
+	PreviousKeys []*KeyVaultAndKeyReference
 
 	// READ-ONLY; The disk encryption set provisioning state.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // EncryptionSettingsCollection - Encryption settings for disk or snapshot
@@ -1207,25 +1207,25 @@ type EncryptionSettingsCollection struct {
 	// REQUIRED; Set this flag to true and provide DiskEncryptionKey and optional KeyEncryptionKey to enable encryption. Set this
 	// flag to false and remove DiskEncryptionKey and KeyEncryptionKey to disable encryption.
 	// If EncryptionSettings is null in the request object, the existing settings remain unchanged.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// A collection of encryption settings, one for each disk volume.
-	EncryptionSettings []*EncryptionSettingsElement `json:"encryptionSettings,omitempty"`
+	EncryptionSettings []*EncryptionSettingsElement
 
 	// Describes what type of encryption is used for the disks. Once this field is set, it cannot be overwritten. '1.0' corresponds
 	// to Azure Disk Encryption with AAD app.'1.1' corresponds to Azure Disk
 	// Encryption.
-	EncryptionSettingsVersion *string `json:"encryptionSettingsVersion,omitempty"`
+	EncryptionSettingsVersion *string
 }
 
 // EncryptionSettingsElement - Encryption settings for one disk volume.
 type EncryptionSettingsElement struct {
 	// Key Vault Secret Url and vault id of the disk encryption key
-	DiskEncryptionKey *KeyVaultAndSecretReference `json:"diskEncryptionKey,omitempty"`
+	DiskEncryptionKey *KeyVaultAndSecretReference
 
 	// Key Vault Key Url and vault id of the key encryption key. KeyEncryptionKey is optional and when provided is used to unwrap
 	// the disk encryption key.
-	KeyEncryptionKey *KeyVaultAndKeyReference `json:"keyEncryptionKey,omitempty"`
+	KeyEncryptionKey *KeyVaultAndKeyReference
 }
 
 // GalleriesClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleriesClient.BeginCreateOrUpdate
@@ -1266,53 +1266,53 @@ type GalleriesClientListOptions struct {
 // Gallery - Specifies information about the Shared Image Gallery that you want to create or update.
 type Gallery struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a Shared Image Gallery.
-	Properties *GalleryProperties `json:"properties,omitempty"`
+	Properties *GalleryProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryApplication - Specifies information about the gallery Application Definition that you want to create or update.
 type GalleryApplication struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a gallery Application Definition.
-	Properties *GalleryApplicationProperties `json:"properties,omitempty"`
+	Properties *GalleryApplicationProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryApplicationList - The List Gallery Applications operation response.
 type GalleryApplicationList struct {
 	// REQUIRED; A list of Gallery Applications.
-	Value []*GalleryApplication `json:"value,omitempty"`
+	Value []*GalleryApplication
 
 	// The uri to fetch the next page of Application Definitions in the Application Gallery. Call ListNext() with this to fetch
 	// the next page of gallery Application Definitions.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // GalleryApplicationProperties - Describes the properties of a gallery Application Definition.
@@ -1321,132 +1321,132 @@ type GalleryApplicationProperties struct {
 	// Possible values are:
 	// Windows
 	// Linux
-	SupportedOSType *OperatingSystemTypes `json:"supportedOSType,omitempty"`
+	SupportedOSType *OperatingSystemTypes
 
 	// The description of this gallery Application Definition resource. This property is updatable.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The end of life date of the gallery Application Definition. This property can be used for decommissioning purposes. This
 	// property is updatable.
-	EndOfLifeDate *time.Time `json:"endOfLifeDate,omitempty"`
+	EndOfLifeDate *time.Time
 
 	// The Eula agreement for the gallery Application Definition.
-	Eula *string `json:"eula,omitempty"`
+	Eula *string
 
 	// The privacy statement uri.
-	PrivacyStatementURI *string `json:"privacyStatementUri,omitempty"`
+	PrivacyStatementURI *string
 
 	// The release note uri.
-	ReleaseNoteURI *string `json:"releaseNoteUri,omitempty"`
+	ReleaseNoteURI *string
 }
 
 // GalleryApplicationUpdate - Specifies information about the gallery Application Definition that you want to update.
 type GalleryApplicationUpdate struct {
 	// Describes the properties of a gallery Application Definition.
-	Properties *GalleryApplicationProperties `json:"properties,omitempty"`
+	Properties *GalleryApplicationProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryApplicationVersion - Specifies information about the gallery Application Version that you want to create or update.
 type GalleryApplicationVersion struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a gallery Image Version.
-	Properties *GalleryApplicationVersionProperties `json:"properties,omitempty"`
+	Properties *GalleryApplicationVersionProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryApplicationVersionList - The List Gallery Application version operation response.
 type GalleryApplicationVersionList struct {
 	// REQUIRED; A list of gallery Application Versions.
-	Value []*GalleryApplicationVersion `json:"value,omitempty"`
+	Value []*GalleryApplicationVersion
 
 	// The uri to fetch the next page of gallery Application Versions. Call ListNext() with this to fetch the next page of gallery
 	// Application Versions.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // GalleryApplicationVersionProperties - Describes the properties of a gallery Image Version.
 type GalleryApplicationVersionProperties struct {
 	// REQUIRED; The publishing profile of a gallery image version.
-	PublishingProfile *GalleryApplicationVersionPublishingProfile `json:"publishingProfile,omitempty"`
+	PublishingProfile *GalleryApplicationVersionPublishingProfile
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *GalleryApplicationVersionPropertiesProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *GalleryApplicationVersionPropertiesProvisioningState
 
 	// READ-ONLY; This is the replication status of the gallery Image Version.
-	ReplicationStatus *ReplicationStatus `json:"replicationStatus,omitempty" azure:"ro"`
+	ReplicationStatus *ReplicationStatus
 }
 
 // GalleryApplicationVersionPublishingProfile - The publishing profile of a gallery image version.
 type GalleryApplicationVersionPublishingProfile struct {
 	// REQUIRED; The source image from which the Image Version is going to be created.
-	Source *UserArtifactSource `json:"source,omitempty"`
+	Source *UserArtifactSource
 
 	// Optional. Whether or not this application reports health.
-	EnableHealthCheck *bool `json:"enableHealthCheck,omitempty"`
+	EnableHealthCheck *bool
 
 	// The end of life date of the gallery Image Version. This property can be used for decommissioning purposes. This property
 	// is updatable.
-	EndOfLifeDate *time.Time `json:"endOfLifeDate,omitempty"`
+	EndOfLifeDate *time.Time
 
 	// If set to true, Virtual Machines deployed from the latest version of the Image Definition won't use this Image Version.
-	ExcludeFromLatest *bool               `json:"excludeFromLatest,omitempty"`
-	ManageActions     *UserArtifactManage `json:"manageActions,omitempty"`
+	ExcludeFromLatest *bool
+	ManageActions     *UserArtifactManage
 
 	// The number of replicas of the Image Version to be created per region. This property would take effect for a region when
 	// regionalReplicaCount is not specified. This property is updatable.
-	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	ReplicaCount *int32
 
 	// Specifies the storage account type to be used to store the image. This property is not updatable.
-	StorageAccountType *StorageAccountType `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountType
 
 	// The target regions where the Image Version is going to be replicated to. This property is updatable.
-	TargetRegions []*TargetRegion `json:"targetRegions,omitempty"`
+	TargetRegions []*TargetRegion
 
 	// READ-ONLY; The timestamp for when the gallery Image Version is published.
-	PublishedDate *time.Time `json:"publishedDate,omitempty" azure:"ro"`
+	PublishedDate *time.Time
 }
 
 // GalleryApplicationVersionUpdate - Specifies information about the gallery Application Version that you want to update.
 type GalleryApplicationVersionUpdate struct {
 	// Describes the properties of a gallery Image Version.
-	Properties *GalleryApplicationVersionProperties `json:"properties,omitempty"`
+	Properties *GalleryApplicationVersionProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryApplicationVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryApplicationVersionsClient.BeginCreateOrUpdate
@@ -1518,7 +1518,7 @@ type GalleryApplicationsClientListByGalleryOptions struct {
 // GalleryArtifactVersionSource - The gallery artifact version source.
 type GalleryArtifactVersionSource struct {
 	// The id of the gallery artifact version source. Can specify a disk uri, snapshot uri, or user image.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // GalleryDataDiskImage - This is the data disk image.
@@ -1526,230 +1526,230 @@ type GalleryDataDiskImage struct {
 	// REQUIRED; This property specifies the logical unit number of the data disk. This value is used to identify data disks within
 	// the Virtual Machine and therefore must be unique for each data disk attached to the
 	// Virtual Machine.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 
 	// The host caching of the disk. Valid values are 'None', 'ReadOnly', and 'ReadWrite'
-	HostCaching *HostCaching `json:"hostCaching,omitempty"`
+	HostCaching *HostCaching
 
 	// The gallery artifact version source.
-	Source *GalleryArtifactVersionSource `json:"source,omitempty"`
+	Source *GalleryArtifactVersionSource
 
 	// READ-ONLY; This property indicates the size of the VHD to be created.
-	SizeInGB *int32 `json:"sizeInGB,omitempty" azure:"ro"`
+	SizeInGB *int32
 }
 
 // GalleryIdentifier - Describes the gallery unique name.
 type GalleryIdentifier struct {
 	// READ-ONLY; The unique name of the Shared Image Gallery. This name is generated automatically by Azure.
-	UniqueName *string `json:"uniqueName,omitempty" azure:"ro"`
+	UniqueName *string
 }
 
 // GalleryImage - Specifies information about the gallery Image Definition that you want to create or update.
 type GalleryImage struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a gallery Image Definition.
-	Properties *GalleryImageProperties `json:"properties,omitempty"`
+	Properties *GalleryImageProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryImageIdentifier - This is the gallery Image Definition identifier.
 type GalleryImageIdentifier struct {
 	// REQUIRED; The name of the gallery Image Definition offer.
-	Offer *string `json:"offer,omitempty"`
+	Offer *string
 
 	// REQUIRED; The name of the gallery Image Definition publisher.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 
 	// REQUIRED; The name of the gallery Image Definition SKU.
-	SKU *string `json:"sku,omitempty"`
+	SKU *string
 }
 
 // GalleryImageList - The List Gallery Images operation response.
 type GalleryImageList struct {
 	// REQUIRED; A list of Shared Image Gallery images.
-	Value []*GalleryImage `json:"value,omitempty"`
+	Value []*GalleryImage
 
 	// The uri to fetch the next page of Image Definitions in the Shared Image Gallery. Call ListNext() with this to fetch the
 	// next page of gallery Image Definitions.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // GalleryImageProperties - Describes the properties of a gallery Image Definition.
 type GalleryImageProperties struct {
 	// REQUIRED; This is the gallery Image Definition identifier.
-	Identifier *GalleryImageIdentifier `json:"identifier,omitempty"`
+	Identifier *GalleryImageIdentifier
 
 	// REQUIRED; This property allows the user to specify whether the virtual machines created under this image are 'Generalized'
 	// or 'Specialized'.
-	OSState *OperatingSystemStateTypes `json:"osState,omitempty"`
+	OSState *OperatingSystemStateTypes
 
 	// REQUIRED; This property allows you to specify the type of the OS that is included in the disk when creating a VM from a
 	// managed image.
 	// Possible values are:
 	// Windows
 	// Linux
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// The description of this gallery Image Definition resource. This property is updatable.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Describes the disallowed disk types.
-	Disallowed *Disallowed `json:"disallowed,omitempty"`
+	Disallowed *Disallowed
 
 	// The end of life date of the gallery Image Definition. This property can be used for decommissioning purposes. This property
 	// is updatable.
-	EndOfLifeDate *time.Time `json:"endOfLifeDate,omitempty"`
+	EndOfLifeDate *time.Time
 
 	// The Eula agreement for the gallery Image Definition.
-	Eula *string `json:"eula,omitempty"`
+	Eula *string
 
 	// The hypervisor generation of the Virtual Machine. Applicable to OS disks only.
-	HyperVGeneration *HyperVGeneration `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGeneration
 
 	// The privacy statement uri.
-	PrivacyStatementURI *string `json:"privacyStatementUri,omitempty"`
+	PrivacyStatementURI *string
 
 	// Describes the gallery Image Definition purchase plan. This is used by marketplace images.
-	PurchasePlan *ImagePurchasePlan `json:"purchasePlan,omitempty"`
+	PurchasePlan *ImagePurchasePlan
 
 	// The properties describe the recommended machine configuration for this Image Definition. These properties are updatable.
-	Recommended *RecommendedMachineConfiguration `json:"recommended,omitempty"`
+	Recommended *RecommendedMachineConfiguration
 
 	// The release note uri.
-	ReleaseNoteURI *string `json:"releaseNoteUri,omitempty"`
+	ReleaseNoteURI *string
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *GalleryImagePropertiesProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *GalleryImagePropertiesProvisioningState
 }
 
 // GalleryImageUpdate - Specifies information about the gallery Image Definition that you want to update.
 type GalleryImageUpdate struct {
 	// Describes the properties of a gallery Image Definition.
-	Properties *GalleryImageProperties `json:"properties,omitempty"`
+	Properties *GalleryImageProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryImageVersion - Specifies information about the gallery Image Version that you want to create or update.
 type GalleryImageVersion struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a gallery Image Version.
-	Properties *GalleryImageVersionProperties `json:"properties,omitempty"`
+	Properties *GalleryImageVersionProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryImageVersionList - The List Gallery Image version operation response.
 type GalleryImageVersionList struct {
 	// REQUIRED; A list of gallery Image Versions.
-	Value []*GalleryImageVersion `json:"value,omitempty"`
+	Value []*GalleryImageVersion
 
 	// The uri to fetch the next page of gallery Image Versions. Call ListNext() with this to fetch the next page of gallery Image
 	// Versions.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // GalleryImageVersionProperties - Describes the properties of a gallery Image Version.
 type GalleryImageVersionProperties struct {
 	// REQUIRED; This is the storage profile of a Gallery Image Version.
-	StorageProfile *GalleryImageVersionStorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *GalleryImageVersionStorageProfile
 
 	// The publishing profile of a gallery Image Version.
-	PublishingProfile *GalleryImageVersionPublishingProfile `json:"publishingProfile,omitempty"`
+	PublishingProfile *GalleryImageVersionPublishingProfile
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *GalleryImageVersionPropertiesProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *GalleryImageVersionPropertiesProvisioningState
 
 	// READ-ONLY; This is the replication status of the gallery Image Version.
-	ReplicationStatus *ReplicationStatus `json:"replicationStatus,omitempty" azure:"ro"`
+	ReplicationStatus *ReplicationStatus
 }
 
 // GalleryImageVersionPublishingProfile - The publishing profile of a gallery Image Version.
 type GalleryImageVersionPublishingProfile struct {
 	// The end of life date of the gallery Image Version. This property can be used for decommissioning purposes. This property
 	// is updatable.
-	EndOfLifeDate *time.Time `json:"endOfLifeDate,omitempty"`
+	EndOfLifeDate *time.Time
 
 	// If set to true, Virtual Machines deployed from the latest version of the Image Definition won't use this Image Version.
-	ExcludeFromLatest *bool `json:"excludeFromLatest,omitempty"`
+	ExcludeFromLatest *bool
 
 	// The number of replicas of the Image Version to be created per region. This property would take effect for a region when
 	// regionalReplicaCount is not specified. This property is updatable.
-	ReplicaCount *int32 `json:"replicaCount,omitempty"`
+	ReplicaCount *int32
 
 	// Specifies the storage account type to be used to store the image. This property is not updatable.
-	StorageAccountType *StorageAccountType `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountType
 
 	// The target regions where the Image Version is going to be replicated to. This property is updatable.
-	TargetRegions []*TargetRegion `json:"targetRegions,omitempty"`
+	TargetRegions []*TargetRegion
 
 	// READ-ONLY; The timestamp for when the gallery Image Version is published.
-	PublishedDate *time.Time `json:"publishedDate,omitempty" azure:"ro"`
+	PublishedDate *time.Time
 }
 
 // GalleryImageVersionStorageProfile - This is the storage profile of a Gallery Image Version.
 type GalleryImageVersionStorageProfile struct {
 	// A list of data disk images.
-	DataDiskImages []*GalleryDataDiskImage `json:"dataDiskImages,omitempty"`
+	DataDiskImages []*GalleryDataDiskImage
 
 	// This is the OS disk image.
-	OSDiskImage *GalleryOSDiskImage `json:"osDiskImage,omitempty"`
+	OSDiskImage *GalleryOSDiskImage
 
 	// The gallery artifact version source.
-	Source *GalleryArtifactVersionSource `json:"source,omitempty"`
+	Source *GalleryArtifactVersionSource
 }
 
 // GalleryImageVersionUpdate - Specifies information about the gallery Image Version that you want to update.
 type GalleryImageVersionUpdate struct {
 	// Describes the properties of a gallery Image Version.
-	Properties *GalleryImageVersionProperties `json:"properties,omitempty"`
+	Properties *GalleryImageVersionProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GalleryImageVersionsClientBeginCreateOrUpdateOptions contains the optional parameters for the GalleryImageVersionsClient.BeginCreateOrUpdate
@@ -1818,61 +1818,61 @@ type GalleryImagesClientListByGalleryOptions struct {
 // GalleryList - The List Galleries operation response.
 type GalleryList struct {
 	// REQUIRED; A list of galleries.
-	Value []*Gallery `json:"value,omitempty"`
+	Value []*Gallery
 
 	// The uri to fetch the next page of galleries. Call ListNext() with this to fetch the next page of galleries.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // GalleryOSDiskImage - This is the OS disk image.
 type GalleryOSDiskImage struct {
 	// The host caching of the disk. Valid values are 'None', 'ReadOnly', and 'ReadWrite'
-	HostCaching *HostCaching `json:"hostCaching,omitempty"`
+	HostCaching *HostCaching
 
 	// The gallery artifact version source.
-	Source *GalleryArtifactVersionSource `json:"source,omitempty"`
+	Source *GalleryArtifactVersionSource
 
 	// READ-ONLY; This property indicates the size of the VHD to be created.
-	SizeInGB *int32 `json:"sizeInGB,omitempty" azure:"ro"`
+	SizeInGB *int32
 }
 
 // GalleryProperties - Describes the properties of a Shared Image Gallery.
 type GalleryProperties struct {
 	// The description of this Shared Image Gallery resource. This property is updatable.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Describes the gallery unique name.
-	Identifier *GalleryIdentifier `json:"identifier,omitempty"`
+	Identifier *GalleryIdentifier
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *GalleryPropertiesProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *GalleryPropertiesProvisioningState
 }
 
 // GalleryUpdate - Specifies information about the Shared Image Gallery that you want to update.
 type GalleryUpdate struct {
 	// Describes the properties of a Shared Image Gallery.
-	Properties *GalleryProperties `json:"properties,omitempty"`
+	Properties *GalleryProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GrantAccessData - Data used for requesting a SAS.
 type GrantAccessData struct {
 	// REQUIRED
-	Access *AccessLevel `json:"access,omitempty"`
+	Access *AccessLevel
 
 	// REQUIRED; Time duration in seconds until the SAS access expires.
-	DurationInSeconds *int32 `json:"durationInSeconds,omitempty"`
+	DurationInSeconds *int32
 }
 
 // HardwareProfile - Specifies the hardware settings for the virtual machine.
@@ -1883,7 +1883,7 @@ type HardwareProfile struct {
 	// List all available virtual machine sizes in an availability set [https://docs.microsoft.com/rest/api/compute/availabilitysets/listavailablesizes]
 	// List all available virtual machine sizes in a region [https://docs.microsoft.com/rest/api/compute/virtualmachinesizes/list]
 	// List all available virtual machine sizes for resizing [https://docs.microsoft.com/rest/api/compute/virtualmachines/listavailablesizes]
-	VMSize *VirtualMachineSizeTypes `json:"vmSize,omitempty"`
+	VMSize *VirtualMachineSizeTypes
 }
 
 // Image - The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual
@@ -1891,32 +1891,32 @@ type HardwareProfile struct {
 // exist.
 type Image struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of an Image.
-	Properties *ImageProperties `json:"properties,omitempty"`
+	Properties *ImageProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ImageDataDisk - Describes a data disk.
 type ImageDataDisk struct {
 	// REQUIRED; Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 
 	// The Virtual Hard Disk.
-	BlobURI *string `json:"blobUri,omitempty"`
+	BlobURI *string
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -1924,60 +1924,60 @@ type ImageDataDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the customer managed disk encryption set resource id for the managed image disk.
-	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters
 
 	// Specifies the size of empty data disks in gigabytes. This element can be used to overwrite the name of the disk in a virtual
 	// machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// The managedDisk.
-	ManagedDisk *SubResource `json:"managedDisk,omitempty"`
+	ManagedDisk *SubResource
 
 	// The snapshot.
-	Snapshot *SubResource `json:"snapshot,omitempty"`
+	Snapshot *SubResource
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot
 	// be used with OS Disk.
-	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountTypes
 }
 
 // ImageDiskReference - The source image used for creating the disk.
 type ImageDiskReference struct {
 	// REQUIRED; A relative uri containing either a Platform Image Repository or user image reference.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// If the disk is created from an image's data disk, this is an index that indicates which of the data disks in the image
 	// to use. For OS disks, this field is null.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 }
 
 // ImageListResult - The List Image operation response.
 type ImageListResult struct {
 	// REQUIRED; The list of Images.
-	Value []*Image `json:"value,omitempty"`
+	Value []*Image
 
 	// The uri to fetch the next page of Images. Call ListNext() with this to fetch the next page of Images.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // ImageOSDisk - Describes an Operating System disk.
 type ImageOSDisk struct {
 	// REQUIRED; The OS State.
-	OSState *OperatingSystemStateTypes `json:"osState,omitempty"`
+	OSState *OperatingSystemStateTypes
 
 	// REQUIRED; This property allows you to specify the type of the OS that is included in the disk if creating a VM from a custom
 	// image.
 	// Possible values are:
 	// Windows
 	// Linux
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// The Virtual Hard Disk.
-	BlobURI *string `json:"blobUri,omitempty"`
+	BlobURI *string
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -1985,52 +1985,52 @@ type ImageOSDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the customer managed disk encryption set resource id for the managed image disk.
-	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters
 
 	// Specifies the size of empty data disks in gigabytes. This element can be used to overwrite the name of the disk in a virtual
 	// machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// The managedDisk.
-	ManagedDisk *SubResource `json:"managedDisk,omitempty"`
+	ManagedDisk *SubResource
 
 	// The snapshot.
-	Snapshot *SubResource `json:"snapshot,omitempty"`
+	Snapshot *SubResource
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot
 	// be used with OS Disk.
-	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountTypes
 }
 
 // ImageProperties - Describes the properties of an Image.
 type ImageProperties struct {
 	// Gets the HyperVGenerationType of the VirtualMachine created from the image
-	HyperVGeneration *HyperVGenerationTypes `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGenerationTypes
 
 	// The source virtual machine from which Image is created.
-	SourceVirtualMachine *SubResource `json:"sourceVirtualMachine,omitempty"`
+	SourceVirtualMachine *SubResource
 
 	// Specifies the storage settings for the virtual machine disks.
-	StorageProfile *ImageStorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *ImageStorageProfile
 
 	// READ-ONLY; The provisioning state.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // ImagePurchasePlan - Describes the gallery Image Definition purchase plan. This is used by marketplace images.
 type ImagePurchasePlan struct {
 	// The plan ID.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The product ID.
-	Product *string `json:"product,omitempty"`
+	Product *string
 
 	// The publisher ID.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 }
 
 // ImageReference - Specifies information about the image to use. You can specify information about platform images, marketplace
@@ -2039,28 +2039,28 @@ type ImagePurchasePlan struct {
 // publisher and offer can only be set when you create the scale set.
 type ImageReference struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Specifies the offer of the platform image or marketplace image used to create the virtual machine.
-	Offer *string `json:"offer,omitempty"`
+	Offer *string
 
 	// The image publisher.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 
 	// The image SKU.
-	SKU *string `json:"sku,omitempty"`
+	SKU *string
 
 	// Specifies the version of the platform image or marketplace image used to create the virtual machine. The allowed formats
 	// are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers.
 	// Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image
 	// will not automatically update after deploy time even if a new version becomes
 	// available.
-	Version *string `json:"version,omitempty"`
+	Version *string
 
 	// READ-ONLY; Specifies in decimal numbers, the version of platform image or marketplace image used to create the virtual
 	// machine. This readonly field differs from 'version', only if the value specified in
 	// 'version' field is 'latest'.
-	ExactVersion *string `json:"exactVersion,omitempty" azure:"ro"`
+	ExactVersion *string
 }
 
 // ImageStorageProfile - Describes a storage profile.
@@ -2068,25 +2068,25 @@ type ImageStorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks []*ImageDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*ImageDataDisk
 
 	// Specifies information about the operating system disk used by the virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	OSDisk *ImageOSDisk `json:"osDisk,omitempty"`
+	OSDisk *ImageOSDisk
 
 	// Specifies whether an image is zone resilient or not. Default is false. Zone resilient images can be created only in regions
 	// that provide Zone Redundant Storage (ZRS).
-	ZoneResilient *bool `json:"zoneResilient,omitempty"`
+	ZoneResilient *bool
 }
 
 // ImageUpdate - The source user image virtual hard disk. Only tags may be updated.
 type ImageUpdate struct {
 	// Describes the properties of an Image.
-	Properties *ImageProperties `json:"properties,omitempty"`
+	Properties *ImageProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // ImagesClientBeginCreateOrUpdateOptions contains the optional parameters for the ImagesClient.BeginCreateOrUpdate method.
@@ -2127,65 +2127,65 @@ type ImagesClientListOptions struct {
 // InnerError - Inner error details.
 type InnerError struct {
 	// The internal error message or exception dump.
-	Errordetail *string `json:"errordetail,omitempty"`
+	Errordetail *string
 
 	// The exception type.
-	Exceptiontype *string `json:"exceptiontype,omitempty"`
+	Exceptiontype *string
 }
 
 // InstanceViewStatus - Instance view status.
 type InstanceViewStatus struct {
 	// The status code.
-	Code *string `json:"code,omitempty"`
+	Code *string
 
 	// The short localizable label for the status.
-	DisplayStatus *string `json:"displayStatus,omitempty"`
+	DisplayStatus *string
 
 	// The level code.
-	Level *StatusLevelTypes `json:"level,omitempty"`
+	Level *StatusLevelTypes
 
 	// The detailed status message, including for alerts and error messages.
-	Message *string `json:"message,omitempty"`
+	Message *string
 
 	// The time of the status.
-	Time *time.Time `json:"time,omitempty"`
+	Time *time.Time
 }
 
 // KeyVaultAndKeyReference - Key Vault Key Url and vault id of KeK, KeK is optional and when provided is used to unwrap the
 // encryptionKey
 type KeyVaultAndKeyReference struct {
 	// REQUIRED; Url pointing to a key or secret in KeyVault
-	KeyURL *string `json:"keyUrl,omitempty"`
+	KeyURL *string
 
 	// REQUIRED; Resource id of the KeyVault containing the key or secret
-	SourceVault *SourceVault `json:"sourceVault,omitempty"`
+	SourceVault *SourceVault
 }
 
 // KeyVaultAndSecretReference - Key Vault Secret Url and vault id of the encryption key
 type KeyVaultAndSecretReference struct {
 	// REQUIRED; Url pointing to a key or secret in KeyVault
-	SecretURL *string `json:"secretUrl,omitempty"`
+	SecretURL *string
 
 	// REQUIRED; Resource id of the KeyVault containing the key or secret
-	SourceVault *SourceVault `json:"sourceVault,omitempty"`
+	SourceVault *SourceVault
 }
 
 // KeyVaultKeyReference - Describes a reference to Key Vault Key
 type KeyVaultKeyReference struct {
 	// REQUIRED; The URL referencing a key encryption key in Key Vault.
-	KeyURL *string `json:"keyUrl,omitempty"`
+	KeyURL *string
 
 	// REQUIRED; The relative URL of the Key Vault containing the key.
-	SourceVault *SubResource `json:"sourceVault,omitempty"`
+	SourceVault *SubResource
 }
 
 // KeyVaultSecretReference - Describes a reference to Key Vault Secret
 type KeyVaultSecretReference struct {
 	// REQUIRED; The URL referencing a secret in a Key Vault.
-	SecretURL *string `json:"secretUrl,omitempty"`
+	SecretURL *string
 
 	// REQUIRED; The relative URL of the Key Vault containing the secret.
-	SourceVault *SubResource `json:"sourceVault,omitempty"`
+	SourceVault *SubResource
 }
 
 // LinuxConfiguration - Specifies the Linux operating system settings on the virtual machine.
@@ -2195,25 +2195,25 @@ type KeyVaultSecretReference struct {
 // [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json].
 type LinuxConfiguration struct {
 	// Specifies whether password authentication should be disabled.
-	DisablePasswordAuthentication *bool `json:"disablePasswordAuthentication,omitempty"`
+	DisablePasswordAuthentication *bool
 
 	// Indicates whether virtual machine agent should be provisioned on the virtual machine.
 	// When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM
 	// Agent is installed on the VM so that extensions can be added to the VM later.
-	ProvisionVMAgent *bool `json:"provisionVMAgent,omitempty"`
+	ProvisionVMAgent *bool
 
 	// Specifies the ssh key configuration for a Linux OS.
-	SSH *SSHConfiguration `json:"ssh,omitempty"`
+	SSH *SSHConfiguration
 }
 
 // ListUsagesResult - The List Usages operation response.
 type ListUsagesResult struct {
 	// REQUIRED; The list of compute resource usages.
-	Value []*Usage `json:"value,omitempty"`
+	Value []*Usage
 
 	// The URI to fetch the next page of compute resource usage information. Call ListNext() with this to fetch the next page
 	// of compute resource usage information.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // LogAnalyticsClientBeginExportRequestRateByIntervalOptions contains the optional parameters for the LogAnalyticsClient.BeginExportRequestRateByInterval
@@ -2233,71 +2233,71 @@ type LogAnalyticsClientBeginExportThrottledRequestsOptions struct {
 // LogAnalyticsOperationResult - LogAnalytics operation status response
 type LogAnalyticsOperationResult struct {
 	// READ-ONLY; LogAnalyticsOutput
-	Properties *LogAnalyticsOutput `json:"properties,omitempty" azure:"ro"`
+	Properties *LogAnalyticsOutput
 }
 
 // LogAnalyticsOutput - LogAnalytics output properties
 type LogAnalyticsOutput struct {
 	// READ-ONLY; Output file Uri path to blob container.
-	Output *string `json:"output,omitempty" azure:"ro"`
+	Output *string
 }
 
 // MaintenanceRedeployStatus - Maintenance Operation Status.
 type MaintenanceRedeployStatus struct {
 	// True, if customer is allowed to perform Maintenance.
-	IsCustomerInitiatedMaintenanceAllowed *bool `json:"isCustomerInitiatedMaintenanceAllowed,omitempty"`
+	IsCustomerInitiatedMaintenanceAllowed *bool
 
 	// Message returned for the last Maintenance Operation.
-	LastOperationMessage *string `json:"lastOperationMessage,omitempty"`
+	LastOperationMessage *string
 
 	// The Last Maintenance Operation Result Code.
-	LastOperationResultCode *MaintenanceOperationResultCodeTypes `json:"lastOperationResultCode,omitempty"`
+	LastOperationResultCode *MaintenanceOperationResultCodeTypes
 
 	// End Time for the Maintenance Window.
-	MaintenanceWindowEndTime *time.Time `json:"maintenanceWindowEndTime,omitempty"`
+	MaintenanceWindowEndTime *time.Time
 
 	// Start Time for the Maintenance Window.
-	MaintenanceWindowStartTime *time.Time `json:"maintenanceWindowStartTime,omitempty"`
+	MaintenanceWindowStartTime *time.Time
 
 	// End Time for the Pre Maintenance Window.
-	PreMaintenanceWindowEndTime *time.Time `json:"preMaintenanceWindowEndTime,omitempty"`
+	PreMaintenanceWindowEndTime *time.Time
 
 	// Start Time for the Pre Maintenance Window.
-	PreMaintenanceWindowStartTime *time.Time `json:"preMaintenanceWindowStartTime,omitempty"`
+	PreMaintenanceWindowStartTime *time.Time
 }
 
 // ManagedDiskParameters - The parameters of a managed disk.
 type ManagedDiskParameters struct {
 	// Specifies the customer managed disk encryption set resource id for the managed disk.
-	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot
 	// be used with OS Disk.
-	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountTypes
 }
 
 // NetworkInterfaceReference - Describes a network interface reference.
 type NetworkInterfaceReference struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Describes a network interface reference properties.
-	Properties *NetworkInterfaceReferenceProperties `json:"properties,omitempty"`
+	Properties *NetworkInterfaceReferenceProperties
 }
 
 // NetworkInterfaceReferenceProperties - Describes a network interface reference properties.
 type NetworkInterfaceReferenceProperties struct {
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 }
 
 // NetworkProfile - Specifies the network interfaces of the virtual machine.
 type NetworkProfile struct {
 	// Specifies the list of resource Ids for the network interfaces associated with the virtual machine.
-	NetworkInterfaces []*NetworkInterfaceReference `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces []*NetworkInterfaceReference
 }
 
 // OSDisk - Specifies information about the operating system disk used by the virtual machine.
@@ -2310,7 +2310,7 @@ type OSDisk struct {
 	// FromImage \u2013 This value is used when you are using an image to create the virtual machine. If you are using a platform
 	// image, you also use the imageReference element described above. If you are
 	// using a marketplace image, you also use the plan element previously described.
-	CreateOption *DiskCreateOptionTypes `json:"createOption,omitempty"`
+	CreateOption *DiskCreateOptionTypes
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -2318,55 +2318,55 @@ type OSDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage.
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the ephemeral Disk Settings for the operating system disk used by the virtual machine.
-	DiffDiskSettings *DiffDiskSettings `json:"diffDiskSettings,omitempty"`
+	DiffDiskSettings *DiffDiskSettings
 
 	// Specifies the size of an empty data disk in gigabytes. This element can be used to overwrite the size of the disk in a
 	// virtual machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Specifies the encryption settings for the OS Disk.
 	// Minimum api-version: 2015-06-15
-	EncryptionSettings *DiskEncryptionSettings `json:"encryptionSettings,omitempty"`
+	EncryptionSettings *DiskEncryptionSettings
 
 	// The source user image virtual hard disk. The virtual hard disk will be copied before being attached to the virtual machine.
 	// If SourceImage is provided, the destination virtual hard drive must not
 	// exist.
-	Image *VirtualHardDisk `json:"image,omitempty"`
+	Image *VirtualHardDisk
 
 	// The managed disk parameters.
-	ManagedDisk *ManagedDiskParameters `json:"managedDisk,omitempty"`
+	ManagedDisk *ManagedDiskParameters
 
 	// The disk name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// This property allows you to specify the type of the OS that is included in the disk if creating a VM from user-image or
 	// a specialized VHD.
 	// Possible values are:
 	// Windows
 	// Linux
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// The virtual hard disk.
-	Vhd *VirtualHardDisk `json:"vhd,omitempty"`
+	Vhd *VirtualHardDisk
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
-	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+	WriteAcceleratorEnabled *bool
 }
 
 // OSDiskImage - Contains the os disk image information.
 type OSDiskImage struct {
 	// REQUIRED; The operating system of the osDiskImage.
-	OperatingSystem *OperatingSystemTypes `json:"operatingSystem,omitempty"`
+	OperatingSystem *OperatingSystemTypes
 }
 
 // OSDiskImageEncryption - Contains encryption settings for an OS disk image.
 type OSDiskImageEncryption struct {
 	// A relative URI containing the resource ID of the disk encryption set.
-	DiskEncryptionSetID *string `json:"diskEncryptionSetId,omitempty"`
+	DiskEncryptionSetID *string
 }
 
 // OSProfile - Specifies the operating system settings for the virtual machine. Some of the settings cannot be changed once
@@ -2388,7 +2388,7 @@ type OSProfile struct {
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-reset-rdp?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// For resetting root password, see Manage users, SSH, and check or repair disks on Azure Linux VMs using the VMAccess Extension
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-vmaccess-extension?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json#reset-root-password]
-	AdminPassword *string `json:"adminPassword,omitempty"`
+	AdminPassword *string
 
 	// Specifies the name of the administrator account.
 	// This property cannot be updated after the VM is created.
@@ -2404,11 +2404,11 @@ type OSProfile struct {
 	// For a list of built-in system users on Linux that should not be used in this field, see Selecting User Names for Linux
 	// on Azure
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-usernames?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
-	AdminUsername *string `json:"adminUsername,omitempty"`
+	AdminUsername *string
 
 	// Specifies whether extension operations should be allowed on the virtual machine.
 	// This may only be set to False when no extensions are present on the virtual machine.
-	AllowExtensionOperations *bool `json:"allowExtensionOperations,omitempty"`
+	AllowExtensionOperations *bool
 
 	// Specifies the host OS name of the virtual machine.
 	// This name cannot be updated after the VM is created.
@@ -2416,7 +2416,7 @@ type OSProfile struct {
 	// Max-length (Linux): 64 characters.
 	// For naming conventions and restrictions see Azure infrastructure services implementation guidelines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-infrastructure-subscription-accounts-guidelines?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json#1-naming-conventions].
-	ComputerName *string `json:"computerName,omitempty"`
+	ComputerName *string
 
 	// Specifies a base-64 encoded string of custom data. The base-64 encoded string is decoded to a binary array that is saved
 	// as a file on the Virtual Machine. The maximum length of the binary array is
@@ -2426,56 +2426,56 @@ type OSProfile struct {
 	// customData is passed to the VM to be saved as a file, for more information see Custom Data on Azure VMs [https://azure.microsoft.com/en-us/blog/custom-data-and-cloud-init-on-windows-azure/]
 	// For using cloud-init for your Linux VM, see Using cloud-init to customize a Linux VM during creation
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
-	CustomData *string `json:"customData,omitempty"`
+	CustomData *string
 
 	// Specifies the Linux operating system settings on the virtual machine.
 	// For a list of supported Linux distributions, see Linux on Azure-Endorsed Distributions
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
 	// For running non-endorsed distributions, see Information for Non-Endorsed Distributions
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json].
-	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
+	LinuxConfiguration *LinuxConfiguration
 
 	// Specifies whether the guest provision signal is required to infer provision success of the virtual machine.
-	RequireGuestProvisionSignal *bool `json:"requireGuestProvisionSignal,omitempty"`
+	RequireGuestProvisionSignal *bool
 
 	// Specifies set of certificates that should be installed onto the virtual machine.
-	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup
 
 	// Specifies Windows operating system settings on the virtual machine.
-	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+	WindowsConfiguration *WindowsConfiguration
 }
 
 // OperationListResult - The List Compute Operation operation response.
 type OperationListResult struct {
 	// READ-ONLY; The list of compute operations
-	Value []*OperationValue `json:"value,omitempty" azure:"ro"`
+	Value []*OperationValue
 }
 
 // OperationValue - Describes the properties of a Compute Operation value.
 type OperationValue struct {
 	// Describes the properties of a Compute Operation Value Display.
-	Display *OperationValueDisplay `json:"display,omitempty"`
+	Display *OperationValueDisplay
 
 	// READ-ONLY; The name of the compute operation.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The origin of the compute operation.
-	Origin *string `json:"origin,omitempty" azure:"ro"`
+	Origin *string
 }
 
 // OperationValueDisplay - Describes the properties of a Compute Operation Value Display.
 type OperationValueDisplay struct {
 	// READ-ONLY; The description of the operation.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; The display name of the compute operation.
-	Operation *string `json:"operation,omitempty" azure:"ro"`
+	Operation *string
 
 	// READ-ONLY; The resource provider for the operation.
-	Provider *string `json:"provider,omitempty" azure:"ro"`
+	Provider *string
 
 	// READ-ONLY; The display name of the resource the operation applies to.
-	Resource *string `json:"resource,omitempty" azure:"ro"`
+	Resource *string
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
@@ -2486,19 +2486,19 @@ type OperationsClientListOptions struct {
 // OrchestrationServiceStateInput - The input for OrchestrationServiceState
 type OrchestrationServiceStateInput struct {
 	// REQUIRED; The action to be performed.
-	Action *OrchestrationServiceStateAction `json:"action,omitempty"`
+	Action *OrchestrationServiceStateAction
 
 	// REQUIRED; The name of the service.
-	ServiceName *OrchestrationServiceNames `json:"serviceName,omitempty"`
+	ServiceName *OrchestrationServiceNames
 }
 
 // OrchestrationServiceSummary - Summary for an orchestration service of a virtual machine scale set.
 type OrchestrationServiceSummary struct {
 	// READ-ONLY; The name of the service.
-	ServiceName *OrchestrationServiceNames `json:"serviceName,omitempty" azure:"ro"`
+	ServiceName *OrchestrationServiceNames
 
 	// READ-ONLY; The current state of the service.
-	ServiceState *OrchestrationServiceState `json:"serviceState,omitempty" azure:"ro"`
+	ServiceState *OrchestrationServiceState
 }
 
 // Plan - Specifies information about the marketplace image used to create the virtual machine. This element is only used
@@ -2508,73 +2508,73 @@ type OrchestrationServiceSummary struct {
 // information and then click Save.
 type Plan struct {
 	// The plan ID.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Specifies the product of the image from the marketplace. This is the same value as Offer under the imageReference element.
-	Product *string `json:"product,omitempty"`
+	Product *string
 
 	// The promotion code.
-	PromotionCode *string `json:"promotionCode,omitempty"`
+	PromotionCode *string
 
 	// The publisher ID.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 }
 
 // ProximityPlacementGroup - Specifies information about the proximity placement group.
 type ProximityPlacementGroup struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a Proximity Placement Group.
-	Properties *ProximityPlacementGroupProperties `json:"properties,omitempty"`
+	Properties *ProximityPlacementGroupProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ProximityPlacementGroupListResult - The List Proximity Placement Group operation response.
 type ProximityPlacementGroupListResult struct {
 	// REQUIRED; The list of proximity placement groups
-	Value []*ProximityPlacementGroup `json:"value,omitempty"`
+	Value []*ProximityPlacementGroup
 
 	// The URI to fetch the next page of proximity placement groups.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // ProximityPlacementGroupProperties - Describes the properties of a Proximity Placement Group.
 type ProximityPlacementGroupProperties struct {
 	// Describes colocation status of the Proximity Placement Group.
-	ColocationStatus *InstanceViewStatus `json:"colocationStatus,omitempty"`
+	ColocationStatus *InstanceViewStatus
 
 	// Specifies the type of the proximity placement group.
 	// Possible values are:
 	// Standard : Co-locate resources within an Azure region or Availability Zone.
 	// Ultra : For future use.
-	ProximityPlacementGroupType *ProximityPlacementGroupType `json:"proximityPlacementGroupType,omitempty"`
+	ProximityPlacementGroupType *ProximityPlacementGroupType
 
 	// READ-ONLY; A list of references to all availability sets in the proximity placement group.
-	AvailabilitySets []*SubResourceWithColocationStatus `json:"availabilitySets,omitempty" azure:"ro"`
+	AvailabilitySets []*SubResourceWithColocationStatus
 
 	// READ-ONLY; A list of references to all virtual machine scale sets in the proximity placement group.
-	VirtualMachineScaleSets []*SubResourceWithColocationStatus `json:"virtualMachineScaleSets,omitempty" azure:"ro"`
+	VirtualMachineScaleSets []*SubResourceWithColocationStatus
 
 	// READ-ONLY; A list of references to all virtual machines in the proximity placement group.
-	VirtualMachines []*SubResourceWithColocationStatus `json:"virtualMachines,omitempty" azure:"ro"`
+	VirtualMachines []*SubResourceWithColocationStatus
 }
 
 // ProximityPlacementGroupUpdate - Specifies information about the proximity placement group.
 type ProximityPlacementGroupUpdate struct {
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // ProximityPlacementGroupsClientCreateOrUpdateOptions contains the optional parameters for the ProximityPlacementGroupsClient.CreateOrUpdate
@@ -2616,215 +2616,215 @@ type ProximityPlacementGroupsClientUpdateOptions struct {
 // PurchasePlan - Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
 type PurchasePlan struct {
 	// REQUIRED; The plan ID.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Specifies the product of the image from the marketplace. This is the same value as Offer under the imageReference
 	// element.
-	Product *string `json:"product,omitempty"`
+	Product *string
 
 	// REQUIRED; The publisher ID.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 }
 
 // RecommendedMachineConfiguration - The properties describe the recommended machine configuration for this Image Definition.
 // These properties are updatable.
 type RecommendedMachineConfiguration struct {
 	// Describes the resource range.
-	Memory *ResourceRange `json:"memory,omitempty"`
+	Memory *ResourceRange
 
 	// Describes the resource range.
-	VCPUs *ResourceRange `json:"vCPUs,omitempty"`
+	VCPUs *ResourceRange
 }
 
 // RecoveryWalkResponse - Response after calling a manual recovery walk
 type RecoveryWalkResponse struct {
 	// READ-ONLY; The next update domain that needs to be walked. Null means walk spanning all update domains has been completed
-	NextPlatformUpdateDomain *int32 `json:"nextPlatformUpdateDomain,omitempty" azure:"ro"`
+	NextPlatformUpdateDomain *int32
 
 	// READ-ONLY; Whether the recovery walk was performed
-	WalkPerformed *bool `json:"walkPerformed,omitempty" azure:"ro"`
+	WalkPerformed *bool
 }
 
 // RegionalReplicationStatus - This is the regional replication status.
 type RegionalReplicationStatus struct {
 	// READ-ONLY; The details of the replication status.
-	Details *string `json:"details,omitempty" azure:"ro"`
+	Details *string
 
 	// READ-ONLY; It indicates progress of the replication job.
-	Progress *int32 `json:"progress,omitempty" azure:"ro"`
+	Progress *int32
 
 	// READ-ONLY; The region to which the gallery Image Version is being replicated to.
-	Region *string `json:"region,omitempty" azure:"ro"`
+	Region *string
 
 	// READ-ONLY; This is the regional replication state.
-	State *ReplicationState `json:"state,omitempty" azure:"ro"`
+	State *ReplicationState
 }
 
 // ReplicationStatus - This is the replication status of the gallery Image Version.
 type ReplicationStatus struct {
 	// READ-ONLY; This is the aggregated replication status based on all the regional replication status flags.
-	AggregatedState *AggregatedReplicationState `json:"aggregatedState,omitempty" azure:"ro"`
+	AggregatedState *AggregatedReplicationState
 
 	// READ-ONLY; This is a summary of replication status for each region.
-	Summary []*RegionalReplicationStatus `json:"summary,omitempty" azure:"ro"`
+	Summary []*RegionalReplicationStatus
 }
 
 // RequestRateByIntervalInput - Api request input for LogAnalytics getRequestRateByInterval Api.
 type RequestRateByIntervalInput struct {
 	// REQUIRED; SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
-	BlobContainerSasURI *string `json:"blobContainerSasUri,omitempty"`
+	BlobContainerSasURI *string
 
 	// REQUIRED; From time of the query
-	FromTime *time.Time `json:"fromTime,omitempty"`
+	FromTime *time.Time
 
 	// REQUIRED; Interval value in minutes used to create LogAnalytics call rate logs.
-	IntervalLength *IntervalInMins `json:"intervalLength,omitempty"`
+	IntervalLength *IntervalInMins
 
 	// REQUIRED; To time of the query
-	ToTime *time.Time `json:"toTime,omitempty"`
+	ToTime *time.Time
 
 	// Group query result by Operation Name.
-	GroupByOperationName *bool `json:"groupByOperationName,omitempty"`
+	GroupByOperationName *bool
 
 	// Group query result by Resource Name.
-	GroupByResourceName *bool `json:"groupByResourceName,omitempty"`
+	GroupByResourceName *bool
 
 	// Group query result by Throttle Policy applied.
-	GroupByThrottlePolicy *bool `json:"groupByThrottlePolicy,omitempty"`
+	GroupByThrottlePolicy *bool
 }
 
 // ResourceRange - Describes the resource range.
 type ResourceRange struct {
 	// The maximum number of the resource.
-	Max *int32 `json:"max,omitempty"`
+	Max *int32
 
 	// The minimum number of the resource.
-	Min *int32 `json:"min,omitempty"`
+	Min *int32
 }
 
 // ResourceSKU - Describes an available Compute SKU.
 type ResourceSKU struct {
 	// READ-ONLY; The api versions that support this SKU.
-	APIVersions []*string `json:"apiVersions,omitempty" azure:"ro"`
+	APIVersions []*string
 
 	// READ-ONLY; A name value pair to describe the capability.
-	Capabilities []*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities []*ResourceSKUCapabilities
 
 	// READ-ONLY; Specifies the number of virtual machines in the scale set.
-	Capacity *ResourceSKUCapacity `json:"capacity,omitempty" azure:"ro"`
+	Capacity *ResourceSKUCapacity
 
 	// READ-ONLY; Metadata for retrieving price info.
-	Costs []*ResourceSKUCosts `json:"costs,omitempty" azure:"ro"`
+	Costs []*ResourceSKUCosts
 
 	// READ-ONLY; The Family of this particular SKU.
-	Family *string `json:"family,omitempty" azure:"ro"`
+	Family *string
 
 	// READ-ONLY; The Kind of resources that are supported in this SKU.
-	Kind *string `json:"kind,omitempty" azure:"ro"`
+	Kind *string
 
 	// READ-ONLY; A list of locations and availability zones in those locations where the SKU is available.
-	LocationInfo []*ResourceSKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
+	LocationInfo []*ResourceSKULocationInfo
 
 	// READ-ONLY; The set of locations that the SKU is available.
-	Locations []*string `json:"locations,omitempty" azure:"ro"`
+	Locations []*string
 
 	// READ-ONLY; The name of SKU.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of resource the SKU applies to.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
-	Restrictions []*ResourceSKURestrictions `json:"restrictions,omitempty" azure:"ro"`
+	Restrictions []*ResourceSKURestrictions
 
 	// READ-ONLY; The Size of the SKU.
-	Size *string `json:"size,omitempty" azure:"ro"`
+	Size *string
 
 	// READ-ONLY; Specifies the tier of virtual machines in a scale set.
 	// Possible Values:
 	// Standard
 	// Basic
-	Tier *string `json:"tier,omitempty" azure:"ro"`
+	Tier *string
 }
 
 // ResourceSKUCapabilities - Describes The SKU capabilities object.
 type ResourceSKUCapabilities struct {
 	// READ-ONLY; An invariant to describe the feature.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; An invariant if the feature is measured by quantity.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // ResourceSKUCapacity - Describes scaling information of a SKU.
 type ResourceSKUCapacity struct {
 	// READ-ONLY; The default capacity.
-	Default *int64 `json:"default,omitempty" azure:"ro"`
+	Default *int64
 
 	// READ-ONLY; The maximum capacity that can be set.
-	Maximum *int64 `json:"maximum,omitempty" azure:"ro"`
+	Maximum *int64
 
 	// READ-ONLY; The minimum capacity.
-	Minimum *int64 `json:"minimum,omitempty" azure:"ro"`
+	Minimum *int64
 
 	// READ-ONLY; The scale type applicable to the sku.
-	ScaleType *ResourceSKUCapacityScaleType `json:"scaleType,omitempty" azure:"ro"`
+	ScaleType *ResourceSKUCapacityScaleType
 }
 
 // ResourceSKUCosts - Describes metadata for retrieving price info.
 type ResourceSKUCosts struct {
 	// READ-ONLY; An invariant to show the extended unit.
-	ExtendedUnit *string `json:"extendedUnit,omitempty" azure:"ro"`
+	ExtendedUnit *string
 
 	// READ-ONLY; Used for querying price from commerce.
-	MeterID *string `json:"meterID,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; The multiplier is needed to extend the base metered cost.
-	Quantity *int64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *int64
 }
 
 type ResourceSKULocationInfo struct {
 	// READ-ONLY; Location of the SKU
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; Details of capabilities available to a SKU in specific zones.
-	ZoneDetails []*ResourceSKUZoneDetails `json:"zoneDetails,omitempty" azure:"ro"`
+	ZoneDetails []*ResourceSKUZoneDetails
 
 	// READ-ONLY; List of availability zones where the SKU is supported.
-	Zones []*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string
 }
 
 type ResourceSKURestrictionInfo struct {
 	// READ-ONLY; Locations where the SKU is restricted
-	Locations []*string `json:"locations,omitempty" azure:"ro"`
+	Locations []*string
 
 	// READ-ONLY; List of availability zones where the SKU is restricted.
-	Zones []*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string
 }
 
 // ResourceSKURestrictions - Describes scaling information of a SKU.
 type ResourceSKURestrictions struct {
 	// READ-ONLY; The reason for restriction.
-	ReasonCode *ResourceSKURestrictionsReasonCode `json:"reasonCode,omitempty" azure:"ro"`
+	ReasonCode *ResourceSKURestrictionsReasonCode
 
 	// READ-ONLY; The information about the restriction where the SKU cannot be used.
-	RestrictionInfo *ResourceSKURestrictionInfo `json:"restrictionInfo,omitempty" azure:"ro"`
+	RestrictionInfo *ResourceSKURestrictionInfo
 
 	// READ-ONLY; The type of restrictions.
-	Type *ResourceSKURestrictionsType `json:"type,omitempty" azure:"ro"`
+	Type *ResourceSKURestrictionsType
 
 	// READ-ONLY; The value of restrictions. If the restriction type is set to location. This would be different locations where
 	// the SKU is restricted.
-	Values []*string `json:"values,omitempty" azure:"ro"`
+	Values []*string
 }
 
 // ResourceSKUZoneDetails - Describes The zonal capabilities of a SKU.
 type ResourceSKUZoneDetails struct {
 	// READ-ONLY; A list of capabilities that are available for the SKU in the specified list of zones.
-	Capabilities []*ResourceSKUCapabilities `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities []*ResourceSKUCapabilities
 
 	// READ-ONLY; The set of zones that the SKU is available in with the specified capabilities.
-	Name []*string `json:"name,omitempty" azure:"ro"`
+	Name []*string
 }
 
 // ResourceSKUsClientListOptions contains the optional parameters for the ResourceSKUsClient.NewListPager method.
@@ -2836,22 +2836,22 @@ type ResourceSKUsClientListOptions struct {
 // ResourceSKUsResult - The List Resource Skus operation response.
 type ResourceSKUsResult struct {
 	// REQUIRED; The list of skus available for the subscription.
-	Value []*ResourceSKU `json:"value,omitempty"`
+	Value []*ResourceSKU
 
 	// The URI to fetch the next page of Resource Skus. Call ListNext() with this URI to fetch the next page of Resource Skus
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // RollbackStatusInfo - Information about rollback on failed VM instances after a OS Upgrade operation.
 type RollbackStatusInfo struct {
 	// READ-ONLY; The number of instances which failed to rollback.
-	FailedRolledbackInstanceCount *int32 `json:"failedRolledbackInstanceCount,omitempty" azure:"ro"`
+	FailedRolledbackInstanceCount *int32
 
 	// READ-ONLY; Error details if OS rollback failed.
-	RollbackError *APIError `json:"rollbackError,omitempty" azure:"ro"`
+	RollbackError *APIError
 
 	// READ-ONLY; The number of instances which have been successfully rolled back.
-	SuccessfullyRolledbackInstanceCount *int32 `json:"successfullyRolledbackInstanceCount,omitempty" azure:"ro"`
+	SuccessfullyRolledbackInstanceCount *int32
 }
 
 // RollingUpgradePolicy - The configuration parameters used while performing a rolling upgrade.
@@ -2860,182 +2860,182 @@ type RollingUpgradePolicy struct {
 	// batch. As this is a maximum, unhealthy instances in previous or future batches
 	// can cause the percentage of instances in a batch to decrease to ensure higher reliability. The default value for this parameter
 	// is 20%.
-	MaxBatchInstancePercent *int32 `json:"maxBatchInstancePercent,omitempty"`
+	MaxBatchInstancePercent *int32
 
 	// The maximum percentage of the total virtual machine instances in the scale set that can be simultaneously unhealthy, either
 	// as a result of being upgraded, or by being found in an unhealthy state by
 	// the virtual machine health checks before the rolling upgrade aborts. This constraint will be checked prior to starting
 	// any batch. The default value for this parameter is 20%.
-	MaxUnhealthyInstancePercent *int32 `json:"maxUnhealthyInstancePercent,omitempty"`
+	MaxUnhealthyInstancePercent *int32
 
 	// The maximum percentage of upgraded virtual machine instances that can be found to be in an unhealthy state. This check
 	// will happen after each batch is upgraded. If this percentage is ever exceeded,
 	// the rolling update aborts. The default value for this parameter is 20%.
-	MaxUnhealthyUpgradedInstancePercent *int32 `json:"maxUnhealthyUpgradedInstancePercent,omitempty"`
+	MaxUnhealthyUpgradedInstancePercent *int32
 
 	// The wait time between completing the update for all virtual machines in one batch and starting the next batch. The time
 	// duration should be specified in ISO 8601 format. The default value is 0 seconds
 	// (PT0S).
-	PauseTimeBetweenBatches *string `json:"pauseTimeBetweenBatches,omitempty"`
+	PauseTimeBetweenBatches *string
 }
 
 // RollingUpgradeProgressInfo - Information about the number of virtual machine instances in each upgrade state.
 type RollingUpgradeProgressInfo struct {
 	// READ-ONLY; The number of instances that have failed to be upgraded successfully.
-	FailedInstanceCount *int32 `json:"failedInstanceCount,omitempty" azure:"ro"`
+	FailedInstanceCount *int32
 
 	// READ-ONLY; The number of instances that are currently being upgraded.
-	InProgressInstanceCount *int32 `json:"inProgressInstanceCount,omitempty" azure:"ro"`
+	InProgressInstanceCount *int32
 
 	// READ-ONLY; The number of instances that have not yet begun to be upgraded.
-	PendingInstanceCount *int32 `json:"pendingInstanceCount,omitempty" azure:"ro"`
+	PendingInstanceCount *int32
 
 	// READ-ONLY; The number of instances that have been successfully upgraded.
-	SuccessfulInstanceCount *int32 `json:"successfulInstanceCount,omitempty" azure:"ro"`
+	SuccessfulInstanceCount *int32
 }
 
 // RollingUpgradeRunningStatus - Information about the current running state of the overall upgrade.
 type RollingUpgradeRunningStatus struct {
 	// READ-ONLY; Code indicating the current status of the upgrade.
-	Code *RollingUpgradeStatusCode `json:"code,omitempty" azure:"ro"`
+	Code *RollingUpgradeStatusCode
 
 	// READ-ONLY; The last action performed on the rolling upgrade.
-	LastAction *RollingUpgradeActionType `json:"lastAction,omitempty" azure:"ro"`
+	LastAction *RollingUpgradeActionType
 
 	// READ-ONLY; Last action time of the upgrade.
-	LastActionTime *time.Time `json:"lastActionTime,omitempty" azure:"ro"`
+	LastActionTime *time.Time
 
 	// READ-ONLY; Start time of the upgrade.
-	StartTime *time.Time `json:"startTime,omitempty" azure:"ro"`
+	StartTime *time.Time
 }
 
 // RollingUpgradeStatusInfo - The status of the latest virtual machine scale set rolling upgrade.
 type RollingUpgradeStatusInfo struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The status of the latest virtual machine scale set rolling upgrade.
-	Properties *RollingUpgradeStatusInfoProperties `json:"properties,omitempty"`
+	Properties *RollingUpgradeStatusInfoProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // RollingUpgradeStatusInfoProperties - The status of the latest virtual machine scale set rolling upgrade.
 type RollingUpgradeStatusInfoProperties struct {
 	// READ-ONLY; Error details for this upgrade, if there are any.
-	Error *APIError `json:"error,omitempty" azure:"ro"`
+	Error *APIError
 
 	// READ-ONLY; The rolling upgrade policies applied for this upgrade.
-	Policy *RollingUpgradePolicy `json:"policy,omitempty" azure:"ro"`
+	Policy *RollingUpgradePolicy
 
 	// READ-ONLY; Information about the number of virtual machine instances in each upgrade state.
-	Progress *RollingUpgradeProgressInfo `json:"progress,omitempty" azure:"ro"`
+	Progress *RollingUpgradeProgressInfo
 
 	// READ-ONLY; Information about the current running state of the overall upgrade.
-	RunningStatus *RollingUpgradeRunningStatus `json:"runningStatus,omitempty" azure:"ro"`
+	RunningStatus *RollingUpgradeRunningStatus
 }
 
 // RunCommandDocument - Describes the properties of a Run Command.
 type RunCommandDocument struct {
 	// REQUIRED; The VM run command description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// REQUIRED; The VM run command id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// REQUIRED; The VM run command label.
-	Label *string `json:"label,omitempty"`
+	Label *string
 
 	// REQUIRED; The Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// REQUIRED; The VM run command schema.
-	Schema *string `json:"$schema,omitempty"`
+	Schema *string
 
 	// REQUIRED; The script to be executed.
-	Script []*string `json:"script,omitempty"`
+	Script []*string
 
 	// The parameters used by the script.
-	Parameters []*RunCommandParameterDefinition `json:"parameters,omitempty"`
+	Parameters []*RunCommandParameterDefinition
 }
 
 // RunCommandDocumentBase - Describes the properties of a Run Command metadata.
 type RunCommandDocumentBase struct {
 	// REQUIRED; The VM run command description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// REQUIRED; The VM run command id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// REQUIRED; The VM run command label.
-	Label *string `json:"label,omitempty"`
+	Label *string
 
 	// REQUIRED; The Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// REQUIRED; The VM run command schema.
-	Schema *string `json:"$schema,omitempty"`
+	Schema *string
 }
 
 // RunCommandInput - Capture Virtual Machine parameters.
 type RunCommandInput struct {
 	// REQUIRED; The run command id.
-	CommandID *string `json:"commandId,omitempty"`
+	CommandID *string
 
 	// The run command parameters.
-	Parameters []*RunCommandInputParameter `json:"parameters,omitempty"`
+	Parameters []*RunCommandInputParameter
 
 	// Optional. The script to be executed. When this value is given, the given script will override the default script of the
 	// command.
-	Script []*string `json:"script,omitempty"`
+	Script []*string
 }
 
 // RunCommandInputParameter - Describes the properties of a run command parameter.
 type RunCommandInputParameter struct {
 	// REQUIRED; The run command parameter name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The run command parameter value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // RunCommandListResult - The List Virtual Machine operation response.
 type RunCommandListResult struct {
 	// REQUIRED; The list of virtual machine run commands.
-	Value []*RunCommandDocumentBase `json:"value,omitempty"`
+	Value []*RunCommandDocumentBase
 
 	// The uri to fetch the next page of run commands. Call ListNext() with this to fetch the next page of run commands.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // RunCommandParameterDefinition - Describes the properties of a run command parameter.
 type RunCommandParameterDefinition struct {
 	// REQUIRED; The run command parameter name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The run command parameter type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// The run command parameter default value.
-	DefaultValue *string `json:"defaultValue,omitempty"`
+	DefaultValue *string
 
 	// The run command parameter required.
-	Required *bool `json:"required,omitempty"`
+	Required *bool
 }
 
 type RunCommandResult struct {
 	// Run command operation response.
-	Value []*InstanceViewStatus `json:"value,omitempty"`
+	Value []*InstanceViewStatus
 }
 
 // SKU - Describes a virtual machine scale set sku. NOTE: If the new VM SKU is not supported on the hardware the scale set
@@ -3043,22 +3043,22 @@ type RunCommandResult struct {
 // SKU name.
 type SKU struct {
 	// Specifies the number of virtual machines in the scale set.
-	Capacity *int64 `json:"capacity,omitempty"`
+	Capacity *int64
 
 	// The sku name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Specifies the tier of virtual machines in a scale set.
 	// Possible Values:
 	// Standard
 	// Basic
-	Tier *string `json:"tier,omitempty"`
+	Tier *string
 }
 
 // SSHConfiguration - SSH configuration for Linux based VMs running on Azure
 type SSHConfiguration struct {
 	// The list of SSH public keys used to authenticate with linux based VMs.
-	PublicKeys []*SSHPublicKey `json:"publicKeys,omitempty"`
+	PublicKeys []*SSHPublicKey
 }
 
 // SSHPublicKey - Contains information about SSH certificate public key and the path on the Linux VM where the public key
@@ -3068,46 +3068,46 @@ type SSHPublicKey struct {
 	// format.
 	// For creating ssh keys, see Create SSH keys on Linux and Mac for Linux VMs in Azure
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json].
-	KeyData *string `json:"keyData,omitempty"`
+	KeyData *string
 
 	// Specifies the full path on the created VM where ssh public key is stored. If the file already exists, the specified key
 	// is appended to the file. Example: /home/user/.ssh/authorized_keys
-	Path *string `json:"path,omitempty"`
+	Path *string
 }
 
 // SSHPublicKeyGenerateKeyPairResult - Response from generation of an SSH key pair.
 type SSHPublicKeyGenerateKeyPairResult struct {
 	// REQUIRED; The ARM resource id in the form of /subscriptions/{SubscriptionId}/resourceGroups/{ResourceGroupName}/providers/Microsoft.Compute/sshPublicKeys/{SshPublicKeyName}
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// REQUIRED; Private key portion of the key pair used to authenticate to a virtual machine through ssh. The private key is
 	// returned in RFC3447 format and should be treated as a secret.
-	PrivateKey *string `json:"privateKey,omitempty"`
+	PrivateKey *string
 
 	// REQUIRED; Public key portion of the key pair used to authenticate to a virtual machine through ssh. The public key is in
 	// ssh-rsa format.
-	PublicKey *string `json:"publicKey,omitempty"`
+	PublicKey *string
 }
 
 // SSHPublicKeyResource - Specifies information about the SSH public key.
 type SSHPublicKeyResource struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the SSH public key.
-	Properties *SSHPublicKeyResourceProperties `json:"properties,omitempty"`
+	Properties *SSHPublicKeyResourceProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SSHPublicKeyResourceProperties - Properties of the SSH public key.
@@ -3116,16 +3116,16 @@ type SSHPublicKeyResourceProperties struct {
 	// resource is created, the publicKey property will be populated when
 	// generateKeyPair is called. If the public key is provided upon resource creation, the provided public key needs to be at
 	// least 2048-bit and in ssh-rsa format.
-	PublicKey *string `json:"publicKey,omitempty"`
+	PublicKey *string
 }
 
 // SSHPublicKeyUpdateResource - Specifies information about the SSH public key.
 type SSHPublicKeyUpdateResource struct {
 	// Properties of the SSH public key.
-	Properties *SSHPublicKeyResourceProperties `json:"properties,omitempty"`
+	Properties *SSHPublicKeyResourceProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // SSHPublicKeysClientCreateOptions contains the optional parameters for the SSHPublicKeysClient.Create method.
@@ -3169,10 +3169,10 @@ type SSHPublicKeysClientUpdateOptions struct {
 // SSHPublicKeysGroupListResult - The list SSH public keys operation response.
 type SSHPublicKeysGroupListResult struct {
 	// REQUIRED; The list of SSH public keys
-	Value []*SSHPublicKeyResource `json:"value,omitempty"`
+	Value []*SSHPublicKeyResource
 
 	// The URI to fetch the next page of SSH public keys. Call ListNext() with this URI to fetch the next page of SSH public keys.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // ScaleInPolicy - Describes a scale-in policy for a virtual machine scale set.
@@ -3190,113 +3190,113 @@ type ScaleInPolicy struct {
 	// will be chosen for removal. For zonal virtual machine scale sets, the
 	// scale set will first be balanced across zones. Within each zone, the newest virtual machines that are not protected will
 	// be chosen for removal.
-	Rules []*VirtualMachineScaleSetScaleInRules `json:"rules,omitempty"`
+	Rules []*VirtualMachineScaleSetScaleInRules
 }
 
 type ScheduledEventsProfile struct {
 	// Specifies Terminate Scheduled Event related configurations.
-	TerminateNotificationProfile *TerminateNotificationProfile `json:"terminateNotificationProfile,omitempty"`
+	TerminateNotificationProfile *TerminateNotificationProfile
 }
 
 type ShareInfoElement struct {
 	// READ-ONLY; A relative URI containing the ID of the VM that has the disk attached.
-	VMURI *string `json:"vmUri,omitempty" azure:"ro"`
+	VMURI *string
 }
 
 // Snapshot resource.
 type Snapshot struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Snapshot resource properties.
-	Properties *SnapshotProperties `json:"properties,omitempty"`
+	Properties *SnapshotProperties
 
 	// The snapshots sku name. Can be StandardLRS, PremiumLRS, or Standard_ZRS.
-	SKU *SnapshotSKU `json:"sku,omitempty"`
+	SKU *SnapshotSKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Unused. Always Null.
-	ManagedBy *string `json:"managedBy,omitempty" azure:"ro"`
+	ManagedBy *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SnapshotList - The List Snapshots operation response.
 type SnapshotList struct {
 	// REQUIRED; A list of snapshots.
-	Value []*Snapshot `json:"value,omitempty"`
+	Value []*Snapshot
 
 	// The uri to fetch the next page of snapshots. Call ListNext() with this to fetch the next page of snapshots.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // SnapshotProperties - Snapshot resource properties.
 type SnapshotProperties struct {
 	// REQUIRED; Disk source information. CreationData information cannot be changed after the disk has been created.
-	CreationData *CreationData `json:"creationData,omitempty"`
+	CreationData *CreationData
 
 	// If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to create. If this
 	// field is present for updates or creation with other options, it indicates a
 	// resize. Resizes are only allowed if the disk is not attached to a running VM, and can only increase the disk's size.
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Encryption property can be used to encrypt data at rest with customer managed keys or platform managed keys.
-	Encryption *Encryption `json:"encryption,omitempty"`
+	Encryption *Encryption
 
 	// Encryption settings collection used be Azure Disk Encryption, can contain multiple encryption settings per disk or snapshot.
-	EncryptionSettingsCollection *EncryptionSettingsCollection `json:"encryptionSettingsCollection,omitempty"`
+	EncryptionSettingsCollection *EncryptionSettingsCollection
 
 	// The hypervisor generation of the Virtual Machine. Applicable to OS disks only.
-	HyperVGeneration *HyperVGeneration `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGeneration
 
 	// Whether a snapshot is incremental. Incremental snapshots on the same disk occupy less space than full snapshots and can
 	// be diffed.
-	Incremental *bool `json:"incremental,omitempty"`
+	Incremental *bool
 
 	// The Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// READ-ONLY; The size of the disk in bytes. This field is read only.
-	DiskSizeBytes *int64 `json:"diskSizeBytes,omitempty" azure:"ro"`
+	DiskSizeBytes *int64
 
 	// READ-ONLY; The disk provisioning state.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; The time when the disk was created.
-	TimeCreated *time.Time `json:"timeCreated,omitempty" azure:"ro"`
+	TimeCreated *time.Time
 
 	// READ-ONLY; Unique Guid identifying the resource.
-	UniqueID *string `json:"uniqueId,omitempty" azure:"ro"`
+	UniqueID *string
 }
 
 // SnapshotSKU - The snapshots sku name. Can be StandardLRS, PremiumLRS, or Standard_ZRS.
 type SnapshotSKU struct {
 	// The sku name.
-	Name *SnapshotStorageAccountTypes `json:"name,omitempty"`
+	Name *SnapshotStorageAccountTypes
 
 	// READ-ONLY; The sku tier.
-	Tier *string `json:"tier,omitempty" azure:"ro"`
+	Tier *string
 }
 
 // SnapshotUpdate - Snapshot update resource.
 type SnapshotUpdate struct {
 	// Snapshot resource update properties.
-	Properties *SnapshotUpdateProperties `json:"properties,omitempty"`
+	Properties *SnapshotUpdateProperties
 
 	// The snapshots sku name. Can be StandardLRS, PremiumLRS, or Standard_ZRS.
-	SKU *SnapshotSKU `json:"sku,omitempty"`
+	SKU *SnapshotSKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // SnapshotUpdateProperties - Snapshot resource update properties.
@@ -3304,16 +3304,16 @@ type SnapshotUpdateProperties struct {
 	// If creationData.createOption is Empty, this field is mandatory and it indicates the size of the disk to create. If this
 	// field is present for updates or creation with other options, it indicates a
 	// resize. Resizes are only allowed if the disk is not attached to a running VM, and can only increase the disk's size.
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Encryption property can be used to encrypt data at rest with customer managed keys or platform managed keys.
-	Encryption *Encryption `json:"encryption,omitempty"`
+	Encryption *Encryption
 
 	// Encryption settings collection used be Azure Disk Encryption, can contain multiple encryption settings per disk or snapshot.
-	EncryptionSettingsCollection *EncryptionSettingsCollection `json:"encryptionSettingsCollection,omitempty"`
+	EncryptionSettingsCollection *EncryptionSettingsCollection
 
 	// the Operating System type.
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 }
 
 // SnapshotsClientBeginCreateOrUpdateOptions contains the optional parameters for the SnapshotsClient.BeginCreateOrUpdate
@@ -3366,7 +3366,7 @@ type SnapshotsClientListOptions struct {
 // SourceVault - The vault id is an Azure Resource Manager Resource id in the form /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.KeyVault/vaults/{vaultName}
 type SourceVault struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // StorageProfile - Specifies the storage settings for the virtual machine disks.
@@ -3374,157 +3374,157 @@ type StorageProfile struct {
 	// Specifies the parameters that are used to add a data disk to a virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks []*DataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*DataDisk
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or
 	// virtual machine images. This element is required when you want to use a platform
 	// image, marketplace image, or virtual machine image, but is not used in other creation operations.
-	ImageReference *ImageReference `json:"imageReference,omitempty"`
+	ImageReference *ImageReference
 
 	// Specifies information about the operating system disk used by the virtual machine.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	OSDisk *OSDisk `json:"osDisk,omitempty"`
+	OSDisk *OSDisk
 }
 
 type SubResource struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 type SubResourceReadOnly struct {
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 type SubResourceWithColocationStatus struct {
 	// Describes colocation status of a resource in the Proximity Placement Group.
-	ColocationStatus *InstanceViewStatus `json:"colocationStatus,omitempty"`
+	ColocationStatus *InstanceViewStatus
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // TargetRegion - Describes the target region information.
 type TargetRegion struct {
 	// REQUIRED; The name of the region.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Optional. Allows users to provide customer managed keys for encrypting the OS and data disks in the gallery artifact.
-	Encryption *EncryptionImages `json:"encryption,omitempty"`
+	Encryption *EncryptionImages
 
 	// The number of replicas of the Image Version to be created per region. This property is updatable.
-	RegionalReplicaCount *int32 `json:"regionalReplicaCount,omitempty"`
+	RegionalReplicaCount *int32
 
 	// Specifies the storage account type to be used to store the image. This property is not updatable.
-	StorageAccountType *StorageAccountType `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountType
 }
 
 type TerminateNotificationProfile struct {
 	// Specifies whether the Terminate Scheduled event is enabled or disabled.
-	Enable *bool `json:"enable,omitempty"`
+	Enable *bool
 
 	// Configurable length of time a Virtual Machine being deleted will have to potentially approve the Terminate Scheduled Event
 	// before the event is auto approved (timed out). The configuration must be
 	// specified in ISO 8601 format, the default value is 5 minutes (PT5M)
-	NotBeforeTimeout *string `json:"notBeforeTimeout,omitempty"`
+	NotBeforeTimeout *string
 }
 
 // ThrottledRequestsInput - Api request input for LogAnalytics getThrottledRequests Api.
 type ThrottledRequestsInput struct {
 	// REQUIRED; SAS Uri of the logging blob container to which LogAnalytics Api writes output logs to.
-	BlobContainerSasURI *string `json:"blobContainerSasUri,omitempty"`
+	BlobContainerSasURI *string
 
 	// REQUIRED; From time of the query
-	FromTime *time.Time `json:"fromTime,omitempty"`
+	FromTime *time.Time
 
 	// REQUIRED; To time of the query
-	ToTime *time.Time `json:"toTime,omitempty"`
+	ToTime *time.Time
 
 	// Group query result by Operation Name.
-	GroupByOperationName *bool `json:"groupByOperationName,omitempty"`
+	GroupByOperationName *bool
 
 	// Group query result by Resource Name.
-	GroupByResourceName *bool `json:"groupByResourceName,omitempty"`
+	GroupByResourceName *bool
 
 	// Group query result by Throttle Policy applied.
-	GroupByThrottlePolicy *bool `json:"groupByThrottlePolicy,omitempty"`
+	GroupByThrottlePolicy *bool
 }
 
 // UpgradeOperationHistoricalStatusInfo - Virtual Machine Scale Set OS Upgrade History operation response.
 type UpgradeOperationHistoricalStatusInfo struct {
 	// READ-ONLY; Resource location
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; Information about the properties of the upgrade operation.
-	Properties *UpgradeOperationHistoricalStatusInfoProperties `json:"properties,omitempty" azure:"ro"`
+	Properties *UpgradeOperationHistoricalStatusInfoProperties
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // UpgradeOperationHistoricalStatusInfoProperties - Describes each OS upgrade on the Virtual Machine Scale Set.
 type UpgradeOperationHistoricalStatusInfoProperties struct {
 	// READ-ONLY; Error Details for this upgrade if there are any.
-	Error *APIError `json:"error,omitempty" azure:"ro"`
+	Error *APIError
 
 	// READ-ONLY; Counts of the VMs in each state.
-	Progress *RollingUpgradeProgressInfo `json:"progress,omitempty" azure:"ro"`
+	Progress *RollingUpgradeProgressInfo
 
 	// READ-ONLY; Information about OS rollback if performed
-	RollbackInfo *RollbackStatusInfo `json:"rollbackInfo,omitempty" azure:"ro"`
+	RollbackInfo *RollbackStatusInfo
 
 	// READ-ONLY; Information about the overall status of the upgrade operation.
-	RunningStatus *UpgradeOperationHistoryStatus `json:"runningStatus,omitempty" azure:"ro"`
+	RunningStatus *UpgradeOperationHistoryStatus
 
 	// READ-ONLY; Invoker of the Upgrade Operation
-	StartedBy *UpgradeOperationInvoker `json:"startedBy,omitempty" azure:"ro"`
+	StartedBy *UpgradeOperationInvoker
 
 	// READ-ONLY; Image Reference details
-	TargetImageReference *ImageReference `json:"targetImageReference,omitempty" azure:"ro"`
+	TargetImageReference *ImageReference
 }
 
 // UpgradeOperationHistoryStatus - Information about the current running state of the overall upgrade.
 type UpgradeOperationHistoryStatus struct {
 	// READ-ONLY; Code indicating the current status of the upgrade.
-	Code *UpgradeState `json:"code,omitempty" azure:"ro"`
+	Code *UpgradeState
 
 	// READ-ONLY; End time of the upgrade.
-	EndTime *time.Time `json:"endTime,omitempty" azure:"ro"`
+	EndTime *time.Time
 
 	// READ-ONLY; Start time of the upgrade.
-	StartTime *time.Time `json:"startTime,omitempty" azure:"ro"`
+	StartTime *time.Time
 }
 
 // UpgradePolicy - Describes an upgrade policy - automatic, manual, or rolling.
 type UpgradePolicy struct {
 	// Configuration parameters used for performing automatic OS Upgrade.
-	AutomaticOSUpgradePolicy *AutomaticOSUpgradePolicy `json:"automaticOSUpgradePolicy,omitempty"`
+	AutomaticOSUpgradePolicy *AutomaticOSUpgradePolicy
 
 	// Specifies the mode of an upgrade to virtual machines in the scale set.
 	// Possible values are:
 	// Manual - You control the application of updates to virtual machines in the scale set. You do this by using the manualUpgrade
 	// action.
 	// Automatic - All virtual machines in the scale set are automatically updated at the same time.
-	Mode *UpgradeMode `json:"mode,omitempty"`
+	Mode *UpgradeMode
 
 	// The configuration parameters used while performing a rolling upgrade.
-	RollingUpgradePolicy *RollingUpgradePolicy `json:"rollingUpgradePolicy,omitempty"`
+	RollingUpgradePolicy *RollingUpgradePolicy
 }
 
 // Usage - Describes Compute Resource Usage.
 type Usage struct {
 	// REQUIRED; The current usage of the resource.
-	CurrentValue *int32 `json:"currentValue,omitempty"`
+	CurrentValue *int32
 
 	// REQUIRED; The maximum permitted usage of the resource.
-	Limit *int64 `json:"limit,omitempty"`
+	Limit *int64
 
 	// REQUIRED; The name of the type of usage.
-	Name *UsageName `json:"name,omitempty"`
+	Name *UsageName
 
 	// REQUIRED; An enum describing the unit of usage measurement.
-	Unit *string `json:"unit,omitempty"`
+	Unit *string
 }
 
 // UsageClientListOptions contains the optional parameters for the UsageClient.NewListPager method.
@@ -3535,47 +3535,47 @@ type UsageClientListOptions struct {
 // UsageName - The Usage Names.
 type UsageName struct {
 	// The localized name of the resource.
-	LocalizedValue *string `json:"localizedValue,omitempty"`
+	LocalizedValue *string
 
 	// The name of the resource.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 type UserArtifactManage struct {
 	// REQUIRED; Required. The path and arguments to install the gallery application. This is limited to 4096 characters.
-	Install *string `json:"install,omitempty"`
+	Install *string
 
 	// REQUIRED; Required. The path and arguments to remove the gallery application. This is limited to 4096 characters.
-	Remove *string `json:"remove,omitempty"`
+	Remove *string
 
 	// Optional. The path and arguments to update the gallery application. If not present, then update operation will invoke remove
 	// command on the previous version and install command on the current version
 	// of the gallery application. This is limited to 4096 characters.
-	Update *string `json:"update,omitempty"`
+	Update *string
 }
 
 // UserArtifactSource - The source image from which the Image Version is going to be created.
 type UserArtifactSource struct {
 	// REQUIRED; Required. The mediaLink of the artifact, must be a readable storage page blob.
-	MediaLink *string `json:"mediaLink,omitempty"`
+	MediaLink *string
 
 	// Optional. The defaultConfigurationLink of the artifact, must be a readable storage page blob.
-	DefaultConfigurationLink *string `json:"defaultConfigurationLink,omitempty"`
+	DefaultConfigurationLink *string
 }
 
 type UserAssignedIdentitiesValue struct {
 	// READ-ONLY; The client id of user assigned identity.
-	ClientID *string `json:"clientId,omitempty" azure:"ro"`
+	ClientID *string
 
 	// READ-ONLY; The principal id of user assigned identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 }
 
 type VMScaleSetConvertToSinglePlacementGroupInput struct {
 	// Id of the placement group in which you want future virtual machine instances to be placed. To query placement group Id,
 	// please use Virtual Machine Scale Set VMs - Get API. If not provided, the
 	// platform will choose one with maximum number of virtual machine instances.
-	ActivePlacementGroupID *string `json:"activePlacementGroupId,omitempty"`
+	ActivePlacementGroupID *string
 }
 
 // VaultCertificate - Describes a single certificate reference in a Key Vault, and where the certificate should reside on
@@ -3586,7 +3586,7 @@ type VaultCertificate struct {
 	// For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name <UppercaseThumbprint>.crt
 	// for the X509 certificate file and <UppercaseThumbprint>.prv for private
 	// key. Both of these files are .pem formatted.
-	CertificateStore *string `json:"certificateStore,omitempty"`
+	CertificateStore *string
 
 	// This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault,
 	// see Add a key or secret to the key vault
@@ -3597,175 +3597,175 @@ type VaultCertificate struct {
 	// "dataType":"pfx",
 	// "password":""
 	// }
-	CertificateURL *string `json:"certificateUrl,omitempty"`
+	CertificateURL *string
 }
 
 // VaultSecretGroup - Describes a set of certificates which are all in the same Key Vault.
 type VaultSecretGroup struct {
 	// The relative URL of the Key Vault containing all of the certificates in VaultCertificates.
-	SourceVault *SubResource `json:"sourceVault,omitempty"`
+	SourceVault *SubResource
 
 	// The list of key vault references in SourceVault which contain certificates.
-	VaultCertificates []*VaultCertificate `json:"vaultCertificates,omitempty"`
+	VaultCertificates []*VaultCertificate
 }
 
 // VirtualHardDisk - Describes the uri of a disk.
 type VirtualHardDisk struct {
 	// Specifies the virtual hard disk's uri.
-	URI *string `json:"uri,omitempty"`
+	URI *string
 }
 
 // VirtualMachine - Describes a Virtual Machine.
 type VirtualMachine struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The identity of the virtual machine, if configured.
-	Identity *VirtualMachineIdentity `json:"identity,omitempty"`
+	Identity *VirtualMachineIdentity
 
 	// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace
 	// images. Before you can use a marketplace image from an API, you must
 	// enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click
 	// Want to deploy programmatically, Get Started ->. Enter any required
 	// information and then click Save.
-	Plan *Plan `json:"plan,omitempty"`
+	Plan *Plan
 
 	// Describes the properties of a Virtual Machine.
-	Properties *VirtualMachineProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The virtual machine zones.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources []*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources []*VirtualMachineExtension
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineAgentInstanceView - The instance view of the VM Agent running on the virtual machine.
 type VirtualMachineAgentInstanceView struct {
 	// The virtual machine extension handler instance view.
-	ExtensionHandlers []*VirtualMachineExtensionHandlerInstanceView `json:"extensionHandlers,omitempty"`
+	ExtensionHandlers []*VirtualMachineExtensionHandlerInstanceView
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// The VM Agent full version.
-	VMAgentVersion *string `json:"vmAgentVersion,omitempty"`
+	VMAgentVersion *string
 }
 
 // VirtualMachineCaptureParameters - Capture Virtual Machine parameters.
 type VirtualMachineCaptureParameters struct {
 	// REQUIRED; The destination container name.
-	DestinationContainerName *string `json:"destinationContainerName,omitempty"`
+	DestinationContainerName *string
 
 	// REQUIRED; Specifies whether to overwrite the destination virtual hard disk, in case of conflict.
-	OverwriteVhds *bool `json:"overwriteVhds,omitempty"`
+	OverwriteVhds *bool
 
 	// REQUIRED; The captured virtual hard disk's name prefix.
-	VhdPrefix *string `json:"vhdPrefix,omitempty"`
+	VhdPrefix *string
 }
 
 // VirtualMachineCaptureResult - Output of virtual machine capture operation.
 type VirtualMachineCaptureResult struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// READ-ONLY; the version of the content
-	ContentVersion *string `json:"contentVersion,omitempty" azure:"ro"`
+	ContentVersion *string
 
 	// READ-ONLY; parameters of the captured virtual machine
-	Parameters []byte `json:"parameters,omitempty" azure:"ro"`
+	Parameters []byte
 
 	// READ-ONLY; a list of resource items of the captured virtual machine
-	Resources []byte `json:"resources,omitempty" azure:"ro"`
+	Resources []byte
 
 	// READ-ONLY; the schema of the captured virtual machine
-	Schema *string `json:"$schema,omitempty" azure:"ro"`
+	Schema *string
 }
 
 // VirtualMachineExtension - Describes a Virtual Machine Extension.
 type VirtualMachineExtension struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a Virtual Machine Extension.
-	Properties *VirtualMachineExtensionProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineExtensionProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineExtensionHandlerInstanceView - The instance view of a virtual machine extension handler.
 type VirtualMachineExtensionHandlerInstanceView struct {
 	// The extension handler status.
-	Status *InstanceViewStatus `json:"status,omitempty"`
+	Status *InstanceViewStatus
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Specifies the version of the script handler.
-	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+	TypeHandlerVersion *string
 }
 
 // VirtualMachineExtensionImage - Describes a Virtual Machine Extension Image.
 type VirtualMachineExtensionImage struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Describes the properties of a Virtual Machine Extension Image.
-	Properties *VirtualMachineExtensionImageProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineExtensionImageProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineExtensionImageProperties - Describes the properties of a Virtual Machine Extension Image.
 type VirtualMachineExtensionImageProperties struct {
 	// REQUIRED; The type of role (IaaS or PaaS) this extension supports.
-	ComputeRole *string `json:"computeRole,omitempty"`
+	ComputeRole *string
 
 	// REQUIRED; The schema defined by publisher, where extension consumers should provide settings in a matching schema.
-	HandlerSchema *string `json:"handlerSchema,omitempty"`
+	HandlerSchema *string
 
 	// REQUIRED; The operating system this extension supports.
-	OperatingSystem *string `json:"operatingSystem,omitempty"`
+	OperatingSystem *string
 
 	// Whether the handler can support multiple extensions.
-	SupportsMultipleExtensions *bool `json:"supportsMultipleExtensions,omitempty"`
+	SupportsMultipleExtensions *bool
 
 	// Whether the extension can be used on xRP VMScaleSets. By default existing extensions are usable on scalesets, but there
 	// might be cases where a publisher wants to explicitly indicate the extension is
 	// only enabled for CRP VMs but not VMSS.
-	VMScaleSetEnabled *bool `json:"vmScaleSetEnabled,omitempty"`
+	VMScaleSetEnabled *bool
 }
 
 // VirtualMachineExtensionImagesClientGetOptions contains the optional parameters for the VirtualMachineExtensionImagesClient.Get
@@ -3792,19 +3792,19 @@ type VirtualMachineExtensionImagesClientListVersionsOptions struct {
 // VirtualMachineExtensionInstanceView - The instance view of a virtual machine extension.
 type VirtualMachineExtensionInstanceView struct {
 	// The virtual machine extension name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// The resource status information.
-	Substatuses []*InstanceViewStatus `json:"substatuses,omitempty"`
+	Substatuses []*InstanceViewStatus
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Specifies the version of the script handler.
-	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+	TypeHandlerVersion *string
 }
 
 // VirtualMachineExtensionProperties - Describes the properties of a Virtual Machine Extension.
@@ -3812,40 +3812,40 @@ type VirtualMachineExtensionProperties struct {
 	// Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed,
 	// however, the extension will not upgrade minor versions unless redeployed, even
 	// with this property set to true.
-	AutoUpgradeMinorVersion *bool `json:"autoUpgradeMinorVersion,omitempty"`
+	AutoUpgradeMinorVersion *bool
 
 	// How the extension handler should be forced to update even if the extension configuration has not changed.
-	ForceUpdateTag *string `json:"forceUpdateTag,omitempty"`
+	ForceUpdateTag *string
 
 	// The virtual machine extension instance view.
-	InstanceView *VirtualMachineExtensionInstanceView `json:"instanceView,omitempty"`
+	InstanceView *VirtualMachineExtensionInstanceView
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte
 
 	// The name of the extension handler publisher.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte `json:"settings,omitempty"`
+	Settings []byte
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Specifies the version of the script handler.
-	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+	TypeHandlerVersion *string
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // VirtualMachineExtensionUpdate - Describes a Virtual Machine Extension.
 type VirtualMachineExtensionUpdate struct {
 	// Describes the properties of a Virtual Machine Extension.
-	Properties *VirtualMachineExtensionUpdateProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineExtensionUpdateProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // VirtualMachineExtensionUpdateProperties - Describes the properties of a Virtual Machine Extension.
@@ -3853,25 +3853,25 @@ type VirtualMachineExtensionUpdateProperties struct {
 	// Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed,
 	// however, the extension will not upgrade minor versions unless redeployed, even
 	// with this property set to true.
-	AutoUpgradeMinorVersion *bool `json:"autoUpgradeMinorVersion,omitempty"`
+	AutoUpgradeMinorVersion *bool
 
 	// How the extension handler should be forced to update even if the extension configuration has not changed.
-	ForceUpdateTag *string `json:"forceUpdateTag,omitempty"`
+	ForceUpdateTag *string
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte
 
 	// The name of the extension handler publisher.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte `json:"settings,omitempty"`
+	Settings []byte
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Specifies the version of the script handler.
-	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+	TypeHandlerVersion *string
 }
 
 // VirtualMachineExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineExtensionsClient.BeginCreateOrUpdate
@@ -3911,13 +3911,13 @@ type VirtualMachineExtensionsClientListOptions struct {
 // VirtualMachineExtensionsListResult - The List Extension operation response
 type VirtualMachineExtensionsListResult struct {
 	// The list of extensions
-	Value []*VirtualMachineExtension `json:"value,omitempty"`
+	Value []*VirtualMachineExtension
 }
 
 // VirtualMachineHealthStatus - The health status of the VM.
 type VirtualMachineHealthStatus struct {
 	// READ-ONLY; The health status information for the VM.
-	Status *InstanceViewStatus `json:"status,omitempty" azure:"ro"`
+	Status *InstanceViewStatus
 }
 
 // VirtualMachineIdentity - Identity for the virtual machine.
@@ -3925,72 +3925,72 @@ type VirtualMachineIdentity struct {
 	// The type of identity used for the virtual machine. The type 'SystemAssigned, UserAssigned' includes both an implicitly
 	// created identity and a set of user assigned identities. The type 'None' will
 	// remove any identities from the virtual machine.
-	Type *ResourceIdentityType `json:"type,omitempty"`
+	Type *ResourceIdentityType
 
 	// The list of user identities associated with the Virtual Machine. The user identity dictionary key references will be ARM
 	// resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities map[string]*UserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*UserAssignedIdentitiesValue
 
 	// READ-ONLY; The principal id of virtual machine identity. This property will only be provided for a system assigned identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The tenant id associated with the virtual machine. This property will only be provided for a system assigned
 	// identity.
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 // VirtualMachineImage - Describes a Virtual Machine Image.
 type VirtualMachineImage struct {
 	// REQUIRED; The supported Azure location of the resource.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// REQUIRED; The name of the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Describes the properties of a Virtual Machine Image.
-	Properties *VirtualMachineImageProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineImageProperties
 
 	// Specifies the tags that are assigned to the virtual machine. For more information about using tags, see Using tags to organize
 	// your Azure resources
 	// [https://docs.microsoft.com/azure/azure-resource-manager/resource-group-using-tags.md].
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // VirtualMachineImageProperties - Describes the properties of a Virtual Machine Image.
 type VirtualMachineImageProperties struct {
 	// Describes automatic OS upgrade properties on the image.
-	AutomaticOSUpgradeProperties *AutomaticOSUpgradeProperties `json:"automaticOSUpgradeProperties,omitempty"`
-	DataDiskImages               []*DataDiskImage              `json:"dataDiskImages,omitempty"`
+	AutomaticOSUpgradeProperties *AutomaticOSUpgradeProperties
+	DataDiskImages               []*DataDiskImage
 
 	// Specifies the HyperVGeneration Type
-	HyperVGeneration *HyperVGenerationTypes `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGenerationTypes
 
 	// Contains the os disk image information.
-	OSDiskImage *OSDiskImage `json:"osDiskImage,omitempty"`
+	OSDiskImage *OSDiskImage
 
 	// Used for establishing the purchase context of any 3rd Party artifact through MarketPlace.
-	Plan *PurchasePlan `json:"plan,omitempty"`
+	Plan *PurchasePlan
 }
 
 // VirtualMachineImageResource - Virtual machine image resource information.
 type VirtualMachineImageResource struct {
 	// REQUIRED; The supported Azure location of the resource.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// REQUIRED; The name of the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Specifies the tags that are assigned to the virtual machine. For more information about using tags, see Using tags to organize
 	// your Azure resources
 	// [https://docs.microsoft.com/azure/azure-resource-manager/resource-group-using-tags.md].
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // VirtualMachineImagesClientGetOptions contains the optional parameters for the VirtualMachineImagesClient.Get method.
@@ -4029,58 +4029,58 @@ type VirtualMachineInstanceView struct {
 	// Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status.
 	// You can easily view the output of your console log.
 	// Azure also enables you to see a screenshot of the VM from the hypervisor.
-	BootDiagnostics *BootDiagnosticsInstanceView `json:"bootDiagnostics,omitempty"`
+	BootDiagnostics *BootDiagnosticsInstanceView
 
 	// The computer name assigned to the virtual machine.
-	ComputerName *string `json:"computerName,omitempty"`
+	ComputerName *string
 
 	// The virtual machine disk information.
-	Disks []*DiskInstanceView `json:"disks,omitempty"`
+	Disks []*DiskInstanceView
 
 	// The extensions information.
-	Extensions []*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineExtensionInstanceView
 
 	// Specifies the HyperVGeneration Type associated with a resource
-	HyperVGeneration *HyperVGenerationType `json:"hyperVGeneration,omitempty"`
+	HyperVGeneration *HyperVGenerationType
 
 	// The Maintenance Operation status on the virtual machine.
-	MaintenanceRedeployStatus *MaintenanceRedeployStatus `json:"maintenanceRedeployStatus,omitempty"`
+	MaintenanceRedeployStatus *MaintenanceRedeployStatus
 
 	// The Operating System running on the virtual machine.
-	OSName *string `json:"osName,omitempty"`
+	OSName *string
 
 	// The version of Operating System running on the virtual machine.
-	OSVersion *string `json:"osVersion,omitempty"`
+	OSVersion *string
 
 	// Specifies the fault domain of the virtual machine.
-	PlatformFaultDomain *int32 `json:"platformFaultDomain,omitempty"`
+	PlatformFaultDomain *int32
 
 	// Specifies the update domain of the virtual machine.
-	PlatformUpdateDomain *int32 `json:"platformUpdateDomain,omitempty"`
+	PlatformUpdateDomain *int32
 
 	// The Remote desktop certificate thumbprint.
-	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
+	RdpThumbPrint *string
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// The VM Agent running on the virtual machine.
-	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
+	VMAgent *VirtualMachineAgentInstanceView
 }
 
 // VirtualMachineListResult - The List Virtual Machine operation response.
 type VirtualMachineListResult struct {
 	// REQUIRED; The list of virtual machines.
-	Value []*VirtualMachine `json:"value,omitempty"`
+	Value []*VirtualMachine
 
 	// The URI to fetch the next page of VMs. Call ListNext() with this URI to fetch the next page of Virtual Machines.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineProperties - Describes the properties of a Virtual Machine.
 type VirtualMachineProperties struct {
 	// Specifies additional capabilities enabled or disabled on the virtual machine.
-	AdditionalCapabilities *AdditionalCapabilities `json:"additionalCapabilities,omitempty"`
+	AdditionalCapabilities *AdditionalCapabilities
 
 	// Specifies information about the availability set that the virtual machine should be assigned to. Virtual machines specified
 	// in the same availability set are allocated to different nodes to maximize
@@ -4092,27 +4092,27 @@ type VirtualMachineProperties struct {
 	// should be under the same resource group as the availability set resource. An
 	// existing VM cannot be added to an availability set.
 	// This property cannot exist along with a non-null properties.virtualMachineScaleSet reference.
-	AvailabilitySet *SubResource `json:"availabilitySet,omitempty"`
+	AvailabilitySet *SubResource
 
 	// Specifies the billing related details of a Azure Spot virtual machine.
 	// Minimum api-version: 2019-03-01.
-	BillingProfile *BillingProfile `json:"billingProfile,omitempty"`
+	BillingProfile *BillingProfile
 
 	// Specifies the boot diagnostic settings state.
 	// Minimum api-version: 2015-06-15.
-	DiagnosticsProfile *DiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *DiagnosticsProfile
 
 	// Specifies the eviction policy for the Azure Spot virtual machine and Azure Spot scale set.
 	// For Azure Spot virtual machines, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2019-03-01.
 	// For Azure Spot scale sets, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2017-10-30-preview.
-	EvictionPolicy *VirtualMachineEvictionPolicyTypes `json:"evictionPolicy,omitempty"`
+	EvictionPolicy *VirtualMachineEvictionPolicyTypes
 
 	// Specifies the hardware settings for the virtual machine.
-	HardwareProfile *HardwareProfile `json:"hardwareProfile,omitempty"`
+	HardwareProfile *HardwareProfile
 
 	// Specifies information about the dedicated host that the virtual machine resides in.
 	// Minimum api-version: 2018-10-01.
-	Host *SubResource `json:"host,omitempty"`
+	Host *SubResource
 
 	// Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that
 	// contain the Windows Server operating system.
@@ -4123,25 +4123,25 @@ type VirtualMachineProperties struct {
 	// For more information, see Azure Hybrid Use Benefit for Windows Server
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// Minimum api-version: 2015-06-15
-	LicenseType *string `json:"licenseType,omitempty"`
+	LicenseType *string
 
 	// Specifies the network interfaces of the virtual machine.
-	NetworkProfile *NetworkProfile `json:"networkProfile,omitempty"`
+	NetworkProfile *NetworkProfile
 
 	// Specifies the operating system settings used while creating the virtual machine. Some of the settings cannot be changed
 	// once VM is provisioned.
-	OSProfile *OSProfile `json:"osProfile,omitempty"`
+	OSProfile *OSProfile
 
 	// Specifies the priority for the virtual machine.
 	// Minimum api-version: 2019-03-01
-	Priority *VirtualMachinePriorityTypes `json:"priority,omitempty"`
+	Priority *VirtualMachinePriorityTypes
 
 	// Specifies information about the proximity placement group that the virtual machine should be assigned to.
 	// Minimum api-version: 2018-04-01.
-	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
+	ProximityPlacementGroup *SubResource
 
 	// Specifies the storage settings for the virtual machine disks.
-	StorageProfile *StorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *StorageProfile
 
 	// Specifies information about the virtual machine scale set that the virtual machine should be assigned to. Virtual machines
 	// specified in the same virtual machine scale set are allocated to different
@@ -4149,17 +4149,17 @@ type VirtualMachineProperties struct {
 	// VM cannot be added to a virtual machine scale set.
 	// This property cannot exist along with a non-null properties.availabilitySet reference.
 	// Minimum api‐version: 2019‐03‐01
-	VirtualMachineScaleSet *SubResource `json:"virtualMachineScaleSet,omitempty"`
+	VirtualMachineScaleSet *SubResource
 
 	// READ-ONLY; The virtual machine instance view.
-	InstanceView *VirtualMachineInstanceView `json:"instanceView,omitempty" azure:"ro"`
+	InstanceView *VirtualMachineInstanceView
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; Specifies the VM unique ID which is a 128-bits identifier that is encoded and stored in all Azure IaaS VMs SMBIOS
 	// and can be read using platform BIOS commands.
-	VMID *string `json:"vmId,omitempty" azure:"ro"`
+	VMID *string
 }
 
 // VirtualMachineReimageParameters - Parameters for Reimaging Virtual Machine. NOTE: Virtual Machine OS disk will always be
@@ -4167,7 +4167,7 @@ type VirtualMachineProperties struct {
 type VirtualMachineReimageParameters struct {
 	// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported
 	// for VM/VMSS with Ephemeral OS disk.
-	TempDisk *bool `json:"tempDisk,omitempty"`
+	TempDisk *bool
 }
 
 // VirtualMachineRunCommandsClientGetOptions contains the optional parameters for the VirtualMachineRunCommandsClient.Get
@@ -4185,48 +4185,48 @@ type VirtualMachineRunCommandsClientListOptions struct {
 // VirtualMachineScaleSet - Describes a Virtual Machine Scale Set.
 type VirtualMachineScaleSet struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The identity of the virtual machine scale set, if configured.
-	Identity *VirtualMachineScaleSetIdentity `json:"identity,omitempty"`
+	Identity *VirtualMachineScaleSetIdentity
 
 	// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace
 	// images. Before you can use a marketplace image from an API, you must
 	// enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click
 	// Want to deploy programmatically, Get Started ->. Enter any required
 	// information and then click Save.
-	Plan *Plan `json:"plan,omitempty"`
+	Plan *Plan
 
 	// Describes the properties of a Virtual Machine Scale Set.
-	Properties *VirtualMachineScaleSetProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetProperties
 
 	// The virtual machine scale set sku.
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineScaleSetDataDisk - Describes a virtual machine scale set data disk.
 type VirtualMachineScaleSetDataDisk struct {
 	// REQUIRED; The create option.
-	CreateOption *DiskCreateOptionTypes `json:"createOption,omitempty"`
+	CreateOption *DiskCreateOptionTypes
 
 	// REQUIRED; Specifies the logical unit number of the data disk. This value is used to identify data disks within the VM and
 	// therefore must be unique for each data disk attached to a VM.
-	Lun *int32 `json:"lun,omitempty"`
+	Lun *int32
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -4234,60 +4234,60 @@ type VirtualMachineScaleSetDataDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the Read-Write IOPS for the managed disk. Should be used only when StorageAccountType is UltraSSD_LRS. If not
 	// specified, a default value would be assigned based on diskSizeGB.
-	DiskIOPSReadWrite *int64 `json:"diskIOPSReadWrite,omitempty"`
+	DiskIOPSReadWrite *int64
 
 	// Specifies the bandwidth in MB per second for the managed disk. Should be used only when StorageAccountType is UltraSSD_LRS.
 	// If not specified, a default value would be assigned based on diskSizeGB.
-	DiskMBpsReadWrite *int64 `json:"diskMBpsReadWrite,omitempty"`
+	DiskMBpsReadWrite *int64
 
 	// Specifies the size of an empty data disk in gigabytes. This element can be used to overwrite the size of the disk in a
 	// virtual machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// The managed disk parameters.
-	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters
 
 	// The disk name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
-	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+	WriteAcceleratorEnabled *bool
 }
 
 // VirtualMachineScaleSetExtension - Describes a Virtual Machine Scale Set Extension.
 type VirtualMachineScaleSetExtension struct {
 	// The name of the extension.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Describes the properties of a Virtual Machine Scale Set Extension.
-	Properties *VirtualMachineScaleSetExtensionProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetExtensionProperties
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineScaleSetExtensionListResult - The List VM scale set extension operation response.
 type VirtualMachineScaleSetExtensionListResult struct {
 	// REQUIRED; The list of VM scale set extensions.
-	Value []*VirtualMachineScaleSetExtension `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetExtension
 
 	// The uri to fetch the next page of VM scale set extensions. Call ListNext() with this to fetch the next page of VM scale
 	// set extensions.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetExtensionProfile - Describes a virtual machine scale set extension profile.
 type VirtualMachineScaleSetExtensionProfile struct {
 	// The virtual machine scale set child extension resources.
-	Extensions []*VirtualMachineScaleSetExtension `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineScaleSetExtension
 }
 
 // VirtualMachineScaleSetExtensionProperties - Describes the properties of a Virtual Machine Scale Set Extension.
@@ -4295,47 +4295,47 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	// Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed,
 	// however, the extension will not upgrade minor versions unless redeployed, even
 	// with this property set to true.
-	AutoUpgradeMinorVersion *bool `json:"autoUpgradeMinorVersion,omitempty"`
+	AutoUpgradeMinorVersion *bool
 
 	// If a value is provided and is different from the previous value, the extension handler will be forced to update even if
 	// the extension configuration has not changed.
-	ForceUpdateTag *string `json:"forceUpdateTag,omitempty"`
+	ForceUpdateTag *string
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte `json:"protectedSettings,omitempty"`
+	ProtectedSettings []byte
 
 	// Collection of extension names after which this extension needs to be provisioned.
-	ProvisionAfterExtensions []*string `json:"provisionAfterExtensions,omitempty"`
+	ProvisionAfterExtensions []*string
 
 	// The name of the extension handler publisher.
-	Publisher *string `json:"publisher,omitempty"`
+	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte `json:"settings,omitempty"`
+	Settings []byte
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Specifies the version of the script handler.
-	TypeHandlerVersion *string `json:"typeHandlerVersion,omitempty"`
+	TypeHandlerVersion *string
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // VirtualMachineScaleSetExtensionUpdate - Describes a Virtual Machine Scale Set Extension.
 type VirtualMachineScaleSetExtensionUpdate struct {
 	// Describes the properties of a Virtual Machine Scale Set Extension.
-	Properties *VirtualMachineScaleSetExtensionProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetExtensionProperties
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the extension.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualMachineScaleSetExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetExtensionsClient.BeginCreateOrUpdate
@@ -4375,13 +4375,13 @@ type VirtualMachineScaleSetExtensionsClientListOptions struct {
 // VirtualMachineScaleSetIPConfiguration - Describes a virtual machine scale set network profile's IP configuration.
 type VirtualMachineScaleSetIPConfiguration struct {
 	// REQUIRED; The IP configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Describes a virtual machine scale set network profile's IP configuration properties.
-	Properties *VirtualMachineScaleSetIPConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetIPConfigurationProperties
 }
 
 // VirtualMachineScaleSetIPConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration
@@ -4390,42 +4390,42 @@ type VirtualMachineScaleSetIPConfigurationProperties struct {
 	// Specifies an array of references to backend address pools of application gateways. A scale set can reference backend address
 	// pools of multiple application gateways. Multiple scale sets cannot use the
 	// same application gateway.
-	ApplicationGatewayBackendAddressPools []*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*SubResource
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups []*SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*SubResource
 
 	// Specifies an array of references to backend address pools of load balancers. A scale set can reference backend address
 	// pools of one public and one internal load balancer. Multiple scale sets cannot
 	// use the same basic sku load balancer.
-	LoadBalancerBackendAddressPools []*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*SubResource
 
 	// Specifies an array of references to inbound Nat pools of the load balancers. A scale set can reference inbound nat pools
 	// of one public and one internal load balancer. Multiple scale sets cannot use
 	// the same basic sku load balancer.
-	LoadBalancerInboundNatPools []*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools []*SubResource
 
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 
 	// Available from Api-Version 2017-03-30 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default
 	// is taken as IPv4. Possible values are: 'IPv4' and 'IPv6'.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAddressVersion *IPVersion
 
 	// The publicIPAddressConfiguration.
-	PublicIPAddressConfiguration *VirtualMachineScaleSetPublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	PublicIPAddressConfiguration *VirtualMachineScaleSetPublicIPAddressConfiguration
 
 	// Specifies the identifier of the subnet.
-	Subnet *APIEntityReference `json:"subnet,omitempty"`
+	Subnet *APIEntityReference
 }
 
 // VirtualMachineScaleSetIPTag - Contains the IP tag associated with the public IP address.
 type VirtualMachineScaleSetIPTag struct {
 	// IP tag type. Example: FirstPartyUsage.
-	IPTagType *string `json:"ipTagType,omitempty"`
+	IPTagType *string
 
 	// IP tag associated with the public IP. Example: SQL, Storage etc.
-	Tag *string `json:"tag,omitempty"`
+	Tag *string
 }
 
 // VirtualMachineScaleSetIdentity - Identity for the virtual machine scale set.
@@ -4433,138 +4433,138 @@ type VirtualMachineScaleSetIdentity struct {
 	// The type of identity used for the virtual machine scale set. The type 'SystemAssigned, UserAssigned' includes both an implicitly
 	// created identity and a set of user assigned identities. The type 'None'
 	// will remove any identities from the virtual machine scale set.
-	Type *ResourceIdentityType `json:"type,omitempty"`
+	Type *ResourceIdentityType
 
 	// The list of user identities associated with the virtual machine scale set. The user identity dictionary key references
 	// will be ARM resource ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities map[string]*VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue
 
 	// READ-ONLY; The principal id of virtual machine scale set identity. This property will only be provided for a system assigned
 	// identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The tenant id associated with the virtual machine scale set. This property will only be provided for a system
 	// assigned identity.
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 type VirtualMachineScaleSetIdentityUserAssignedIdentitiesValue struct {
 	// READ-ONLY; The client id of user assigned identity.
-	ClientID *string `json:"clientId,omitempty" azure:"ro"`
+	ClientID *string
 
 	// READ-ONLY; The principal id of user assigned identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 }
 
 // VirtualMachineScaleSetInstanceView - The instance view of a virtual machine scale set.
 type VirtualMachineScaleSetInstanceView struct {
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// READ-ONLY; The extensions information.
-	Extensions []*VirtualMachineScaleSetVMExtensionsSummary `json:"extensions,omitempty" azure:"ro"`
+	Extensions []*VirtualMachineScaleSetVMExtensionsSummary
 
 	// READ-ONLY; The orchestration services information.
-	OrchestrationServices []*OrchestrationServiceSummary `json:"orchestrationServices,omitempty" azure:"ro"`
+	OrchestrationServices []*OrchestrationServiceSummary
 
 	// READ-ONLY; The instance view status summary for the virtual machine scale set.
-	VirtualMachine *VirtualMachineScaleSetInstanceViewStatusesSummary `json:"virtualMachine,omitempty" azure:"ro"`
+	VirtualMachine *VirtualMachineScaleSetInstanceViewStatusesSummary
 }
 
 // VirtualMachineScaleSetInstanceViewStatusesSummary - Instance view statuses summary for virtual machines of a virtual machine
 // scale set.
 type VirtualMachineScaleSetInstanceViewStatusesSummary struct {
 	// READ-ONLY; The extensions information.
-	StatusesSummary []*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary []*VirtualMachineStatusCodeCount
 }
 
 // VirtualMachineScaleSetListOSUpgradeHistory - List of Virtual Machine Scale Set OS Upgrade History operation response.
 type VirtualMachineScaleSetListOSUpgradeHistory struct {
 	// REQUIRED; The list of OS upgrades performed on the virtual machine scale set.
-	Value []*UpgradeOperationHistoricalStatusInfo `json:"value,omitempty"`
+	Value []*UpgradeOperationHistoricalStatusInfo
 
 	// The uri to fetch the next page of OS Upgrade History. Call ListNext() with this to fetch the next page of history of upgrades.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetListResult - The List Virtual Machine operation response.
 type VirtualMachineScaleSetListResult struct {
 	// REQUIRED; The list of virtual machine scale sets.
-	Value []*VirtualMachineScaleSet `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSet
 
 	// The uri to fetch the next page of Virtual Machine Scale Sets. Call ListNext() with this to fetch the next page of VMSS.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetListSKUsResult - The Virtual Machine Scale Set List Skus operation response.
 type VirtualMachineScaleSetListSKUsResult struct {
 	// REQUIRED; The list of skus available for the virtual machine scale set.
-	Value []*VirtualMachineScaleSetSKU `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetSKU
 
 	// The uri to fetch the next page of Virtual Machine Scale Set Skus. Call ListNext() with this to fetch the next page of VMSS
 	// Skus.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetListWithLinkResult - The List Virtual Machine operation response.
 type VirtualMachineScaleSetListWithLinkResult struct {
 	// REQUIRED; The list of virtual machine scale sets.
-	Value []*VirtualMachineScaleSet `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSet
 
 	// The uri to fetch the next page of Virtual Machine Scale Sets. Call ListNext() with this to fetch the next page of Virtual
 	// Machine Scale Sets.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetManagedDiskParameters - Describes the parameters of a ScaleSet managed disk.
 type VirtualMachineScaleSetManagedDiskParameters struct {
 	// Specifies the customer managed disk encryption set resource id for the managed disk.
-	DiskEncryptionSet *DiskEncryptionSetParameters `json:"diskEncryptionSet,omitempty"`
+	DiskEncryptionSet *DiskEncryptionSetParameters
 
 	// Specifies the storage account type for the managed disk. NOTE: UltraSSD_LRS can only be used with data disks, it cannot
 	// be used with OS Disk.
-	StorageAccountType *StorageAccountTypes `json:"storageAccountType,omitempty"`
+	StorageAccountType *StorageAccountTypes
 }
 
 // VirtualMachineScaleSetNetworkConfiguration - Describes a virtual machine scale set network profile's network configurations.
 type VirtualMachineScaleSetNetworkConfiguration struct {
 	// REQUIRED; The network configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Describes a virtual machine scale set network profile's IP configuration.
-	Properties *VirtualMachineScaleSetNetworkConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetNetworkConfigurationProperties
 }
 
 // VirtualMachineScaleSetNetworkConfigurationDNSSettings - Describes a virtual machines scale sets network configuration's
 // DNS settings.
 type VirtualMachineScaleSetNetworkConfigurationDNSSettings struct {
 	// List of DNS servers IP addresses
-	DNSServers []*string `json:"dnsServers,omitempty"`
+	DNSServers []*string
 }
 
 // VirtualMachineScaleSetNetworkConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration.
 type VirtualMachineScaleSetNetworkConfigurationProperties struct {
 	// REQUIRED; Specifies the IP configurations of the network interface.
-	IPConfigurations []*VirtualMachineScaleSetIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualMachineScaleSetIPConfiguration
 
 	// The dns settings to be applied on the network interfaces.
-	DNSSettings *VirtualMachineScaleSetNetworkConfigurationDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *VirtualMachineScaleSetNetworkConfigurationDNSSettings
 
 	// Specifies whether the network interface is accelerated networking-enabled.
-	EnableAcceleratedNetworking *bool `json:"enableAcceleratedNetworking,omitempty"`
+	EnableAcceleratedNetworking *bool
 
 	// Whether IP forwarding enabled on this NIC.
-	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
+	EnableIPForwarding *bool
 
 	// The network security group.
-	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SubResource
 
 	// Specifies the primary network interface in case the virtual machine has more than 1 network interface.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 }
 
 // VirtualMachineScaleSetNetworkProfile - Describes a virtual machine scale set network profile.
@@ -4572,10 +4572,10 @@ type VirtualMachineScaleSetNetworkProfile struct {
 	// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The
 	// reference will be in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
-	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
+	HealthProbe *APIEntityReference
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration
 }
 
 // VirtualMachineScaleSetOSDisk - Describes a virtual machine scale set operating system disk.
@@ -4584,7 +4584,7 @@ type VirtualMachineScaleSetOSDisk struct {
 	// The only allowed value is: FromImage \u2013 This value is used when you are using an image to create the virtual machine.
 	// If you are using a platform image, you also use the imageReference element
 	// described above. If you are using a marketplace image, you also use the plan element previously described.
-	CreateOption *DiskCreateOptionTypes `json:"createOption,omitempty"`
+	CreateOption *DiskCreateOptionTypes
 
 	// Specifies the caching requirements.
 	// Possible values are:
@@ -4592,37 +4592,37 @@ type VirtualMachineScaleSetOSDisk struct {
 	// ReadOnly
 	// ReadWrite
 	// Default: None for Standard storage. ReadOnly for Premium storage
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the ephemeral disk Settings for the operating system disk used by the virtual machine scale set.
-	DiffDiskSettings *DiffDiskSettings `json:"diffDiskSettings,omitempty"`
+	DiffDiskSettings *DiffDiskSettings
 
 	// Specifies the size of the operating system disk in gigabytes. This element can be used to overwrite the size of the disk
 	// in a virtual machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// Specifies information about the unmanaged user image to base the scale set on.
-	Image *VirtualHardDisk `json:"image,omitempty"`
+	Image *VirtualHardDisk
 
 	// The managed disk parameters.
-	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters
 
 	// The disk name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// This property allows you to specify the type of the OS that is included in the disk if creating a VM from user-image or
 	// a specialized VHD.
 	// Possible values are:
 	// Windows
 	// Linux
-	OSType *OperatingSystemTypes `json:"osType,omitempty"`
+	OSType *OperatingSystemTypes
 
 	// Specifies the container urls that are used to store operating system disks for the scale set.
-	VhdContainers []*string `json:"vhdContainers,omitempty"`
+	VhdContainers []*string
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
-	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+	WriteAcceleratorEnabled *bool
 }
 
 // VirtualMachineScaleSetOSProfile - Describes a virtual machine scale set OS profile.
@@ -4643,7 +4643,7 @@ type VirtualMachineScaleSetOSProfile struct {
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-reset-rdp?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// For resetting root password, see Manage users, SSH, and check or repair disks on Azure Linux VMs using the VMAccess Extension
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-vmaccess-extension?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json#reset-root-password]
-	AdminPassword *string `json:"adminPassword,omitempty"`
+	AdminPassword *string
 
 	// Specifies the name of the administrator account.
 	// Windows-only restriction: Cannot end in "."
@@ -4658,31 +4658,31 @@ type VirtualMachineScaleSetOSProfile struct {
 	// For a list of built-in system users on Linux that should not be used in this field, see Selecting User Names for Linux
 	// on Azure
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-usernames?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
-	AdminUsername *string `json:"adminUsername,omitempty"`
+	AdminUsername *string
 
 	// Specifies the computer name prefix for all of the virtual machines in the scale set. Computer name prefixes must be 1 to
 	// 15 characters long.
-	ComputerNamePrefix *string `json:"computerNamePrefix,omitempty"`
+	ComputerNamePrefix *string
 
 	// Specifies a base-64 encoded string of custom data. The base-64 encoded string is decoded to a binary array that is saved
 	// as a file on the Virtual Machine. The maximum length of the binary array is
 	// 65535 bytes.
 	// For using cloud-init for your VM, see Using cloud-init to customize a Linux VM during creation
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-using-cloud-init?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
-	CustomData *string `json:"customData,omitempty"`
+	CustomData *string
 
 	// Specifies the Linux operating system settings on the virtual machine.
 	// For a list of supported Linux distributions, see Linux on Azure-Endorsed Distributions
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-endorsed-distros?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json]
 	// For running non-endorsed distributions, see Information for Non-Endorsed Distributions
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-create-upload-generic?toc=%2fazure%2fvirtual-machines%2flinux%2ftoc.json].
-	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
+	LinuxConfiguration *LinuxConfiguration
 
 	// Specifies set of certificates that should be installed onto the virtual machines in the scale set.
-	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup
 
 	// Specifies Windows operating system settings on the virtual machine.
-	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+	WindowsConfiguration *WindowsConfiguration
 }
 
 // VirtualMachineScaleSetProperties - Describes the properties of a Virtual Machine Scale Set.
@@ -4690,59 +4690,59 @@ type VirtualMachineScaleSetProperties struct {
 	// Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance:
 	// whether the Virtual Machines have the capability to support attaching
 	// managed data disks with UltraSSD_LRS storage account type.
-	AdditionalCapabilities *AdditionalCapabilities `json:"additionalCapabilities,omitempty"`
+	AdditionalCapabilities *AdditionalCapabilities
 
 	// Policy for automatic repairs.
-	AutomaticRepairsPolicy *AutomaticRepairsPolicy `json:"automaticRepairsPolicy,omitempty"`
+	AutomaticRepairsPolicy *AutomaticRepairsPolicy
 
 	// When Overprovision is enabled, extensions are launched only on the requested number of VMs which are finally kept. This
 	// property will hence ensure that the extensions do not run on the extra
 	// overprovisioned VMs.
-	DoNotRunExtensionsOnOverprovisionedVMs *bool `json:"doNotRunExtensionsOnOverprovisionedVMs,omitempty"`
+	DoNotRunExtensionsOnOverprovisionedVMs *bool
 
 	// Specifies whether the Virtual Machine Scale Set should be overprovisioned.
-	Overprovision *bool `json:"overprovision,omitempty"`
+	Overprovision *bool
 
 	// Fault Domain count for each placement group.
-	PlatformFaultDomainCount *int32 `json:"platformFaultDomainCount,omitempty"`
+	PlatformFaultDomainCount *int32
 
 	// Specifies information about the proximity placement group that the virtual machine scale set should be assigned to.
 	// Minimum api-version: 2018-04-01.
-	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
+	ProximityPlacementGroup *SubResource
 
 	// Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set
 	// is scaled-in.
-	ScaleInPolicy *ScaleInPolicy `json:"scaleInPolicy,omitempty"`
+	ScaleInPolicy *ScaleInPolicy
 
 	// When true this limits the scale set to a single placement group, of max size 100 virtual machines. NOTE: If singlePlacementGroup
 	// is true, it may be modified to false. However, if singlePlacementGroup
 	// is false, it may not be modified to true.
-	SinglePlacementGroup *bool `json:"singlePlacementGroup,omitempty"`
+	SinglePlacementGroup *bool
 
 	// The upgrade policy.
-	UpgradePolicy *UpgradePolicy `json:"upgradePolicy,omitempty"`
+	UpgradePolicy *UpgradePolicy
 
 	// The virtual machine profile.
-	VirtualMachineProfile *VirtualMachineScaleSetVMProfile `json:"virtualMachineProfile,omitempty"`
+	VirtualMachineProfile *VirtualMachineScaleSetVMProfile
 
 	// Whether to force strictly even Virtual Machine distribution cross x-zones in case there is zone outage.
-	ZoneBalance *bool `json:"zoneBalance,omitempty"`
+	ZoneBalance *bool
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; Specifies the ID which uniquely identifies a Virtual Machine Scale Set.
-	UniqueID *string `json:"uniqueId,omitempty" azure:"ro"`
+	UniqueID *string
 }
 
 // VirtualMachineScaleSetPublicIPAddressConfiguration - Describes a virtual machines scale set IP Configuration's PublicIPAddress
 // configuration
 type VirtualMachineScaleSetPublicIPAddressConfiguration struct {
 	// REQUIRED; The publicIP address configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
-	Properties *VirtualMachineScaleSetPublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetPublicIPAddressConfigurationProperties
 }
 
 // VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings - Describes a virtual machines scale sets network configuration's
@@ -4750,38 +4750,38 @@ type VirtualMachineScaleSetPublicIPAddressConfiguration struct {
 type VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings struct {
 	// REQUIRED; The Domain name label.The concatenation of the domain name label and vm index will be the domain name labels
 	// of the PublicIPAddress resources that will be created
-	DomainNameLabel *string `json:"domainNameLabel,omitempty"`
+	DomainNameLabel *string
 }
 
 // VirtualMachineScaleSetPublicIPAddressConfigurationProperties - Describes a virtual machines scale set IP Configuration's
 // PublicIPAddress configuration
 type VirtualMachineScaleSetPublicIPAddressConfigurationProperties struct {
 	// The dns settings to be applied on the publicIP addresses .
-	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings
 
 	// The list of IP tags associated with the public IP address.
-	IPTags []*VirtualMachineScaleSetIPTag `json:"ipTags,omitempty"`
+	IPTags []*VirtualMachineScaleSetIPTag
 
 	// The idle timeout of the public IP address.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// Available from Api-Version 2019-07-01 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default
 	// is taken as IPv4. Possible values are: 'IPv4' and 'IPv6'.
-	PublicIPAddressVersion *IPVersion `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAddressVersion *IPVersion
 
 	// The PublicIPPrefix from which to allocate publicIP addresses.
-	PublicIPPrefix *SubResource `json:"publicIPPrefix,omitempty"`
+	PublicIPPrefix *SubResource
 }
 
 // VirtualMachineScaleSetReimageParameters - Describes a Virtual Machine Scale Set VM Reimage Parameters.
 type VirtualMachineScaleSetReimageParameters struct {
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation
 	// being performed on all virtual machines in the virtual machine scale set.
-	InstanceIDs []*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string
 
 	// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported
 	// for VM/VMSS with Ephemeral OS disk.
-	TempDisk *bool `json:"tempDisk,omitempty"`
+	TempDisk *bool
 }
 
 // VirtualMachineScaleSetRollingUpgradesClientBeginCancelOptions contains the optional parameters for the VirtualMachineScaleSetRollingUpgradesClient.BeginCancel
@@ -4814,28 +4814,28 @@ type VirtualMachineScaleSetRollingUpgradesClientGetLatestOptions struct {
 // VirtualMachineScaleSetSKU - Describes an available virtual machine scale set sku.
 type VirtualMachineScaleSetSKU struct {
 	// READ-ONLY; Specifies the number of virtual machines in the scale set.
-	Capacity *VirtualMachineScaleSetSKUCapacity `json:"capacity,omitempty" azure:"ro"`
+	Capacity *VirtualMachineScaleSetSKUCapacity
 
 	// READ-ONLY; The type of resource the sku applies to.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; The Sku.
-	SKU *SKU `json:"sku,omitempty" azure:"ro"`
+	SKU *SKU
 }
 
 // VirtualMachineScaleSetSKUCapacity - Describes scaling information of a sku.
 type VirtualMachineScaleSetSKUCapacity struct {
 	// READ-ONLY; The default capacity.
-	DefaultCapacity *int64 `json:"defaultCapacity,omitempty" azure:"ro"`
+	DefaultCapacity *int64
 
 	// READ-ONLY; The maximum capacity that can be set.
-	Maximum *int64 `json:"maximum,omitempty" azure:"ro"`
+	Maximum *int64
 
 	// READ-ONLY; The minimum capacity.
-	Minimum *int64 `json:"minimum,omitempty" azure:"ro"`
+	Minimum *int64
 
 	// READ-ONLY; The scale type applicable to the sku.
-	ScaleType *VirtualMachineScaleSetSKUScaleType `json:"scaleType,omitempty" azure:"ro"`
+	ScaleType *VirtualMachineScaleSetSKUScaleType
 }
 
 // VirtualMachineScaleSetStorageProfile - Describes a virtual machine scale set storage profile.
@@ -4843,35 +4843,35 @@ type VirtualMachineScaleSetStorageProfile struct {
 	// Specifies the parameters that are used to add data disks to the virtual machines in the scale set.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	DataDisks []*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*VirtualMachineScaleSetDataDisk
 
 	// Specifies information about the image to use. You can specify information about platform images, marketplace images, or
 	// virtual machine images. This element is required when you want to use a platform
 	// image, marketplace image, or virtual machine image, but is not used in other creation operations.
-	ImageReference *ImageReference `json:"imageReference,omitempty"`
+	ImageReference *ImageReference
 
 	// Specifies information about the operating system disk used by the virtual machines in the scale set.
 	// For more information about disks, see About disks and VHDs for Azure virtual machines
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-about-disks-vhds?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json].
-	OSDisk *VirtualMachineScaleSetOSDisk `json:"osDisk,omitempty"`
+	OSDisk *VirtualMachineScaleSetOSDisk
 }
 
 // VirtualMachineScaleSetUpdate - Describes a Virtual Machine Scale Set.
 type VirtualMachineScaleSetUpdate struct {
 	// The identity of the virtual machine scale set, if configured.
-	Identity *VirtualMachineScaleSetIdentity `json:"identity,omitempty"`
+	Identity *VirtualMachineScaleSetIdentity
 
 	// The purchase plan when deploying a virtual machine scale set from VM Marketplace images.
-	Plan *Plan `json:"plan,omitempty"`
+	Plan *Plan
 
 	// Describes the properties of a Virtual Machine Scale Set.
-	Properties *VirtualMachineScaleSetUpdateProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateProperties
 
 	// The virtual machine scale set sku.
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // VirtualMachineScaleSetUpdateIPConfiguration - Describes a virtual machine scale set network profile's IP configuration.
@@ -4879,77 +4879,77 @@ type VirtualMachineScaleSetUpdate struct {
 // network
 type VirtualMachineScaleSetUpdateIPConfiguration struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The IP configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Describes a virtual machine scale set network profile's IP configuration properties.
-	Properties *VirtualMachineScaleSetUpdateIPConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateIPConfigurationProperties
 }
 
 // VirtualMachineScaleSetUpdateIPConfigurationProperties - Describes a virtual machine scale set network profile's IP configuration
 // properties.
 type VirtualMachineScaleSetUpdateIPConfigurationProperties struct {
 	// The application gateway backend address pools.
-	ApplicationGatewayBackendAddressPools []*SubResource `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*SubResource
 
 	// Specifies an array of references to application security group.
-	ApplicationSecurityGroups []*SubResource `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*SubResource
 
 	// The load balancer backend address pools.
-	LoadBalancerBackendAddressPools []*SubResource `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*SubResource
 
 	// The load balancer inbound nat pools.
-	LoadBalancerInboundNatPools []*SubResource `json:"loadBalancerInboundNatPools,omitempty"`
+	LoadBalancerInboundNatPools []*SubResource
 
 	// Specifies the primary IP Configuration in case the network interface has more than one IP Configuration.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 
 	// Available from Api-Version 2017-03-30 onwards, it represents whether the specific ipconfiguration is IPv4 or IPv6. Default
 	// is taken as IPv4. Possible values are: 'IPv4' and 'IPv6'.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAddressVersion *IPVersion
 
 	// The publicIPAddressConfiguration.
-	PublicIPAddressConfiguration *VirtualMachineScaleSetUpdatePublicIPAddressConfiguration `json:"publicIPAddressConfiguration,omitempty"`
+	PublicIPAddressConfiguration *VirtualMachineScaleSetUpdatePublicIPAddressConfiguration
 
 	// The subnet.
-	Subnet *APIEntityReference `json:"subnet,omitempty"`
+	Subnet *APIEntityReference
 }
 
 // VirtualMachineScaleSetUpdateNetworkConfiguration - Describes a virtual machine scale set network profile's network configurations.
 type VirtualMachineScaleSetUpdateNetworkConfiguration struct {
 	// Resource Id
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The network configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Describes a virtual machine scale set updatable network profile's IP configuration.Use this object for updating network
 	// profile's IP Configuration.
-	Properties *VirtualMachineScaleSetUpdateNetworkConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetUpdateNetworkConfigurationProperties
 }
 
 // VirtualMachineScaleSetUpdateNetworkConfigurationProperties - Describes a virtual machine scale set updatable network profile's
 // IP configuration.Use this object for updating network profile's IP Configuration.
 type VirtualMachineScaleSetUpdateNetworkConfigurationProperties struct {
 	// The dns settings to be applied on the network interfaces.
-	DNSSettings *VirtualMachineScaleSetNetworkConfigurationDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *VirtualMachineScaleSetNetworkConfigurationDNSSettings
 
 	// Specifies whether the network interface is accelerated networking-enabled.
-	EnableAcceleratedNetworking *bool `json:"enableAcceleratedNetworking,omitempty"`
+	EnableAcceleratedNetworking *bool
 
 	// Whether IP forwarding enabled on this NIC.
-	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
+	EnableIPForwarding *bool
 
 	// The virtual machine scale set IP Configuration.
-	IPConfigurations []*VirtualMachineScaleSetUpdateIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualMachineScaleSetUpdateIPConfiguration
 
 	// The network security group.
-	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SubResource
 
 	// Whether this is a primary NIC on a virtual machine.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 }
 
 // VirtualMachineScaleSetUpdateNetworkProfile - Describes a virtual machine scale set network profile.
@@ -4957,51 +4957,51 @@ type VirtualMachineScaleSetUpdateNetworkProfile struct {
 	// A reference to a load balancer probe used to determine the health of an instance in the virtual machine scale set. The
 	// reference will be in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}'.
-	HealthProbe *APIEntityReference `json:"healthProbe,omitempty"`
+	HealthProbe *APIEntityReference
 
 	// The list of network configurations.
-	NetworkInterfaceConfigurations []*VirtualMachineScaleSetUpdateNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetUpdateNetworkConfiguration
 }
 
 // VirtualMachineScaleSetUpdateOSDisk - Describes virtual machine scale set operating system disk Update Object. This should
 // be used for Updating VMSS OS Disk.
 type VirtualMachineScaleSetUpdateOSDisk struct {
 	// The caching type.
-	Caching *CachingTypes `json:"caching,omitempty"`
+	Caching *CachingTypes
 
 	// Specifies the size of the operating system disk in gigabytes. This element can be used to overwrite the size of the disk
 	// in a virtual machine image.
 	// This value cannot be larger than 1023 GB
-	DiskSizeGB *int32 `json:"diskSizeGB,omitempty"`
+	DiskSizeGB *int32
 
 	// The Source User Image VirtualHardDisk. This VirtualHardDisk will be copied before using it to attach to the Virtual Machine.
 	// If SourceImage is provided, the destination VirtualHardDisk should not
 	// exist.
-	Image *VirtualHardDisk `json:"image,omitempty"`
+	Image *VirtualHardDisk
 
 	// The managed disk parameters.
-	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters `json:"managedDisk,omitempty"`
+	ManagedDisk *VirtualMachineScaleSetManagedDiskParameters
 
 	// The list of virtual hard disk container uris.
-	VhdContainers []*string `json:"vhdContainers,omitempty"`
+	VhdContainers []*string
 
 	// Specifies whether writeAccelerator should be enabled or disabled on the disk.
-	WriteAcceleratorEnabled *bool `json:"writeAcceleratorEnabled,omitempty"`
+	WriteAcceleratorEnabled *bool
 }
 
 // VirtualMachineScaleSetUpdateOSProfile - Describes a virtual machine scale set OS profile.
 type VirtualMachineScaleSetUpdateOSProfile struct {
 	// A base-64 encoded string of custom data.
-	CustomData *string `json:"customData,omitempty"`
+	CustomData *string
 
 	// The Linux Configuration of the OS profile.
-	LinuxConfiguration *LinuxConfiguration `json:"linuxConfiguration,omitempty"`
+	LinuxConfiguration *LinuxConfiguration
 
 	// The List of certificates for addition to the VM.
-	Secrets []*VaultSecretGroup `json:"secrets,omitempty"`
+	Secrets []*VaultSecretGroup
 
 	// The Windows Configuration of the OS profile.
-	WindowsConfiguration *WindowsConfiguration `json:"windowsConfiguration,omitempty"`
+	WindowsConfiguration *WindowsConfiguration
 }
 
 // VirtualMachineScaleSetUpdateProperties - Describes the properties of a Virtual Machine Scale Set.
@@ -5009,137 +5009,137 @@ type VirtualMachineScaleSetUpdateProperties struct {
 	// Specifies additional capabilities enabled or disabled on the Virtual Machines in the Virtual Machine Scale Set. For instance:
 	// whether the Virtual Machines have the capability to support attaching
 	// managed data disks with UltraSSD_LRS storage account type.
-	AdditionalCapabilities *AdditionalCapabilities `json:"additionalCapabilities,omitempty"`
+	AdditionalCapabilities *AdditionalCapabilities
 
 	// Policy for automatic repairs.
-	AutomaticRepairsPolicy *AutomaticRepairsPolicy `json:"automaticRepairsPolicy,omitempty"`
+	AutomaticRepairsPolicy *AutomaticRepairsPolicy
 
 	// When Overprovision is enabled, extensions are launched only on the requested number of VMs which are finally kept. This
 	// property will hence ensure that the extensions do not run on the extra
 	// overprovisioned VMs.
-	DoNotRunExtensionsOnOverprovisionedVMs *bool `json:"doNotRunExtensionsOnOverprovisionedVMs,omitempty"`
+	DoNotRunExtensionsOnOverprovisionedVMs *bool
 
 	// Specifies whether the Virtual Machine Scale Set should be overprovisioned.
-	Overprovision *bool `json:"overprovision,omitempty"`
+	Overprovision *bool
 
 	// Specifies information about the proximity placement group that the virtual machine scale set should be assigned to.
 	// Minimum api-version: 2018-04-01.
-	ProximityPlacementGroup *SubResource `json:"proximityPlacementGroup,omitempty"`
+	ProximityPlacementGroup *SubResource
 
 	// Specifies the scale-in policy that decides which virtual machines are chosen for removal when a Virtual Machine Scale Set
 	// is scaled-in.
-	ScaleInPolicy *ScaleInPolicy `json:"scaleInPolicy,omitempty"`
+	ScaleInPolicy *ScaleInPolicy
 
 	// When true this limits the scale set to a single placement group, of max size 100 virtual machines. NOTE: If singlePlacementGroup
 	// is true, it may be modified to false. However, if singlePlacementGroup
 	// is false, it may not be modified to true.
-	SinglePlacementGroup *bool `json:"singlePlacementGroup,omitempty"`
+	SinglePlacementGroup *bool
 
 	// The upgrade policy.
-	UpgradePolicy *UpgradePolicy `json:"upgradePolicy,omitempty"`
+	UpgradePolicy *UpgradePolicy
 
 	// The virtual machine profile.
-	VirtualMachineProfile *VirtualMachineScaleSetUpdateVMProfile `json:"virtualMachineProfile,omitempty"`
+	VirtualMachineProfile *VirtualMachineScaleSetUpdateVMProfile
 }
 
 // VirtualMachineScaleSetUpdatePublicIPAddressConfiguration - Describes a virtual machines scale set IP Configuration's PublicIPAddress
 // configuration
 type VirtualMachineScaleSetUpdatePublicIPAddressConfiguration struct {
 	// The publicIP address configuration name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Describes a virtual machines scale set IP Configuration's PublicIPAddress configuration
-	Properties *VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties
 }
 
 // VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties - Describes a virtual machines scale set IP Configuration's
 // PublicIPAddress configuration
 type VirtualMachineScaleSetUpdatePublicIPAddressConfigurationProperties struct {
 	// The dns settings to be applied on the publicIP addresses .
-	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *VirtualMachineScaleSetPublicIPAddressConfigurationDNSSettings
 
 	// The idle timeout of the public IP address.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 }
 
 // VirtualMachineScaleSetUpdateStorageProfile - Describes a virtual machine scale set storage profile.
 type VirtualMachineScaleSetUpdateStorageProfile struct {
 	// The data disks.
-	DataDisks []*VirtualMachineScaleSetDataDisk `json:"dataDisks,omitempty"`
+	DataDisks []*VirtualMachineScaleSetDataDisk
 
 	// The image reference.
-	ImageReference *ImageReference `json:"imageReference,omitempty"`
+	ImageReference *ImageReference
 
 	// The OS disk.
-	OSDisk *VirtualMachineScaleSetUpdateOSDisk `json:"osDisk,omitempty"`
+	OSDisk *VirtualMachineScaleSetUpdateOSDisk
 }
 
 // VirtualMachineScaleSetUpdateVMProfile - Describes a virtual machine scale set virtual machine profile.
 type VirtualMachineScaleSetUpdateVMProfile struct {
 	// Specifies the billing related details of a Azure Spot VMSS.
 	// Minimum api-version: 2019-03-01.
-	BillingProfile *BillingProfile `json:"billingProfile,omitempty"`
+	BillingProfile *BillingProfile
 
 	// The virtual machine scale set diagnostics profile.
-	DiagnosticsProfile *DiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *DiagnosticsProfile
 
 	// The virtual machine scale set extension profile.
-	ExtensionProfile *VirtualMachineScaleSetExtensionProfile `json:"extensionProfile,omitempty"`
+	ExtensionProfile *VirtualMachineScaleSetExtensionProfile
 
 	// The license type, which is for bring your own license scenario.
-	LicenseType *string `json:"licenseType,omitempty"`
+	LicenseType *string
 
 	// The virtual machine scale set network profile.
-	NetworkProfile *VirtualMachineScaleSetUpdateNetworkProfile `json:"networkProfile,omitempty"`
+	NetworkProfile *VirtualMachineScaleSetUpdateNetworkProfile
 
 	// The virtual machine scale set OS profile.
-	OSProfile *VirtualMachineScaleSetUpdateOSProfile `json:"osProfile,omitempty"`
+	OSProfile *VirtualMachineScaleSetUpdateOSProfile
 
 	// Specifies Scheduled Event related configurations.
-	ScheduledEventsProfile *ScheduledEventsProfile `json:"scheduledEventsProfile,omitempty"`
+	ScheduledEventsProfile *ScheduledEventsProfile
 
 	// The virtual machine scale set storage profile.
-	StorageProfile *VirtualMachineScaleSetUpdateStorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *VirtualMachineScaleSetUpdateStorageProfile
 }
 
 // VirtualMachineScaleSetVM - Describes a virtual machine scale set virtual machine.
 type VirtualMachineScaleSetVM struct {
 	// REQUIRED; Resource location
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace
 	// images. Before you can use a marketplace image from an API, you must
 	// enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click
 	// Want to deploy programmatically, Get Started ->. Enter any required
 	// information and then click Save.
-	Plan *Plan `json:"plan,omitempty"`
+	Plan *Plan
 
 	// Describes the properties of a virtual machine scale set virtual machine.
-	Properties *VirtualMachineScaleSetVMProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineScaleSetVMProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource Id
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The virtual machine instance ID.
-	InstanceID *string `json:"instanceId,omitempty" azure:"ro"`
+	InstanceID *string
 
 	// READ-ONLY; Resource name
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The virtual machine child extension resources.
-	Resources []*VirtualMachineExtension `json:"resources,omitempty" azure:"ro"`
+	Resources []*VirtualMachineExtension
 
 	// READ-ONLY; The virtual machine SKU.
-	SKU *SKU `json:"sku,omitempty" azure:"ro"`
+	SKU *SKU
 
 	// READ-ONLY; Resource type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; The virtual machine zones.
-	Zones []*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string
 }
 
 // VirtualMachineScaleSetVMExtensionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualMachineScaleSetVMExtensionsClient.BeginCreateOrUpdate
@@ -5180,23 +5180,23 @@ type VirtualMachineScaleSetVMExtensionsClientListOptions struct {
 // VirtualMachineScaleSetVMExtensionsSummary - Extensions summary for virtual machines of a virtual machine scale set.
 type VirtualMachineScaleSetVMExtensionsSummary struct {
 	// READ-ONLY; The extension name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The extensions information.
-	StatusesSummary []*VirtualMachineStatusCodeCount `json:"statusesSummary,omitempty" azure:"ro"`
+	StatusesSummary []*VirtualMachineStatusCodeCount
 }
 
 // VirtualMachineScaleSetVMInstanceIDs - Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceIDs struct {
 	// The virtual machine scale set instance ids. Omitting the virtual machine scale set instance ids will result in the operation
 	// being performed on all virtual machines in the virtual machine scale set.
-	InstanceIDs []*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string
 }
 
 // VirtualMachineScaleSetVMInstanceRequiredIDs - Specifies a list of virtual machine instance IDs from the VM scale set.
 type VirtualMachineScaleSetVMInstanceRequiredIDs struct {
 	// REQUIRED; The virtual machine scale set instance ids.
-	InstanceIDs []*string `json:"instanceIds,omitempty"`
+	InstanceIDs []*string
 }
 
 // VirtualMachineScaleSetVMInstanceView - The instance view of a virtual machine scale set VM.
@@ -5204,72 +5204,72 @@ type VirtualMachineScaleSetVMInstanceView struct {
 	// Boot Diagnostics is a debugging feature which allows you to view Console Output and Screenshot to diagnose VM status.
 	// You can easily view the output of your console log.
 	// Azure also enables you to see a screenshot of the VM from the hypervisor.
-	BootDiagnostics *BootDiagnosticsInstanceView `json:"bootDiagnostics,omitempty"`
+	BootDiagnostics *BootDiagnosticsInstanceView
 
 	// The disks information.
-	Disks []*DiskInstanceView `json:"disks,omitempty"`
+	Disks []*DiskInstanceView
 
 	// The extensions information.
-	Extensions []*VirtualMachineExtensionInstanceView `json:"extensions,omitempty"`
+	Extensions []*VirtualMachineExtensionInstanceView
 
 	// The Maintenance Operation status on the virtual machine.
-	MaintenanceRedeployStatus *MaintenanceRedeployStatus `json:"maintenanceRedeployStatus,omitempty"`
+	MaintenanceRedeployStatus *MaintenanceRedeployStatus
 
 	// The placement group in which the VM is running. If the VM is deallocated it will not have a placementGroupId.
-	PlacementGroupID *string `json:"placementGroupId,omitempty"`
+	PlacementGroupID *string
 
 	// The Fault Domain count.
-	PlatformFaultDomain *int32 `json:"platformFaultDomain,omitempty"`
+	PlatformFaultDomain *int32
 
 	// The Update Domain count.
-	PlatformUpdateDomain *int32 `json:"platformUpdateDomain,omitempty"`
+	PlatformUpdateDomain *int32
 
 	// The Remote desktop certificate thumbprint.
-	RdpThumbPrint *string `json:"rdpThumbPrint,omitempty"`
+	RdpThumbPrint *string
 
 	// The resource status information.
-	Statuses []*InstanceViewStatus `json:"statuses,omitempty"`
+	Statuses []*InstanceViewStatus
 
 	// The VM Agent running on the virtual machine.
-	VMAgent *VirtualMachineAgentInstanceView `json:"vmAgent,omitempty"`
+	VMAgent *VirtualMachineAgentInstanceView
 
 	// READ-ONLY; The health status for the VM.
-	VMHealth *VirtualMachineHealthStatus `json:"vmHealth,omitempty" azure:"ro"`
+	VMHealth *VirtualMachineHealthStatus
 }
 
 // VirtualMachineScaleSetVMListResult - The List Virtual Machine Scale Set VMs operation response.
 type VirtualMachineScaleSetVMListResult struct {
 	// REQUIRED; The list of virtual machine scale sets VMs.
-	Value []*VirtualMachineScaleSetVM `json:"value,omitempty"`
+	Value []*VirtualMachineScaleSetVM
 
 	// The uri to fetch the next page of Virtual Machine Scale Set VMs. Call ListNext() with this to fetch the next page of VMSS
 	// VMs
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // VirtualMachineScaleSetVMNetworkProfileConfiguration - Describes a virtual machine scale set VM network profile.
 type VirtualMachineScaleSetVMNetworkProfileConfiguration struct {
 	// The list of network configurations.
-	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration `json:"networkInterfaceConfigurations,omitempty"`
+	NetworkInterfaceConfigurations []*VirtualMachineScaleSetNetworkConfiguration
 }
 
 // VirtualMachineScaleSetVMProfile - Describes a virtual machine scale set virtual machine profile.
 type VirtualMachineScaleSetVMProfile struct {
 	// Specifies the billing related details of a Azure Spot VMSS.
 	// Minimum api-version: 2019-03-01.
-	BillingProfile *BillingProfile `json:"billingProfile,omitempty"`
+	BillingProfile *BillingProfile
 
 	// Specifies the boot diagnostic settings state.
 	// Minimum api-version: 2015-06-15.
-	DiagnosticsProfile *DiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *DiagnosticsProfile
 
 	// Specifies the eviction policy for the Azure Spot virtual machine and Azure Spot scale set.
 	// For Azure Spot virtual machines, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2019-03-01.
 	// For Azure Spot scale sets, both 'Deallocate' and 'Delete' are supported and the minimum api-version is 2017-10-30-preview.
-	EvictionPolicy *VirtualMachineEvictionPolicyTypes `json:"evictionPolicy,omitempty"`
+	EvictionPolicy *VirtualMachineEvictionPolicyTypes
 
 	// Specifies a collection of settings for extensions installed on virtual machines in the scale set.
-	ExtensionProfile *VirtualMachineScaleSetExtensionProfile `json:"extensionProfile,omitempty"`
+	ExtensionProfile *VirtualMachineScaleSetExtensionProfile
 
 	// Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that
 	// contain the Windows Server operating system.
@@ -5280,23 +5280,23 @@ type VirtualMachineScaleSetVMProfile struct {
 	// For more information, see Azure Hybrid Use Benefit for Windows Server
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// Minimum api-version: 2015-06-15
-	LicenseType *string `json:"licenseType,omitempty"`
+	LicenseType *string
 
 	// Specifies properties of the network interfaces of the virtual machines in the scale set.
-	NetworkProfile *VirtualMachineScaleSetNetworkProfile `json:"networkProfile,omitempty"`
+	NetworkProfile *VirtualMachineScaleSetNetworkProfile
 
 	// Specifies the operating system settings for the virtual machines in the scale set.
-	OSProfile *VirtualMachineScaleSetOSProfile `json:"osProfile,omitempty"`
+	OSProfile *VirtualMachineScaleSetOSProfile
 
 	// Specifies the priority for the virtual machines in the scale set.
 	// Minimum api-version: 2017-10-30-preview
-	Priority *VirtualMachinePriorityTypes `json:"priority,omitempty"`
+	Priority *VirtualMachinePriorityTypes
 
 	// Specifies Scheduled Event related configurations.
-	ScheduledEventsProfile *ScheduledEventsProfile `json:"scheduledEventsProfile,omitempty"`
+	ScheduledEventsProfile *ScheduledEventsProfile
 
 	// Specifies the storage settings for the virtual machine disks.
-	StorageProfile *VirtualMachineScaleSetStorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *VirtualMachineScaleSetStorageProfile
 }
 
 // VirtualMachineScaleSetVMProperties - Describes the properties of a virtual machine scale set virtual machine.
@@ -5304,7 +5304,7 @@ type VirtualMachineScaleSetVMProperties struct {
 	// Specifies additional capabilities enabled or disabled on the virtual machine in the scale set. For instance: whether the
 	// virtual machine has the capability to support attaching managed data disks with
 	// UltraSSD_LRS storage account type.
-	AdditionalCapabilities *AdditionalCapabilities `json:"additionalCapabilities,omitempty"`
+	AdditionalCapabilities *AdditionalCapabilities
 
 	// Specifies information about the availability set that the virtual machine should be assigned to. Virtual machines specified
 	// in the same availability set are allocated to different nodes to maximize
@@ -5314,14 +5314,14 @@ type VirtualMachineScaleSetVMProperties struct {
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-planned-maintenance?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// Currently, a VM can only be added to availability set at creation time. An existing VM cannot be added to an availability
 	// set.
-	AvailabilitySet *SubResource `json:"availabilitySet,omitempty"`
+	AvailabilitySet *SubResource
 
 	// Specifies the boot diagnostic settings state.
 	// Minimum api-version: 2015-06-15.
-	DiagnosticsProfile *DiagnosticsProfile `json:"diagnosticsProfile,omitempty"`
+	DiagnosticsProfile *DiagnosticsProfile
 
 	// Specifies the hardware settings for the virtual machine.
-	HardwareProfile *HardwareProfile `json:"hardwareProfile,omitempty"`
+	HardwareProfile *HardwareProfile
 
 	// Specifies that the image or disk that is being used was licensed on-premises. This element is only used for images that
 	// contain the Windows Server operating system.
@@ -5332,55 +5332,55 @@ type VirtualMachineScaleSetVMProperties struct {
 	// For more information, see Azure Hybrid Use Benefit for Windows Server
 	// [https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-hybrid-use-benefit-licensing?toc=%2fazure%2fvirtual-machines%2fwindows%2ftoc.json]
 	// Minimum api-version: 2015-06-15
-	LicenseType *string `json:"licenseType,omitempty"`
+	LicenseType *string
 
 	// Specifies the network interfaces of the virtual machine.
-	NetworkProfile *NetworkProfile `json:"networkProfile,omitempty"`
+	NetworkProfile *NetworkProfile
 
 	// Specifies the network profile configuration of the virtual machine.
-	NetworkProfileConfiguration *VirtualMachineScaleSetVMNetworkProfileConfiguration `json:"networkProfileConfiguration,omitempty"`
+	NetworkProfileConfiguration *VirtualMachineScaleSetVMNetworkProfileConfiguration
 
 	// Specifies the operating system settings for the virtual machine.
-	OSProfile *OSProfile `json:"osProfile,omitempty"`
+	OSProfile *OSProfile
 
 	// Specifies the protection policy of the virtual machine.
-	ProtectionPolicy *VirtualMachineScaleSetVMProtectionPolicy `json:"protectionPolicy,omitempty"`
+	ProtectionPolicy *VirtualMachineScaleSetVMProtectionPolicy
 
 	// Specifies the storage settings for the virtual machine disks.
-	StorageProfile *StorageProfile `json:"storageProfile,omitempty"`
+	StorageProfile *StorageProfile
 
 	// READ-ONLY; The virtual machine instance view.
-	InstanceView *VirtualMachineScaleSetVMInstanceView `json:"instanceView,omitempty" azure:"ro"`
+	InstanceView *VirtualMachineScaleSetVMInstanceView
 
 	// READ-ONLY; Specifies whether the latest model has been applied to the virtual machine.
-	LatestModelApplied *bool `json:"latestModelApplied,omitempty" azure:"ro"`
+	LatestModelApplied *bool
 
 	// READ-ONLY; Specifies whether the model applied to the virtual machine is the model of the virtual machine scale set or
 	// the customized model for the virtual machine.
-	ModelDefinitionApplied *string `json:"modelDefinitionApplied,omitempty" azure:"ro"`
+	ModelDefinitionApplied *string
 
 	// READ-ONLY; The provisioning state, which only appears in the response.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; Azure VM unique ID.
-	VMID *string `json:"vmId,omitempty" azure:"ro"`
+	VMID *string
 }
 
 // VirtualMachineScaleSetVMProtectionPolicy - The protection policy of a virtual machine scale set VM.
 type VirtualMachineScaleSetVMProtectionPolicy struct {
 	// Indicates that the virtual machine scale set VM shouldn't be considered for deletion during a scale-in operation.
-	ProtectFromScaleIn *bool `json:"protectFromScaleIn,omitempty"`
+	ProtectFromScaleIn *bool
 
 	// Indicates that model updates or actions (including scale-in) initiated on the virtual machine scale set should not be applied
 	// to the virtual machine scale set VM.
-	ProtectFromScaleSetActions *bool `json:"protectFromScaleSetActions,omitempty"`
+	ProtectFromScaleSetActions *bool
 }
 
 // VirtualMachineScaleSetVMReimageParameters - Describes a Virtual Machine Scale Set VM Reimage Parameters.
 type VirtualMachineScaleSetVMReimageParameters struct {
 	// Specifies whether to reimage temp disk. Default value: false. Note: This temp disk reimage parameter is only supported
 	// for VM/VMSS with Ephemeral OS disk.
-	TempDisk *bool `json:"tempDisk,omitempty"`
+	TempDisk *bool
 }
 
 // VirtualMachineScaleSetVMsClientBeginDeallocateOptions contains the optional parameters for the VirtualMachineScaleSetVMsClient.BeginDeallocate
@@ -5664,28 +5664,28 @@ type VirtualMachineScaleSetsClientListSKUsOptions struct {
 // VirtualMachineSize - Describes the properties of a VM size.
 type VirtualMachineSize struct {
 	// The maximum number of data disks that can be attached to the virtual machine size.
-	MaxDataDiskCount *int32 `json:"maxDataDiskCount,omitempty"`
+	MaxDataDiskCount *int32
 
 	// The amount of memory, in MB, supported by the virtual machine size.
-	MemoryInMB *int32 `json:"memoryInMB,omitempty"`
+	MemoryInMB *int32
 
 	// The name of the virtual machine size.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The number of cores supported by the virtual machine size.
-	NumberOfCores *int32 `json:"numberOfCores,omitempty"`
+	NumberOfCores *int32
 
 	// The OS disk size, in MB, allowed by the virtual machine size.
-	OSDiskSizeInMB *int32 `json:"osDiskSizeInMB,omitempty"`
+	OSDiskSizeInMB *int32
 
 	// The resource disk size, in MB, allowed by the virtual machine size.
-	ResourceDiskSizeInMB *int32 `json:"resourceDiskSizeInMB,omitempty"`
+	ResourceDiskSizeInMB *int32
 }
 
 // VirtualMachineSizeListResult - The List Virtual Machine operation response.
 type VirtualMachineSizeListResult struct {
 	// The list of virtual machine sizes.
-	Value []*VirtualMachineSize `json:"value,omitempty"`
+	Value []*VirtualMachineSize
 }
 
 // VirtualMachineSizesClientListOptions contains the optional parameters for the VirtualMachineSizesClient.NewListPager method.
@@ -5696,32 +5696,32 @@ type VirtualMachineSizesClientListOptions struct {
 // VirtualMachineStatusCodeCount - The status code and count of the virtual machine scale set instance view status summary.
 type VirtualMachineStatusCodeCount struct {
 	// READ-ONLY; The instance view status code.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The number of instances having a particular status code.
-	Count *int32 `json:"count,omitempty" azure:"ro"`
+	Count *int32
 }
 
 // VirtualMachineUpdate - Describes a Virtual Machine Update.
 type VirtualMachineUpdate struct {
 	// The identity of the virtual machine, if configured.
-	Identity *VirtualMachineIdentity `json:"identity,omitempty"`
+	Identity *VirtualMachineIdentity
 
 	// Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace
 	// images. Before you can use a marketplace image from an API, you must
 	// enable the image for programmatic use. In the Azure portal, find the marketplace image that you want to use and then click
 	// Want to deploy programmatically, Get Started ->. Enter any required
 	// information and then click Save.
-	Plan *Plan `json:"plan,omitempty"`
+	Plan *Plan
 
 	// Describes the properties of a Virtual Machine.
-	Properties *VirtualMachineProperties `json:"properties,omitempty"`
+	Properties *VirtualMachineProperties
 
 	// Resource tags
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The virtual machine zones.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 }
 
 // VirtualMachinesClientBeginCaptureOptions contains the optional parameters for the VirtualMachinesClient.BeginCapture method.
@@ -5868,7 +5868,7 @@ type VirtualMachinesClientSimulateEvictionOptions struct {
 // WinRMConfiguration - Describes Windows Remote Management configuration of the VM
 type WinRMConfiguration struct {
 	// The list of Windows Remote Management listeners
-	Listeners []*WinRMListener `json:"listeners,omitempty"`
+	Listeners []*WinRMListener
 }
 
 // WinRMListener - Describes Protocol and thumbprint of Windows Remote Management listener
@@ -5882,36 +5882,36 @@ type WinRMListener struct {
 	// "dataType":"pfx",
 	// "password":""
 	// }
-	CertificateURL *string `json:"certificateUrl,omitempty"`
+	CertificateURL *string
 
 	// Specifies the protocol of WinRM listener.
 	// Possible values are:
 	// http
 	// https
-	Protocol *ProtocolTypes `json:"protocol,omitempty"`
+	Protocol *ProtocolTypes
 }
 
 // WindowsConfiguration - Specifies Windows operating system settings on the virtual machine.
 type WindowsConfiguration struct {
 	// Specifies additional base-64 encoded XML formatted information that can be included in the Unattend.xml file, which is
 	// used by Windows Setup.
-	AdditionalUnattendContent []*AdditionalUnattendContent `json:"additionalUnattendContent,omitempty"`
+	AdditionalUnattendContent []*AdditionalUnattendContent
 
 	// Indicates whether Automatic Updates is enabled for the Windows virtual machine. Default value is true.
 	// For virtual machine scale sets, this property can be updated and updates will take effect on OS reprovisioning.
-	EnableAutomaticUpdates *bool `json:"enableAutomaticUpdates,omitempty"`
+	EnableAutomaticUpdates *bool
 
 	// Indicates whether virtual machine agent should be provisioned on the virtual machine.
 	// When this property is not specified in the request body, default behavior is to set it to true. This will ensure that VM
 	// Agent is installed on the VM so that extensions can be added to the VM later.
-	ProvisionVMAgent *bool `json:"provisionVMAgent,omitempty"`
+	ProvisionVMAgent *bool
 
 	// Specifies the time zone of the virtual machine. e.g. "Pacific Standard Time".
 	// Possible values can be TimeZoneInfo.Id [https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.id?#System_TimeZoneInfo_Id]
 	// value from time zones returned by TimeZoneInfo.GetSystemTimeZones
 	// [https://docs.microsoft.com/en-us/dotnet/api/system.timezoneinfo.getsystemtimezones].
-	TimeZone *string `json:"timeZone,omitempty"`
+	TimeZone *string
 
 	// Specifies the Windows Remote Management listeners. This enables remote Windows PowerShell.
-	WinRM *WinRMConfiguration `json:"winRM,omitempty"`
+	WinRM *WinRMConfiguration
 }

--- a/test/consumption/2019-10-01/armconsumption/zz_models.go
+++ b/test/consumption/2019-10-01/armconsumption/zz_models.go
@@ -29,110 +29,110 @@ type AggregatedCostClientGetForBillingPeriodByManagementGroupOptions struct {
 // Amount - The amount plus currency .
 type Amount struct {
 	// READ-ONLY; Amount currency.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Amount.
-	Value *float64 `json:"value,omitempty" azure:"ro"`
+	Value *float64
 }
 
 // AmountWithExchangeRate - Reseller details
 type AmountWithExchangeRate struct {
 	// READ-ONLY; Amount currency.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Exchange Rate.
-	ExchangeRate *float64 `json:"exchangeRate,omitempty" azure:"ro"`
+	ExchangeRate *float64
 
 	// READ-ONLY; Exchange rate month.
-	ExchangeRateMonth *float32 `json:"exchangeRateMonth,omitempty" azure:"ro"`
+	ExchangeRateMonth *float32
 
 	// READ-ONLY; Amount.
-	Value *float64 `json:"value,omitempty" azure:"ro"`
+	Value *float64
 }
 
 // Balance - A balance resource.
 type Balance struct {
 	// The properties of the balance.
-	Properties *BalanceProperties `json:"properties,omitempty"`
+	Properties *BalanceProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BalanceProperties - The properties of the balance.
 type BalanceProperties struct {
 	// The billing frequency.
-	BillingFrequency *BillingFrequency `json:"billingFrequency,omitempty"`
+	BillingFrequency *BillingFrequency
 
 	// READ-ONLY; List of Adjustments (Promo credit, SIE credit etc.).
-	AdjustmentDetails []*BalancePropertiesAdjustmentDetailsItem `json:"adjustmentDetails,omitempty" azure:"ro"`
+	AdjustmentDetails []*BalancePropertiesAdjustmentDetailsItem
 
 	// READ-ONLY; Total adjustment amount.
-	Adjustments *float64 `json:"adjustments,omitempty" azure:"ro"`
+	Adjustments *float64
 
 	// READ-ONLY; Total charges for Azure Marketplace.
-	AzureMarketplaceServiceCharges *float64 `json:"azureMarketplaceServiceCharges,omitempty" azure:"ro"`
+	AzureMarketplaceServiceCharges *float64
 
 	// READ-ONLY; The beginning balance for the billing period.
-	BeginningBalance *float64 `json:"beginningBalance,omitempty" azure:"ro"`
+	BeginningBalance *float64
 
 	// READ-ONLY; Charges Billed separately.
-	ChargesBilledSeparately *float64 `json:"chargesBilledSeparately,omitempty" azure:"ro"`
+	ChargesBilledSeparately *float64
 
 	// READ-ONLY; The ISO currency in which the meter is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; The ending balance for the billing period (for open periods this will be updated daily).
-	EndingBalance *float64 `json:"endingBalance,omitempty" azure:"ro"`
+	EndingBalance *float64
 
 	// READ-ONLY; Total new purchase amount.
-	NewPurchases *float64 `json:"newPurchases,omitempty" azure:"ro"`
+	NewPurchases *float64
 
 	// READ-ONLY; List of new purchases.
-	NewPurchasesDetails []*BalancePropertiesNewPurchasesDetailsItem `json:"newPurchasesDetails,omitempty" azure:"ro"`
+	NewPurchasesDetails []*BalancePropertiesNewPurchasesDetailsItem
 
 	// READ-ONLY; Price is hidden or not.
-	PriceHidden *bool `json:"priceHidden,omitempty" azure:"ro"`
+	PriceHidden *bool
 
 	// READ-ONLY; Overage for Azure services.
-	ServiceOverage *float64 `json:"serviceOverage,omitempty" azure:"ro"`
+	ServiceOverage *float64
 
 	// READ-ONLY; serviceOverage + chargesBilledSeparately.
-	TotalOverage *float64 `json:"totalOverage,omitempty" azure:"ro"`
+	TotalOverage *float64
 
 	// READ-ONLY; Azure service commitment + total Overage.
-	TotalUsage *float64 `json:"totalUsage,omitempty" azure:"ro"`
+	TotalUsage *float64
 
 	// READ-ONLY; Total Commitment usage.
-	Utilized *float64 `json:"utilized,omitempty" azure:"ro"`
+	Utilized *float64
 }
 
 type BalancePropertiesAdjustmentDetailsItem struct {
 	// READ-ONLY; the name of new adjustment.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; the value of new adjustment.
-	Value *float64 `json:"value,omitempty" azure:"ro"`
+	Value *float64
 }
 
 type BalancePropertiesNewPurchasesDetailsItem struct {
 	// READ-ONLY; the name of new purchase.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; the value of new purchase.
-	Value *float64 `json:"value,omitempty" azure:"ro"`
+	Value *float64
 }
 
 // BalancesClientGetByBillingAccountOptions contains the optional parameters for the BalancesClient.GetByBillingAccount method.
@@ -150,95 +150,95 @@ type BalancesClientGetForBillingPeriodByBillingAccountOptions struct {
 type Budget struct {
 	// eTag of the resource. To handle concurrent update scenario, this field will be used to determine whether the user is updating
 	// the latest version or not.
-	ETag *string `json:"eTag,omitempty"`
+	ETag *string
 
 	// The properties of the budget.
-	Properties *BudgetProperties `json:"properties,omitempty"`
+	Properties *BudgetProperties
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BudgetComparisonExpression - The comparison expression to be used in the budgets.
 type BudgetComparisonExpression struct {
 	// REQUIRED; The name of the column to use in comparison.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The operator to use for comparison.
-	Operator *BudgetOperatorType `json:"operator,omitempty"`
+	Operator *BudgetOperatorType
 
 	// REQUIRED; Array of values to use for comparison
-	Values []*string `json:"values,omitempty"`
+	Values []*string
 }
 
 // BudgetFilter - May be used to filter budgets by resource group, resource, or meter.
 type BudgetFilter struct {
 	// The logical "AND" expression. Must have at least 2 items.
-	And []*BudgetFilterProperties `json:"and,omitempty"`
+	And []*BudgetFilterProperties
 
 	// Has comparison expression for a dimension
-	Dimensions *BudgetComparisonExpression `json:"dimensions,omitempty"`
+	Dimensions *BudgetComparisonExpression
 
 	// The logical "NOT" expression.
-	Not *BudgetFilterProperties `json:"not,omitempty"`
+	Not *BudgetFilterProperties
 
 	// Has comparison expression for a tag
-	Tags *BudgetComparisonExpression `json:"tags,omitempty"`
+	Tags *BudgetComparisonExpression
 }
 
 // BudgetFilterProperties - The Dimensions or Tags to filter a budget by.
 type BudgetFilterProperties struct {
 	// Has comparison expression for a dimension
-	Dimensions *BudgetComparisonExpression `json:"dimensions,omitempty"`
+	Dimensions *BudgetComparisonExpression
 
 	// Has comparison expression for a tag
-	Tags *BudgetComparisonExpression `json:"tags,omitempty"`
+	Tags *BudgetComparisonExpression
 }
 
 // BudgetProperties - The properties of the budget.
 type BudgetProperties struct {
 	// REQUIRED; The total amount of cost to track with the budget
-	Amount *float64 `json:"amount,omitempty"`
+	Amount *float64
 
 	// REQUIRED; The category of the budget, whether the budget tracks cost or usage.
-	Category *CategoryType `json:"category,omitempty"`
+	Category *CategoryType
 
 	// REQUIRED; The time covered by a budget. Tracking of the amount will be reset based on the time grain. BillingMonth, BillingQuarter,
 	// and BillingAnnual are only supported by WD customers
-	TimeGrain *TimeGrainType `json:"timeGrain,omitempty"`
+	TimeGrain *TimeGrainType
 
 	// REQUIRED; Has start and end date of the budget. The start date must be first of the month and should be less than the end
 	// date. Budget start date must be on or after June 1, 2017. Future start date should not
 	// be more than twelve months. Past start date should be selected within the timegrain period. There are no restrictions on
 	// the end date.
-	TimePeriod *BudgetTimePeriod `json:"timePeriod,omitempty"`
+	TimePeriod *BudgetTimePeriod
 
 	// May be used to filter budgets by user-specified dimensions and/or tags.
-	Filter *BudgetFilter `json:"filter,omitempty"`
+	Filter *BudgetFilter
 
 	// Dictionary of notifications associated with the budget. Budget can have up to five notifications.
-	Notifications map[string]*Notification `json:"notifications,omitempty"`
+	Notifications map[string]*Notification
 
 	// READ-ONLY; The current amount of cost which is being tracked for a budget.
-	CurrentSpend *CurrentSpend `json:"currentSpend,omitempty" azure:"ro"`
+	CurrentSpend *CurrentSpend
 
 	// READ-ONLY; The forecasted cost which is being tracked for a budget.
-	ForecastSpend *ForecastSpend `json:"forecastSpend,omitempty" azure:"ro"`
+	ForecastSpend *ForecastSpend
 }
 
 // BudgetTimePeriod - The start and end date for a budget.
 type BudgetTimePeriod struct {
 	// REQUIRED; The start date for the budget.
-	StartDate *time.Time `json:"startDate,omitempty"`
+	StartDate *time.Time
 
 	// The end date for the budget. If not provided, we default this to 10 years from the start date.
-	EndDate *time.Time `json:"endDate,omitempty"`
+	EndDate *time.Time
 }
 
 // BudgetsClientCreateOrUpdateOptions contains the optional parameters for the BudgetsClient.CreateOrUpdate method.
@@ -264,10 +264,10 @@ type BudgetsClientListOptions struct {
 // BudgetsListResult - Result of listing budgets. It contains a list of available budgets in the scope provided.
 type BudgetsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of budgets.
-	Value []*Budget `json:"value,omitempty" azure:"ro"`
+	Value []*Budget
 }
 
 // ChargeSummaryClassification provides polymorphic access to related types.
@@ -282,22 +282,22 @@ type ChargeSummaryClassification interface {
 // ChargeSummary - A charge summary resource.
 type ChargeSummary struct {
 	// REQUIRED; Specifies the kind of charge summary.
-	Kind *ChargeSummaryKind `json:"kind,omitempty"`
+	Kind *ChargeSummaryKind
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetChargeSummary implements the ChargeSummaryClassification interface for type ChargeSummary.
@@ -322,67 +322,67 @@ type ChargesClientListOptions struct {
 // ChargesListResult - Result of listing charge summary.
 type ChargesListResult struct {
 	// READ-ONLY; The list of charge summary
-	Value []ChargeSummaryClassification `json:"value,omitempty" azure:"ro"`
+	Value []ChargeSummaryClassification
 }
 
 // CreditBalanceSummary - Summary of credit balances.
 type CreditBalanceSummary struct {
 	// READ-ONLY; Current balance.
-	CurrentBalance *Amount `json:"currentBalance,omitempty" azure:"ro"`
+	CurrentBalance *Amount
 
 	// READ-ONLY; Current balance.
-	CurrentBalanceInBillingCurrency *AmountWithExchangeRate `json:"currentBalanceInBillingCurrency,omitempty" azure:"ro"`
+	CurrentBalanceInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Estimated balance.
-	EstimatedBalance *Amount `json:"estimatedBalance,omitempty" azure:"ro"`
+	EstimatedBalance *Amount
 
 	// READ-ONLY; Current balance.
-	EstimatedBalanceInBillingCurrency *AmountWithExchangeRate `json:"estimatedBalanceInBillingCurrency,omitempty" azure:"ro"`
+	EstimatedBalanceInBillingCurrency *AmountWithExchangeRate
 }
 
 // CreditSummary - A credit summary resource.
 type CreditSummary struct {
 	// The properties of the credit summary.
-	Properties *CreditSummaryProperties `json:"properties,omitempty"`
+	Properties *CreditSummaryProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // CreditSummaryProperties - The properties of the credit summary.
 type CreditSummaryProperties struct {
 	// READ-ONLY; Summary of balances associated with this credit summary.
-	BalanceSummary *CreditBalanceSummary `json:"balanceSummary,omitempty" azure:"ro"`
+	BalanceSummary *CreditBalanceSummary
 
 	// READ-ONLY; Billing Currency.
-	BillingCurrency *string `json:"billingCurrency,omitempty" azure:"ro"`
+	BillingCurrency *string
 
 	// READ-ONLY; Credit Currency
-	CreditCurrency *string `json:"creditCurrency,omitempty" azure:"ro"`
+	CreditCurrency *string
 
 	// READ-ONLY; Expired credit.
-	ExpiredCredit *Amount `json:"expiredCredit,omitempty" azure:"ro"`
+	ExpiredCredit *Amount
 
 	// READ-ONLY; Pending credit adjustments.
-	PendingCreditAdjustments *Amount `json:"pendingCreditAdjustments,omitempty" azure:"ro"`
+	PendingCreditAdjustments *Amount
 
 	// READ-ONLY; Pending eligible charges.
-	PendingEligibleCharges *Amount `json:"pendingEligibleCharges,omitempty" azure:"ro"`
+	PendingEligibleCharges *Amount
 
 	// READ-ONLY; Reseller details.
-	Reseller *Reseller `json:"reseller,omitempty" azure:"ro"`
+	Reseller *Reseller
 }
 
 // CreditsClientGetOptions contains the optional parameters for the CreditsClient.Get method.
@@ -393,94 +393,94 @@ type CreditsClientGetOptions struct {
 // CurrentSpend - The current amount of cost which is being tracked for a budget.
 type CurrentSpend struct {
 	// READ-ONLY; The total amount of cost which is being tracked by the budget.
-	Amount *float64 `json:"amount,omitempty" azure:"ro"`
+	Amount *float64
 
 	// READ-ONLY; The unit of measure for the budget amount.
-	Unit *string `json:"unit,omitempty" azure:"ro"`
+	Unit *string
 }
 
 // EventProperties - The event properties.
 type EventProperties struct {
 	// The type of event.
-	EventType *EventType `json:"eventType,omitempty"`
+	EventType *EventType
 
 	// READ-ONLY; Adjustments amount.
-	Adjustments *Amount `json:"adjustments,omitempty" azure:"ro"`
+	Adjustments *Amount
 
 	// READ-ONLY; Current balance.
-	AdjustmentsInBillingCurrency *AmountWithExchangeRate `json:"adjustmentsInBillingCurrency,omitempty" azure:"ro"`
+	AdjustmentsInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Billing Currency.
-	BillingCurrency *string `json:"billingCurrency,omitempty" azure:"ro"`
+	BillingCurrency *string
 
 	// READ-ONLY; Charges amount.
-	Charges *Amount `json:"charges,omitempty" azure:"ro"`
+	Charges *Amount
 
 	// READ-ONLY; Current balance.
-	ChargesInBillingCurrency *AmountWithExchangeRate `json:"chargesInBillingCurrency,omitempty" azure:"ro"`
+	ChargesInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Closed balance.
-	ClosedBalance *Amount `json:"closedBalance,omitempty" azure:"ro"`
+	ClosedBalance *Amount
 
 	// READ-ONLY; Current balance.
-	ClosedBalanceInBillingCurrency *AmountWithExchangeRate `json:"closedBalanceInBillingCurrency,omitempty" azure:"ro"`
+	ClosedBalanceInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Credit Currency
-	CreditCurrency *string `json:"creditCurrency,omitempty" azure:"ro"`
+	CreditCurrency *string
 
 	// READ-ONLY; Credit expired.
-	CreditExpired *Amount `json:"creditExpired,omitempty" azure:"ro"`
+	CreditExpired *Amount
 
 	// READ-ONLY; Current balance.
-	CreditExpiredInBillingCurrency *AmountWithExchangeRate `json:"creditExpiredInBillingCurrency,omitempty" azure:"ro"`
+	CreditExpiredInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Transaction description.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; Invoice number.
-	InvoiceNumber *string `json:"invoiceNumber,omitempty" azure:"ro"`
+	InvoiceNumber *string
 
 	// READ-ONLY; New Credit.
-	NewCredit *Amount `json:"newCredit,omitempty" azure:"ro"`
+	NewCredit *Amount
 
 	// READ-ONLY; Current balance.
-	NewCreditInBillingCurrency *AmountWithExchangeRate `json:"newCreditInBillingCurrency,omitempty" azure:"ro"`
+	NewCreditInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Reseller details.
-	Reseller *Reseller `json:"reseller,omitempty" azure:"ro"`
+	Reseller *Reseller
 
 	// READ-ONLY; Transaction date.
-	TransactionDate *time.Time `json:"transactionDate,omitempty" azure:"ro"`
+	TransactionDate *time.Time
 }
 
 // EventSummary - An event summary resource.
 type EventSummary struct {
 	// The event properties.
-	Properties *EventProperties `json:"properties,omitempty"`
+	Properties *EventProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // Events - Result of listing event summary.
 type Events struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of event summary.
-	Value []*EventSummary `json:"value,omitempty" azure:"ro"`
+	Value []*EventSummary
 }
 
 // EventsClientListOptions contains the optional parameters for the EventsClient.NewListPager method.
@@ -491,66 +491,66 @@ type EventsClientListOptions struct {
 // Forecast - A forecast resource.
 type Forecast struct {
 	// The properties of the forecast charge.
-	Properties *ForecastProperties `json:"properties,omitempty"`
+	Properties *ForecastProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ForecastProperties - The properties of the forecast charge.
 type ForecastProperties struct {
 	// The type of the charge. Could be actual or forecast
-	ChargeType *ChargeType `json:"chargeType,omitempty"`
+	ChargeType *ChargeType
 
 	// The granularity of forecast. Please note that Yearly is not currently supported in this API. The API will provide responses
 	// in the Monthly grain if Yearly is selected. To get yearly grain data, please
 	// use our newer Forecast API.
-	Grain *Grain `json:"grain,omitempty"`
+	Grain *Grain
 
 	// READ-ONLY; The amount of charge
-	Charge *float64 `json:"charge,omitempty" azure:"ro"`
+	Charge *float64
 
 	// READ-ONLY; The details about the forecast confidence levels. This is populated only when chargeType is Forecast.
-	ConfidenceLevels []*ForecastPropertiesConfidenceLevelsItem `json:"confidenceLevels,omitempty" azure:"ro"`
+	ConfidenceLevels []*ForecastPropertiesConfidenceLevelsItem
 
 	// READ-ONLY; The ISO currency in which the meter is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; The usage date of the forecast.
-	UsageDate *string `json:"usageDate,omitempty" azure:"ro"`
+	UsageDate *string
 }
 
 type ForecastPropertiesConfidenceLevelsItem struct {
 	// The boundary of the percentage, values could be 'Upper' or 'Lower'
-	Bound *Bound `json:"bound,omitempty"`
+	Bound *Bound
 
 	// READ-ONLY; The percentage level of the confidence
-	Percentage *float64 `json:"percentage,omitempty" azure:"ro"`
+	Percentage *float64
 
 	// READ-ONLY; The amount of forecast within the percentage level
-	Value *float64 `json:"value,omitempty" azure:"ro"`
+	Value *float64
 }
 
 // ForecastSpend - The forecasted cost which is being tracked for a budget.
 type ForecastSpend struct {
 	// READ-ONLY; The forecasted cost for the total time period which is being tracked by the budget. This value is only provided
 	// if the budget contains a forecast alert type.
-	Amount *float64 `json:"amount,omitempty" azure:"ro"`
+	Amount *float64
 
 	// READ-ONLY; The unit of measure for the budget amount.
-	Unit *string `json:"unit,omitempty" azure:"ro"`
+	Unit *string
 }
 
 // ForecastsClientListOptions contains the optional parameters for the ForecastsClient.NewListPager method.
@@ -564,31 +564,31 @@ type ForecastsClientListOptions struct {
 // ForecastsListResult - Result of listing forecasts. It contains a list of available forecasts.
 type ForecastsListResult struct {
 	// READ-ONLY; The list of forecasts.
-	Value []*Forecast `json:"value,omitempty" azure:"ro"`
+	Value []*Forecast
 }
 
 // LegacyChargeSummary - Legacy charge summary.
 type LegacyChargeSummary struct {
 	// REQUIRED; Specifies the kind of charge summary.
-	Kind *ChargeSummaryKind `json:"kind,omitempty"`
+	Kind *ChargeSummaryKind
 
 	// REQUIRED; Properties for legacy charge summary
-	Properties *LegacyChargeSummaryProperties `json:"properties,omitempty"`
+	Properties *LegacyChargeSummaryProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetChargeSummary implements the ChargeSummaryClassification interface for type LegacyChargeSummary.
@@ -606,55 +606,55 @@ func (l *LegacyChargeSummary) GetChargeSummary() *ChargeSummary {
 // LegacyChargeSummaryProperties - The properties of legacy charge summary.
 type LegacyChargeSummaryProperties struct {
 	// READ-ONLY; Azure Charges.
-	AzureCharges *float64 `json:"azureCharges,omitempty" azure:"ro"`
+	AzureCharges *float64
 
 	// READ-ONLY; The id of the billing period resource that the charge belongs to.
-	BillingPeriodID *string `json:"billingPeriodId,omitempty" azure:"ro"`
+	BillingPeriodID *string
 
 	// READ-ONLY; Charges Billed separately.
-	ChargesBilledSeparately *float64 `json:"chargesBilledSeparately,omitempty" azure:"ro"`
+	ChargesBilledSeparately *float64
 
 	// READ-ONLY; Currency Code
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Marketplace Charges.
-	MarketplaceCharges *float64 `json:"marketplaceCharges,omitempty" azure:"ro"`
+	MarketplaceCharges *float64
 
 	// READ-ONLY; Usage end date.
-	UsageEnd *string `json:"usageEnd,omitempty" azure:"ro"`
+	UsageEnd *string
 
 	// READ-ONLY; Usage start date.
-	UsageStart *string `json:"usageStart,omitempty" azure:"ro"`
+	UsageStart *string
 }
 
 // LegacyReservationRecommendation - Legacy reservation recommendation.
 type LegacyReservationRecommendation struct {
 	// REQUIRED; Specifies the kind of reservation recommendation.
-	Kind *ReservationRecommendationKind `json:"kind,omitempty"`
+	Kind *ReservationRecommendationKind
 
 	// REQUIRED; Properties for legacy reservation recommendation
-	Properties *LegacyReservationRecommendationProperties `json:"properties,omitempty"`
+	Properties *LegacyReservationRecommendationProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource location
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource sku
-	SKU *string `json:"sku,omitempty" azure:"ro"`
+	SKU *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetReservationRecommendation implements the ReservationRecommendationClassification interface for type LegacyReservationRecommendation.
@@ -674,138 +674,138 @@ func (l *LegacyReservationRecommendation) GetReservationRecommendation() *Reserv
 // LegacyReservationRecommendationProperties - The properties of the reservation recommendation.
 type LegacyReservationRecommendationProperties struct {
 	// READ-ONLY; The total amount of cost without reserved instances.
-	CostWithNoReservedInstances *float64 `json:"costWithNoReservedInstances,omitempty" azure:"ro"`
+	CostWithNoReservedInstances *float64
 
 	// READ-ONLY; The usage date for looking back.
-	FirstUsageDate *time.Time `json:"firstUsageDate,omitempty" azure:"ro"`
+	FirstUsageDate *time.Time
 
 	// READ-ONLY; The instance Flexibility Group.
-	InstanceFlexibilityGroup *string `json:"instanceFlexibilityGroup,omitempty" azure:"ro"`
+	InstanceFlexibilityGroup *string
 
 	// READ-ONLY; The instance Flexibility Ratio.
-	InstanceFlexibilityRatio *float32 `json:"instanceFlexibilityRatio,omitempty" azure:"ro"`
+	InstanceFlexibilityRatio *float32
 
 	// READ-ONLY; The number of days of usage to look back for recommendation.
-	LookBackPeriod *string `json:"lookBackPeriod,omitempty" azure:"ro"`
+	LookBackPeriod *string
 
 	// READ-ONLY; The meter id (GUID)
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; Total estimated savings with reserved instances.
-	NetSavings *float64 `json:"netSavings,omitempty" azure:"ro"`
+	NetSavings *float64
 
 	// READ-ONLY; The normalized Size.
-	NormalizedSize *string `json:"normalizedSize,omitempty" azure:"ro"`
+	NormalizedSize *string
 
 	// READ-ONLY; Recommended quality for reserved instances.
-	RecommendedQuantity *float64 `json:"recommendedQuantity,omitempty" azure:"ro"`
+	RecommendedQuantity *float64
 
 	// READ-ONLY; The recommended Quantity Normalized.
-	RecommendedQuantityNormalized *float32 `json:"recommendedQuantityNormalized,omitempty" azure:"ro"`
+	RecommendedQuantityNormalized *float32
 
 	// READ-ONLY; The azure resource type.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; List of sku properties
-	SKUProperties []*SKUProperty `json:"skuProperties,omitempty" azure:"ro"`
+	SKUProperties []*SKUProperty
 
 	// READ-ONLY; Shared or single recommendation.
-	Scope *string `json:"scope,omitempty" azure:"ro"`
+	Scope *string
 
 	// READ-ONLY; RI recommendations in one or three year terms.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 
 	// READ-ONLY; The total amount of cost with reserved instances.
-	TotalCostWithReservedInstances *float64 `json:"totalCostWithReservedInstances,omitempty" azure:"ro"`
+	TotalCostWithReservedInstances *float64
 }
 
 // LegacyReservationTransactionProperties - The properties of a legacy reservation transaction.
 type LegacyReservationTransactionProperties struct {
 	// READ-ONLY; The name of the account that makes the transaction.
-	AccountName *string `json:"accountName,omitempty" azure:"ro"`
+	AccountName *string
 
 	// READ-ONLY; The email of the account owner that makes the transaction.
-	AccountOwnerEmail *string `json:"accountOwnerEmail,omitempty" azure:"ro"`
+	AccountOwnerEmail *string
 
 	// READ-ONLY; The charge of the transaction.
-	Amount *float64 `json:"amount,omitempty" azure:"ro"`
+	Amount *float64
 
 	// READ-ONLY; This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.
-	ArmSKUName *string `json:"armSkuName,omitempty" azure:"ro"`
+	ArmSKUName *string
 
 	// READ-ONLY; The billing frequency, which can be either one-time or recurring.
-	BillingFrequency *string `json:"billingFrequency,omitempty" azure:"ro"`
+	BillingFrequency *string
 
 	// READ-ONLY; The cost center of this department if it is a department and a cost center is provided.
-	CostCenter *string `json:"costCenter,omitempty" azure:"ro"`
+	CostCenter *string
 
 	// READ-ONLY; The ISO currency in which the transaction is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; The current enrollment.
-	CurrentEnrollment *string `json:"currentEnrollment,omitempty" azure:"ro"`
+	CurrentEnrollment *string
 
 	// READ-ONLY; The department name.
-	DepartmentName *string `json:"departmentName,omitempty" azure:"ro"`
+	DepartmentName *string
 
 	// READ-ONLY; The description of the transaction.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; The date of the transaction
-	EventDate *time.Time `json:"eventDate,omitempty" azure:"ro"`
+	EventDate *time.Time
 
 	// READ-ONLY; The type of the transaction (Purchase, Cancel, etc.)
-	EventType *string `json:"eventType,omitempty" azure:"ro"`
+	EventType *string
 
 	// READ-ONLY; The purchasing enrollment.
-	PurchasingEnrollment *string `json:"purchasingEnrollment,omitempty" azure:"ro"`
+	PurchasingEnrollment *string
 
 	// READ-ONLY; The subscription guid that makes the transaction.
-	PurchasingSubscriptionGUID *string `json:"purchasingSubscriptionGuid,omitempty" azure:"ro"`
+	PurchasingSubscriptionGUID *string
 
 	// READ-ONLY; The subscription name that makes the transaction.
-	PurchasingSubscriptionName *string `json:"purchasingSubscriptionName,omitempty" azure:"ro"`
+	PurchasingSubscriptionName *string
 
 	// READ-ONLY; The quantity of the transaction.
-	Quantity *float64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *float64
 
 	// READ-ONLY; The region of the transaction.
-	Region *string `json:"region,omitempty" azure:"ro"`
+	Region *string
 
 	// READ-ONLY; The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents
 	// a single purchase transaction. A reservation order contains reservations. The reservation
 	// order specifies the VM size and region for the reservations.
-	ReservationOrderID *string `json:"reservationOrderId,omitempty" azure:"ro"`
+	ReservationOrderID *string
 
 	// READ-ONLY; The name of the reservation order.
-	ReservationOrderName *string `json:"reservationOrderName,omitempty" azure:"ro"`
+	ReservationOrderName *string
 
 	// READ-ONLY; This is the term of the transaction.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 }
 
 // LegacyUsageDetail - Legacy usage detail.
 type LegacyUsageDetail struct {
 	// REQUIRED; Specifies the kind of usage details.
-	Kind *UsageDetailsKind `json:"kind,omitempty"`
+	Kind *UsageDetailsKind
 
 	// REQUIRED; Properties for legacy usage details
-	Properties *LegacyUsageDetailProperties `json:"properties,omitempty"`
+	Properties *LegacyUsageDetailProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetUsageDetail implements the UsageDetailClassification interface for type LegacyUsageDetail.
@@ -823,204 +823,204 @@ func (l *LegacyUsageDetail) GetUsageDetail() *UsageDetail {
 // LegacyUsageDetailProperties - The properties of the legacy usage detail.
 type LegacyUsageDetailProperties struct {
 	// READ-ONLY; Account Name.
-	AccountName *string `json:"accountName,omitempty" azure:"ro"`
+	AccountName *string
 
 	// READ-ONLY; Account Owner Id.
-	AccountOwnerID *string `json:"accountOwnerId,omitempty" azure:"ro"`
+	AccountOwnerID *string
 
 	// READ-ONLY; Additional details of this usage item. By default this is not populated, unless it's specified in $expand. Use
 	// this field to get usage line item specific details such as the actual VM Size
 	// (ServiceType) or the ratio in which the reservation discount is applied.
-	AdditionalInfo *string `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo *string
 
 	// READ-ONLY; Billing Account identifier.
-	BillingAccountID *string `json:"billingAccountId,omitempty" azure:"ro"`
+	BillingAccountID *string
 
 	// READ-ONLY; Billing Account Name.
-	BillingAccountName *string `json:"billingAccountName,omitempty" azure:"ro"`
+	BillingAccountName *string
 
 	// READ-ONLY; Billing Currency.
-	BillingCurrency *string `json:"billingCurrency,omitempty" azure:"ro"`
+	BillingCurrency *string
 
 	// READ-ONLY; The billing period end date.
-	BillingPeriodEndDate *time.Time `json:"billingPeriodEndDate,omitempty" azure:"ro"`
+	BillingPeriodEndDate *time.Time
 
 	// READ-ONLY; The billing period start date.
-	BillingPeriodStartDate *time.Time `json:"billingPeriodStartDate,omitempty" azure:"ro"`
+	BillingPeriodStartDate *time.Time
 
 	// READ-ONLY; Billing Profile identifier.
-	BillingProfileID *string `json:"billingProfileId,omitempty" azure:"ro"`
+	BillingProfileID *string
 
 	// READ-ONLY; Billing Profile Name.
-	BillingProfileName *string `json:"billingProfileName,omitempty" azure:"ro"`
+	BillingProfileName *string
 
 	// READ-ONLY; Indicates a charge represents credits, usage, a Marketplace purchase, a reservation fee, or a refund.
-	ChargeType *string `json:"chargeType,omitempty" azure:"ro"`
+	ChargeType *string
 
 	// READ-ONLY; Consumed service name. Name of the azure resource provider that emits the usage or was purchased. This value
 	// is not provided for marketplace usage.
-	ConsumedService *string `json:"consumedService,omitempty" azure:"ro"`
+	ConsumedService *string
 
 	// READ-ONLY; The amount of cost before tax.
-	Cost *float64 `json:"cost,omitempty" azure:"ro"`
+	Cost *float64
 
 	// READ-ONLY; The cost center of this department if it is a department and a cost center is provided.
-	CostCenter *string `json:"costCenter,omitempty" azure:"ro"`
+	CostCenter *string
 
 	// READ-ONLY; Date for the usage record.
-	Date *time.Time `json:"date,omitempty" azure:"ro"`
+	Date *time.Time
 
 	// READ-ONLY; Effective Price that's charged for the usage.
-	EffectivePrice *float64 `json:"effectivePrice,omitempty" azure:"ro"`
+	EffectivePrice *float64
 
 	// READ-ONLY; Indicates how frequently this charge will occur. OneTime for purchases which only happen once, Monthly for fees
 	// which recur every month, and UsageBased for charges based on how much a service is used.
-	Frequency *string `json:"frequency,omitempty" azure:"ro"`
+	Frequency *string
 
 	// READ-ONLY; Invoice Section Name.
-	InvoiceSection *string `json:"invoiceSection,omitempty" azure:"ro"`
+	InvoiceSection *string
 
 	// READ-ONLY; Is Azure Credit Eligible.
-	IsAzureCreditEligible *bool `json:"isAzureCreditEligible,omitempty" azure:"ro"`
+	IsAzureCreditEligible *bool
 
 	// READ-ONLY; The details about the meter. By default this is not populated, unless it's specified in $expand.
-	MeterDetails *MeterDetailsResponse `json:"meterDetails,omitempty" azure:"ro"`
+	MeterDetails *MeterDetailsResponse
 
 	// READ-ONLY; The meter id (GUID). Not available for marketplace. For reserved instance this represents the primary meter
 	// for which the reservation was purchased. For the actual VM Size for which the reservation is
 	// purchased see productOrderName.
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; Offer Id. Ex: MS-AZR-0017P, MS-AZR-0148P.
-	OfferID *string `json:"offerId,omitempty" azure:"ro"`
+	OfferID *string
 
 	// READ-ONLY; Part Number of the service used. Can be used to join with the price sheet. Not available for marketplace.
-	PartNumber *string `json:"partNumber,omitempty" azure:"ro"`
+	PartNumber *string
 
 	// READ-ONLY; Plan Name.
-	PlanName *string `json:"planName,omitempty" azure:"ro"`
+	PlanName *string
 
 	// READ-ONLY; Product name for the consumed service or purchase. Not available for Marketplace.
-	Product *string `json:"product,omitempty" azure:"ro"`
+	Product *string
 
 	// READ-ONLY; Product Order Id. For reservations this is the Reservation Order ID.
-	ProductOrderID *string `json:"productOrderId,omitempty" azure:"ro"`
+	ProductOrderID *string
 
 	// READ-ONLY; Product Order Name. For reservations this is the SKU that was purchased.
-	ProductOrderName *string `json:"productOrderName,omitempty" azure:"ro"`
+	ProductOrderName *string
 
 	// READ-ONLY; Publisher Name.
-	PublisherName *string `json:"publisherName,omitempty" azure:"ro"`
+	PublisherName *string
 
 	// READ-ONLY; Publisher Type.
-	PublisherType *string `json:"publisherType,omitempty" azure:"ro"`
+	PublisherType *string
 
 	// READ-ONLY; The usage quantity.
-	Quantity *float64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *float64
 
 	// READ-ONLY; ARM resource id of the reservation. Only applies to records relevant to reservations.
-	ReservationID *string `json:"reservationId,omitempty" azure:"ro"`
+	ReservationID *string
 
 	// READ-ONLY; User provided display name of the reservation. Last known name for a particular day is populated in the daily
 	// data. Only applies to records relevant to reservations.
-	ReservationName *string `json:"reservationName,omitempty" azure:"ro"`
+	ReservationName *string
 
 	// READ-ONLY; Resource Group Name.
-	ResourceGroup *string `json:"resourceGroup,omitempty" azure:"ro"`
+	ResourceGroup *string
 
 	// READ-ONLY; Azure resource manager resource identifier.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; Resource Location.
-	ResourceLocation *string `json:"resourceLocation,omitempty" azure:"ro"`
+	ResourceLocation *string
 
 	// READ-ONLY; Resource Name.
-	ResourceName *string `json:"resourceName,omitempty" azure:"ro"`
+	ResourceName *string
 
 	// READ-ONLY; Service Info 1.
-	ServiceInfo1 *string `json:"serviceInfo1,omitempty" azure:"ro"`
+	ServiceInfo1 *string
 
 	// READ-ONLY; Service Info 2.
-	ServiceInfo2 *string `json:"serviceInfo2,omitempty" azure:"ro"`
+	ServiceInfo2 *string
 
 	// READ-ONLY; Subscription guid.
-	SubscriptionID *string `json:"subscriptionId,omitempty" azure:"ro"`
+	SubscriptionID *string
 
 	// READ-ONLY; Subscription name.
-	SubscriptionName *string `json:"subscriptionName,omitempty" azure:"ro"`
+	SubscriptionName *string
 
 	// READ-ONLY; Term (in months). 1 month for monthly recurring purchase. 12 months for a 1 year reservation. 36 months for
 	// a 3 year reservation.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 
 	// READ-ONLY; Unit Price is the price applicable to you. (your EA or other contract price).
-	UnitPrice *float64 `json:"unitPrice,omitempty" azure:"ro"`
+	UnitPrice *float64
 }
 
 // LotProperties - The lot properties.
 type LotProperties struct {
 	// READ-ONLY; Billing Currency.
-	BillingCurrency *string `json:"billingCurrency,omitempty" azure:"ro"`
+	BillingCurrency *string
 
 	// READ-ONLY; Closed balance.
-	ClosedBalance *Amount `json:"closedBalance,omitempty" azure:"ro"`
+	ClosedBalance *Amount
 
 	// READ-ONLY; Current balance.
-	ClosedBalanceInBillingCurrency *AmountWithExchangeRate `json:"closedBalanceInBillingCurrency,omitempty" azure:"ro"`
+	ClosedBalanceInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; Credit Currency
-	CreditCurrency *string `json:"creditCurrency,omitempty" azure:"ro"`
+	CreditCurrency *string
 
 	// READ-ONLY; Expiration date.
-	ExpirationDate *time.Time `json:"expirationDate,omitempty" azure:"ro"`
+	ExpirationDate *time.Time
 
 	// READ-ONLY; Original amount.
-	OriginalAmount *Amount `json:"originalAmount,omitempty" azure:"ro"`
+	OriginalAmount *Amount
 
 	// READ-ONLY; Current balance.
-	OriginalAmountInBillingCurrency *AmountWithExchangeRate `json:"originalAmountInBillingCurrency,omitempty" azure:"ro"`
+	OriginalAmountInBillingCurrency *AmountWithExchangeRate
 
 	// READ-ONLY; PO number.
-	PoNumber *string `json:"poNumber,omitempty" azure:"ro"`
+	PoNumber *string
 
 	// READ-ONLY; Reseller details.
-	Reseller *Reseller `json:"reseller,omitempty" azure:"ro"`
+	Reseller *Reseller
 
 	// READ-ONLY; Lot source.
-	Source *LotSource `json:"source,omitempty" azure:"ro"`
+	Source *LotSource
 
 	// READ-ONLY; Start date.
-	StartDate *time.Time `json:"startDate,omitempty" azure:"ro"`
+	StartDate *time.Time
 }
 
 // LotSummary - A lot summary resource.
 type LotSummary struct {
 	// The lot properties.
-	Properties *LotProperties `json:"properties,omitempty"`
+	Properties *LotProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // Lots - Result of listing lot summary.
 type Lots struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of lot summary.
-	Value []*LotSummary `json:"value,omitempty" azure:"ro"`
+	Value []*LotSummary
 }
 
 // LotsClientListOptions contains the optional parameters for the LotsClient.NewListPager method.
@@ -1031,157 +1031,157 @@ type LotsClientListOptions struct {
 // ManagementGroupAggregatedCostProperties - The properties of the Management Group Aggregated Cost.
 type ManagementGroupAggregatedCostProperties struct {
 	// Children of a management group
-	Children []*ManagementGroupAggregatedCostResult `json:"children,omitempty"`
+	Children []*ManagementGroupAggregatedCostResult
 
 	// List of subscription Guids excluded from the calculation of aggregated cost
-	ExcludedSubscriptions []*string `json:"excludedSubscriptions,omitempty"`
+	ExcludedSubscriptions []*string
 
 	// List of subscription Guids included in the calculation of aggregated cost
-	IncludedSubscriptions []*string `json:"includedSubscriptions,omitempty"`
+	IncludedSubscriptions []*string
 
 	// READ-ONLY; Azure Charges.
-	AzureCharges *float64 `json:"azureCharges,omitempty" azure:"ro"`
+	AzureCharges *float64
 
 	// READ-ONLY; The id of the billing period resource that the aggregated cost belongs to.
-	BillingPeriodID *string `json:"billingPeriodId,omitempty" azure:"ro"`
+	BillingPeriodID *string
 
 	// READ-ONLY; Charges Billed Separately.
-	ChargesBilledSeparately *float64 `json:"chargesBilledSeparately,omitempty" azure:"ro"`
+	ChargesBilledSeparately *float64
 
 	// READ-ONLY; The ISO currency in which the meter is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Marketplace Charges.
-	MarketplaceCharges *float64 `json:"marketplaceCharges,omitempty" azure:"ro"`
+	MarketplaceCharges *float64
 
 	// READ-ONLY; The end of the date time range covered by the aggregated cost.
-	UsageEnd *time.Time `json:"usageEnd,omitempty" azure:"ro"`
+	UsageEnd *time.Time
 
 	// READ-ONLY; The start of the date time range covered by aggregated cost.
-	UsageStart *time.Time `json:"usageStart,omitempty" azure:"ro"`
+	UsageStart *time.Time
 }
 
 // ManagementGroupAggregatedCostResult - A management group aggregated cost resource.
 type ManagementGroupAggregatedCostResult struct {
 	// The properties of the Management Group Aggregated Cost.
-	Properties *ManagementGroupAggregatedCostProperties `json:"properties,omitempty"`
+	Properties *ManagementGroupAggregatedCostProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // Marketplace - An marketplace resource.
 type Marketplace struct {
 	// The properties of the marketplace usage detail.
-	Properties *MarketplaceProperties `json:"properties,omitempty"`
+	Properties *MarketplaceProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // MarketplaceProperties - The properties of the marketplace usage detail.
 type MarketplaceProperties struct {
 	// READ-ONLY; Account name.
-	AccountName *string `json:"accountName,omitempty" azure:"ro"`
+	AccountName *string
 
 	// READ-ONLY; Additional information.
-	AdditionalInfo *string `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo *string
 
 	// READ-ONLY; Additional details of this usage item. By default this is not populated, unless it's specified in $expand.
-	AdditionalProperties *string `json:"additionalProperties,omitempty" azure:"ro"`
+	AdditionalProperties *string
 
 	// READ-ONLY; The id of the billing period resource that the usage belongs to.
-	BillingPeriodID *string `json:"billingPeriodId,omitempty" azure:"ro"`
+	BillingPeriodID *string
 
 	// READ-ONLY; The quantity of usage.
-	ConsumedQuantity *float64 `json:"consumedQuantity,omitempty" azure:"ro"`
+	ConsumedQuantity *float64
 
 	// READ-ONLY; Consumed service name.
-	ConsumedService *string `json:"consumedService,omitempty" azure:"ro"`
+	ConsumedService *string
 
 	// READ-ONLY; The cost center of this department if it is a department and a costcenter exists
-	CostCenter *string `json:"costCenter,omitempty" azure:"ro"`
+	CostCenter *string
 
 	// READ-ONLY; The ISO currency in which the meter is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Department name.
-	DepartmentName *string `json:"departmentName,omitempty" azure:"ro"`
+	DepartmentName *string
 
 	// READ-ONLY; The uri of the resource instance that the usage is about.
-	InstanceID *string `json:"instanceId,omitempty" azure:"ro"`
+	InstanceID *string
 
 	// READ-ONLY; The name of the resource instance that the usage is about.
-	InstanceName *string `json:"instanceName,omitempty" azure:"ro"`
+	InstanceName *string
 
 	// READ-ONLY; The estimated usage is subject to change.
-	IsEstimated *bool `json:"isEstimated,omitempty" azure:"ro"`
+	IsEstimated *bool
 
 	// READ-ONLY; Flag indicating whether this is a recurring charge or not.
-	IsRecurringCharge *bool `json:"isRecurringCharge,omitempty" azure:"ro"`
+	IsRecurringCharge *bool
 
 	// READ-ONLY; The meter id (GUID).
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; The type of offer.
-	OfferName *string `json:"offerName,omitempty" azure:"ro"`
+	OfferName *string
 
 	// READ-ONLY; The order number.
-	OrderNumber *string `json:"orderNumber,omitempty" azure:"ro"`
+	OrderNumber *string
 
 	// READ-ONLY; The name of plan.
-	PlanName *string `json:"planName,omitempty" azure:"ro"`
+	PlanName *string
 
 	// READ-ONLY; The amount of cost before tax.
-	PretaxCost *float64 `json:"pretaxCost,omitempty" azure:"ro"`
+	PretaxCost *float64
 
 	// READ-ONLY; The name of publisher.
-	PublisherName *string `json:"publisherName,omitempty" azure:"ro"`
+	PublisherName *string
 
 	// READ-ONLY; The name of resource group.
-	ResourceGroup *string `json:"resourceGroup,omitempty" azure:"ro"`
+	ResourceGroup *string
 
 	// READ-ONLY; The marketplace resource rate.
-	ResourceRate *float64 `json:"resourceRate,omitempty" azure:"ro"`
+	ResourceRate *float64
 
 	// READ-ONLY; Subscription guid.
-	SubscriptionGUID *string `json:"subscriptionGuid,omitempty" azure:"ro"`
+	SubscriptionGUID *string
 
 	// READ-ONLY; Subscription name.
-	SubscriptionName *string `json:"subscriptionName,omitempty" azure:"ro"`
+	SubscriptionName *string
 
 	// READ-ONLY; The unit of measure.
-	UnitOfMeasure *string `json:"unitOfMeasure,omitempty" azure:"ro"`
+	UnitOfMeasure *string
 
 	// READ-ONLY; The end of the date time range covered by the usage detail.
-	UsageEnd *time.Time `json:"usageEnd,omitempty" azure:"ro"`
+	UsageEnd *time.Time
 
 	// READ-ONLY; The start of the date time range covered by the usage detail.
-	UsageStart *time.Time `json:"usageStart,omitempty" azure:"ro"`
+	UsageStart *time.Time
 }
 
 // MarketplacesClientListOptions contains the optional parameters for the MarketplacesClient.NewListPager method.
@@ -1202,82 +1202,82 @@ type MarketplacesClientListOptions struct {
 // order by billing period.
 type MarketplacesListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of marketplaces.
-	Value []*Marketplace `json:"value,omitempty" azure:"ro"`
+	Value []*Marketplace
 }
 
 // MeterDetails - The properties of the meter detail.
 type MeterDetails struct {
 	// READ-ONLY; The category of the meter, for example, 'Cloud services', 'Networking', etc..
-	MeterCategory *string `json:"meterCategory,omitempty" azure:"ro"`
+	MeterCategory *string
 
 	// READ-ONLY; The location in which the Azure service is available.
-	MeterLocation *string `json:"meterLocation,omitempty" azure:"ro"`
+	MeterLocation *string
 
 	// READ-ONLY; The name of the meter, within the given meter category
-	MeterName *string `json:"meterName,omitempty" azure:"ro"`
+	MeterName *string
 
 	// READ-ONLY; The subcategory of the meter, for example, 'A6 Cloud services', 'ExpressRoute (IXP)', etc..
-	MeterSubCategory *string `json:"meterSubCategory,omitempty" azure:"ro"`
+	MeterSubCategory *string
 
 	// READ-ONLY; The pretax listing price.
-	PretaxStandardRate *float64 `json:"pretaxStandardRate,omitempty" azure:"ro"`
+	PretaxStandardRate *float64
 
 	// READ-ONLY; The name of the service.
-	ServiceName *string `json:"serviceName,omitempty" azure:"ro"`
+	ServiceName *string
 
 	// READ-ONLY; The service tier.
-	ServiceTier *string `json:"serviceTier,omitempty" azure:"ro"`
+	ServiceTier *string
 
 	// READ-ONLY; The total included quantity associated with the offer.
-	TotalIncludedQuantity *float64 `json:"totalIncludedQuantity,omitempty" azure:"ro"`
+	TotalIncludedQuantity *float64
 
 	// READ-ONLY; The unit in which the meter consumption is charged, for example, 'Hours', 'GB', etc.
-	Unit *string `json:"unit,omitempty" azure:"ro"`
+	Unit *string
 }
 
 // MeterDetailsResponse - The properties of the meter detail.
 type MeterDetailsResponse struct {
 	// READ-ONLY; The category of the meter, for example, 'Cloud services', 'Networking', etc..
-	MeterCategory *string `json:"meterCategory,omitempty" azure:"ro"`
+	MeterCategory *string
 
 	// READ-ONLY; The name of the meter, within the given meter category
-	MeterName *string `json:"meterName,omitempty" azure:"ro"`
+	MeterName *string
 
 	// READ-ONLY; The subcategory of the meter, for example, 'A6 Cloud services', 'ExpressRoute (IXP)', etc..
-	MeterSubCategory *string `json:"meterSubCategory,omitempty" azure:"ro"`
+	MeterSubCategory *string
 
 	// READ-ONLY; The service family.
-	ServiceFamily *string `json:"serviceFamily,omitempty" azure:"ro"`
+	ServiceFamily *string
 
 	// READ-ONLY; The unit in which the meter consumption is charged, for example, 'Hours', 'GB', etc.
-	UnitOfMeasure *string `json:"unitOfMeasure,omitempty" azure:"ro"`
+	UnitOfMeasure *string
 }
 
 // ModernChargeSummary - Modern charge summary.
 type ModernChargeSummary struct {
 	// REQUIRED; Specifies the kind of charge summary.
-	Kind *ChargeSummaryKind `json:"kind,omitempty"`
+	Kind *ChargeSummaryKind
 
 	// REQUIRED; Properties for modern charge summary
-	Properties *ModernChargeSummaryProperties `json:"properties,omitempty"`
+	Properties *ModernChargeSummaryProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetChargeSummary implements the ChargeSummaryClassification interface for type ModernChargeSummary.
@@ -1295,70 +1295,70 @@ func (m *ModernChargeSummary) GetChargeSummary() *ChargeSummary {
 // ModernChargeSummaryProperties - The properties of modern charge summary.
 type ModernChargeSummaryProperties struct {
 	// READ-ONLY; Azure Charges.
-	AzureCharges *Amount `json:"azureCharges,omitempty" azure:"ro"`
+	AzureCharges *Amount
 
 	// READ-ONLY; Billing Account Id
-	BillingAccountID *string `json:"billingAccountId,omitempty" azure:"ro"`
+	BillingAccountID *string
 
 	// READ-ONLY; The id of the billing period resource that the charge belongs to.
-	BillingPeriodID *string `json:"billingPeriodId,omitempty" azure:"ro"`
+	BillingPeriodID *string
 
 	// READ-ONLY; Billing Profile Id
-	BillingProfileID *string `json:"billingProfileId,omitempty" azure:"ro"`
+	BillingProfileID *string
 
 	// READ-ONLY; Charges Billed separately.
-	ChargesBilledSeparately *Amount `json:"chargesBilledSeparately,omitempty" azure:"ro"`
+	ChargesBilledSeparately *Amount
 
 	// READ-ONLY; Customer Id
-	CustomerID *string `json:"customerId,omitempty" azure:"ro"`
+	CustomerID *string
 
 	// READ-ONLY; Invoice Section Id
-	InvoiceSectionID *string `json:"invoiceSectionId,omitempty" azure:"ro"`
+	InvoiceSectionID *string
 
 	// READ-ONLY; Is charge Invoiced
-	IsInvoiced *bool `json:"isInvoiced,omitempty" azure:"ro"`
+	IsInvoiced *bool
 
 	// READ-ONLY; Marketplace Charges.
-	MarketplaceCharges *Amount `json:"marketplaceCharges,omitempty" azure:"ro"`
+	MarketplaceCharges *Amount
 
 	// READ-ONLY; Usage end date.
-	UsageEnd *string `json:"usageEnd,omitempty" azure:"ro"`
+	UsageEnd *string
 
 	// READ-ONLY; Usage start date.
-	UsageStart *string `json:"usageStart,omitempty" azure:"ro"`
+	UsageStart *string
 }
 
 // ModernReservationRecommendation - Modern reservation recommendation.
 type ModernReservationRecommendation struct {
 	// REQUIRED; Specifies the kind of reservation recommendation.
-	Kind *ReservationRecommendationKind `json:"kind,omitempty"`
+	Kind *ReservationRecommendationKind
 
 	// REQUIRED; Properties for modern reservation recommendation
-	Properties *ModernReservationRecommendationProperties `json:"properties,omitempty"`
+	Properties *ModernReservationRecommendationProperties
 
 	// READ-ONLY; Resource eTag.
-	ETag *string `json:"eTag,omitempty" azure:"ro"`
+	ETag *string
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource location
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource sku
-	SKU *string `json:"sku,omitempty" azure:"ro"`
+	SKU *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetReservationRecommendation implements the ReservationRecommendationClassification interface for type ModernReservationRecommendation.
@@ -1378,174 +1378,174 @@ func (m *ModernReservationRecommendation) GetReservationRecommendation() *Reserv
 // ModernReservationRecommendationProperties - The properties of the reservation recommendation.
 type ModernReservationRecommendationProperties struct {
 	// READ-ONLY; The total amount of cost without reserved instances.
-	CostWithNoReservedInstances *Amount `json:"costWithNoReservedInstances,omitempty" azure:"ro"`
+	CostWithNoReservedInstances *Amount
 
 	// READ-ONLY; The usage date for looking back.
-	FirstUsageDate *time.Time `json:"firstUsageDate,omitempty" azure:"ro"`
+	FirstUsageDate *time.Time
 
 	// READ-ONLY; The instance Flexibility Group.
-	InstanceFlexibilityGroup *string `json:"instanceFlexibilityGroup,omitempty" azure:"ro"`
+	InstanceFlexibilityGroup *string
 
 	// READ-ONLY; The instance Flexibility Ratio.
-	InstanceFlexibilityRatio *float32 `json:"instanceFlexibilityRatio,omitempty" azure:"ro"`
+	InstanceFlexibilityRatio *float32
 
 	// READ-ONLY; Resource Location.
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; The number of days of usage to look back for recommendation.
-	LookBackPeriod *int32 `json:"lookBackPeriod,omitempty" azure:"ro"`
+	LookBackPeriod *int32
 
 	// READ-ONLY; The meter id (GUID)
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; Total estimated savings with reserved instances.
-	NetSavings *Amount `json:"netSavings,omitempty" azure:"ro"`
+	NetSavings *Amount
 
 	// READ-ONLY; The normalized Size.
-	NormalizedSize *string `json:"normalizedSize,omitempty" azure:"ro"`
+	NormalizedSize *string
 
 	// READ-ONLY; Recommended quality for reserved instances.
-	RecommendedQuantity *float64 `json:"recommendedQuantity,omitempty" azure:"ro"`
+	RecommendedQuantity *float64
 
 	// READ-ONLY; The recommended Quantity Normalized.
-	RecommendedQuantityNormalized *float32 `json:"recommendedQuantityNormalized,omitempty" azure:"ro"`
+	RecommendedQuantityNormalized *float32
 
 	// READ-ONLY; The Azure resource type.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; This is the ARM Sku name.
-	SKUName *string `json:"skuName,omitempty" azure:"ro"`
+	SKUName *string
 
 	// READ-ONLY; List of sku properties
-	SKUProperties []*SKUProperty `json:"skuProperties,omitempty" azure:"ro"`
+	SKUProperties []*SKUProperty
 
 	// READ-ONLY; Shared or single recommendation.
-	Scope *string `json:"scope,omitempty" azure:"ro"`
+	Scope *string
 
 	// READ-ONLY; The Azure subscription ID.
-	SubscriptionID *string `json:"subscriptionId,omitempty" azure:"ro"`
+	SubscriptionID *string
 
 	// READ-ONLY; RI recommendations in one or three year terms.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 
 	// READ-ONLY; The total amount of cost with reserved instances.
-	TotalCostWithReservedInstances *Amount `json:"totalCostWithReservedInstances,omitempty" azure:"ro"`
+	TotalCostWithReservedInstances *Amount
 }
 
 // ModernReservationTransaction - Modern Reservation transaction resource.
 type ModernReservationTransaction struct {
 	// REQUIRED; The properties of a modern reservation transaction.
-	Properties *ModernReservationTransactionProperties `json:"properties,omitempty"`
+	Properties *ModernReservationTransactionProperties
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags []*string `json:"tags,omitempty" azure:"ro"`
+	Tags []*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ModernReservationTransactionProperties - The properties of a modern reservation transaction.
 type ModernReservationTransactionProperties struct {
 	// READ-ONLY; The charge of the transaction.
-	Amount *float64 `json:"amount,omitempty" azure:"ro"`
+	Amount *float64
 
 	// READ-ONLY; This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.
-	ArmSKUName *string `json:"armSkuName,omitempty" azure:"ro"`
+	ArmSKUName *string
 
 	// READ-ONLY; The billing frequency, which can be either one-time or recurring.
-	BillingFrequency *string `json:"billingFrequency,omitempty" azure:"ro"`
+	BillingFrequency *string
 
 	// READ-ONLY; Billing profile Id.
-	BillingProfileID *string `json:"billingProfileId,omitempty" azure:"ro"`
+	BillingProfileID *string
 
 	// READ-ONLY; Billing profile name.
-	BillingProfileName *string `json:"billingProfileName,omitempty" azure:"ro"`
+	BillingProfileName *string
 
 	// READ-ONLY; The ISO currency in which the transaction is charged, for example, USD.
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; The description of the transaction.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; The date of the transaction
-	EventDate *time.Time `json:"eventDate,omitempty" azure:"ro"`
+	EventDate *time.Time
 
 	// READ-ONLY; The type of the transaction (Purchase, Cancel, etc.)
-	EventType *string `json:"eventType,omitempty" azure:"ro"`
+	EventType *string
 
 	// READ-ONLY; Invoice Number
-	Invoice *string `json:"invoice,omitempty" azure:"ro"`
+	Invoice *string
 
 	// READ-ONLY; Invoice Id as on the invoice where the specific transaction appears.
-	InvoiceID *string `json:"invoiceId,omitempty" azure:"ro"`
+	InvoiceID *string
 
 	// READ-ONLY; Invoice Section Id
-	InvoiceSectionID *string `json:"invoiceSectionId,omitempty" azure:"ro"`
+	InvoiceSectionID *string
 
 	// READ-ONLY; Invoice Section Name.
-	InvoiceSectionName *string `json:"invoiceSectionName,omitempty" azure:"ro"`
+	InvoiceSectionName *string
 
 	// READ-ONLY; The subscription guid that makes the transaction.
-	PurchasingSubscriptionGUID *string `json:"purchasingSubscriptionGuid,omitempty" azure:"ro"`
+	PurchasingSubscriptionGUID *string
 
 	// READ-ONLY; The subscription name that makes the transaction.
-	PurchasingSubscriptionName *string `json:"purchasingSubscriptionName,omitempty" azure:"ro"`
+	PurchasingSubscriptionName *string
 
 	// READ-ONLY; The quantity of the transaction.
-	Quantity *float64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *float64
 
 	// READ-ONLY; The region of the transaction.
-	Region *string `json:"region,omitempty" azure:"ro"`
+	Region *string
 
 	// READ-ONLY; The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents
 	// a single purchase transaction. A reservation order contains reservations. The reservation
 	// order specifies the VM size and region for the reservations.
-	ReservationOrderID *string `json:"reservationOrderId,omitempty" azure:"ro"`
+	ReservationOrderID *string
 
 	// READ-ONLY; The name of the reservation order.
-	ReservationOrderName *string `json:"reservationOrderName,omitempty" azure:"ro"`
+	ReservationOrderName *string
 
 	// READ-ONLY; This is the term of the transaction.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 }
 
 // ModernReservationTransactionsListResult - Result of listing reservation recommendations.
 type ModernReservationTransactionsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of reservation recommendations.
-	Value []*ModernReservationTransaction `json:"value,omitempty" azure:"ro"`
+	Value []*ModernReservationTransaction
 }
 
 // ModernUsageDetail - Modern usage detail.
 type ModernUsageDetail struct {
 	// REQUIRED; Specifies the kind of usage details.
-	Kind *UsageDetailsKind `json:"kind,omitempty"`
+	Kind *UsageDetailsKind
 
 	// REQUIRED; Properties for modern usage details
-	Properties *ModernUsageDetailProperties `json:"properties,omitempty"`
+	Properties *ModernUsageDetailProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetUsageDetail implements the UsageDetailClassification interface for type ModernUsageDetail.
@@ -1564,220 +1564,220 @@ func (m *ModernUsageDetail) GetUsageDetail() *UsageDetail {
 type ModernUsageDetailProperties struct {
 	// READ-ONLY; Additional details of this usage item. Use this field to get usage line item specific details such as the actual
 	// VM Size (ServiceType) or the ratio in which the reservation discount is applied.
-	AdditionalInfo *string `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo *string
 
 	// READ-ONLY; Billing Account identifier.
-	BillingAccountID *string `json:"billingAccountId,omitempty" azure:"ro"`
+	BillingAccountID *string
 
 	// READ-ONLY; Name of the Billing Account.
-	BillingAccountName *string `json:"billingAccountName,omitempty" azure:"ro"`
+	BillingAccountName *string
 
 	// READ-ONLY; The currency defining the billed cost.
-	BillingCurrencyCode *string `json:"billingCurrencyCode,omitempty" azure:"ro"`
+	BillingCurrencyCode *string
 
 	// READ-ONLY; Billing Period End Date as in the invoice.
-	BillingPeriodEndDate *time.Time `json:"billingPeriodEndDate,omitempty" azure:"ro"`
+	BillingPeriodEndDate *time.Time
 
 	// READ-ONLY; Billing Period Start Date as in the invoice.
-	BillingPeriodStartDate *time.Time `json:"billingPeriodStartDate,omitempty" azure:"ro"`
+	BillingPeriodStartDate *time.Time
 
 	// READ-ONLY; Identifier for the billing profile that groups costs across invoices in the a singular billing currency across
 	// across the customers who have onboarded the Microsoft customer agreement and the
 	// customers in CSP who have made entitlement purchases like SaaS, Marketplace, RI, etc.
-	BillingProfileID *string `json:"billingProfileId,omitempty" azure:"ro"`
+	BillingProfileID *string
 
 	// READ-ONLY; Name of the billing profile that groups costs across invoices in the a singular billing currency across across
 	// the customers who have onboarded the Microsoft customer agreement and the customers in
 	// CSP who have made entitlement purchases like SaaS, Marketplace, RI, etc.
-	BillingProfileName *string `json:"billingProfileName,omitempty" azure:"ro"`
+	BillingProfileName *string
 
 	// READ-ONLY; Indicates a charge represents credits, usage, a Marketplace purchase, a reservation fee, or a refund.
-	ChargeType *string `json:"chargeType,omitempty" azure:"ro"`
+	ChargeType *string
 
 	// READ-ONLY; Consumed service name. Name of the azure resource provider that emits the usage or was purchased. This value
 	// is not provided for marketplace usage.
-	ConsumedService *string `json:"consumedService,omitempty" azure:"ro"`
+	ConsumedService *string
 
 	// READ-ONLY; The cost center of this department if it is a department and a cost center is provided.
-	CostCenter *string `json:"costCenter,omitempty" azure:"ro"`
+	CostCenter *string
 
 	// READ-ONLY; ExtendedCost or blended cost before tax in billed currency.
-	CostInBillingCurrency *float64 `json:"costInBillingCurrency,omitempty" azure:"ro"`
+	CostInBillingCurrency *float64
 
 	// READ-ONLY; ExtendedCost or blended cost before tax in pricing currency to correlate with prices.
-	CostInPricingCurrency *float64 `json:"costInPricingCurrency,omitempty" azure:"ro"`
+	CostInPricingCurrency *float64
 
 	// READ-ONLY; Estimated extendedCost or blended cost before tax in USD.
-	CostInUSD *float64 `json:"costInUSD,omitempty" azure:"ro"`
+	CostInUSD *float64
 
 	// READ-ONLY; Name of the customer's AAD tenant.
-	CustomerName *string `json:"customerName,omitempty" azure:"ro"`
+	CustomerName *string
 
 	// READ-ONLY; Identifier of the customer's AAD tenant.
-	CustomerTenantID *string `json:"customerTenantId,omitempty" azure:"ro"`
+	CustomerTenantID *string
 
 	// READ-ONLY; Date for the usage record.
-	Date *time.Time `json:"date,omitempty" azure:"ro"`
+	Date *time.Time
 
 	// READ-ONLY; Exchange rate used in conversion from pricing currency to billing currency.
-	ExchangeRate *string `json:"exchangeRate,omitempty" azure:"ro"`
+	ExchangeRate *string
 
 	// READ-ONLY; Date on which exchange rate used in conversion from pricing currency to billing currency.
-	ExchangeRateDate *time.Time `json:"exchangeRateDate,omitempty" azure:"ro"`
+	ExchangeRateDate *time.Time
 
 	// READ-ONLY; Exchange Rate from pricing currency to billing currency.
-	ExchangeRatePricingToBilling *float64 `json:"exchangeRatePricingToBilling,omitempty" azure:"ro"`
+	ExchangeRatePricingToBilling *float64
 
 	// READ-ONLY; Indicates how frequently this charge will occur. OneTime for purchases which only happen once, Monthly for fees
 	// which recur every month, and UsageBased for charges based on how much a service is used.
-	Frequency *string `json:"frequency,omitempty" azure:"ro"`
+	Frequency *string
 
 	// READ-ONLY; Instance Name.
-	InstanceName *string `json:"instanceName,omitempty" azure:"ro"`
+	InstanceName *string
 
 	// READ-ONLY; Invoice ID as on the invoice where the specific transaction appears.
-	InvoiceID *string `json:"invoiceId,omitempty" azure:"ro"`
+	InvoiceID *string
 
 	// READ-ONLY; Identifier of the project that is being charged in the invoice. Not applicable for Microsoft Customer Agreements
 	// onboarded by partners.
-	InvoiceSectionID *string `json:"invoiceSectionId,omitempty" azure:"ro"`
+	InvoiceSectionID *string
 
 	// READ-ONLY; Name of the project that is being charged in the invoice. Not applicable for Microsoft Customer Agreements onboarded
 	// by partners.
-	InvoiceSectionName *string `json:"invoiceSectionName,omitempty" azure:"ro"`
+	InvoiceSectionName *string
 
 	// READ-ONLY; Determines if the cost is eligible to be paid for using Azure credits.
-	IsAzureCreditEligible *bool `json:"isAzureCreditEligible,omitempty" azure:"ro"`
+	IsAzureCreditEligible *bool
 
 	// READ-ONLY; Market Price that's charged for the usage.
-	MarketPrice *float64 `json:"marketPrice,omitempty" azure:"ro"`
+	MarketPrice *float64
 
 	// READ-ONLY; Identifies the top-level service for the usage.
-	MeterCategory *string `json:"meterCategory,omitempty" azure:"ro"`
+	MeterCategory *string
 
 	// READ-ONLY; The meter id (GUID). Not available for marketplace. For reserved instance this represents the primary meter
 	// for which the reservation was purchased. For the actual VM Size for which the reservation is
 	// purchased see productOrderName.
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; Identifies the name of the meter against which consumption is measured.
-	MeterName *string `json:"meterName,omitempty" azure:"ro"`
+	MeterName *string
 
 	// READ-ONLY; Identifies the location of the datacenter for certain services that are priced based on datacenter location.
-	MeterRegion *string `json:"meterRegion,omitempty" azure:"ro"`
+	MeterRegion *string
 
 	// READ-ONLY; Defines the type or sub-category of Azure service that can affect the rate.
-	MeterSubCategory *string `json:"meterSubCategory,omitempty" azure:"ro"`
+	MeterSubCategory *string
 
 	// READ-ONLY; Flag to indicate if partner earned credit has been applied or not.
-	PartnerEarnedCreditApplied *string `json:"partnerEarnedCreditApplied,omitempty" azure:"ro"`
+	PartnerEarnedCreditApplied *string
 
 	// READ-ONLY; Rate of discount applied if there is a partner earned credit (PEC) based on partner admin link access.
-	PartnerEarnedCreditRate *float64 `json:"partnerEarnedCreditRate,omitempty" azure:"ro"`
+	PartnerEarnedCreditRate *float64
 
 	// READ-ONLY; Name of the partner' AAD tenant.
-	PartnerName *string `json:"partnerName,omitempty" azure:"ro"`
+	PartnerName *string
 
 	// READ-ONLY; Identifier for the partner's AAD tenant.
-	PartnerTenantID *string `json:"partnerTenantId,omitempty" azure:"ro"`
+	PartnerTenantID *string
 
 	// READ-ONLY; Retail price for the resource.
-	PayGPrice *float64 `json:"payGPrice,omitempty" azure:"ro"`
+	PayGPrice *float64
 
 	// READ-ONLY; The amount of PayG cost before tax in billing currency.
-	PaygCostInBillingCurrency *float64 `json:"paygCostInBillingCurrency,omitempty" azure:"ro"`
+	PaygCostInBillingCurrency *float64
 
 	// READ-ONLY; The amount of PayG cost before tax in US Dollar currency.
-	PaygCostInUSD *float64 `json:"paygCostInUSD,omitempty" azure:"ro"`
+	PaygCostInUSD *float64
 
 	// READ-ONLY; Reference to an original invoice there is a refund (negative cost). This is populated only when there is a refund.
-	PreviousInvoiceID *string `json:"previousInvoiceId,omitempty" azure:"ro"`
+	PreviousInvoiceID *string
 
 	// READ-ONLY; Pricing Billing Currency.
-	PricingCurrencyCode *string `json:"pricingCurrencyCode,omitempty" azure:"ro"`
+	PricingCurrencyCode *string
 
 	// READ-ONLY; Name of the product that has accrued charges by consumption or purchase as listed in the invoice. Not available
 	// for Marketplace.
-	Product *string `json:"product,omitempty" azure:"ro"`
+	Product *string
 
 	// READ-ONLY; Identifier for the product that has accrued charges by consumption or purchase . This is the concatenated key
 	// of productId and SkuId in partner center.
-	ProductIdentifier *string `json:"productIdentifier,omitempty" azure:"ro"`
+	ProductIdentifier *string
 
 	// READ-ONLY; The identifier for the asset or Azure plan name that the subscription belongs to. For example: Azure Plan. For
 	// reservations this is the Reservation Order ID.
-	ProductOrderID *string `json:"productOrderId,omitempty" azure:"ro"`
+	ProductOrderID *string
 
 	// READ-ONLY; Product Order Name. For reservations this is the SKU that was purchased.
-	ProductOrderName *string `json:"productOrderName,omitempty" azure:"ro"`
+	ProductOrderName *string
 
 	// READ-ONLY; Publisher Id.
-	PublisherID *string `json:"publisherId,omitempty" azure:"ro"`
+	PublisherID *string
 
 	// READ-ONLY; Name of the publisher of the service including Microsoft or Third Party publishers.
-	PublisherName *string `json:"publisherName,omitempty" azure:"ro"`
+	PublisherName *string
 
 	// READ-ONLY; Type of publisher that identifies if the publisher is first party, third party reseller or third party agency.
-	PublisherType *string `json:"publisherType,omitempty" azure:"ro"`
+	PublisherType *string
 
 	// READ-ONLY; Measure the quantity purchased or consumed.The amount of the meter used during the billing period.
-	Quantity *float64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *float64
 
 	// READ-ONLY; MPNId for the reseller associated with the subscription.
-	ResellerMpnID *string `json:"resellerMpnId,omitempty" azure:"ro"`
+	ResellerMpnID *string
 
 	// READ-ONLY; Reseller Name.
-	ResellerName *string `json:"resellerName,omitempty" azure:"ro"`
+	ResellerName *string
 
 	// READ-ONLY; ARM resource id of the reservation. Only applies to records relevant to reservations.
-	ReservationID *string `json:"reservationId,omitempty" azure:"ro"`
+	ReservationID *string
 
 	// READ-ONLY; User provided display name of the reservation. Last known name for a particular day is populated in the daily
 	// data. Only applies to records relevant to reservations.
-	ReservationName *string `json:"reservationName,omitempty" azure:"ro"`
+	ReservationName *string
 
 	// READ-ONLY; Name of the Azure resource group used for cohesive lifecycle management of resources.
-	ResourceGroup *string `json:"resourceGroup,omitempty" azure:"ro"`
+	ResourceGroup *string
 
 	// READ-ONLY; Name of the resource location.
-	ResourceLocation *string `json:"resourceLocation,omitempty" azure:"ro"`
+	ResourceLocation *string
 
 	// READ-ONLY; Resource Location Normalized.
-	ResourceLocationNormalized *string `json:"resourceLocationNormalized,omitempty" azure:"ro"`
+	ResourceLocationNormalized *string
 
 	// READ-ONLY; List the service family for the product purchased or charged (Example: Storage ; Compute).
-	ServiceFamily *string `json:"serviceFamily,omitempty" azure:"ro"`
+	ServiceFamily *string
 
 	// READ-ONLY; Service Info 1.
-	ServiceInfo1 *string `json:"serviceInfo1,omitempty" azure:"ro"`
+	ServiceInfo1 *string
 
 	// READ-ONLY; Service Info 2.
-	ServiceInfo2 *string `json:"serviceInfo2,omitempty" azure:"ro"`
+	ServiceInfo2 *string
 
 	// READ-ONLY; End date for the period when the service usage was rated for charges. The prices for Azure services are determined
 	// based on the rating period.
-	ServicePeriodEndDate *time.Time `json:"servicePeriodEndDate,omitempty" azure:"ro"`
+	ServicePeriodEndDate *time.Time
 
 	// READ-ONLY; Start date for the rating period when the service usage was rated for charges. The prices for Azure services
 	// are determined for the rating period.
-	ServicePeriodStartDate *time.Time `json:"servicePeriodStartDate,omitempty" azure:"ro"`
+	ServicePeriodStartDate *time.Time
 
 	// READ-ONLY; Unique Microsoft generated identifier for the Azure Subscription.
-	SubscriptionGUID *string `json:"subscriptionGuid,omitempty" azure:"ro"`
+	SubscriptionGUID *string
 
 	// READ-ONLY; Name of the Azure Subscription.
-	SubscriptionName *string `json:"subscriptionName,omitempty" azure:"ro"`
+	SubscriptionName *string
 
 	// READ-ONLY; Term (in months). Displays the term for the validity of the offer. For example. In case of reserved instances
 	// it displays 12 months for yearly term of reserved instance. For one time purchases or
 	// recurring purchases, the terms displays 1 month; This is not applicable for Azure consumption.
-	Term *string `json:"term,omitempty" azure:"ro"`
+	Term *string
 
 	// READ-ONLY; Identifies the Unit that the service is charged in. For example, GB, hours, 10,000 s.
-	UnitOfMeasure *string `json:"unitOfMeasure,omitempty" azure:"ro"`
+	UnitOfMeasure *string
 
 	// READ-ONLY; Unit Price is the price applicable to you. (your EA or other contract price).
-	UnitPrice *float64 `json:"unitPrice,omitempty" azure:"ro"`
+	UnitPrice *float64
 }
 
 // Notification - The notification associated with a budget.
@@ -1785,67 +1785,67 @@ type Notification struct {
 	// REQUIRED; Email addresses to send the budget notification to when the threshold is exceeded. Must have at least one contact
 	// email or contact group specified at the Subscription or Resource Group scopes. All
 	// other scopes must have at least one contact email specified.
-	ContactEmails []*string `json:"contactEmails,omitempty"`
+	ContactEmails []*string
 
 	// REQUIRED; The notification is enabled or not.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// REQUIRED; The comparison operator.
-	Operator *OperatorType `json:"operator,omitempty"`
+	Operator *OperatorType
 
 	// REQUIRED; Threshold value associated with a notification. Notification is sent when the cost exceeded the threshold. It
 	// is always percent and has to be between 0 and 1000.
-	Threshold *float64 `json:"threshold,omitempty"`
+	Threshold *float64
 
 	// Action groups to send the budget notification to when the threshold is exceeded. Must be provided as a fully qualified
 	// Azure resource id. Only supported at Subscription or Resource Group scopes.
-	ContactGroups []*string `json:"contactGroups,omitempty"`
+	ContactGroups []*string
 
 	// Contact roles to send the budget notification to when the threshold is exceeded.
-	ContactRoles []*string `json:"contactRoles,omitempty"`
+	ContactRoles []*string
 
 	// Language in which the recipient will receive the notification
-	Locale *CultureCode `json:"locale,omitempty"`
+	Locale *CultureCode
 
 	// The type of threshold
-	ThresholdType *ThresholdType `json:"thresholdType,omitempty"`
+	ThresholdType *ThresholdType
 }
 
 // Operation - A Consumption REST API operation.
 type Operation struct {
 	// The object that represents the operation.
-	Display *OperationDisplay `json:"display,omitempty"`
+	Display *OperationDisplay
 
 	// READ-ONLY; Operation Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Operation name: {provider}/{resource}/{operation}.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 }
 
 // OperationDisplay - The object that represents the operation.
 type OperationDisplay struct {
 	// READ-ONLY; Description of the operation.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; Operation type: Read, write, delete, etc.
-	Operation *string `json:"operation,omitempty" azure:"ro"`
+	Operation *string
 
 	// READ-ONLY; Service provider: Microsoft.Consumption.
-	Provider *string `json:"provider,omitempty" azure:"ro"`
+	Provider *string
 
 	// READ-ONLY; Resource on which the operation is performed: UsageDetail, etc.
-	Resource *string `json:"resource,omitempty" azure:"ro"`
+	Resource *string
 }
 
 // OperationListResult - Result of listing consumption operations. It contains a list of operations and a URL link to get
 // the next set of results.
 type OperationListResult struct {
 	// READ-ONLY; URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; List of consumption operations supported by the Microsoft.Consumption resource provider.
-	Value []*Operation `json:"value,omitempty" azure:"ro"`
+	Value []*Operation
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
@@ -1883,144 +1883,144 @@ type PriceSheetClientGetOptions struct {
 // PriceSheetModel - price sheet result. It contains the pricesheet associated with billing period
 type PriceSheetModel struct {
 	// READ-ONLY; Pricesheet download details.
-	Download *MeterDetails `json:"download,omitempty" azure:"ro"`
+	Download *MeterDetails
 
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; Price sheet
-	Pricesheets []*PriceSheetProperties `json:"pricesheets,omitempty" azure:"ro"`
+	Pricesheets []*PriceSheetProperties
 }
 
 // PriceSheetProperties - The properties of the price sheet.
 type PriceSheetProperties struct {
 	// READ-ONLY; The id of the billing period resource that the usage belongs to.
-	BillingPeriodID *string `json:"billingPeriodId,omitempty" azure:"ro"`
+	BillingPeriodID *string
 
 	// READ-ONLY; Currency Code
-	CurrencyCode *string `json:"currencyCode,omitempty" azure:"ro"`
+	CurrencyCode *string
 
 	// READ-ONLY; Included quality for an offer
-	IncludedQuantity *float64 `json:"includedQuantity,omitempty" azure:"ro"`
+	IncludedQuantity *float64
 
 	// READ-ONLY; The details about the meter. By default this is not populated, unless it's specified in $expand.
-	MeterDetails *MeterDetails `json:"meterDetails,omitempty" azure:"ro"`
+	MeterDetails *MeterDetails
 
 	// READ-ONLY; The meter id (GUID)
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; Offer Id
-	OfferID *string `json:"offerId,omitempty" azure:"ro"`
+	OfferID *string
 
 	// READ-ONLY; Part Number
-	PartNumber *string `json:"partNumber,omitempty" azure:"ro"`
+	PartNumber *string
 
 	// READ-ONLY; Unit of measure
-	UnitOfMeasure *string `json:"unitOfMeasure,omitempty" azure:"ro"`
+	UnitOfMeasure *string
 
 	// READ-ONLY; Unit Price
-	UnitPrice *float64 `json:"unitPrice,omitempty" azure:"ro"`
+	UnitPrice *float64
 }
 
 // PriceSheetResult - An pricesheet resource.
 type PriceSheetResult struct {
 	// price sheet result. It contains the pricesheet associated with billing period
-	Properties *PriceSheetModel `json:"properties,omitempty"`
+	Properties *PriceSheetModel
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // Reseller details
 type Reseller struct {
 	// READ-ONLY; Reseller Description.
-	ResellerDescription *string `json:"resellerDescription,omitempty" azure:"ro"`
+	ResellerDescription *string
 
 	// READ-ONLY; Reseller id.
-	ResellerID *string `json:"resellerId,omitempty" azure:"ro"`
+	ResellerID *string
 }
 
 // ReservationDetail - reservation detail resource.
 type ReservationDetail struct {
 	// The properties of the reservation detail.
-	Properties *ReservationDetailProperties `json:"properties,omitempty"`
+	Properties *ReservationDetailProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ReservationDetailProperties - The properties of the reservation detail.
 type ReservationDetailProperties struct {
 	// READ-ONLY; The instance Flexibility Group.
-	InstanceFlexibilityGroup *string `json:"instanceFlexibilityGroup,omitempty" azure:"ro"`
+	InstanceFlexibilityGroup *string
 
 	// READ-ONLY; The instance Flexibility Ratio.
-	InstanceFlexibilityRatio *string `json:"instanceFlexibilityRatio,omitempty" azure:"ro"`
+	InstanceFlexibilityRatio *string
 
 	// READ-ONLY; This identifier is the name of the resource or the fully qualified Resource ID.
-	InstanceID *string `json:"instanceId,omitempty" azure:"ro"`
+	InstanceID *string
 
 	// READ-ONLY; The reservation kind.
-	Kind *string `json:"kind,omitempty" azure:"ro"`
+	Kind *string
 
 	// READ-ONLY; The reservation ID is the identifier of a reservation within a reservation order. Each reservation is the grouping
 	// for applying the benefit scope and also specifies the number of instances to which
 	// the reservation benefit can be applied to.
-	ReservationID *string `json:"reservationId,omitempty" azure:"ro"`
+	ReservationID *string
 
 	// READ-ONLY; The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents
 	// a single purchase transaction. A reservation order contains reservations. The reservation
 	// order specifies the VM size and region for the reservations.
-	ReservationOrderID *string `json:"reservationOrderId,omitempty" azure:"ro"`
+	ReservationOrderID *string
 
 	// READ-ONLY; This is the total hours reserved for the day. E.g. if reservation for 1 instance was made on 1 PM, this will
 	// be 11 hours for that day and 24 hours from subsequent days.
-	ReservedHours *float64 `json:"reservedHours,omitempty" azure:"ro"`
+	ReservedHours *float64
 
 	// READ-ONLY; This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.
-	SKUName *string `json:"skuName,omitempty" azure:"ro"`
+	SKUName *string
 
 	// READ-ONLY; This is the total count of instances that are reserved for the reservationId.
-	TotalReservedQuantity *float64 `json:"totalReservedQuantity,omitempty" azure:"ro"`
+	TotalReservedQuantity *float64
 
 	// READ-ONLY; The date on which consumption occurred.
-	UsageDate *time.Time `json:"usageDate,omitempty" azure:"ro"`
+	UsageDate *time.Time
 
 	// READ-ONLY; This is the total hours used by the instance.
-	UsedHours *float64 `json:"usedHours,omitempty" azure:"ro"`
+	UsedHours *float64
 }
 
 // ReservationDetailsListResult - Result of listing reservation details.
 type ReservationDetailsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of reservation details.
-	Value []*ReservationDetail `json:"value,omitempty" azure:"ro"`
+	Value []*ReservationDetail
 }
 
 // ReservationRecommendationClassification provides polymorphic access to related types.
@@ -2035,28 +2035,28 @@ type ReservationRecommendationClassification interface {
 // ReservationRecommendation - A reservation recommendation resource.
 type ReservationRecommendation struct {
 	// REQUIRED; Specifies the kind of reservation recommendation.
-	Kind *ReservationRecommendationKind `json:"kind,omitempty"`
+	Kind *ReservationRecommendationKind
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource location
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource sku
-	SKU *string `json:"sku,omitempty" azure:"ro"`
+	SKU *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetReservationRecommendation implements the ReservationRecommendationClassification interface for type ReservationRecommendation.
@@ -2067,25 +2067,25 @@ func (r *ReservationRecommendation) GetReservationRecommendation() *ReservationR
 // ReservationRecommendationDetailsCalculatedSavingsProperties - Details of estimated savings.
 type ReservationRecommendationDetailsCalculatedSavingsProperties struct {
 	// The number of reserved units used to calculate savings. Always 1 for virtual machines.
-	ReservedUnitCount *float32 `json:"reservedUnitCount,omitempty"`
+	ReservedUnitCount *float32
 
 	// READ-ONLY; The cost without reservation.
-	OnDemandCost *float32 `json:"onDemandCost,omitempty" azure:"ro"`
+	OnDemandCost *float32
 
 	// READ-ONLY; The difference between total reservation cost and reservation cost.
-	OverageCost *float32 `json:"overageCost,omitempty" azure:"ro"`
+	OverageCost *float32
 
 	// READ-ONLY; The quantity for calculated savings.
-	Quantity *float32 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *float32
 
 	// READ-ONLY; The exact cost of the estimated usage using reservation.
-	ReservationCost *float32 `json:"reservationCost,omitempty" azure:"ro"`
+	ReservationCost *float32
 
 	// READ-ONLY; The amount saved by purchasing the recommended quantity of reservation.
-	Savings *float32 `json:"savings,omitempty" azure:"ro"`
+	Savings *float32
 
 	// READ-ONLY; The cost of the suggested quantity.
-	TotalReservationCost *float32 `json:"totalReservationCost,omitempty" azure:"ro"`
+	TotalReservationCost *float32
 }
 
 // ReservationRecommendationDetailsClientGetOptions contains the optional parameters for the ReservationRecommendationDetailsClient.Get
@@ -2097,114 +2097,114 @@ type ReservationRecommendationDetailsClientGetOptions struct {
 // ReservationRecommendationDetailsModel - Reservation recommendation details.
 type ReservationRecommendationDetailsModel struct {
 	// Resource eTag.
-	ETag *string `json:"eTag,omitempty"`
+	ETag *string
 
 	// Resource Location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The properties of the reservation recommendation.
-	Properties *ReservationRecommendationDetailsProperties `json:"properties,omitempty"`
+	Properties *ReservationRecommendationDetailsProperties
 
 	// Resource sku
-	SKU *string `json:"sku,omitempty"`
+	SKU *string
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ReservationRecommendationDetailsProperties - The properties of the reservation recommendation.
 type ReservationRecommendationDetailsProperties struct {
 	// READ-ONLY; An ISO 4217 currency code identifier for the costs and savings
-	Currency *string `json:"currency,omitempty" azure:"ro"`
+	Currency *string
 
 	// READ-ONLY; Resource specific properties.
-	Resource *ReservationRecommendationDetailsResourceProperties `json:"resource,omitempty" azure:"ro"`
+	Resource *ReservationRecommendationDetailsResourceProperties
 
 	// READ-ONLY; Resource Group.
-	ResourceGroup *string `json:"resourceGroup,omitempty" azure:"ro"`
+	ResourceGroup *string
 
 	// READ-ONLY; Savings information for the recommendation.
-	Savings *ReservationRecommendationDetailsSavingsProperties `json:"savings,omitempty" azure:"ro"`
+	Savings *ReservationRecommendationDetailsSavingsProperties
 
 	// READ-ONLY; Scope of the reservation, ex: Single or Shared.
-	Scope *string `json:"scope,omitempty" azure:"ro"`
+	Scope *string
 
 	// READ-ONLY; Historical usage details used to calculate the estimated savings.
-	Usage *ReservationRecommendationDetailsUsageProperties `json:"usage,omitempty" azure:"ro"`
+	Usage *ReservationRecommendationDetailsUsageProperties
 }
 
 // ReservationRecommendationDetailsResourceProperties - Details of the resource.
 type ReservationRecommendationDetailsResourceProperties struct {
 	// READ-ONLY; List of subscriptions for which the reservation is applied.
-	AppliedScopes []*string `json:"appliedScopes,omitempty" azure:"ro"`
+	AppliedScopes []*string
 
 	// READ-ONLY; On demand rate of the resource.
-	OnDemandRate *float32 `json:"onDemandRate,omitempty" azure:"ro"`
+	OnDemandRate *float32
 
 	// READ-ONLY; Azure product ex: StandardE8sv3 etc.
-	Product *string `json:"product,omitempty" azure:"ro"`
+	Product *string
 
 	// READ-ONLY; Azure resource region ex:EastUS, WestUS etc.
-	Region *string `json:"region,omitempty" azure:"ro"`
+	Region *string
 
 	// READ-ONLY; Reservation rate of the resource.
-	ReservationRate *float32 `json:"reservationRate,omitempty" azure:"ro"`
+	ReservationRate *float32
 
 	// READ-ONLY; The azure resource type.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 }
 
 // ReservationRecommendationDetailsSavingsProperties - Details of the estimated savings.
 type ReservationRecommendationDetailsSavingsProperties struct {
 	// List of calculated savings.
-	CalculatedSavings []*ReservationRecommendationDetailsCalculatedSavingsProperties `json:"calculatedSavings,omitempty"`
+	CalculatedSavings []*ReservationRecommendationDetailsCalculatedSavingsProperties
 
 	// READ-ONLY; Number of days of usage to look back used for computing the recommendation.
-	LookBackPeriod *int32 `json:"lookBackPeriod,omitempty" azure:"ro"`
+	LookBackPeriod *int32
 
 	// READ-ONLY; Number of recommended units of the resource.
-	RecommendedQuantity *float32 `json:"recommendedQuantity,omitempty" azure:"ro"`
+	RecommendedQuantity *float32
 
 	// READ-ONLY; Term period of the reservation, ex: P1Y or P3Y.
-	ReservationOrderTerm *string `json:"reservationOrderTerm,omitempty" azure:"ro"`
+	ReservationOrderTerm *string
 
 	// READ-ONLY; Type of savings, ex: instance.
-	SavingsType *string `json:"savingsType,omitempty" azure:"ro"`
+	SavingsType *string
 
 	// READ-ONLY; Measurement unit ex: hour etc.
-	UnitOfMeasure *string `json:"unitOfMeasure,omitempty" azure:"ro"`
+	UnitOfMeasure *string
 }
 
 // ReservationRecommendationDetailsUsageProperties - Details about historical usage data that has been used for computing
 // the recommendation.
 type ReservationRecommendationDetailsUsageProperties struct {
 	// READ-ONLY; The first usage date used for looking back for computing the recommendation.
-	FirstConsumptionDate *string `json:"firstConsumptionDate,omitempty" azure:"ro"`
+	FirstConsumptionDate *string
 
 	// READ-ONLY; The last usage date used for looking back for computing the recommendation.
-	LastConsumptionDate *string `json:"lastConsumptionDate,omitempty" azure:"ro"`
+	LastConsumptionDate *string
 
 	// READ-ONLY; What the usage data values represent ex: virtual machine instance.
-	LookBackUnitType *string `json:"lookBackUnitType,omitempty" azure:"ro"`
+	LookBackUnitType *string
 
 	// READ-ONLY; The breakdown of historical resource usage. The values are in the order of usage between the firstConsumptionDate
 	// and the lastConsumptionDate.
-	UsageData []*float32 `json:"usageData,omitempty" azure:"ro"`
+	UsageData []*float32
 
 	// READ-ONLY; The grain of the values represented in the usage data ex: hourly.
-	UsageGrain *string `json:"usageGrain,omitempty" azure:"ro"`
+	UsageGrain *string
 }
 
 // ReservationRecommendationsClientListOptions contains the optional parameters for the ReservationRecommendationsClient.NewListPager
@@ -2223,121 +2223,121 @@ type ReservationRecommendationsClientListOptions struct {
 // ReservationRecommendationsListResult - Result of listing reservation recommendations.
 type ReservationRecommendationsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The link (url) to the previous page of results.
-	PreviousLink *string `json:"previousLink,omitempty" azure:"ro"`
+	PreviousLink *string
 
 	// READ-ONLY; The total amount of cost.
-	TotalCost *string `json:"totalCost,omitempty" azure:"ro"`
+	TotalCost *string
 
 	// READ-ONLY; The list of reservation recommendations.
-	Value []ReservationRecommendationClassification `json:"value,omitempty" azure:"ro"`
+	Value []ReservationRecommendationClassification
 }
 
 // ReservationSummariesListResult - Result of listing reservation summaries.
 type ReservationSummariesListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of reservation summaries.
-	Value []*ReservationSummary `json:"value,omitempty" azure:"ro"`
+	Value []*ReservationSummary
 }
 
 // ReservationSummary - reservation summary resource.
 type ReservationSummary struct {
 	// The properties of the reservation summary.
-	Properties *ReservationSummaryProperties `json:"properties,omitempty"`
+	Properties *ReservationSummaryProperties
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ReservationSummaryProperties - The properties of the reservation summary.
 type ReservationSummaryProperties struct {
 	// READ-ONLY; This is average utilization for the entire time range. (day or month depending on the grain)
-	AvgUtilizationPercentage *float64 `json:"avgUtilizationPercentage,omitempty" azure:"ro"`
+	AvgUtilizationPercentage *float64
 
 	// READ-ONLY; The reservation kind.
-	Kind *string `json:"kind,omitempty" azure:"ro"`
+	Kind *string
 
 	// READ-ONLY; This is the maximum hourly utilization in the usage time (day or month). E.g. if usage record corresponds to
 	// 12/10/2017 and on that for hour 4 and 5, utilization was 100%, this field will return 100%
 	// for that day.
-	MaxUtilizationPercentage *float64 `json:"maxUtilizationPercentage,omitempty" azure:"ro"`
+	MaxUtilizationPercentage *float64
 
 	// READ-ONLY; This is the minimum hourly utilization in the usage time (day or month). E.g. if usage record corresponds to
 	// 12/10/2017 and on that for hour 4 and 5, utilization was 10%, this field will return 10%
 	// for that day
-	MinUtilizationPercentage *float64 `json:"minUtilizationPercentage,omitempty" azure:"ro"`
+	MinUtilizationPercentage *float64
 
 	// READ-ONLY; This is the purchased quantity for the reservationId.
-	PurchasedQuantity *float64 `json:"purchasedQuantity,omitempty" azure:"ro"`
+	PurchasedQuantity *float64
 
 	// READ-ONLY; This is the remaining quantity for the reservationId.
-	RemainingQuantity *float64 `json:"remainingQuantity,omitempty" azure:"ro"`
+	RemainingQuantity *float64
 
 	// READ-ONLY; The reservation ID is the identifier of a reservation within a reservation order. Each reservation is the grouping
 	// for applying the benefit scope and also specifies the number of instances to which
 	// the reservation benefit can be applied to.
-	ReservationID *string `json:"reservationId,omitempty" azure:"ro"`
+	ReservationID *string
 
 	// READ-ONLY; The reservation order ID is the identifier for a reservation purchase. Each reservation order ID represents
 	// a single purchase transaction. A reservation order contains reservations. The reservation
 	// order specifies the VM size and region for the reservations.
-	ReservationOrderID *string `json:"reservationOrderId,omitempty" azure:"ro"`
+	ReservationOrderID *string
 
 	// READ-ONLY; This is the total hours reserved. E.g. if reservation for 1 instance was made on 1 PM, this will be 11 hours
 	// for that day and 24 hours from subsequent days
-	ReservedHours *float64 `json:"reservedHours,omitempty" azure:"ro"`
+	ReservedHours *float64
 
 	// READ-ONLY; This is the ARM Sku name. It can be used to join with the serviceType field in additional info in usage records.
-	SKUName *string `json:"skuName,omitempty" azure:"ro"`
+	SKUName *string
 
 	// READ-ONLY; This is the total count of instances that are reserved for the reservationId.
-	TotalReservedQuantity *float64 `json:"totalReservedQuantity,omitempty" azure:"ro"`
+	TotalReservedQuantity *float64
 
 	// READ-ONLY; Data corresponding to the utilization record. If the grain of data is monthly, it will be first day of month.
-	UsageDate *time.Time `json:"usageDate,omitempty" azure:"ro"`
+	UsageDate *time.Time
 
 	// READ-ONLY; Total used hours by the reservation
-	UsedHours *float64 `json:"usedHours,omitempty" azure:"ro"`
+	UsedHours *float64
 
 	// READ-ONLY; This is the used quantity for the reservationId.
-	UsedQuantity *float64 `json:"usedQuantity,omitempty" azure:"ro"`
+	UsedQuantity *float64
 
 	// READ-ONLY; This is the utilized percentage for the reservation Id.
-	UtilizedPercentage *float64 `json:"utilizedPercentage,omitempty" azure:"ro"`
+	UtilizedPercentage *float64
 }
 
 // ReservationTransaction - Reservation transaction resource.
 type ReservationTransaction struct {
 	// The properties of a legacy reservation transaction.
-	Properties *LegacyReservationTransactionProperties `json:"properties,omitempty"`
+	Properties *LegacyReservationTransactionProperties
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags []*string `json:"tags,omitempty" azure:"ro"`
+	Tags []*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ReservationTransactionsClientListByBillingProfileOptions contains the optional parameters for the ReservationTransactionsClient.NewListByBillingProfilePager
@@ -2359,10 +2359,10 @@ type ReservationTransactionsClientListOptions struct {
 // ReservationTransactionsListResult - Result of listing reservation recommendations.
 type ReservationTransactionsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of reservation recommendations.
-	Value []*ReservationTransaction `json:"value,omitempty" azure:"ro"`
+	Value []*ReservationTransaction
 }
 
 // ReservationsDetailsClientListByReservationOrderAndReservationOptions contains the optional parameters for the ReservationsDetailsClient.NewListByReservationOrderAndReservationPager
@@ -2425,31 +2425,31 @@ type ReservationsSummariesClientListOptions struct {
 // SKUProperty - The Sku property
 type SKUProperty struct {
 	// READ-ONLY; The name of sku property.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The value of sku property.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // Tag - The tag resource.
 type Tag struct {
 	// Tag key.
-	Key *string `json:"key,omitempty"`
+	Key *string
 
 	// Tag values.
-	Value []*string `json:"value,omitempty"`
+	Value []*string
 }
 
 // TagProperties - The properties of the tag.
 type TagProperties struct {
 	// A list of Tag.
-	Tags []*Tag `json:"tags,omitempty"`
+	Tags []*Tag
 
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The link (url) to the previous page of results.
-	PreviousLink *string `json:"previousLink,omitempty" azure:"ro"`
+	PreviousLink *string
 }
 
 // TagsClientGetOptions contains the optional parameters for the TagsClient.Get method.
@@ -2461,19 +2461,19 @@ type TagsClientGetOptions struct {
 type TagsResult struct {
 	// eTag of the resource. To handle concurrent update scenario, this field will be used to determine whether the user is updating
 	// the latest version or not.
-	ETag *string `json:"eTag,omitempty"`
+	ETag *string
 
 	// The properties of the tag.
-	Properties *TagProperties `json:"properties,omitempty"`
+	Properties *TagProperties
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // UsageDetailClassification provides polymorphic access to related types.
@@ -2488,22 +2488,22 @@ type UsageDetailClassification interface {
 // UsageDetail - An usage detail resource.
 type UsageDetail struct {
 	// REQUIRED; Specifies the kind of usage details.
-	Kind *UsageDetailsKind `json:"kind,omitempty"`
+	Kind *UsageDetailsKind
 
 	// READ-ONLY; Resource etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource Id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource tags.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetUsageDetail implements the UsageDetailClassification interface for type UsageDetail.
@@ -2534,8 +2534,8 @@ type UsageDetailsClientListOptions struct {
 // order by billing period.
 type UsageDetailsListResult struct {
 	// READ-ONLY; The link (url) to the next page of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of usage details.
-	Value []UsageDetailClassification `json:"value,omitempty" azure:"ro"`
+	Value []UsageDetailClassification
 }

--- a/test/databoxedge/2021-02-01/armdataboxedge/zz_models.go
+++ b/test/databoxedge/2021-02-01/armdataboxedge/zz_models.go
@@ -23,19 +23,19 @@ type AddonClassification interface {
 // Addon - Role Addon
 type Addon struct {
 	// REQUIRED; Addon type.
-	Kind *AddonType `json:"kind,omitempty"`
+	Kind *AddonType
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Addon type
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetAddon implements the AddonClassification interface for type Addon.
@@ -44,10 +44,10 @@ func (a *Addon) GetAddon() *Addon { return a }
 // AddonList - Collection of all the Role addon on the Azure Stack Edge device.
 type AddonList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The Value.
-	Value []AddonClassification `json:"value,omitempty" azure:"ro"`
+	Value []AddonClassification
 }
 
 // AddonsClientBeginCreateOrUpdateOptions contains the optional parameters for the AddonsClient.BeginCreateOrUpdate method.
@@ -75,88 +75,88 @@ type AddonsClientListByRoleOptions struct {
 // Address - The shipping address of the customer.
 type Address struct {
 	// REQUIRED; The country name.
-	Country *string `json:"country,omitempty"`
+	Country *string
 
 	// The address line1.
-	AddressLine1 *string `json:"addressLine1,omitempty"`
+	AddressLine1 *string
 
 	// The address line2.
-	AddressLine2 *string `json:"addressLine2,omitempty"`
+	AddressLine2 *string
 
 	// The address line3.
-	AddressLine3 *string `json:"addressLine3,omitempty"`
+	AddressLine3 *string
 
 	// The city name.
-	City *string `json:"city,omitempty"`
+	City *string
 
 	// The postal code.
-	PostalCode *string `json:"postalCode,omitempty"`
+	PostalCode *string
 
 	// The state name.
-	State *string `json:"state,omitempty"`
+	State *string
 }
 
 // Alert on the data box edge/gateway device.
 type Alert struct {
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Properties of alert.
-	Properties *AlertProperties `json:"properties,omitempty" azure:"ro"`
+	Properties *AlertProperties
 
 	// READ-ONLY; Alert generated in the resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AlertErrorDetails - Error details for the alert.
 type AlertErrorDetails struct {
 	// READ-ONLY; Error code.
-	ErrorCode *string `json:"errorCode,omitempty" azure:"ro"`
+	ErrorCode *string
 
 	// READ-ONLY; Error Message.
-	ErrorMessage *string `json:"errorMessage,omitempty" azure:"ro"`
+	ErrorMessage *string
 
 	// READ-ONLY; Number of occurrences.
-	Occurrences *int32 `json:"occurrences,omitempty" azure:"ro"`
+	Occurrences *int32
 }
 
 // AlertList - Collection of alerts.
 type AlertList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The value.
-	Value []*Alert `json:"value,omitempty" azure:"ro"`
+	Value []*Alert
 }
 
 // AlertProperties - Properties of alert.
 type AlertProperties struct {
 	// READ-ONLY; Alert type.
-	AlertType *string `json:"alertType,omitempty" azure:"ro"`
+	AlertType *string
 
 	// READ-ONLY; UTC time when the alert appeared.
-	AppearedAtDateTime *time.Time `json:"appearedAtDateTime,omitempty" azure:"ro"`
+	AppearedAtDateTime *time.Time
 
 	// READ-ONLY; Alert details.
-	DetailedInformation map[string]*string `json:"detailedInformation,omitempty" azure:"ro"`
+	DetailedInformation map[string]*string
 
 	// READ-ONLY; Error details of the alert.
-	ErrorDetails *AlertErrorDetails `json:"errorDetails,omitempty" azure:"ro"`
+	ErrorDetails *AlertErrorDetails
 
 	// READ-ONLY; Alert recommendation.
-	Recommendation *string `json:"recommendation,omitempty" azure:"ro"`
+	Recommendation *string
 
 	// READ-ONLY; Severity of the alert.
-	Severity *AlertSeverity `json:"severity,omitempty" azure:"ro"`
+	Severity *AlertSeverity
 
 	// READ-ONLY; Alert title.
-	Title *string `json:"title,omitempty" azure:"ro"`
+	Title *string
 }
 
 // AlertsClientGetOptions contains the optional parameters for the AlertsClient.Get method.
@@ -173,22 +173,22 @@ type AlertsClientListByDataBoxEdgeDeviceOptions struct {
 // ArcAddon - Arc Addon.
 type ArcAddon struct {
 	// REQUIRED; Addon type.
-	Kind *AddonType `json:"kind,omitempty"`
+	Kind *AddonType
 
 	// REQUIRED; Properties specific to Arc addon.
-	Properties *ArcAddonProperties `json:"properties,omitempty"`
+	Properties *ArcAddonProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Addon type
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetAddon implements the AddonClassification interface for type ArcAddon.
@@ -205,46 +205,46 @@ func (a *ArcAddon) GetAddon() *Addon {
 // ArcAddonProperties - Arc addon properties.
 type ArcAddonProperties struct {
 	// REQUIRED; Arc resource group name
-	ResourceGroupName *string `json:"resourceGroupName,omitempty"`
+	ResourceGroupName *string
 
 	// REQUIRED; Arc resource location
-	ResourceLocation *string `json:"resourceLocation,omitempty"`
+	ResourceLocation *string
 
 	// REQUIRED; Arc resource Name
-	ResourceName *string `json:"resourceName,omitempty"`
+	ResourceName *string
 
 	// REQUIRED; Arc resource subscription Id
-	SubscriptionID *string `json:"subscriptionId,omitempty"`
+	SubscriptionID *string
 
 	// READ-ONLY; Host OS supported by the Arc addon.
-	HostPlatform *PlatformType `json:"hostPlatform,omitempty" azure:"ro"`
+	HostPlatform *PlatformType
 
 	// READ-ONLY; Platform where the runtime is hosted.
-	HostPlatformType *HostPlatformType `json:"hostPlatformType,omitempty" azure:"ro"`
+	HostPlatformType *HostPlatformType
 
 	// READ-ONLY; Addon Provisioning State
-	ProvisioningState *AddonState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *AddonState
 
 	// READ-ONLY; Arc resource version
-	Version *string `json:"version,omitempty" azure:"ro"`
+	Version *string
 }
 
 // AsymmetricEncryptedSecret - Represent the secrets intended for encryption with asymmetric key pair.
 type AsymmetricEncryptedSecret struct {
 	// REQUIRED; The algorithm used to encrypt "Value".
-	EncryptionAlgorithm *EncryptionAlgorithm `json:"encryptionAlgorithm,omitempty"`
+	EncryptionAlgorithm *EncryptionAlgorithm
 
 	// REQUIRED; The value of the secret.
-	Value *string `json:"value,omitempty"`
+	Value *string
 
 	// Thumbprint certificate used to encrypt \"Value\". If the value is unencrypted, it will be null.
-	EncryptionCertThumbprint *string `json:"encryptionCertThumbprint,omitempty"`
+	EncryptionCertThumbprint *string
 }
 
 // Authentication mechanism for IoT devices.
 type Authentication struct {
 	// Symmetric key for authentication.
-	SymmetricKey *SymmetricKey `json:"symmetricKey,omitempty"`
+	SymmetricKey *SymmetricKey
 }
 
 // AvailableSKUsClientListOptions contains the optional parameters for the AvailableSKUsClient.NewListPager method.
@@ -255,46 +255,46 @@ type AvailableSKUsClientListOptions struct {
 // AzureContainerInfo - Azure container mapping of the endpoint.
 type AzureContainerInfo struct {
 	// REQUIRED; Container name (Based on the data format specified, this represents the name of Azure Files/Page blob/Block blob).
-	ContainerName *string `json:"containerName,omitempty"`
+	ContainerName *string
 
 	// REQUIRED; Storage format used for the file represented by the share.
-	DataFormat *AzureContainerDataFormat `json:"dataFormat,omitempty"`
+	DataFormat *AzureContainerDataFormat
 
 	// REQUIRED; ID of the storage account credential used to access storage.
-	StorageAccountCredentialID *string `json:"storageAccountCredentialId,omitempty"`
+	StorageAccountCredentialID *string
 }
 
 // BandwidthSchedule - The bandwidth schedule details.
 type BandwidthSchedule struct {
 	// REQUIRED; The properties of the bandwidth schedule.
-	Properties *BandwidthScheduleProperties `json:"properties,omitempty"`
+	Properties *BandwidthScheduleProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Bandwidth object related to ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BandwidthScheduleProperties - The properties of the bandwidth schedule.
 type BandwidthScheduleProperties struct {
 	// REQUIRED; The days of the week when this schedule is applicable.
-	Days []*DayOfWeek `json:"days,omitempty"`
+	Days []*DayOfWeek
 
 	// REQUIRED; The bandwidth rate in Mbps.
-	RateInMbps *int32 `json:"rateInMbps,omitempty"`
+	RateInMbps *int32
 
 	// REQUIRED; The start time of the schedule in UTC.
-	Start *string `json:"start,omitempty"`
+	Start *string
 
 	// REQUIRED; The stop time of the schedule in UTC.
-	Stop *string `json:"stop,omitempty"`
+	Stop *string
 }
 
 // BandwidthSchedulesClientBeginCreateOrUpdateOptions contains the optional parameters for the BandwidthSchedulesClient.BeginCreateOrUpdate
@@ -325,19 +325,19 @@ type BandwidthSchedulesClientListByDataBoxEdgeDeviceOptions struct {
 // BandwidthSchedulesList - The collection of bandwidth schedules.
 type BandwidthSchedulesList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of bandwidth schedules.
-	Value []*BandwidthSchedule `json:"value,omitempty" azure:"ro"`
+	Value []*BandwidthSchedule
 }
 
 // ClientAccessRight - The mapping between a particular client IP and the type of access client has on the NFS share.
 type ClientAccessRight struct {
 	// REQUIRED; Type of access to be allowed for the client.
-	AccessPermission *ClientPermissionType `json:"accessPermission,omitempty"`
+	AccessPermission *ClientPermissionType
 
 	// REQUIRED; IP of the client.
-	Client *string `json:"client,omitempty"`
+	Client *string
 }
 
 // CloudEdgeManagementRole - The preview of Virtual Machine Cloud Management from the Azure supports deploying and managing
@@ -347,22 +347,22 @@ type ClientAccessRight struct {
 // https://azure.microsoft.com/en-us/support/legal/preview-supplemental-terms/ for additional details.
 type CloudEdgeManagementRole struct {
 	// REQUIRED; Role type.
-	Kind *RoleTypes `json:"kind,omitempty"`
+	Kind *RoleTypes
 
 	// Properties specific to CloudEdgeManagementRole role.
-	Properties *CloudEdgeManagementRoleProperties `json:"properties,omitempty"`
+	Properties *CloudEdgeManagementRoleProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Role configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetRole implements the RoleClassification interface for type CloudEdgeManagementRole.
@@ -379,94 +379,94 @@ func (c *CloudEdgeManagementRole) GetRole() *Role {
 // CloudEdgeManagementRoleProperties - CloudEdgeManagement Role properties.
 type CloudEdgeManagementRoleProperties struct {
 	// REQUIRED; Role status.
-	RoleStatus *RoleStatus `json:"roleStatus,omitempty"`
+	RoleStatus *RoleStatus
 
 	// READ-ONLY; Edge Profile of the resource
-	EdgeProfile *EdgeProfile `json:"edgeProfile,omitempty" azure:"ro"`
+	EdgeProfile *EdgeProfile
 
 	// READ-ONLY; Local Edge Management Status
-	LocalManagementStatus *RoleStatus `json:"localManagementStatus,omitempty" azure:"ro"`
+	LocalManagementStatus *RoleStatus
 }
 
 // CniConfig - Cni configuration
 type CniConfig struct {
 	// READ-ONLY; Pod Subnet
-	PodSubnet *string `json:"podSubnet,omitempty" azure:"ro"`
+	PodSubnet *string
 
 	// READ-ONLY; Service subnet
-	ServiceSubnet *string `json:"serviceSubnet,omitempty" azure:"ro"`
+	ServiceSubnet *string
 
 	// READ-ONLY; Cni type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; Cni version
-	Version *string `json:"version,omitempty" azure:"ro"`
+	Version *string
 }
 
 // ComputeResource - Compute infrastructure Resource
 type ComputeResource struct {
 	// REQUIRED; Memory in GB
-	MemoryInGB *int64 `json:"memoryInGB,omitempty"`
+	MemoryInGB *int64
 
 	// REQUIRED; Processor count
-	ProcessorCount *int32 `json:"processorCount,omitempty"`
+	ProcessorCount *int32
 }
 
 // ContactDetails - Contains all the contact details of the customer.
 type ContactDetails struct {
 	// REQUIRED; The name of the company.
-	CompanyName *string `json:"companyName,omitempty"`
+	CompanyName *string
 
 	// REQUIRED; The contact person name.
-	ContactPerson *string `json:"contactPerson,omitempty"`
+	ContactPerson *string
 
 	// REQUIRED; The email list.
-	EmailList []*string `json:"emailList,omitempty"`
+	EmailList []*string
 
 	// REQUIRED; The phone number.
-	Phone *string `json:"phone,omitempty"`
+	Phone *string
 }
 
 // Container - Represents a container on the Data Box Edge/Gateway device.
 type Container struct {
 	// REQUIRED; The container properties.
-	Properties *ContainerProperties `json:"properties,omitempty"`
+	Properties *ContainerProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Container in DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ContainerList - Collection of all the containers on the Data Box Edge/Gateway device.
 type ContainerList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of containers.
-	Value []*Container `json:"value,omitempty" azure:"ro"`
+	Value []*Container
 }
 
 // ContainerProperties - The container properties.
 type ContainerProperties struct {
 	// REQUIRED; DataFormat for Container
-	DataFormat *AzureContainerDataFormat `json:"dataFormat,omitempty"`
+	DataFormat *AzureContainerDataFormat
 
 	// READ-ONLY; Current status of the container.
-	ContainerStatus *ContainerStatus `json:"containerStatus,omitempty" azure:"ro"`
+	ContainerStatus *ContainerStatus
 
 	// READ-ONLY; The UTC time when container got created.
-	CreatedDateTime *time.Time `json:"createdDateTime,omitempty" azure:"ro"`
+	CreatedDateTime *time.Time
 
 	// READ-ONLY; Details of the refresh job on this container.
-	RefreshDetails *RefreshDetails `json:"refreshDetails,omitempty" azure:"ro"`
+	RefreshDetails *RefreshDetails
 }
 
 // ContainersClientBeginCreateOrUpdateOptions contains the optional parameters for the ContainersClient.BeginCreateOrUpdate
@@ -502,19 +502,19 @@ type ContainersClientListByStorageAccountOptions struct {
 // DCAccessCode - DC Access code in the case of Self Managed Shipping.
 type DCAccessCode struct {
 	// DCAccessCode properties.
-	Properties *DCAccessCodeProperties `json:"properties,omitempty"`
+	Properties *DCAccessCodeProperties
 }
 
 // DCAccessCodeProperties - DCAccessCode Properties.
 type DCAccessCodeProperties struct {
 	// DCAccess Code for the Self Managed shipment.
-	AuthCode *string `json:"authCode,omitempty"`
+	AuthCode *string
 }
 
 // DataResidency - Wraps data-residency related information for edge-resource and this should be used with ARM layer.
 type DataResidency struct {
 	// DataResidencyType enum
-	Type *DataResidencyType `json:"type,omitempty"`
+	Type *DataResidencyType
 }
 
 // Device - The Data Box Edge/Gateway device.
@@ -522,185 +522,185 @@ type Device struct {
 	// REQUIRED; The location of the device. This is a supported and registered Azure geographical region (for example, West US,
 	// East US, or Southeast Asia). The geographical region of a device cannot be changed once
 	// it is created, but if an identical geographical region is specified on update, the request will succeed.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The etag for the devices.
-	Etag *string `json:"etag,omitempty"`
+	Etag *string
 
 	// Msi identity of the resource
-	Identity *ResourceIdentity `json:"identity,omitempty"`
+	Identity *ResourceIdentity
 
 	// The kind of the device.
-	Kind *DataBoxEdgeDeviceKind `json:"kind,omitempty"`
+	Kind *DataBoxEdgeDeviceKind
 
 	// The properties of the Data Box Edge/Gateway device.
-	Properties *DeviceProperties `json:"properties,omitempty"`
+	Properties *DeviceProperties
 
 	// The SKU type.
-	SKU *SKUType `json:"sku,omitempty"`
+	SKU *SKUType
 
 	// The list of tags that describe the device. These tags can be used to view and group this device (across resource groups).
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DeviceExtendedInfo - The extended Info of the Data Box Edge/Gateway device.
 type DeviceExtendedInfo struct {
 	// The extended info properties.
-	Properties *DeviceExtendedInfoProperties `json:"properties,omitempty"`
+	Properties *DeviceExtendedInfoProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DeviceExtendedInfoPatch - The Data Box Edge/Gateway device extended info patch.
 type DeviceExtendedInfoPatch struct {
 	// The name for Channel Integrity Key stored in the Client Key Vault
-	ChannelIntegrityKeyName *string `json:"channelIntegrityKeyName,omitempty"`
+	ChannelIntegrityKeyName *string
 
 	// The version of Channel Integrity Key stored in the Client Key Vault
-	ChannelIntegrityKeyVersion *string `json:"channelIntegrityKeyVersion,omitempty"`
+	ChannelIntegrityKeyVersion *string
 
 	// The Key Vault ARM Id for client secrets
-	ClientSecretStoreID *string `json:"clientSecretStoreId,omitempty"`
+	ClientSecretStoreID *string
 
 	// The url to access the Client Key Vault
-	ClientSecretStoreURL *string `json:"clientSecretStoreUrl,omitempty"`
+	ClientSecretStoreURL *string
 
 	// For changing or to initiate the resync to key-vault set the status to KeyVaultSyncPending, rest of the status will not
 	// be applicable.
-	SyncStatus *KeyVaultSyncStatus `json:"syncStatus,omitempty"`
+	SyncStatus *KeyVaultSyncStatus
 }
 
 // DeviceExtendedInfoProperties - The properties of the Data Box Edge/Gateway device extended info.
 type DeviceExtendedInfoProperties struct {
 	// The name of Channel Integrity Key stored in the Client Key Vault
-	ChannelIntegrityKeyName *string `json:"channelIntegrityKeyName,omitempty"`
+	ChannelIntegrityKeyName *string
 
 	// The version of Channel Integrity Key stored in the Client Key Vault
-	ChannelIntegrityKeyVersion *string `json:"channelIntegrityKeyVersion,omitempty"`
+	ChannelIntegrityKeyVersion *string
 
 	// The Key Vault ARM Id for client secrets
-	ClientSecretStoreID *string `json:"clientSecretStoreId,omitempty"`
+	ClientSecretStoreID *string
 
 	// The url to access the Client Key Vault
-	ClientSecretStoreURL *string `json:"clientSecretStoreUrl,omitempty"`
+	ClientSecretStoreURL *string
 
 	// The public part of the encryption certificate. Client uses this to encrypt any secret.
-	EncryptionKey *string `json:"encryptionKey,omitempty"`
+	EncryptionKey *string
 
 	// The digital signature of encrypted certificate.
-	EncryptionKeyThumbprint *string `json:"encryptionKeyThumbprint,omitempty"`
+	EncryptionKeyThumbprint *string
 
 	// Key vault sync status
-	KeyVaultSyncStatus *KeyVaultSyncStatus `json:"keyVaultSyncStatus,omitempty"`
+	KeyVaultSyncStatus *KeyVaultSyncStatus
 
 	// READ-ONLY; Device secrets, will be returned only with ODataFilter $expand=deviceSecrets
-	DeviceSecrets map[string]*Secret `json:"deviceSecrets,omitempty" azure:"ro"`
+	DeviceSecrets map[string]*Secret
 
 	// READ-ONLY; The Resource ID of the Resource.
-	ResourceKey *string `json:"resourceKey,omitempty" azure:"ro"`
+	ResourceKey *string
 }
 
 // DeviceList - The collection of Data Box Edge/Gateway devices.
 type DeviceList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of Data Box Edge/Gateway devices.
-	Value []*Device `json:"value,omitempty" azure:"ro"`
+	Value []*Device
 }
 
 // DevicePatch - The Data Box Edge/Gateway device patch.
 type DevicePatch struct {
 	// Msi identity of the resource
-	Identity *ResourceIdentity `json:"identity,omitempty"`
+	Identity *ResourceIdentity
 
 	// The properties associated with the Data Box Edge/Gateway resource
-	Properties *DevicePropertiesPatch `json:"properties,omitempty"`
+	Properties *DevicePropertiesPatch
 
 	// The tags attached to the Data Box Edge/Gateway resource.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // DeviceProperties - The properties of the Data Box Edge/Gateway device.
 type DeviceProperties struct {
 	// The status of the Data Box Edge/Gateway device.
-	DataBoxEdgeDeviceStatus *DataBoxEdgeDeviceStatus `json:"dataBoxEdgeDeviceStatus,omitempty"`
+	DataBoxEdgeDeviceStatus *DataBoxEdgeDeviceStatus
 
 	// The details of data-residency related properties for this resource
-	DataResidency *DataResidency `json:"dataResidency,omitempty"`
+	DataResidency *DataResidency
 
 	// READ-ONLY; Type of compute roles configured.
-	ConfiguredRoleTypes []*RoleTypes `json:"configuredRoleTypes,omitempty" azure:"ro"`
+	ConfiguredRoleTypes []*RoleTypes
 
 	// READ-ONLY; The Data Box Edge/Gateway device culture.
-	Culture *string `json:"culture,omitempty" azure:"ro"`
+	Culture *string
 
 	// READ-ONLY; The Description of the Data Box Edge/Gateway device.
-	Description *string `json:"description,omitempty" azure:"ro"`
+	Description *string
 
 	// READ-ONLY; The device software version number of the device (eg: 1.2.18105.6).
-	DeviceHcsVersion *string `json:"deviceHcsVersion,omitempty" azure:"ro"`
+	DeviceHcsVersion *string
 
 	// READ-ONLY; The Data Box Edge/Gateway device local capacity in MB.
-	DeviceLocalCapacity *int64 `json:"deviceLocalCapacity,omitempty" azure:"ro"`
+	DeviceLocalCapacity *int64
 
 	// READ-ONLY; The Data Box Edge/Gateway device model.
-	DeviceModel *string `json:"deviceModel,omitempty" azure:"ro"`
+	DeviceModel *string
 
 	// READ-ONLY; The Data Box Edge/Gateway device software version.
-	DeviceSoftwareVersion *string `json:"deviceSoftwareVersion,omitempty" azure:"ro"`
+	DeviceSoftwareVersion *string
 
 	// READ-ONLY; The type of the Data Box Edge/Gateway device.
-	DeviceType *DeviceType `json:"deviceType,omitempty" azure:"ro"`
+	DeviceType *DeviceType
 
 	// READ-ONLY; The details of Edge Profile for this resource
-	EdgeProfile *EdgeProfile `json:"edgeProfile,omitempty" azure:"ro"`
+	EdgeProfile *EdgeProfile
 
 	// READ-ONLY; The Data Box Edge/Gateway device name.
-	FriendlyName *string `json:"friendlyName,omitempty" azure:"ro"`
+	FriendlyName *string
 
 	// READ-ONLY; The description of the Data Box Edge/Gateway device model.
-	ModelDescription *string `json:"modelDescription,omitempty" azure:"ro"`
+	ModelDescription *string
 
 	// READ-ONLY; The number of nodes in the cluster.
-	NodeCount *int32 `json:"nodeCount,omitempty" azure:"ro"`
+	NodeCount *int32
 
 	// READ-ONLY; The details of the move operation on this resource.
-	ResourceMoveDetails *ResourceMoveDetails `json:"resourceMoveDetails,omitempty" azure:"ro"`
+	ResourceMoveDetails *ResourceMoveDetails
 
 	// READ-ONLY; The Serial Number of Data Box Edge/Gateway device.
-	SerialNumber *string `json:"serialNumber,omitempty" azure:"ro"`
+	SerialNumber *string
 
 	// READ-ONLY; DataBoxEdge Device Properties
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The Data Box Edge/Gateway device timezone.
-	TimeZone *string `json:"timeZone,omitempty" azure:"ro"`
+	TimeZone *string
 }
 
 // DevicePropertiesPatch - The Data Box Edge/Gateway device properties patch.
 type DevicePropertiesPatch struct {
 	// Edge Profile property of the Data Box Edge/Gateway device
-	EdgeProfile *EdgeProfilePatch `json:"edgeProfile,omitempty"`
+	EdgeProfile *EdgeProfilePatch
 }
 
 // DevicesClientBeginCreateOrUpdateSecuritySettingsOptions contains the optional parameters for the DevicesClient.BeginCreateOrUpdateSecuritySettings
@@ -800,43 +800,43 @@ type DevicesClientUploadCertificateOptions struct {
 // DiagnosticProactiveLogCollectionSettings - The diagnostic proactive log collection settings of a device.
 type DiagnosticProactiveLogCollectionSettings struct {
 	// REQUIRED; Properties of the diagnostic proactive log collection settings.
-	Properties *ProactiveLogCollectionSettingsProperties `json:"properties,omitempty"`
+	Properties *ProactiveLogCollectionSettingsProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; DiagnosticProactiveLogCollectionSettings
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DiagnosticRemoteSupportSettings - The remote support settings of a device.
 type DiagnosticRemoteSupportSettings struct {
 	// REQUIRED; Properties of the remote support settings.
-	Properties *DiagnosticRemoteSupportSettingsProperties `json:"properties,omitempty"`
+	Properties *DiagnosticRemoteSupportSettingsProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; DiagnosticRemoteSupportSettings
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DiagnosticRemoteSupportSettingsProperties - The properties of remote support settings.
 type DiagnosticRemoteSupportSettingsProperties struct {
 	// Remote support settings list according to the RemoteApplicationType
-	RemoteSupportSettingsList []*RemoteSupportSettings `json:"remoteSupportSettingsList,omitempty"`
+	RemoteSupportSettingsList []*RemoteSupportSettings
 }
 
 // DiagnosticSettingsClientBeginUpdateDiagnosticProactiveLogCollectionSettingsOptions contains the optional parameters for
@@ -868,62 +868,62 @@ type DiagnosticSettingsClientGetDiagnosticRemoteSupportSettingsOptions struct {
 // EdgeProfile - Details about Edge Profile for the resource
 type EdgeProfile struct {
 	// Edge Profile Subscription
-	Subscription *EdgeProfileSubscription `json:"subscription,omitempty"`
+	Subscription *EdgeProfileSubscription
 }
 
 // EdgeProfilePatch - The Data Box Edge/Gateway Edge Profile patch.
 type EdgeProfilePatch struct {
 	// The Data Box Edge/Gateway Edge Profile Subscription patch
-	Subscription *EdgeProfileSubscriptionPatch `json:"subscription,omitempty"`
+	Subscription *EdgeProfileSubscriptionPatch
 }
 
 // EdgeProfileSubscription - Subscription details for the Edge Profile
 type EdgeProfileSubscription struct {
 	// ARM ID of the subscription
-	ID               *string                 `json:"id,omitempty"`
-	Properties       *SubscriptionProperties `json:"properties,omitempty"`
-	RegistrationDate *string                 `json:"registrationDate,omitempty"`
+	ID               *string
+	Properties       *SubscriptionProperties
+	RegistrationDate *string
 
 	// Edge Subscription Registration ID
-	RegistrationID *string            `json:"registrationId,omitempty"`
-	State          *SubscriptionState `json:"state,omitempty"`
-	SubscriptionID *string            `json:"subscriptionId,omitempty"`
+	RegistrationID *string
+	State          *SubscriptionState
+	SubscriptionID *string
 }
 
 // EdgeProfileSubscriptionPatch - The Data Box Edge/Gateway Edge Profile Subscription patch.
 type EdgeProfileSubscriptionPatch struct {
 	// The path ID that uniquely identifies the subscription of the edge profile.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // EtcdInfo - Etcd configuration
 type EtcdInfo struct {
 	// READ-ONLY; Etcd type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; Etcd version
-	Version *string `json:"version,omitempty" azure:"ro"`
+	Version *string
 }
 
 // FileEventTrigger - Trigger details.
 type FileEventTrigger struct {
 	// REQUIRED; Trigger Kind.
-	Kind *TriggerEventType `json:"kind,omitempty"`
+	Kind *TriggerEventType
 
 	// REQUIRED; File trigger properties.
-	Properties *FileTriggerProperties `json:"properties,omitempty"`
+	Properties *FileTriggerProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Trigger in DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetTrigger implements the TriggerClassification interface for type FileEventTrigger.
@@ -940,90 +940,90 @@ func (f *FileEventTrigger) GetTrigger() *Trigger {
 // FileSourceInfo - File source details.
 type FileSourceInfo struct {
 	// REQUIRED; File share ID.
-	ShareID *string `json:"shareId,omitempty"`
+	ShareID *string
 }
 
 // FileTriggerProperties - File trigger properties.
 type FileTriggerProperties struct {
 	// REQUIRED; Role sink info.
-	SinkInfo *RoleSinkInfo `json:"sinkInfo,omitempty"`
+	SinkInfo *RoleSinkInfo
 
 	// REQUIRED; File event source details.
-	SourceInfo *FileSourceInfo `json:"sourceInfo,omitempty"`
+	SourceInfo *FileSourceInfo
 
 	// A custom context tag typically used to correlate the trigger against its usage. For example, if a periodic timer trigger
 	// is intended for certain specific IoT modules in the device, the tag can be the
 	// name or the image URL of the module.
-	CustomContextTag *string `json:"customContextTag,omitempty"`
+	CustomContextTag *string
 }
 
 // GenerateCertResponse - Used in activation key generation flow.
 type GenerateCertResponse struct {
 	// Gets or sets expiry time in UTC
-	ExpiryTimeInUTC *string `json:"expiryTimeInUTC,omitempty"`
+	ExpiryTimeInUTC *string
 
 	// Gets or sets base64 encoded private part of the certificate, needed to form the activation key
-	PrivateKey *string `json:"privateKey,omitempty"`
+	PrivateKey *string
 
 	// Gets or sets base64 encoded certificate raw data, this is the public part needed to be uploaded to cert vault
-	PublicKey *string `json:"publicKey,omitempty"`
+	PublicKey *string
 }
 
 // IPv4Config - Details related to the IPv4 address configuration.
 type IPv4Config struct {
 	// READ-ONLY; The IPv4 gateway of the network adapter.
-	Gateway *string `json:"gateway,omitempty" azure:"ro"`
+	Gateway *string
 
 	// READ-ONLY; The IPv4 address of the network adapter.
-	IPAddress *string `json:"ipAddress,omitempty" azure:"ro"`
+	IPAddress *string
 
 	// READ-ONLY; The IPv4 subnet of the network adapter.
-	Subnet *string `json:"subnet,omitempty" azure:"ro"`
+	Subnet *string
 }
 
 // IPv6Config - Details related to the IPv6 address configuration.
 type IPv6Config struct {
 	// READ-ONLY; The IPv6 gateway of the network adapter.
-	Gateway *string `json:"gateway,omitempty" azure:"ro"`
+	Gateway *string
 
 	// READ-ONLY; The IPv6 address of the network adapter.
-	IPAddress *string `json:"ipAddress,omitempty" azure:"ro"`
+	IPAddress *string
 
 	// READ-ONLY; The IPv6 prefix of the network adapter.
-	PrefixLength *int32 `json:"prefixLength,omitempty" azure:"ro"`
+	PrefixLength *int32
 }
 
 // ImageRepositoryCredential - Image repository credential.
 type ImageRepositoryCredential struct {
 	// REQUIRED; Image repository url (e.g.: mcr.microsoft.com).
-	ImageRepositoryURL *string `json:"imageRepositoryUrl,omitempty"`
+	ImageRepositoryURL *string
 
 	// REQUIRED; Repository user name.
-	UserName *string `json:"userName,omitempty"`
+	UserName *string
 
 	// Repository user password.
-	Password *AsymmetricEncryptedSecret `json:"password,omitempty"`
+	Password *AsymmetricEncryptedSecret
 }
 
 // IoTAddon - IoT Addon.
 type IoTAddon struct {
 	// REQUIRED; Addon type.
-	Kind *AddonType `json:"kind,omitempty"`
+	Kind *AddonType
 
 	// REQUIRED; Properties specific to IOT addon.
-	Properties *IoTAddonProperties `json:"properties,omitempty"`
+	Properties *IoTAddonProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Addon type
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetAddon implements the AddonClassification interface for type IoTAddon.
@@ -1040,71 +1040,71 @@ func (i *IoTAddon) GetAddon() *Addon {
 // IoTAddonProperties - IoT addon properties.
 type IoTAddonProperties struct {
 	// REQUIRED; IoT device metadata to which appliance needs to be connected.
-	IoTDeviceDetails *IoTDeviceInfo `json:"ioTDeviceDetails,omitempty"`
+	IoTDeviceDetails *IoTDeviceInfo
 
 	// REQUIRED; IoT edge device to which the IoT Addon needs to be configured.
-	IoTEdgeDeviceDetails *IoTDeviceInfo `json:"ioTEdgeDeviceDetails,omitempty"`
+	IoTEdgeDeviceDetails *IoTDeviceInfo
 
 	// READ-ONLY; Host OS supported by the IoT addon.
-	HostPlatform *PlatformType `json:"hostPlatform,omitempty" azure:"ro"`
+	HostPlatform *PlatformType
 
 	// READ-ONLY; Platform where the runtime is hosted.
-	HostPlatformType *HostPlatformType `json:"hostPlatformType,omitempty" azure:"ro"`
+	HostPlatformType *HostPlatformType
 
 	// READ-ONLY; Addon Provisioning State
-	ProvisioningState *AddonState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *AddonState
 
 	// READ-ONLY; Version of IoT running on the appliance.
-	Version *string `json:"version,omitempty" azure:"ro"`
+	Version *string
 }
 
 // IoTDeviceInfo - Metadata of IoT device/IoT Edge device to be configured.
 type IoTDeviceInfo struct {
 	// REQUIRED; ID of the IoT device/edge device.
-	DeviceID *string `json:"deviceId,omitempty"`
+	DeviceID *string
 
 	// REQUIRED; Host name for the IoT hub associated to the device.
-	IoTHostHub *string `json:"ioTHostHub,omitempty"`
+	IoTHostHub *string
 
 	// Encrypted IoT device/IoT edge device connection string.
-	Authentication *Authentication `json:"authentication,omitempty"`
+	Authentication *Authentication
 
 	// Id for the IoT hub associated to the device.
-	IoTHostHubID *string `json:"ioTHostHubId,omitempty"`
+	IoTHostHubID *string
 }
 
 // IoTEdgeAgentInfo - IoT edge agent details is optional, this will be used for download system Agent module while bootstrapping
 // IoT Role if specified.
 type IoTEdgeAgentInfo struct {
 	// REQUIRED; Name of the IoT edge agent image.
-	ImageName *string `json:"imageName,omitempty"`
+	ImageName *string
 
 	// REQUIRED; Image Tag.
-	Tag *string `json:"tag,omitempty"`
+	Tag *string
 
 	// Image repository details.
-	ImageRepository *ImageRepositoryCredential `json:"imageRepository,omitempty"`
+	ImageRepository *ImageRepositoryCredential
 }
 
 // IoTRole - Compute role.
 type IoTRole struct {
 	// REQUIRED; Role type.
-	Kind *RoleTypes `json:"kind,omitempty"`
+	Kind *RoleTypes
 
 	// Properties specific to IoT role.
-	Properties *IoTRoleProperties `json:"properties,omitempty"`
+	Properties *IoTRoleProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Role configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetRole implements the RoleClassification interface for type IoTRole.
@@ -1121,110 +1121,110 @@ func (i *IoTRole) GetRole() *Role {
 // IoTRoleProperties - IoT role properties.
 type IoTRoleProperties struct {
 	// REQUIRED; Host OS supported by the IoT role.
-	HostPlatform *PlatformType `json:"hostPlatform,omitempty"`
+	HostPlatform *PlatformType
 
 	// REQUIRED; IoT device metadata to which data box edge device needs to be connected.
-	IoTDeviceDetails *IoTDeviceInfo `json:"ioTDeviceDetails,omitempty"`
+	IoTDeviceDetails *IoTDeviceInfo
 
 	// REQUIRED; IoT edge device to which the IoT role needs to be configured.
-	IoTEdgeDeviceDetails *IoTDeviceInfo `json:"ioTEdgeDeviceDetails,omitempty"`
+	IoTEdgeDeviceDetails *IoTDeviceInfo
 
 	// REQUIRED; Role status.
-	RoleStatus *RoleStatus `json:"roleStatus,omitempty"`
+	RoleStatus *RoleStatus
 
 	// Resource allocation
-	ComputeResource *ComputeResource `json:"computeResource,omitempty"`
+	ComputeResource *ComputeResource
 
 	// Iot edge agent details to download the agent and bootstrap iot runtime.
-	IoTEdgeAgentInfo *IoTEdgeAgentInfo `json:"ioTEdgeAgentInfo,omitempty"`
+	IoTEdgeAgentInfo *IoTEdgeAgentInfo
 
 	// Mount points of shares in role(s).
-	ShareMappings []*MountPointMap `json:"shareMappings,omitempty"`
+	ShareMappings []*MountPointMap
 
 	// READ-ONLY; Platform where the Iot runtime is hosted.
-	HostPlatformType *HostPlatformType `json:"hostPlatformType,omitempty" azure:"ro"`
+	HostPlatformType *HostPlatformType
 }
 
 // Job - A device job.
 type Job struct {
 	// READ-ONLY; The UTC date and time at which the job completed.
-	EndTime *time.Time `json:"endTime,omitempty" azure:"ro"`
+	EndTime *time.Time
 
 	// READ-ONLY; The error details.
-	Error *JobErrorDetails `json:"error,omitempty" azure:"ro"`
+	Error *JobErrorDetails
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the object.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The percentage of the job that is complete.
-	PercentComplete *int32 `json:"percentComplete,omitempty" azure:"ro"`
+	PercentComplete *int32
 
 	// READ-ONLY; The properties of the job.
-	Properties *JobProperties `json:"properties,omitempty" azure:"ro"`
+	Properties *JobProperties
 
 	// READ-ONLY; The UTC date and time at which the job started.
-	StartTime *time.Time `json:"startTime,omitempty" azure:"ro"`
+	StartTime *time.Time
 
 	// READ-ONLY; The current status of the job.
-	Status *JobStatus `json:"status,omitempty" azure:"ro"`
+	Status *JobStatus
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // JobErrorDetails - The job error information containing the list of job errors.
 type JobErrorDetails struct {
 	// READ-ONLY; The code intended for programmatic access.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The error details.
-	ErrorDetails []*JobErrorItem `json:"errorDetails,omitempty" azure:"ro"`
+	ErrorDetails []*JobErrorItem
 
 	// READ-ONLY; The message that describes the error in detail.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 }
 
 // JobErrorItem - The job error items.
 type JobErrorItem struct {
 	// READ-ONLY; The code intended for programmatic access.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The message that describes the error in detail.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 
 	// READ-ONLY; The recommended actions.
-	Recommendations []*string `json:"recommendations,omitempty" azure:"ro"`
+	Recommendations []*string
 }
 
 // JobProperties - The properties for the job.
 type JobProperties struct {
 	// If only subfolders need to be refreshed, then the subfolder path inside the share or container. (The path is empty if there
 	// are no subfolders.)
-	Folder *string `json:"folder,omitempty"`
+	Folder *string
 
 	// READ-ONLY; Current stage of the update operation.
-	CurrentStage *UpdateOperationStage `json:"currentStage,omitempty" azure:"ro"`
+	CurrentStage *UpdateOperationStage
 
 	// READ-ONLY; The download progress.
-	DownloadProgress *UpdateDownloadProgress `json:"downloadProgress,omitempty" azure:"ro"`
+	DownloadProgress *UpdateDownloadProgress
 
 	// READ-ONLY; Local share/remote container relative path to the error manifest file of the refresh.
-	ErrorManifestFile *string `json:"errorManifestFile,omitempty" azure:"ro"`
+	ErrorManifestFile *string
 
 	// READ-ONLY; The install progress.
-	InstallProgress *UpdateInstallProgress `json:"installProgress,omitempty" azure:"ro"`
+	InstallProgress *UpdateInstallProgress
 
 	// READ-ONLY; The type of the job.
-	JobType *JobType `json:"jobType,omitempty" azure:"ro"`
+	JobType *JobType
 
 	// READ-ONLY; ARM ID of the entity that was refreshed.
-	RefreshedEntityID *string `json:"refreshedEntityId,omitempty" azure:"ro"`
+	RefreshedEntityID *string
 
 	// READ-ONLY; Total number of errors encountered during the refresh process.
-	TotalRefreshErrors *int32 `json:"totalRefreshErrors,omitempty" azure:"ro"`
+	TotalRefreshErrors *int32
 }
 
 // JobsClientGetOptions contains the optional parameters for the JobsClient.Get method.
@@ -1235,22 +1235,22 @@ type JobsClientGetOptions struct {
 // KubernetesClusterInfo - Kubernetes cluster configuration
 type KubernetesClusterInfo struct {
 	// REQUIRED; Kubernetes cluster version
-	Version *string `json:"version,omitempty"`
+	Version *string
 
 	// READ-ONLY; Etcd configuration
-	EtcdInfo *EtcdInfo `json:"etcdInfo,omitempty" azure:"ro"`
+	EtcdInfo *EtcdInfo
 
 	// READ-ONLY; Kubernetes cluster nodes
-	Nodes []*NodeInfo `json:"nodes,omitempty" azure:"ro"`
+	Nodes []*NodeInfo
 }
 
 // KubernetesIPConfiguration - Kubernetes node IP configuration
 type KubernetesIPConfiguration struct {
 	// IP address of the Kubernetes node.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 
 	// READ-ONLY; Port of the Kubernetes node.
-	Port *string `json:"port,omitempty" azure:"ro"`
+	Port *string
 }
 
 // KubernetesRole - The limited preview of Kubernetes Cluster Management from the Azure supports:
@@ -1267,22 +1267,22 @@ type KubernetesIPConfiguration struct {
 // https://azure.microsoft.com/en-us/support/legal/preview-supplemental-terms/
 type KubernetesRole struct {
 	// REQUIRED; Role type.
-	Kind *RoleTypes `json:"kind,omitempty"`
+	Kind *RoleTypes
 
 	// Properties specific to Kubernetes role.
-	Properties *KubernetesRoleProperties `json:"properties,omitempty"`
+	Properties *KubernetesRoleProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Role configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetRole implements the RoleClassification interface for type KubernetesRole.
@@ -1299,106 +1299,106 @@ func (k *KubernetesRole) GetRole() *Role {
 // KubernetesRoleCompute - Kubernetes role compute resource
 type KubernetesRoleCompute struct {
 	// REQUIRED; VM profile
-	VMProfile *string `json:"vmProfile,omitempty"`
+	VMProfile *string
 
 	// READ-ONLY; Memory in bytes
-	MemoryInBytes *int64 `json:"memoryInBytes,omitempty" azure:"ro"`
+	MemoryInBytes *int64
 
 	// READ-ONLY; Processor count
-	ProcessorCount *int32 `json:"processorCount,omitempty" azure:"ro"`
+	ProcessorCount *int32
 }
 
 // KubernetesRoleNetwork - Kubernetes role network resource
 type KubernetesRoleNetwork struct {
 	// READ-ONLY; Cni configuration
-	CniConfig *CniConfig `json:"cniConfig,omitempty" azure:"ro"`
+	CniConfig *CniConfig
 
 	// READ-ONLY; Load balancer configuration
-	LoadBalancerConfig *LoadBalancerConfig `json:"loadBalancerConfig,omitempty" azure:"ro"`
+	LoadBalancerConfig *LoadBalancerConfig
 }
 
 // KubernetesRoleProperties - Kubernetes role properties.
 type KubernetesRoleProperties struct {
 	// REQUIRED; Host OS supported by the Kubernetes role.
-	HostPlatform *PlatformType `json:"hostPlatform,omitempty"`
+	HostPlatform *PlatformType
 
 	// REQUIRED; Kubernetes cluster configuration
-	KubernetesClusterInfo *KubernetesClusterInfo `json:"kubernetesClusterInfo,omitempty"`
+	KubernetesClusterInfo *KubernetesClusterInfo
 
 	// REQUIRED; Kubernetes role resources
-	KubernetesRoleResources *KubernetesRoleResources `json:"kubernetesRoleResources,omitempty"`
+	KubernetesRoleResources *KubernetesRoleResources
 
 	// REQUIRED; Role status.
-	RoleStatus *RoleStatus `json:"roleStatus,omitempty"`
+	RoleStatus *RoleStatus
 
 	// READ-ONLY; Platform where the runtime is hosted.
-	HostPlatformType *HostPlatformType `json:"hostPlatformType,omitempty" azure:"ro"`
+	HostPlatformType *HostPlatformType
 
 	// READ-ONLY; State of Kubernetes deployment
-	ProvisioningState *KubernetesState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *KubernetesState
 }
 
 // KubernetesRoleResources - Kubernetes role resources
 type KubernetesRoleResources struct {
 	// REQUIRED; Kubernetes role compute resource
-	Compute *KubernetesRoleCompute `json:"compute,omitempty"`
+	Compute *KubernetesRoleCompute
 
 	// Kubernetes role storage resource
-	Storage *KubernetesRoleStorage `json:"storage,omitempty"`
+	Storage *KubernetesRoleStorage
 
 	// READ-ONLY; Kubernetes role network resource
-	Network *KubernetesRoleNetwork `json:"network,omitempty" azure:"ro"`
+	Network *KubernetesRoleNetwork
 }
 
 // KubernetesRoleStorage - Kubernetes role storage resource
 type KubernetesRoleStorage struct {
 	// Mount points of shares in role(s).
-	Endpoints []*MountPointMap `json:"endpoints,omitempty"`
+	Endpoints []*MountPointMap
 
 	// READ-ONLY; Kubernetes storage class info.
-	StorageClasses []*KubernetesRoleStorageClassInfo `json:"storageClasses,omitempty" azure:"ro"`
+	StorageClasses []*KubernetesRoleStorageClassInfo
 }
 
 // KubernetesRoleStorageClassInfo - Kubernetes storage class info.
 type KubernetesRoleStorageClassInfo struct {
 	// READ-ONLY; Storage class name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; If provisioned storage is posix compliant.
-	PosixCompliant *PosixComplianceStatus `json:"posixCompliant,omitempty" azure:"ro"`
+	PosixCompliant *PosixComplianceStatus
 
 	// READ-ONLY; Storage class type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LoadBalancerConfig - Load balancer configuration
 type LoadBalancerConfig struct {
 	// READ-ONLY; Load balancer type
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; Load balancer version
-	Version *string `json:"version,omitempty" azure:"ro"`
+	Version *string
 }
 
 // MECRole - MEC role.
 type MECRole struct {
 	// REQUIRED; Role type.
-	Kind *RoleTypes `json:"kind,omitempty"`
+	Kind *RoleTypes
 
 	// Properties specific to MEC role.
-	Properties *MECRoleProperties `json:"properties,omitempty"`
+	Properties *MECRoleProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Role configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetRole implements the RoleClassification interface for type MECRole.
@@ -1415,109 +1415,109 @@ func (m *MECRole) GetRole() *Role {
 // MECRoleProperties - MEC role properties.
 type MECRoleProperties struct {
 	// REQUIRED; Role status.
-	RoleStatus *RoleStatus `json:"roleStatus,omitempty"`
+	RoleStatus *RoleStatus
 
 	// Activation key of the MEC.
-	ConnectionString *AsymmetricEncryptedSecret `json:"connectionString,omitempty"`
+	ConnectionString *AsymmetricEncryptedSecret
 
 	// Controller Endpoint.
-	ControllerEndpoint *string `json:"controllerEndpoint,omitempty"`
+	ControllerEndpoint *string
 
 	// Unique Id of the Resource.
-	ResourceUniqueID *string `json:"resourceUniqueId,omitempty"`
+	ResourceUniqueID *string
 }
 
 // MetricConfiguration - Metric configuration.
 type MetricConfiguration struct {
 	// REQUIRED; Host name for the IoT hub associated to the device.
-	CounterSets []*MetricCounterSet `json:"counterSets,omitempty"`
+	CounterSets []*MetricCounterSet
 
 	// REQUIRED; The Resource ID on which the metrics should be pushed.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 
 	// The MDM account to which the counters should be pushed.
-	MdmAccount *string `json:"mdmAccount,omitempty"`
+	MdmAccount *string
 
 	// The MDM namespace to which the counters should be pushed. This is required if MDMAccount is specified
-	MetricNameSpace *string `json:"metricNameSpace,omitempty"`
+	MetricNameSpace *string
 }
 
 // MetricCounter - The metric counter
 type MetricCounter struct {
 	// REQUIRED; The counter name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The additional dimensions to be added to metric.
-	AdditionalDimensions []*MetricDimension `json:"additionalDimensions,omitempty"`
+	AdditionalDimensions []*MetricDimension
 
 	// The dimension filter.
-	DimensionFilter []*MetricDimension `json:"dimensionFilter,omitempty"`
+	DimensionFilter []*MetricDimension
 
 	// The instance from which counter should be collected.
-	Instance *string `json:"instance,omitempty"`
+	Instance *string
 }
 
 // MetricCounterSet - The metric counter set
 type MetricCounterSet struct {
 	// REQUIRED; The counters that should be collected in this set.
-	Counters []*MetricCounter `json:"counters,omitempty"`
+	Counters []*MetricCounter
 }
 
 // MetricDimension - The metric dimension
 type MetricDimension struct {
 	// REQUIRED; The dimension value.
-	SourceName *string `json:"sourceName,omitempty"`
+	SourceName *string
 
 	// REQUIRED; The dimension type.
-	SourceType *string `json:"sourceType,omitempty"`
+	SourceType *string
 }
 
 // MetricDimensionV1 - Metric Dimension v1.
 type MetricDimensionV1 struct {
 	// Display name of the metrics dimension.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// Name of the metrics dimension.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// To be exported to shoe box.
-	ToBeExportedForShoebox *bool `json:"toBeExportedForShoebox,omitempty"`
+	ToBeExportedForShoebox *bool
 }
 
 // MetricSpecificationV1 - Metric specification version 1.
 type MetricSpecificationV1 struct {
 	// Metric aggregation type.
-	AggregationType *MetricAggregationType `json:"aggregationType,omitempty"`
+	AggregationType *MetricAggregationType
 
 	// Metric category.
-	Category *MetricCategory `json:"category,omitempty"`
+	Category *MetricCategory
 
 	// Metric dimensions, other than default dimension which is resource.
-	Dimensions []*MetricDimensionV1 `json:"dimensions,omitempty"`
+	Dimensions []*MetricDimensionV1
 
 	// Description of the metric to be displayed.
-	DisplayDescription *string `json:"displayDescription,omitempty"`
+	DisplayDescription *string
 
 	// Display name of the metric.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// Set true to fill the gaps with zero.
-	FillGapWithZero *bool `json:"fillGapWithZero,omitempty"`
+	FillGapWithZero *bool
 
 	// Name of the metric.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource name override.
-	ResourceIDDimensionNameOverride *string `json:"resourceIdDimensionNameOverride,omitempty"`
+	ResourceIDDimensionNameOverride *string
 
 	// Support metric aggregation type.
-	SupportedAggregationTypes []*MetricAggregationType `json:"supportedAggregationTypes,omitempty"`
+	SupportedAggregationTypes []*MetricAggregationType
 
 	// Support granularity of metrics.
-	SupportedTimeGrainTypes []*TimeGrain `json:"supportedTimeGrainTypes,omitempty"`
+	SupportedTimeGrainTypes []*TimeGrain
 
 	// Metric units.
-	Unit *MetricUnit `json:"unit,omitempty"`
+	Unit *MetricUnit
 }
 
 // MonitoringConfigClientBeginCreateOrUpdateOptions contains the optional parameters for the MonitoringConfigClient.BeginCreateOrUpdate
@@ -1546,133 +1546,133 @@ type MonitoringConfigClientListOptions struct {
 // MonitoringMetricConfiguration - The metric setting details for the role
 type MonitoringMetricConfiguration struct {
 	// REQUIRED; The metric setting properties.
-	Properties *MonitoringMetricConfigurationProperties `json:"properties,omitempty"`
+	Properties *MonitoringMetricConfigurationProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; MonitoringConfiguration on ASE device
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // MonitoringMetricConfigurationList - Collection of metric configurations.
 type MonitoringMetricConfigurationList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of metric configurations.
-	Value []*MonitoringMetricConfiguration `json:"value,omitempty" azure:"ro"`
+	Value []*MonitoringMetricConfiguration
 }
 
 // MonitoringMetricConfigurationProperties - Metrics properties
 type MonitoringMetricConfigurationProperties struct {
 	// REQUIRED; The metrics configuration details
-	MetricConfigurations []*MetricConfiguration `json:"metricConfigurations,omitempty"`
+	MetricConfigurations []*MetricConfiguration
 }
 
 // MountPointMap - The share mount point.
 type MountPointMap struct {
 	// REQUIRED; ID of the share mounted to the role VM.
-	ShareID *string `json:"shareId,omitempty"`
+	ShareID *string
 
 	// READ-ONLY; Mount point for the share.
-	MountPoint *string `json:"mountPoint,omitempty" azure:"ro"`
+	MountPoint *string
 
 	// READ-ONLY; Mounting type.
-	MountType *MountType `json:"mountType,omitempty" azure:"ro"`
+	MountType *MountType
 
 	// READ-ONLY; ID of the role to which share is mounted.
-	RoleID *string `json:"roleId,omitempty" azure:"ro"`
+	RoleID *string
 
 	// READ-ONLY; Role type.
-	RoleType *RoleTypes `json:"roleType,omitempty" azure:"ro"`
+	RoleType *RoleTypes
 }
 
 // NetworkAdapter - Represents the networkAdapter on a device.
 type NetworkAdapter struct {
 	// Value indicating whether this adapter has DHCP enabled.
-	DhcpStatus *NetworkAdapterDHCPStatus `json:"dhcpStatus,omitempty"`
+	DhcpStatus *NetworkAdapterDHCPStatus
 
 	// Value indicating whether this adapter is RDMA capable.
-	RdmaStatus *NetworkAdapterRDMAStatus `json:"rdmaStatus,omitempty"`
+	RdmaStatus *NetworkAdapterRDMAStatus
 
 	// READ-ONLY; Instance ID of network adapter.
-	AdapterID *string `json:"adapterId,omitempty" azure:"ro"`
+	AdapterID *string
 
 	// READ-ONLY; Hardware position of network adapter.
-	AdapterPosition *NetworkAdapterPosition `json:"adapterPosition,omitempty" azure:"ro"`
+	AdapterPosition *NetworkAdapterPosition
 
 	// READ-ONLY; The list of DNS Servers of the device.
-	DNSServers []*string `json:"dnsServers,omitempty" azure:"ro"`
+	DNSServers []*string
 
 	// READ-ONLY; The IPv4 configuration of the network adapter.
-	IPv4Configuration *IPv4Config `json:"ipv4Configuration,omitempty" azure:"ro"`
+	IPv4Configuration *IPv4Config
 
 	// READ-ONLY; The IPv6 configuration of the network adapter.
-	IPv6Configuration *IPv6Config `json:"ipv6Configuration,omitempty" azure:"ro"`
+	IPv6Configuration *IPv6Config
 
 	// READ-ONLY; The IPv6 local address.
-	IPv6LinkLocalAddress *string `json:"ipv6LinkLocalAddress,omitempty" azure:"ro"`
+	IPv6LinkLocalAddress *string
 
 	// READ-ONLY; Logical index of the adapter.
-	Index *int32 `json:"index,omitempty" azure:"ro"`
+	Index *int32
 
 	// READ-ONLY; Hardware label for the adapter.
-	Label *string `json:"label,omitempty" azure:"ro"`
+	Label *string
 
 	// READ-ONLY; Link speed.
-	LinkSpeed *int64 `json:"linkSpeed,omitempty" azure:"ro"`
+	LinkSpeed *int64
 
 	// READ-ONLY; MAC address.
-	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
+	MacAddress *string
 
 	// READ-ONLY; Network adapter name.
-	NetworkAdapterName *string `json:"networkAdapterName,omitempty" azure:"ro"`
+	NetworkAdapterName *string
 
 	// READ-ONLY; Node ID of the network adapter.
-	NodeID *string `json:"nodeId,omitempty" azure:"ro"`
+	NodeID *string
 
 	// READ-ONLY; Value indicating whether this adapter is valid.
-	Status *NetworkAdapterStatus `json:"status,omitempty" azure:"ro"`
+	Status *NetworkAdapterStatus
 }
 
 // NetworkAdapterPosition - The network adapter position.
 type NetworkAdapterPosition struct {
 	// READ-ONLY; The network group.
-	NetworkGroup *NetworkGroup `json:"networkGroup,omitempty" azure:"ro"`
+	NetworkGroup *NetworkGroup
 
 	// READ-ONLY; The port.
-	Port *int32 `json:"port,omitempty" azure:"ro"`
+	Port *int32
 }
 
 // NetworkSettings - The network settings of a device.
 type NetworkSettings struct {
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The properties of network settings of a device.
-	Properties *NetworkSettingsProperties `json:"properties,omitempty" azure:"ro"`
+	Properties *NetworkSettingsProperties
 
 	// READ-ONLY; NetworkSettings on ASE device
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // NetworkSettingsProperties - The properties of network settings.
 type NetworkSettingsProperties struct {
 	// READ-ONLY; The network adapter list on the device.
-	NetworkAdapters []*NetworkAdapter `json:"networkAdapters,omitempty" azure:"ro"`
+	NetworkAdapters []*NetworkAdapter
 }
 
 // Node - Represents a single node in a Data box Edge/Gateway device Gateway devices, standalone Edge devices and a single
@@ -1680,61 +1680,61 @@ type NetworkSettingsProperties struct {
 // than 1 nodes
 type Node struct {
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The properties of the node
-	Properties *NodeProperties `json:"properties,omitempty" azure:"ro"`
+	Properties *NodeProperties
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // NodeInfo - Kubernetes node info
 type NodeInfo struct {
 	// IP Configuration of the Kubernetes node.
-	IPConfiguration []*KubernetesIPConfiguration `json:"ipConfiguration,omitempty"`
+	IPConfiguration []*KubernetesIPConfiguration
 
 	// READ-ONLY; Node name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Node type - Master/Worker
-	Type *KubernetesNodeType `json:"type,omitempty" azure:"ro"`
+	Type *KubernetesNodeType
 }
 
 // NodeList - Collection of Nodes.
 type NodeList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of Nodes.
-	Value []*Node `json:"value,omitempty" azure:"ro"`
+	Value []*Node
 }
 
 // NodeProperties - This class represents the nodes in a highly available cluster
 type NodeProperties struct {
 	// READ-ONLY; Serial number of the Chassis
-	NodeChassisSerialNumber *string `json:"nodeChassisSerialNumber,omitempty" azure:"ro"`
+	NodeChassisSerialNumber *string
 
 	// READ-ONLY; Display Name of the individual node
-	NodeDisplayName *string `json:"nodeDisplayName,omitempty" azure:"ro"`
+	NodeDisplayName *string
 
 	// READ-ONLY; Friendly software version name that is currently installed on the node
-	NodeFriendlySoftwareVersion *string `json:"nodeFriendlySoftwareVersion,omitempty" azure:"ro"`
+	NodeFriendlySoftwareVersion *string
 
 	// READ-ONLY; HCS version that is currently installed on the node
-	NodeHcsVersion *string `json:"nodeHcsVersion,omitempty" azure:"ro"`
+	NodeHcsVersion *string
 
 	// READ-ONLY; Guid instance id of the node
-	NodeInstanceID *string `json:"nodeInstanceId,omitempty" azure:"ro"`
+	NodeInstanceID *string
 
 	// READ-ONLY; Serial number of the individual node
-	NodeSerialNumber *string `json:"nodeSerialNumber,omitempty" azure:"ro"`
+	NodeSerialNumber *string
 
 	// READ-ONLY; The current status of the individual node
-	NodeStatus *NodeStatus `json:"nodeStatus,omitempty" azure:"ro"`
+	NodeStatus *NodeStatus
 }
 
 // NodesClientListByDataBoxEdgeDeviceOptions contains the optional parameters for the NodesClient.NewListByDataBoxEdgeDevicePager
@@ -1746,40 +1746,40 @@ type NodesClientListByDataBoxEdgeDeviceOptions struct {
 // Operations.
 type Operation struct {
 	// Properties displayed for the operation.
-	Display *OperationDisplay `json:"display,omitempty"`
+	Display *OperationDisplay
 
 	// Is data action.
-	IsDataAction *bool `json:"isDataAction,omitempty"`
+	IsDataAction *bool
 
 	// Name of the operation.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Origin of the operation.
-	Origin *string `json:"origin,omitempty"`
+	Origin *string
 
 	// Operation properties.
-	Properties *OperationProperties `json:"properties,omitempty"`
+	Properties *OperationProperties
 }
 
 // OperationDisplay - Operation display properties.
 type OperationDisplay struct {
 	// Description of the operation to be performed.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Operation to be performed on the resource.
-	Operation *string `json:"operation,omitempty"`
+	Operation *string
 
 	// Provider name.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 
 	// The type of resource in which the operation is performed.
-	Resource *string `json:"resource,omitempty"`
+	Resource *string
 }
 
 // OperationProperties - Operation properties.
 type OperationProperties struct {
 	// Service specification.
-	ServiceSpecification *ServiceSpecification `json:"serviceSpecification,omitempty"`
+	ServiceSpecification *ServiceSpecification
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
@@ -1790,10 +1790,10 @@ type OperationsClientListOptions struct {
 // OperationsList - The list of operations used for the discovery of available provider operations.
 type OperationsList struct {
 	// REQUIRED; The value.
-	Value []*Operation `json:"value,omitempty"`
+	Value []*Operation
 
 	// Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // OperationsStatusClientGetOptions contains the optional parameters for the OperationsStatusClient.Get method.
@@ -1804,74 +1804,74 @@ type OperationsStatusClientGetOptions struct {
 // Order - The order details.
 type Order struct {
 	// The order properties.
-	Properties *OrderProperties `json:"properties,omitempty"`
+	Properties *OrderProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Order configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // OrderList - List of order entities.
 type OrderList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of orders.
-	Value []*Order `json:"value,omitempty" azure:"ro"`
+	Value []*Order
 }
 
 // OrderProperties - Order properties.
 type OrderProperties struct {
 	// REQUIRED; The contact details.
-	ContactInformation *ContactDetails `json:"contactInformation,omitempty"`
+	ContactInformation *ContactDetails
 
 	// ShipmentType of the order
-	ShipmentType *ShipmentType `json:"shipmentType,omitempty"`
+	ShipmentType *ShipmentType
 
 	// The shipping address.
-	ShippingAddress *Address `json:"shippingAddress,omitempty"`
+	ShippingAddress *Address
 
 	// READ-ONLY; Current status of the order.
-	CurrentStatus *OrderStatus `json:"currentStatus,omitempty" azure:"ro"`
+	CurrentStatus *OrderStatus
 
 	// READ-ONLY; Tracking information for the package delivered to the customer whether it has an original or a replacement device.
-	DeliveryTrackingInfo []*TrackingInfo `json:"deliveryTrackingInfo,omitempty" azure:"ro"`
+	DeliveryTrackingInfo []*TrackingInfo
 
 	// READ-ONLY; List of status changes in the order.
-	OrderHistory []*OrderStatus `json:"orderHistory,omitempty" azure:"ro"`
+	OrderHistory []*OrderStatus
 
 	// READ-ONLY; Tracking information for the package returned from the customer whether it has an original or a replacement
 	// device.
-	ReturnTrackingInfo []*TrackingInfo `json:"returnTrackingInfo,omitempty" azure:"ro"`
+	ReturnTrackingInfo []*TrackingInfo
 
 	// READ-ONLY; Serial number of the device.
-	SerialNumber *string `json:"serialNumber,omitempty" azure:"ro"`
+	SerialNumber *string
 }
 
 // OrderStatus - Represents a single status change.
 type OrderStatus struct {
 	// REQUIRED; Status of the order as per the allowed status types.
-	Status *OrderState `json:"status,omitempty"`
+	Status *OrderState
 
 	// Comments related to this status change.
-	Comments *string `json:"comments,omitempty"`
+	Comments *string
 
 	// READ-ONLY; Dictionary to hold generic information which is not stored by the already existing properties
-	AdditionalOrderDetails map[string]*string `json:"additionalOrderDetails,omitempty" azure:"ro"`
+	AdditionalOrderDetails map[string]*string
 
 	// READ-ONLY; Tracking information related to the state in the ordering flow
-	TrackingInformation *TrackingInfo `json:"trackingInformation,omitempty" azure:"ro"`
+	TrackingInformation *TrackingInfo
 
 	// READ-ONLY; Time of status update.
-	UpdateDateTime *time.Time `json:"updateDateTime,omitempty" azure:"ro"`
+	UpdateDateTime *time.Time
 }
 
 // OrdersClientBeginCreateOrUpdateOptions contains the optional parameters for the OrdersClient.BeginCreateOrUpdate method.
@@ -1905,22 +1905,22 @@ type OrdersClientListDCAccessCodeOptions struct {
 // PeriodicTimerEventTrigger - Trigger details.
 type PeriodicTimerEventTrigger struct {
 	// REQUIRED; Trigger Kind.
-	Kind *TriggerEventType `json:"kind,omitempty"`
+	Kind *TriggerEventType
 
 	// REQUIRED; Periodic timer trigger properties.
-	Properties *PeriodicTimerProperties `json:"properties,omitempty"`
+	Properties *PeriodicTimerProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Trigger in DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetTrigger implements the TriggerClassification interface for type PeriodicTimerEventTrigger.
@@ -1937,96 +1937,96 @@ func (p *PeriodicTimerEventTrigger) GetTrigger() *Trigger {
 // PeriodicTimerProperties - Periodic timer trigger properties.
 type PeriodicTimerProperties struct {
 	// REQUIRED; Role Sink information.
-	SinkInfo *RoleSinkInfo `json:"sinkInfo,omitempty"`
+	SinkInfo *RoleSinkInfo
 
 	// REQUIRED; Periodic timer details.
-	SourceInfo *PeriodicTimerSourceInfo `json:"sourceInfo,omitempty"`
+	SourceInfo *PeriodicTimerSourceInfo
 
 	// A custom context tag typically used to correlate the trigger against its usage. For example, if a periodic timer trigger
 	// is intended for certain specific IoT modules in the device, the tag can be the
 	// name or the image URL of the module.
-	CustomContextTag *string `json:"customContextTag,omitempty"`
+	CustomContextTag *string
 }
 
 // PeriodicTimerSourceInfo - Periodic timer event source.
 type PeriodicTimerSourceInfo struct {
 	// REQUIRED; Periodic frequency at which timer event needs to be raised. Supports daily, hourly, minutes, and seconds.
-	Schedule *string `json:"schedule,omitempty"`
+	Schedule *string
 
 	// REQUIRED; The time of the day that results in a valid trigger. Schedule is computed with reference to the time specified
 	// upto seconds. If timezone is not specified the time will considered to be in device
 	// timezone. The value will always be returned as UTC time.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Topic where periodic events are published to IoT device.
-	Topic *string `json:"topic,omitempty"`
+	Topic *string
 }
 
 // ProactiveLogCollectionSettingsProperties - The properties of proactive log collection settings.
 type ProactiveLogCollectionSettingsProperties struct {
 	// REQUIRED; Proactive diagnostic collection consent flag
-	UserConsent *ProactiveDiagnosticsConsent `json:"userConsent,omitempty"`
+	UserConsent *ProactiveDiagnosticsConsent
 }
 
 // RawCertificateData - Raw Certificate Data.
 type RawCertificateData struct {
 	// REQUIRED; The base64 encoded certificate raw data.
-	Certificate *string `json:"certificate,omitempty"`
+	Certificate *string
 
 	// The authentication type.
-	AuthenticationType *AuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *AuthenticationType
 }
 
 // RefreshDetails - Fields for tracking refresh job on the share or container.
 type RefreshDetails struct {
 	// Indicates the relative path of the error xml for the last refresh job on this particular share or container, if any. This
 	// could be a failed job or a successful job.
-	ErrorManifestFile *string `json:"errorManifestFile,omitempty"`
+	ErrorManifestFile *string
 
 	// If a refresh job is currently in progress on this share or container, this field indicates the ARM resource ID of that
 	// job. The field is empty if no job is in progress.
-	InProgressRefreshJobID *string `json:"inProgressRefreshJobId,omitempty"`
+	InProgressRefreshJobID *string
 
 	// Indicates the completed time for the last refresh job on this particular share or container, if any.This could be a failed
 	// job or a successful job.
-	LastCompletedRefreshJobTimeInUTC *time.Time `json:"lastCompletedRefreshJobTimeInUTC,omitempty"`
+	LastCompletedRefreshJobTimeInUTC *time.Time
 
 	// Indicates the id of the last refresh job on this particular share or container,if any. This could be a failed job or a
 	// successful job.
-	LastJob *string `json:"lastJob,omitempty"`
+	LastJob *string
 }
 
 // RemoteSupportSettings - RemoteApplicationType for which remote support settings is being modified
 type RemoteSupportSettings struct {
 	// Access level allowed for this remote application type
-	AccessLevel *AccessLevel `json:"accessLevel,omitempty"`
+	AccessLevel *AccessLevel
 
 	// Expiration time stamp
-	ExpirationTimeStampInUTC *time.Time `json:"expirationTimeStampInUTC,omitempty"`
+	ExpirationTimeStampInUTC *time.Time
 
 	// Remote application type
-	RemoteApplicationType *RemoteApplicationType `json:"remoteApplicationType,omitempty"`
+	RemoteApplicationType *RemoteApplicationType
 }
 
 // ResourceIdentity - Msi identity details of the resource
 type ResourceIdentity struct {
 	// Identity type
-	Type *MsiIdentityType `json:"type,omitempty"`
+	Type *MsiIdentityType
 
 	// READ-ONLY; Service Principal Id backing the Msi
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; Home Tenant Id
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 // ResourceMoveDetails - Fields for tracking resource move
 type ResourceMoveDetails struct {
 	// Denotes whether move operation is in progress
-	OperationInProgress *ResourceMoveStatus `json:"operationInProgress,omitempty"`
+	OperationInProgress *ResourceMoveStatus
 
 	// Denotes the timeout of the operation to finish
-	OperationInProgressLockTimeoutInUTC *time.Time `json:"operationInProgressLockTimeoutInUTC,omitempty"`
+	OperationInProgressLockTimeoutInUTC *time.Time
 }
 
 // RoleClassification provides polymorphic access to related types.
@@ -2041,19 +2041,19 @@ type RoleClassification interface {
 // Role - Compute role.
 type Role struct {
 	// REQUIRED; Role type.
-	Kind *RoleTypes `json:"kind,omitempty"`
+	Kind *RoleTypes
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Role configured on ASE resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetRole implements the RoleClassification interface for type Role.
@@ -2062,16 +2062,16 @@ func (r *Role) GetRole() *Role { return r }
 // RoleList - Collection of all the roles on the Data Box Edge device.
 type RoleList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The Value.
-	Value []RoleClassification `json:"value,omitempty" azure:"ro"`
+	Value []RoleClassification
 }
 
 // RoleSinkInfo - Compute role against which events will be raised.
 type RoleSinkInfo struct {
 	// REQUIRED; Compute role ID.
-	RoleID *string `json:"roleId,omitempty"`
+	RoleID *string
 }
 
 // RolesClientBeginCreateOrUpdateOptions contains the optional parameters for the RolesClient.BeginCreateOrUpdate method.
@@ -2100,124 +2100,124 @@ type RolesClientListByDataBoxEdgeDeviceOptions struct {
 // SKU - The Sku information.
 type SKU struct {
 	// READ-ONLY; The API versions in which Sku is available.
-	APIVersions []*string `json:"apiVersions,omitempty" azure:"ro"`
+	APIVersions []*string
 
 	// READ-ONLY; Links to the next set of results
-	Availability *SKUAvailability `json:"availability,omitempty" azure:"ro"`
+	Availability *SKUAvailability
 
 	// READ-ONLY; The capability info of the SKU.
-	Capabilities []*SKUCapability `json:"capabilities,omitempty" azure:"ro"`
+	Capabilities []*SKUCapability
 
 	// READ-ONLY; The pricing info of the Sku.
-	Costs []*SKUCost `json:"costs,omitempty" azure:"ro"`
+	Costs []*SKUCost
 
 	// READ-ONLY; The Sku family.
-	Family *string `json:"family,omitempty" azure:"ro"`
+	Family *string
 
 	// READ-ONLY; The Sku kind.
-	Kind *string `json:"kind,omitempty" azure:"ro"`
+	Kind *string
 
 	// READ-ONLY; Availability of the Sku for the location/zone/site.
-	LocationInfo []*SKULocationInfo `json:"locationInfo,omitempty" azure:"ro"`
+	LocationInfo []*SKULocationInfo
 
 	// READ-ONLY; Availability of the Sku for the region.
-	Locations []*string `json:"locations,omitempty" azure:"ro"`
+	Locations []*string
 
 	// READ-ONLY; The Sku name.
-	Name *SKUName `json:"name,omitempty" azure:"ro"`
+	Name *SKUName
 
 	// READ-ONLY; The type of the resource.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; List of Shipment Types supported by this SKU
-	ShipmentTypes []*ShipmentType `json:"shipmentTypes,omitempty" azure:"ro"`
+	ShipmentTypes []*ShipmentType
 
 	// READ-ONLY; Sku can be signed up by customer or not.
-	SignupOption *SKUSignupOption `json:"signupOption,omitempty" azure:"ro"`
+	SignupOption *SKUSignupOption
 
 	// READ-ONLY; The Sku kind.
-	Size *string `json:"size,omitempty" azure:"ro"`
+	Size *string
 
 	// READ-ONLY; The Sku tier.
-	Tier *SKUTier `json:"tier,omitempty" azure:"ro"`
+	Tier *SKUTier
 
 	// READ-ONLY; Availability of the Sku as preview/stable.
-	Version *SKUVersion `json:"version,omitempty" azure:"ro"`
+	Version *SKUVersion
 }
 
 // SKUCapability - The metadata to describe the capability.
 type SKUCapability struct {
 	// READ-ONLY; An invariant to describe the feature.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; An invariant if the feature is measured by quantity.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // SKUCost - The metadata for retrieving price info.
 type SKUCost struct {
 	// READ-ONLY; The extended unit.
-	ExtendedUnit *string `json:"extendedUnit,omitempty" azure:"ro"`
+	ExtendedUnit *string
 
 	// READ-ONLY; Used for querying price from commerce.
-	MeterID *string `json:"meterId,omitempty" azure:"ro"`
+	MeterID *string
 
 	// READ-ONLY; The cost quantity.
-	Quantity *int64 `json:"quantity,omitempty" azure:"ro"`
+	Quantity *int64
 }
 
 // SKUList - List of SKU Information objects.
 type SKUList struct {
 	// READ-ONLY; Links to the next set of results
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; List of ResourceType Sku
-	Value []*SKU `json:"value,omitempty" azure:"ro"`
+	Value []*SKU
 }
 
 // SKULocationInfo - The location info.
 type SKULocationInfo struct {
 	// READ-ONLY; The location.
-	Location *string `json:"location,omitempty" azure:"ro"`
+	Location *string
 
 	// READ-ONLY; The sites.
-	Sites []*string `json:"sites,omitempty" azure:"ro"`
+	Sites []*string
 
 	// READ-ONLY; The zones.
-	Zones []*string `json:"zones,omitempty" azure:"ro"`
+	Zones []*string
 }
 
 // SKUType - The SKU type.
 type SKUType struct {
 	// SKU name.
-	Name *SKUName `json:"name,omitempty"`
+	Name *SKUName
 
 	// The SKU tier. This is based on the SKU name.
-	Tier *SKUTier `json:"tier,omitempty"`
+	Tier *SKUTier
 }
 
 // Secret - Holds device secret either as a KeyVault reference or as an encrypted value.
 type Secret struct {
 	// Encrypted (using device public key) secret value.
-	EncryptedSecret *AsymmetricEncryptedSecret `json:"encryptedSecret,omitempty"`
+	EncryptedSecret *AsymmetricEncryptedSecret
 
 	// Id of the Key-Vault where secret is stored (ex: secrets/AuthClientSecret/82ef4346187a4033a10d629cde07d740).
-	KeyVaultID *string `json:"keyVaultId,omitempty"`
+	KeyVaultID *string
 }
 
 // SecuritySettings - The security settings of a device.
 type SecuritySettings struct {
 	// REQUIRED; Properties of the security settings.
-	Properties *SecuritySettingsProperties `json:"properties,omitempty"`
+	Properties *SecuritySettingsProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SecuritySettingsProperties - The properties of security settings.
@@ -2225,82 +2225,82 @@ type SecuritySettingsProperties struct {
 	// REQUIRED; Device administrator password as an encrypted string (encrypted using RSA PKCS #1) is used to sign into the local
 	// web UI of the device. The Actual password should have at least 8 characters that are a
 	// combination of uppercase, lowercase, numeric, and special characters.
-	DeviceAdminPassword *AsymmetricEncryptedSecret `json:"deviceAdminPassword,omitempty"`
+	DeviceAdminPassword *AsymmetricEncryptedSecret
 }
 
 // ServiceSpecification - Service specification.
 type ServiceSpecification struct {
 	// Metric specification as defined by shoebox.
-	MetricSpecifications []*MetricSpecificationV1 `json:"metricSpecifications,omitempty"`
+	MetricSpecifications []*MetricSpecificationV1
 }
 
 // Share - Represents a share on the Data Box Edge/Gateway device.
 type Share struct {
 	// REQUIRED; The share properties.
-	Properties *ShareProperties `json:"properties,omitempty"`
+	Properties *ShareProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Share on ASE device
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ShareAccessRight - Specifies the mapping between this particular user and the type of access he has on shares on this device.
 type ShareAccessRight struct {
 	// REQUIRED; Type of access to be allowed on the share for this user.
-	AccessType *ShareAccessType `json:"accessType,omitempty"`
+	AccessType *ShareAccessType
 
 	// REQUIRED; The share ID.
-	ShareID *string `json:"shareId,omitempty"`
+	ShareID *string
 }
 
 // ShareList - Collection of all the shares on the Data Box Edge/Gateway device.
 type ShareList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of shares.
-	Value []*Share `json:"value,omitempty" azure:"ro"`
+	Value []*Share
 }
 
 // ShareProperties - The share properties.
 type ShareProperties struct {
 	// REQUIRED; Access protocol to be used by the share.
-	AccessProtocol *ShareAccessProtocol `json:"accessProtocol,omitempty"`
+	AccessProtocol *ShareAccessProtocol
 
 	// REQUIRED; Current monitoring status of the share.
-	MonitoringStatus *MonitoringStatus `json:"monitoringStatus,omitempty"`
+	MonitoringStatus *MonitoringStatus
 
 	// REQUIRED; Current status of the share.
-	ShareStatus *ShareStatus `json:"shareStatus,omitempty"`
+	ShareStatus *ShareStatus
 
 	// Azure container mapping for the share.
-	AzureContainerInfo *AzureContainerInfo `json:"azureContainerInfo,omitempty"`
+	AzureContainerInfo *AzureContainerInfo
 
 	// List of IP addresses and corresponding access rights on the share(required for NFS protocol).
-	ClientAccessRights []*ClientAccessRight `json:"clientAccessRights,omitempty"`
+	ClientAccessRights []*ClientAccessRight
 
 	// Data policy of the share.
-	DataPolicy *DataPolicy `json:"dataPolicy,omitempty"`
+	DataPolicy *DataPolicy
 
 	// Description for the share.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Details of the refresh job on this share.
-	RefreshDetails *RefreshDetails `json:"refreshDetails,omitempty"`
+	RefreshDetails *RefreshDetails
 
 	// Mapping of users and corresponding access rights on the share (required for SMB protocol).
-	UserAccessRights []*UserAccessRight `json:"userAccessRights,omitempty"`
+	UserAccessRights []*UserAccessRight
 
 	// READ-ONLY; Share mount point to the role.
-	ShareMappings []*MountPointMap `json:"shareMappings,omitempty" azure:"ro"`
+	ShareMappings []*MountPointMap
 }
 
 // SharesClientBeginCreateOrUpdateOptions contains the optional parameters for the SharesClient.BeginCreateOrUpdate method.
@@ -2335,73 +2335,73 @@ type SharesClientListByDataBoxEdgeDeviceOptions struct {
 // StorageAccount - Represents a Storage Account on the Data Box Edge/Gateway device.
 type StorageAccount struct {
 	// REQUIRED; The Storage Account properties.
-	Properties *StorageAccountProperties `json:"properties,omitempty"`
+	Properties *StorageAccountProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; StorageAccount object on ASE device
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // StorageAccountCredential - The storage account credential.
 type StorageAccountCredential struct {
 	// REQUIRED; The storage account credential properties.
-	Properties *StorageAccountCredentialProperties `json:"properties,omitempty"`
+	Properties *StorageAccountCredentialProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; StorageAccountCredential object
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // StorageAccountCredentialList - The collection of storage account credentials.
 type StorageAccountCredentialList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The value.
-	Value []*StorageAccountCredential `json:"value,omitempty" azure:"ro"`
+	Value []*StorageAccountCredential
 }
 
 // StorageAccountCredentialProperties - The storage account credential properties.
 type StorageAccountCredentialProperties struct {
 	// REQUIRED; Type of storage accessed on the storage account.
-	AccountType *AccountType `json:"accountType,omitempty"`
+	AccountType *AccountType
 
 	// REQUIRED; Alias for the storage account.
-	Alias *string `json:"alias,omitempty"`
+	Alias *string
 
 	// REQUIRED; Signifies whether SSL needs to be enabled or not.
-	SSLStatus *SSLStatus `json:"sslStatus,omitempty"`
+	SSLStatus *SSLStatus
 
 	// Encrypted storage key.
-	AccountKey *AsymmetricEncryptedSecret `json:"accountKey,omitempty"`
+	AccountKey *AsymmetricEncryptedSecret
 
 	// Blob end point for private clouds.
-	BlobDomainName *string `json:"blobDomainName,omitempty"`
+	BlobDomainName *string
 
 	// Connection string for the storage account. Use this string if username and account key are not specified.
-	ConnectionString *string `json:"connectionString,omitempty"`
+	ConnectionString *string
 
 	// Id of the storage account.
-	StorageAccountID *string `json:"storageAccountId,omitempty"`
+	StorageAccountID *string
 
 	// Username for the storage account.
-	UserName *string `json:"userName,omitempty"`
+	UserName *string
 }
 
 // StorageAccountCredentialsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountCredentialsClient.BeginCreateOrUpdate
@@ -2433,31 +2433,31 @@ type StorageAccountCredentialsClientListByDataBoxEdgeDeviceOptions struct {
 // StorageAccountList - Collection of all the Storage Accounts on the Data Box Edge/Gateway device.
 type StorageAccountList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of storageAccounts.
-	Value []*StorageAccount `json:"value,omitempty" azure:"ro"`
+	Value []*StorageAccount
 }
 
 // StorageAccountProperties - The storage account properties.
 type StorageAccountProperties struct {
 	// REQUIRED; Data policy of the storage Account.
-	DataPolicy *DataPolicy `json:"dataPolicy,omitempty"`
+	DataPolicy *DataPolicy
 
 	// Description for the storage Account.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Storage Account Credential Id
-	StorageAccountCredentialID *string `json:"storageAccountCredentialId,omitempty"`
+	StorageAccountCredentialID *string
 
 	// Current status of the storage account
-	StorageAccountStatus *StorageAccountStatus `json:"storageAccountStatus,omitempty"`
+	StorageAccountStatus *StorageAccountStatus
 
 	// READ-ONLY; BlobEndpoint of Storage Account
-	BlobEndpoint *string `json:"blobEndpoint,omitempty" azure:"ro"`
+	BlobEndpoint *string
 
 	// READ-ONLY; The Container Count. Present only for Storage Accounts with DataPolicy set to Cloud.
-	ContainerCount *int32 `json:"containerCount,omitempty" azure:"ro"`
+	ContainerCount *int32
 }
 
 // StorageAccountsClientBeginCreateOrUpdateOptions contains the optional parameters for the StorageAccountsClient.BeginCreateOrUpdate
@@ -2485,29 +2485,29 @@ type StorageAccountsClientListByDataBoxEdgeDeviceOptions struct {
 }
 
 type SubscriptionProperties struct {
-	LocationPlacementID *string                           `json:"locationPlacementId,omitempty"`
-	QuotaID             *string                           `json:"quotaId,omitempty"`
-	RegisteredFeatures  []*SubscriptionRegisteredFeatures `json:"registeredFeatures,omitempty"`
-	SerializedDetails   *string                           `json:"serializedDetails,omitempty"`
-	TenantID            *string                           `json:"tenantId,omitempty"`
+	LocationPlacementID *string
+	QuotaID             *string
+	RegisteredFeatures  []*SubscriptionRegisteredFeatures
+	SerializedDetails   *string
+	TenantID            *string
 }
 
 type SubscriptionRegisteredFeatures struct {
-	Name  *string `json:"name,omitempty"`
-	State *string `json:"state,omitempty"`
+	Name  *string
+	State *string
 }
 
 // SupportPackageRequestProperties - The share properties.
 type SupportPackageRequestProperties struct {
 	// Type of files, which need to be included in the logs This will contain the type of logs (Default/DefaultWithDumps/None/All/DefaultWithArchived)
 	// or a comma separated list of log types that are required
-	Include *string `json:"include,omitempty"`
+	Include *string
 
 	// MaximumTimeStamp until where logs need to be collected
-	MaximumTimeStamp *time.Time `json:"maximumTimeStamp,omitempty"`
+	MaximumTimeStamp *time.Time
 
 	// MinimumTimeStamp from where logs need to be collected
-	MinimumTimeStamp *time.Time `json:"minimumTimeStamp,omitempty"`
+	MinimumTimeStamp *time.Time
 }
 
 // SupportPackagesClientBeginTriggerSupportPackageOptions contains the optional parameters for the SupportPackagesClient.BeginTriggerSupportPackage
@@ -2520,43 +2520,43 @@ type SupportPackagesClientBeginTriggerSupportPackageOptions struct {
 // SymmetricKey - Symmetric key for authentication.
 type SymmetricKey struct {
 	// Connection string based on the symmetric key.
-	ConnectionString *AsymmetricEncryptedSecret `json:"connectionString,omitempty"`
+	ConnectionString *AsymmetricEncryptedSecret
 }
 
 // SystemData - Metadata pertaining to creation and last modification of the resource.
 type SystemData struct {
 	// The timestamp of resource creation (UTC).
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
+	CreatedAt *time.Time
 
 	// The identity that created the resource.
-	CreatedBy *string `json:"createdBy,omitempty"`
+	CreatedBy *string
 
 	// The type of identity that created the resource.
-	CreatedByType *CreatedByType `json:"createdByType,omitempty"`
+	CreatedByType *CreatedByType
 
 	// The type of identity that last modified the resource.
-	LastModifiedAt *time.Time `json:"lastModifiedAt,omitempty"`
+	LastModifiedAt *time.Time
 
 	// The identity that last modified the resource.
-	LastModifiedBy *string `json:"lastModifiedBy,omitempty"`
+	LastModifiedBy *string
 
 	// The type of identity that last modified the resource.
-	LastModifiedByType *CreatedByType `json:"lastModifiedByType,omitempty"`
+	LastModifiedByType *CreatedByType
 }
 
 // TrackingInfo - Tracking courier information.
 type TrackingInfo struct {
 	// Name of the carrier used in the delivery.
-	CarrierName *string `json:"carrierName,omitempty"`
+	CarrierName *string
 
 	// Serial number of the device being tracked.
-	SerialNumber *string `json:"serialNumber,omitempty"`
+	SerialNumber *string
 
 	// Tracking ID of the shipment.
-	TrackingID *string `json:"trackingId,omitempty"`
+	TrackingID *string
 
 	// Tracking URL of the shipment.
-	TrackingURL *string `json:"trackingUrl,omitempty"`
+	TrackingURL *string
 }
 
 // TriggerClassification provides polymorphic access to related types.
@@ -2571,19 +2571,19 @@ type TriggerClassification interface {
 // Trigger details.
 type Trigger struct {
 	// REQUIRED; Trigger Kind.
-	Kind *TriggerEventType `json:"kind,omitempty"`
+	Kind *TriggerEventType
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Trigger in DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // GetTrigger implements the TriggerClassification interface for type Trigger.
@@ -2592,25 +2592,25 @@ func (t *Trigger) GetTrigger() *Trigger { return t }
 // TriggerList - Collection of all trigger on the data box edge device.
 type TriggerList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of triggers.
-	Value []TriggerClassification `json:"value,omitempty" azure:"ro"`
+	Value []TriggerClassification
 }
 
 // TriggerSupportPackageRequest - The request object for trigger support package.
 type TriggerSupportPackageRequest struct {
 	// REQUIRED; The TriggerSupportPackageRequest properties.
-	Properties *SupportPackageRequestProperties `json:"properties,omitempty"`
+	Properties *SupportPackageRequestProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // TriggersClientBeginCreateOrUpdateOptions contains the optional parameters for the TriggersClient.BeginCreateOrUpdate method.
@@ -2640,241 +2640,241 @@ type TriggersClientListByDataBoxEdgeDeviceOptions struct {
 // UpdateDetails - Update Specific attributes
 type UpdateDetails struct {
 	// Estimated Install Time for the update
-	EstimatedInstallTimeInMins *int32 `json:"estimatedInstallTimeInMins,omitempty"`
+	EstimatedInstallTimeInMins *int32
 
 	// Friendly Version Number
-	FriendlyVersionNumber *string `json:"friendlyVersionNumber,omitempty"`
+	FriendlyVersionNumber *string
 
 	// Impact of Installing an updateType
-	InstallationImpact *InstallationImpact `json:"installationImpact,omitempty"`
+	InstallationImpact *InstallationImpact
 
 	// Indicates if updates are available and at least one of the updates needs a reboot.
-	RebootBehavior *InstallRebootBehavior `json:"rebootBehavior,omitempty"`
+	RebootBehavior *InstallRebootBehavior
 
 	// Status of the update.
-	Status *UpdateStatus `json:"status,omitempty"`
+	Status *UpdateStatus
 
 	// Target Version number
-	TargetVersion *string `json:"targetVersion,omitempty"`
+	TargetVersion *string
 
 	// Size of the update(In Bytes)
-	UpdateSize *float64 `json:"updateSize,omitempty"`
+	UpdateSize *float64
 
 	// Title of the Update
-	UpdateTitle *string `json:"updateTitle,omitempty"`
+	UpdateTitle *string
 
 	// Type of the Update
-	UpdateType *UpdateType `json:"updateType,omitempty"`
+	UpdateType *UpdateType
 }
 
 // UpdateDownloadProgress - Details about the download progress of update.
 type UpdateDownloadProgress struct {
 	// READ-ONLY; The download phase.
-	DownloadPhase *DownloadPhase `json:"downloadPhase,omitempty" azure:"ro"`
+	DownloadPhase *DownloadPhase
 
 	// READ-ONLY; Number of updates downloaded.
-	NumberOfUpdatesDownloaded *int32 `json:"numberOfUpdatesDownloaded,omitempty" azure:"ro"`
+	NumberOfUpdatesDownloaded *int32
 
 	// READ-ONLY; Number of updates to download.
-	NumberOfUpdatesToDownload *int32 `json:"numberOfUpdatesToDownload,omitempty" azure:"ro"`
+	NumberOfUpdatesToDownload *int32
 
 	// READ-ONLY; Percentage of completion.
-	PercentComplete *int32 `json:"percentComplete,omitempty" azure:"ro"`
+	PercentComplete *int32
 
 	// READ-ONLY; Total bytes downloaded.
-	TotalBytesDownloaded *float64 `json:"totalBytesDownloaded,omitempty" azure:"ro"`
+	TotalBytesDownloaded *float64
 
 	// READ-ONLY; Total bytes to download.
-	TotalBytesToDownload *float64 `json:"totalBytesToDownload,omitempty" azure:"ro"`
+	TotalBytesToDownload *float64
 }
 
 // UpdateInstallProgress - Progress details during installation of updates.
 type UpdateInstallProgress struct {
 	// READ-ONLY; Number of updates installed.
-	NumberOfUpdatesInstalled *int32 `json:"numberOfUpdatesInstalled,omitempty" azure:"ro"`
+	NumberOfUpdatesInstalled *int32
 
 	// READ-ONLY; Number of updates to install.
-	NumberOfUpdatesToInstall *int32 `json:"numberOfUpdatesToInstall,omitempty" azure:"ro"`
+	NumberOfUpdatesToInstall *int32
 
 	// READ-ONLY; Percentage completed.
-	PercentComplete *int32 `json:"percentComplete,omitempty" azure:"ro"`
+	PercentComplete *int32
 }
 
 // UpdateSummary - Details about ongoing updates and availability of updates on the device.
 type UpdateSummary struct {
 	// The device update information summary.
-	Properties *UpdateSummaryProperties `json:"properties,omitempty"`
+	Properties *UpdateSummaryProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; UpdateSummary Result
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // UpdateSummaryProperties - The device update information summary.
 type UpdateSummaryProperties struct {
 	// The last time when a scan was done on the device.
-	DeviceLastScannedDateTime *time.Time `json:"deviceLastScannedDateTime,omitempty"`
+	DeviceLastScannedDateTime *time.Time
 
 	// The current version of the device in format: 1.2.17312.13.",
-	DeviceVersionNumber *string `json:"deviceVersionNumber,omitempty"`
+	DeviceVersionNumber *string
 
 	// The current version of the device in text format.
-	FriendlyDeviceVersionName *string `json:"friendlyDeviceVersionName,omitempty"`
+	FriendlyDeviceVersionName *string
 
 	// The time when the last scan job was completed (success/cancelled/failed) on the appliance.
-	LastCompletedScanJobDateTime *time.Time `json:"lastCompletedScanJobDateTime,omitempty"`
+	LastCompletedScanJobDateTime *time.Time
 
 	// The time when the Last Install job was completed successfully on the appliance
-	LastSuccessfulInstallJobDateTime *time.Time `json:"lastSuccessfulInstallJobDateTime,omitempty"`
+	LastSuccessfulInstallJobDateTime *time.Time
 
 	// Time when the last scan job is successfully completed.
-	LastSuccessfulScanJobTime *time.Time `json:"lastSuccessfulScanJobTime,omitempty"`
+	LastSuccessfulScanJobTime *time.Time
 
 	// READ-ONLY; The job ID of the download job in progress.
-	InProgressDownloadJobID *string `json:"inProgressDownloadJobId,omitempty" azure:"ro"`
+	InProgressDownloadJobID *string
 
 	// READ-ONLY; The time when the currently running download (if any) started.
-	InProgressDownloadJobStartedDateTime *time.Time `json:"inProgressDownloadJobStartedDateTime,omitempty" azure:"ro"`
+	InProgressDownloadJobStartedDateTime *time.Time
 
 	// READ-ONLY; The job ID of the install job in progress.
-	InProgressInstallJobID *string `json:"inProgressInstallJobId,omitempty" azure:"ro"`
+	InProgressInstallJobID *string
 
 	// READ-ONLY; The time when the currently running install (if any) started.
-	InProgressInstallJobStartedDateTime *time.Time `json:"inProgressInstallJobStartedDateTime,omitempty" azure:"ro"`
+	InProgressInstallJobStartedDateTime *time.Time
 
 	// READ-ONLY; The time when the last Download job was completed (success/cancelled/failed) on the appliance.
-	LastCompletedDownloadJobDateTime *time.Time `json:"lastCompletedDownloadJobDateTime,omitempty" azure:"ro"`
+	LastCompletedDownloadJobDateTime *time.Time
 
 	// READ-ONLY; JobId of the last ran download job.(Can be success/cancelled/failed)
-	LastCompletedDownloadJobID *string `json:"lastCompletedDownloadJobId,omitempty" azure:"ro"`
+	LastCompletedDownloadJobID *string
 
 	// READ-ONLY; The time when the last Install job was completed (success/cancelled/failed) on the appliance.
-	LastCompletedInstallJobDateTime *time.Time `json:"lastCompletedInstallJobDateTime,omitempty" azure:"ro"`
+	LastCompletedInstallJobDateTime *time.Time
 
 	// READ-ONLY; JobId of the last ran install job.(Can be success/cancelled/failed)
-	LastCompletedInstallJobID *string `json:"lastCompletedInstallJobId,omitempty" azure:"ro"`
+	LastCompletedInstallJobID *string
 
 	// READ-ONLY; JobStatus of the last ran download job.
-	LastDownloadJobStatus *JobStatus `json:"lastDownloadJobStatus,omitempty" azure:"ro"`
+	LastDownloadJobStatus *JobStatus
 
 	// READ-ONLY; JobStatus of the last ran install job.
-	LastInstallJobStatus *JobStatus `json:"lastInstallJobStatus,omitempty" azure:"ro"`
+	LastInstallJobStatus *JobStatus
 
 	// READ-ONLY; The current update operation.
-	OngoingUpdateOperation *UpdateOperation `json:"ongoingUpdateOperation,omitempty" azure:"ro"`
+	OngoingUpdateOperation *UpdateOperation
 
 	// READ-ONLY; Indicates if updates are available and at least one of the updates needs a reboot.
-	RebootBehavior *InstallRebootBehavior `json:"rebootBehavior,omitempty" azure:"ro"`
+	RebootBehavior *InstallRebootBehavior
 
 	// READ-ONLY; The number of updates available for the current device version as per the last device scan.
-	TotalNumberOfUpdatesAvailable *int32 `json:"totalNumberOfUpdatesAvailable,omitempty" azure:"ro"`
+	TotalNumberOfUpdatesAvailable *int32
 
 	// READ-ONLY; The total number of items pending download.
-	TotalNumberOfUpdatesPendingDownload *int32 `json:"totalNumberOfUpdatesPendingDownload,omitempty" azure:"ro"`
+	TotalNumberOfUpdatesPendingDownload *int32
 
 	// READ-ONLY; The total number of items pending install.
-	TotalNumberOfUpdatesPendingInstall *int32 `json:"totalNumberOfUpdatesPendingInstall,omitempty" azure:"ro"`
+	TotalNumberOfUpdatesPendingInstall *int32
 
 	// READ-ONLY; The total time in Minutes
-	TotalTimeInMinutes *int32 `json:"totalTimeInMinutes,omitempty" azure:"ro"`
+	TotalTimeInMinutes *int32
 
 	// READ-ONLY; The total size of updates available for download in bytes.
-	TotalUpdateSizeInBytes *float64 `json:"totalUpdateSizeInBytes,omitempty" azure:"ro"`
+	TotalUpdateSizeInBytes *float64
 
 	// READ-ONLY; The list of updates available for install.
-	UpdateTitles []*string `json:"updateTitles,omitempty" azure:"ro"`
+	UpdateTitles []*string
 
 	// READ-ONLY; The list of updates available for install.
-	Updates []*UpdateDetails `json:"updates,omitempty" azure:"ro"`
+	Updates []*UpdateDetails
 }
 
 // UploadCertificateRequest - The upload certificate request.
 type UploadCertificateRequest struct {
 	// REQUIRED; The Base 64 encoded certificate raw data.
-	Properties *RawCertificateData `json:"properties,omitempty"`
+	Properties *RawCertificateData
 }
 
 // UploadCertificateResponse - The upload registration certificate response.
 type UploadCertificateResponse struct {
 	// Specifies authentication type.
-	AuthType *AuthenticationType `json:"authType,omitempty"`
+	AuthType *AuthenticationType
 
 	// READ-ONLY; Identifier of the target resource that is the recipient of the requested token.
-	AADAudience *string `json:"aadAudience,omitempty" azure:"ro"`
+	AADAudience *string
 
 	// READ-ONLY; Azure Active Directory tenant authority.
-	AADAuthority *string `json:"aadAuthority,omitempty" azure:"ro"`
+	AADAuthority *string
 
 	// READ-ONLY; Azure Active Directory tenant ID.
-	AADTenantID *string `json:"aadTenantId,omitempty" azure:"ro"`
+	AADTenantID *string
 
 	// READ-ONLY; The azure management endpoint audience.
-	AzureManagementEndpointAudience *string `json:"azureManagementEndpointAudience,omitempty" azure:"ro"`
+	AzureManagementEndpointAudience *string
 
 	// READ-ONLY; The resource ID of the Data Box Edge/Gateway device.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; Azure Active Directory service principal client ID.
-	ServicePrincipalClientID *string `json:"servicePrincipalClientId,omitempty" azure:"ro"`
+	ServicePrincipalClientID *string
 
 	// READ-ONLY; Azure Active Directory service principal object ID.
-	ServicePrincipalObjectID *string `json:"servicePrincipalObjectId,omitempty" azure:"ro"`
+	ServicePrincipalObjectID *string
 }
 
 // User - Represents a user who has access to one or more shares on the Data Box Edge/Gateway device.
 type User struct {
 	// REQUIRED; The storage account credential properties.
-	Properties *UserProperties `json:"properties,omitempty"`
+	Properties *UserProperties
 
 	// READ-ONLY; The path ID that uniquely identifies the object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The object name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; User in DataBoxEdge Resource
-	SystemData *SystemData `json:"systemData,omitempty" azure:"ro"`
+	SystemData *SystemData
 
 	// READ-ONLY; The hierarchical type of the object.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // UserAccessRight - The mapping between a particular user and the access type on the SMB share.
 type UserAccessRight struct {
 	// REQUIRED; Type of access to be allowed for the user.
-	AccessType *ShareAccessType `json:"accessType,omitempty"`
+	AccessType *ShareAccessType
 
 	// REQUIRED; User ID (already existing in the device).
-	UserID *string `json:"userId,omitempty"`
+	UserID *string
 }
 
 // UserList - Collection of users.
 type UserList struct {
 	// READ-ONLY; Link to the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; The list of users.
-	Value []*User `json:"value,omitempty" azure:"ro"`
+	Value []*User
 }
 
 // UserProperties - The user properties.
 type UserProperties struct {
 	// REQUIRED; Type of the user.
-	UserType *UserType `json:"userType,omitempty"`
+	UserType *UserType
 
 	// The password details.
-	EncryptedPassword *AsymmetricEncryptedSecret `json:"encryptedPassword,omitempty"`
+	EncryptedPassword *AsymmetricEncryptedSecret
 
 	// READ-ONLY; List of shares that the user has rights on. This field should not be specified during user creation.
-	ShareAccessRights []*ShareAccessRight `json:"shareAccessRights,omitempty" azure:"ro"`
+	ShareAccessRights []*ShareAccessRight
 }
 
 // UsersClientBeginCreateOrUpdateOptions contains the optional parameters for the UsersClient.BeginCreateOrUpdate method.

--- a/test/keyvault/7.2/azkeyvault/zz_models.go
+++ b/test/keyvault/7.2/azkeyvault/zz_models.go
@@ -14,323 +14,323 @@ import "time"
 // Action - The action that will be executed.
 type Action struct {
 	// The type of the action.
-	ActionType *ActionType `json:"action_type,omitempty"`
+	ActionType *ActionType
 }
 
 // AdministratorDetails - Details of the organization administrator of the certificate issuer.
 type AdministratorDetails struct {
 	// Email address.
-	EmailAddress *string `json:"email,omitempty"`
+	EmailAddress *string
 
 	// First name.
-	FirstName *string `json:"first_name,omitempty"`
+	FirstName *string
 
 	// Last name.
-	LastName *string `json:"last_name,omitempty"`
+	LastName *string
 
 	// Phone number.
-	Phone *string `json:"phone,omitempty"`
+	Phone *string
 }
 
 // Attributes - The object attributes managed by the KeyVault service.
 type Attributes struct {
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	Expires *time.Time `json:"exp,omitempty"`
+	Expires *time.Time
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // BackupCertificateResult - The backup certificate result, containing the backup blob.
 type BackupCertificateResult struct {
 	// READ-ONLY; The backup blob containing the backed up certificate.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // BackupKeyResult - The backup key result, containing the backup blob.
 type BackupKeyResult struct {
 	// READ-ONLY; The backup blob containing the backed up key.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // BackupSecretResult - The backup secret result, containing the backup blob.
 type BackupSecretResult struct {
 	// READ-ONLY; The backup blob containing the backed up secret.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // BackupStorageResult - The backup storage result, containing the backup blob.
 type BackupStorageResult struct {
 	// READ-ONLY; The backup blob containing the backed up storage account.
-	Value []byte `json:"value,omitempty" azure:"ro"`
+	Value []byte
 }
 
 // CertificateAttributes - The certificate management attributes.
 type CertificateAttributes struct {
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	Expires *time.Time `json:"exp,omitempty"`
+	Expires *time.Time
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for certificates in the current vault. If it contains
 	// 'Purgeable', the certificate can be permanently deleted by a privileged user; otherwise,
 	// only the system can purge the certificate, at the end of the retention interval.
-	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // CertificateBundle - A certificate bundle consists of a certificate (X509) plus its attributes.
 type CertificateBundle struct {
 	// The certificate attributes.
-	Attributes *CertificateAttributes `json:"attributes,omitempty"`
+	Attributes *CertificateAttributes
 
 	// CER contents of x509 certificate.
-	Cer []byte `json:"cer,omitempty"`
+	Cer []byte
 
 	// The content type of the secret.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The key id.
-	Kid *string `json:"kid,omitempty" azure:"ro"`
+	Kid *string
 
 	// READ-ONLY; The management policy.
-	Policy *CertificatePolicy `json:"policy,omitempty" azure:"ro"`
+	Policy *CertificatePolicy
 
 	// READ-ONLY; The secret id.
-	Sid *string `json:"sid,omitempty" azure:"ro"`
+	Sid *string
 
 	// READ-ONLY; Thumbprint of the certificate.
-	X509Thumbprint []byte `json:"x5t,omitempty" azure:"ro"`
+	X509Thumbprint []byte
 }
 
 // CertificateCreateParameters - The certificate create parameters.
 type CertificateCreateParameters struct {
 	// The attributes of the certificate (optional).
-	CertificateAttributes *CertificateAttributes `json:"attributes,omitempty"`
+	CertificateAttributes *CertificateAttributes
 
 	// The management policy for the certificate.
-	CertificatePolicy *CertificatePolicy `json:"policy,omitempty"`
+	CertificatePolicy *CertificatePolicy
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // CertificateImportParameters - The certificate import parameters.
 type CertificateImportParameters struct {
 	// REQUIRED; Base64 encoded representation of the certificate object to import. This certificate needs to contain the private
 	// key.
-	Base64EncodedCertificate *string `json:"value,omitempty"`
+	Base64EncodedCertificate *string
 
 	// The attributes of the certificate (optional).
-	CertificateAttributes *CertificateAttributes `json:"attributes,omitempty"`
+	CertificateAttributes *CertificateAttributes
 
 	// The management policy for the certificate.
-	CertificatePolicy *CertificatePolicy `json:"policy,omitempty"`
+	CertificatePolicy *CertificatePolicy
 
 	// If the private key in base64EncodedCertificate is encrypted, the password used for encryption.
-	Password *string `json:"pwd,omitempty"`
+	Password *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 type CertificateInfoObject struct {
 	// REQUIRED; Certificates needed from customer
-	Certificates []*SecurityDomainCertificateItem `json:"certificates,omitempty"`
+	Certificates []*SecurityDomainCertificateItem
 
 	// Customer to specify the number of certificates (minimum 2 and maximum 10) to restore Security Domain
-	Required *int32 `json:"required,omitempty"`
+	Required *int32
 }
 
 // CertificateIssuerItem - The certificate issuer item containing certificate issuer metadata.
 type CertificateIssuerItem struct {
 	// Certificate Identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 }
 
 // CertificateIssuerListResult - The certificate issuer list result.
 type CertificateIssuerListResult struct {
 	// READ-ONLY; The URL to get the next set of certificate issuers.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of certificate issuers in the key vault along with a link to the next page
 	// of certificate issuers.
-	Value []*CertificateIssuerItem `json:"value,omitempty" azure:"ro"`
+	Value []*CertificateIssuerItem
 }
 
 // CertificateIssuerSetParameters - The certificate issuer set parameters.
 type CertificateIssuerSetParameters struct {
 	// REQUIRED; The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 
 	// Attributes of the issuer object.
-	Attributes *IssuerAttributes `json:"attributes,omitempty"`
+	Attributes *IssuerAttributes
 
 	// The credentials to be used for the issuer.
-	Credentials *IssuerCredentials `json:"credentials,omitempty"`
+	Credentials *IssuerCredentials
 
 	// Details of the organization as provided to the issuer.
-	OrganizationDetails *OrganizationDetails `json:"org_details,omitempty"`
+	OrganizationDetails *OrganizationDetails
 }
 
 // CertificateIssuerUpdateParameters - The certificate issuer update parameters.
 type CertificateIssuerUpdateParameters struct {
 	// Attributes of the issuer object.
-	Attributes *IssuerAttributes `json:"attributes,omitempty"`
+	Attributes *IssuerAttributes
 
 	// The credentials to be used for the issuer.
-	Credentials *IssuerCredentials `json:"credentials,omitempty"`
+	Credentials *IssuerCredentials
 
 	// Details of the organization as provided to the issuer.
-	OrganizationDetails *OrganizationDetails `json:"org_details,omitempty"`
+	OrganizationDetails *OrganizationDetails
 
 	// The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 }
 
 // CertificateItem - The certificate item containing certificate metadata.
 type CertificateItem struct {
 	// The certificate management attributes.
-	Attributes *CertificateAttributes `json:"attributes,omitempty"`
+	Attributes *CertificateAttributes
 
 	// Certificate identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// Thumbprint of the certificate.
-	X509Thumbprint []byte `json:"x5t,omitempty"`
+	X509Thumbprint []byte
 }
 
 // CertificateListResult - The certificate list result.
 type CertificateListResult struct {
 	// READ-ONLY; The URL to get the next set of certificates.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of certificates in the key vault along with a link to the next page of
 	// certificates.
-	Value []*CertificateItem `json:"value,omitempty" azure:"ro"`
+	Value []*CertificateItem
 }
 
 // CertificateMergeParameters - The certificate merge parameters
 type CertificateMergeParameters struct {
 	// REQUIRED; The certificate or the certificate chain to merge.
-	X509Certificates [][]byte `json:"x5c,omitempty"`
+	X509Certificates [][]byte
 
 	// The attributes of the certificate (optional).
-	CertificateAttributes *CertificateAttributes `json:"attributes,omitempty"`
+	CertificateAttributes *CertificateAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // CertificateOperation - A certificate operation is returned in case of asynchronous requests.
 type CertificateOperation struct {
 	// Indicates if cancellation was requested on the certificate operation.
-	CancellationRequested *bool `json:"cancellation_requested,omitempty"`
+	CancellationRequested *bool
 
 	// The certificate signing request (CSR) that is being used in the certificate operation.
-	Csr []byte `json:"csr,omitempty"`
+	Csr []byte
 
 	// Error encountered, if any, during the certificate operation.
-	Error *ErrorInfo `json:"error,omitempty"`
+	Error *ErrorInfo
 
 	// Parameters for the issuer of the X509 component of a certificate.
-	IssuerParameters *IssuerParameters `json:"issuer,omitempty"`
+	IssuerParameters *IssuerParameters
 
 	// Identifier for the certificate operation.
-	RequestID *string `json:"request_id,omitempty"`
+	RequestID *string
 
 	// Status of the certificate operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// The status details of the certificate operation.
-	StatusDetails *string `json:"status_details,omitempty"`
+	StatusDetails *string
 
 	// Location which contains the result of the certificate operation.
-	Target *string `json:"target,omitempty"`
+	Target *string
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // CertificateOperationUpdateParameter - The certificate operation update parameters.
 type CertificateOperationUpdateParameter struct {
 	// REQUIRED; Indicates if cancellation was requested on the certificate operation.
-	CancellationRequested *bool `json:"cancellation_requested,omitempty"`
+	CancellationRequested *bool
 }
 
 // CertificatePolicy - Management policy for a certificate.
 type CertificatePolicy struct {
 	// The certificate attributes.
-	Attributes *CertificateAttributes `json:"attributes,omitempty"`
+	Attributes *CertificateAttributes
 
 	// Parameters for the issuer of the X509 component of a certificate.
-	IssuerParameters *IssuerParameters `json:"issuer,omitempty"`
+	IssuerParameters *IssuerParameters
 
 	// Properties of the key backing a certificate.
-	KeyProperties *KeyProperties `json:"key_props,omitempty"`
+	KeyProperties *KeyProperties
 
 	// Actions that will be performed by Key Vault over the lifetime of a certificate.
-	LifetimeActions []*LifetimeAction `json:"lifetime_actions,omitempty"`
+	LifetimeActions []*LifetimeAction
 
 	// Properties of the secret backing a certificate.
-	SecretProperties *SecretProperties `json:"secret_props,omitempty"`
+	SecretProperties *SecretProperties
 
 	// Properties of the X509 component of a certificate.
-	X509CertificateProperties *X509CertificateProperties `json:"x509_props,omitempty"`
+	X509CertificateProperties *X509CertificateProperties
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // CertificateRestoreParameters - The certificate restore parameters.
 type CertificateRestoreParameters struct {
 	// REQUIRED; The backup blob associated with a certificate bundle.
-	CertificateBundleBackup []byte `json:"value,omitempty"`
+	CertificateBundleBackup []byte
 }
 
 // CertificateUpdateParameters - The certificate update parameters.
 type CertificateUpdateParameters struct {
 	// The attributes of the certificate (optional).
-	CertificateAttributes *CertificateAttributes `json:"attributes,omitempty"`
+	CertificateAttributes *CertificateAttributes
 
 	// The management policy for the certificate.
-	CertificatePolicy *CertificatePolicy `json:"policy,omitempty"`
+	CertificatePolicy *CertificatePolicy
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // ClientBackupCertificateOptions contains the optional parameters for the Client.BackupCertificate method.
@@ -780,409 +780,409 @@ type ClientWrapKeyOptions struct {
 // Contact - The contact information for the vault certificates.
 type Contact struct {
 	// Email address.
-	EmailAddress *string `json:"email,omitempty"`
+	EmailAddress *string
 
 	// Name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Phone number.
-	Phone *string `json:"phone,omitempty"`
+	Phone *string
 }
 
 // Contacts - The contacts for the vault certificates.
 type Contacts struct {
 	// The contact list for the vault certificates.
-	ContactList []*Contact `json:"contacts,omitempty"`
+	ContactList []*Contact
 
 	// READ-ONLY; Identifier for the contacts collection.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // DeletedCertificateBundle - A Deleted Certificate consisting of its previous id, attributes and its tags, as well as information
 // on when it will be purged.
 type DeletedCertificateBundle struct {
 	// The certificate attributes.
-	Attributes *CertificateAttributes `json:"attributes,omitempty"`
+	Attributes *CertificateAttributes
 
 	// CER contents of x509 certificate.
-	Cer []byte `json:"cer,omitempty"`
+	Cer []byte
 
 	// The content type of the secret.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The url of the recovery object, used to identify and recover the deleted certificate.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The time when the certificate was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; The certificate id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The key id.
-	Kid *string `json:"kid,omitempty" azure:"ro"`
+	Kid *string
 
 	// READ-ONLY; The management policy.
-	Policy *CertificatePolicy `json:"policy,omitempty" azure:"ro"`
+	Policy *CertificatePolicy
 
 	// READ-ONLY; The time when the certificate is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; The secret id.
-	Sid *string `json:"sid,omitempty" azure:"ro"`
+	Sid *string
 
 	// READ-ONLY; Thumbprint of the certificate.
-	X509Thumbprint []byte `json:"x5t,omitempty" azure:"ro"`
+	X509Thumbprint []byte
 }
 
 // DeletedCertificateItem - The deleted certificate item containing metadata about the deleted certificate.
 type DeletedCertificateItem struct {
 	// The certificate management attributes.
-	Attributes *CertificateAttributes `json:"attributes,omitempty"`
+	Attributes *CertificateAttributes
 
 	// Certificate identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The url of the recovery object, used to identify and recover the deleted certificate.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// Thumbprint of the certificate.
-	X509Thumbprint []byte `json:"x5t,omitempty"`
+	X509Thumbprint []byte
 
 	// READ-ONLY; The time when the certificate was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; The time when the certificate is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedCertificateListResult - A list of certificates that have been deleted in this vault.
 type DeletedCertificateListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted certificates.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of deleted certificates in the vault along with a link to the next page
 	// of deleted certificates
-	Value []*DeletedCertificateItem `json:"value,omitempty" azure:"ro"`
+	Value []*DeletedCertificateItem
 }
 
 // DeletedKeyBundle - A DeletedKeyBundle consisting of a WebKey plus its Attributes and deletion info
 type DeletedKeyBundle struct {
 	// The key management attributes.
-	Attributes *KeyAttributes `json:"attributes,omitempty"`
+	Attributes *KeyAttributes
 
 	// The Json web key.
-	Key *JSONWebKey `json:"key,omitempty"`
+	Key *JSONWebKey
 
 	// The url of the recovery object, used to identify and recover the deleted key.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The time when the key was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
 	// be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedKeyItem - The deleted key item containing the deleted key metadata and information about deletion.
 type DeletedKeyItem struct {
 	// The key management attributes.
-	Attributes *KeyAttributes `json:"attributes,omitempty"`
+	Attributes *KeyAttributes
 
 	// Key identifier.
-	Kid *string `json:"kid,omitempty"`
+	Kid *string
 
 	// The url of the recovery object, used to identify and recover the deleted key.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The time when the key was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
 	// be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// READ-ONLY; The time when the key is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedKeyListResult - A list of keys that have been deleted in this vault.
 type DeletedKeyListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted keys.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of deleted keys in the vault along with a link to the next page of deleted
 	// keys
-	Value []*DeletedKeyItem `json:"value,omitempty" azure:"ro"`
+	Value []*DeletedKeyItem
 }
 
 // DeletedSasDefinitionBundle - A deleted SAS definition bundle consisting of its previous id, attributes and its tags, as
 // well as information on when it will be purged.
 type DeletedSasDefinitionBundle struct {
 	// The url of the recovery object, used to identify and recover the deleted SAS definition.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The SAS definition attributes.
-	Attributes *SasDefinitionAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *SasDefinitionAttributes
 
 	// READ-ONLY; The time when the SAS definition was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; The SAS definition id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The type of SAS token the SAS definition will create.
-	SasType *SasTokenType `json:"sasType,omitempty" azure:"ro"`
+	SasType *SasTokenType
 
 	// READ-ONLY; The time when the SAS definition is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; Storage account SAS definition secret id.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; The SAS definition token template signed with an arbitrary key. Tokens created according to the SAS definition
 	// will have the same properties as the template.
-	TemplateURI *string `json:"templateUri,omitempty" azure:"ro"`
+	TemplateURI *string
 
 	// READ-ONLY; The validity period of SAS tokens created according to the SAS definition.
-	ValidityPeriod *string `json:"validityPeriod,omitempty" azure:"ro"`
+	ValidityPeriod *string
 }
 
 // DeletedSasDefinitionItem - The deleted SAS definition item containing metadata about the deleted SAS definition.
 type DeletedSasDefinitionItem struct {
 	// The url of the recovery object, used to identify and recover the deleted SAS definition.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The SAS definition management attributes.
-	Attributes *SasDefinitionAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *SasDefinitionAttributes
 
 	// READ-ONLY; The time when the SAS definition was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; The storage SAS identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The time when the SAS definition is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; The storage account SAS definition secret id.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // DeletedSasDefinitionListResult - The deleted SAS definition list result
 type DeletedSasDefinitionListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted SAS definitions.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of the deleted SAS definitions in the vault along with a link to the next
 	// page of deleted sas definitions
-	Value []*DeletedSasDefinitionItem `json:"value,omitempty" azure:"ro"`
+	Value []*DeletedSasDefinitionItem
 }
 
 // DeletedSecretBundle - A Deleted Secret consisting of its previous id, attributes and its tags, as well as information on
 // when it will be purged.
 type DeletedSecretBundle struct {
 	// The secret management attributes.
-	Attributes *SecretAttributes `json:"attributes,omitempty"`
+	Attributes *SecretAttributes
 
 	// The content type of the secret.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The secret id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The url of the recovery object, used to identify and recover the deleted secret.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The secret value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 
 	// READ-ONLY; The time when the secret was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV
 	// certificate.
-	Kid *string `json:"kid,omitempty" azure:"ro"`
+	Kid *string
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed
 	// will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// READ-ONLY; The time when the secret is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedSecretItem - The deleted secret item containing metadata about the deleted secret.
 type DeletedSecretItem struct {
 	// The secret management attributes.
-	Attributes *SecretAttributes `json:"attributes,omitempty"`
+	Attributes *SecretAttributes
 
 	// Type of the secret value such as a password.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// Secret identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The url of the recovery object, used to identify and recover the deleted secret.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; The time when the secret was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a key backing a certificate, then managed
 	// will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 
 	// READ-ONLY; The time when the secret is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 }
 
 // DeletedSecretListResult - The deleted secret list result
 type DeletedSecretListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted secrets.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of the deleted secrets in the vault along with a link to the next page
 	// of deleted secrets
-	Value []*DeletedSecretItem `json:"value,omitempty" azure:"ro"`
+	Value []*DeletedSecretItem
 }
 
 // DeletedStorageAccountItem - The deleted storage account item containing metadata about the deleted storage account.
 type DeletedStorageAccountItem struct {
 	// The url of the recovery object, used to identify and recover the deleted storage account.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The storage account management attributes.
-	Attributes *StorageAccountAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *StorageAccountAttributes
 
 	// READ-ONLY; The time when the storage account was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; Storage identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Storage account resource Id.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; The time when the storage account is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // DeletedStorageBundle - A deleted storage account bundle consisting of its previous id, attributes and its tags, as well
 // as information on when it will be purged.
 type DeletedStorageBundle struct {
 	// The url of the recovery object, used to identify and recover the deleted storage account.
-	RecoveryID *string `json:"recoveryId,omitempty"`
+	RecoveryID *string
 
 	// READ-ONLY; The current active storage account key name.
-	ActiveKeyName *string `json:"activeKeyName,omitempty" azure:"ro"`
+	ActiveKeyName *string
 
 	// READ-ONLY; The storage account attributes.
-	Attributes *StorageAccountAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *StorageAccountAttributes
 
 	// READ-ONLY; whether keyvault should manage the storage account for the user.
-	AutoRegenerateKey *bool `json:"autoRegenerateKey,omitempty" azure:"ro"`
+	AutoRegenerateKey *bool
 
 	// READ-ONLY; The time when the storage account was deleted, in UTC
-	DeletedDate *time.Time `json:"deletedDate,omitempty" azure:"ro"`
+	DeletedDate *time.Time
 
 	// READ-ONLY; The storage account id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The key regeneration time duration specified in ISO-8601 format.
-	RegenerationPeriod *string `json:"regenerationPeriod,omitempty" azure:"ro"`
+	RegenerationPeriod *string
 
 	// READ-ONLY; The storage account resource id.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; The time when the storage account is scheduled to be purged, in UTC
-	ScheduledPurgeDate *time.Time `json:"scheduledPurgeDate,omitempty" azure:"ro"`
+	ScheduledPurgeDate *time.Time
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // DeletedStorageListResult - The deleted storage account list result
 type DeletedStorageListResult struct {
 	// READ-ONLY; The URL to get the next set of deleted storage accounts.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of the deleted storage accounts in the vault along with a link to the next
 	// page of deleted storage accounts
-	Value []*DeletedStorageAccountItem `json:"value,omitempty" azure:"ro"`
+	Value []*DeletedStorageAccountItem
 }
 
 // Error - The key vault error exception.
 type Error struct {
 	// READ-ONLY; The key vault server error.
-	Error *ErrorInfo `json:"error,omitempty" azure:"ro"`
+	Error *ErrorInfo
 }
 
 // ErrorInfo - The key vault server error.
 type ErrorInfo struct {
 	// READ-ONLY; The error code.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The key vault server error.
-	InnerError *ErrorInfo `json:"innererror,omitempty" azure:"ro"`
+	InnerError *ErrorInfo
 
 	// READ-ONLY; The error message.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 }
 
 // FullBackupOperation - Full backup operation
 type FullBackupOperation struct {
 	// The Azure blob storage container Uri which contains the full backup
-	AzureStorageBlobContainerURI *string `json:"azureStorageBlobContainerUri,omitempty"`
+	AzureStorageBlobContainerURI *string
 
 	// The end time of the backup operation in UTC
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Error encountered, if any, during the full backup operation.
-	Error *ErrorInfo `json:"error,omitempty"`
+	Error *ErrorInfo
 
 	// Identifier for the full backup operation.
-	JobID *string `json:"jobId,omitempty"`
+	JobID *string
 
 	// The start time of the backup operation in UTC
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Status of the backup operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// The status details of backup operation.
-	StatusDetails *string `json:"statusDetails,omitempty"`
+	StatusDetails *string
 }
 
 // HSMSecurityDomainClientBeginDownloadOptions contains the optional parameters for the HSMSecurityDomainClient.BeginDownload
@@ -1220,430 +1220,430 @@ type HSMSecurityDomainClientUploadPendingOptions struct {
 // IssuerAttributes - The attributes of an issuer managed by the Key Vault service.
 type IssuerAttributes struct {
 	// Determines whether the issuer is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // IssuerBundle - The issuer for Key Vault certificate.
 type IssuerBundle struct {
 	// Attributes of the issuer object.
-	Attributes *IssuerAttributes `json:"attributes,omitempty"`
+	Attributes *IssuerAttributes
 
 	// The credentials to be used for the issuer.
-	Credentials *IssuerCredentials `json:"credentials,omitempty"`
+	Credentials *IssuerCredentials
 
 	// Details of the organization as provided to the issuer.
-	OrganizationDetails *OrganizationDetails `json:"org_details,omitempty"`
+	OrganizationDetails *OrganizationDetails
 
 	// The issuer provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 
 	// READ-ONLY; Identifier for the issuer object.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // IssuerCredentials - The credentials to be used for the certificate issuer.
 type IssuerCredentials struct {
 	// The user name/account name/account id.
-	AccountID *string `json:"account_id,omitempty"`
+	AccountID *string
 
 	// The password/secret/account key.
-	Password *string `json:"pwd,omitempty"`
+	Password *string
 }
 
 // IssuerParameters - Parameters for the issuer of the X509 component of a certificate.
 type IssuerParameters struct {
 	// Indicates if the certificates generated under this policy should be published to certificate transparency logs.
-	CertificateTransparency *bool `json:"cert_transparency,omitempty"`
+	CertificateTransparency *bool
 
 	// Certificate type as supported by the provider (optional); for example 'OV-SSL', 'EV-SSL'
-	CertificateType *string `json:"cty,omitempty"`
+	CertificateType *string
 
 	// Name of the referenced issuer object or reserved names; for example, 'Self' or 'Unknown'.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // JSONWebKey - As of http://tools.ietf.org/html/draft-ietf-jose-json-web-key-18
 type JSONWebKey struct {
 	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	Crv *JSONWebKeyCurveName `json:"crv,omitempty"`
+	Crv *JSONWebKeyCurveName
 
 	// RSA private exponent, or the D component of an EC private key.
-	D []byte `json:"d,omitempty"`
+	D []byte
 
 	// RSA private key parameter.
-	DP []byte `json:"dp,omitempty"`
+	DP []byte
 
 	// RSA private key parameter.
-	DQ []byte `json:"dq,omitempty"`
+	DQ []byte
 
 	// RSA public exponent.
-	E []byte `json:"e,omitempty"`
+	E []byte
 
 	// Symmetric key.
-	K      []byte    `json:"k,omitempty"`
-	KeyOps []*string `json:"key_ops,omitempty"`
+	K      []byte
+	KeyOps []*string
 
 	// Key identifier.
-	Kid *string `json:"kid,omitempty"`
+	Kid *string
 
 	// JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
-	Kty *JSONWebKeyType `json:"kty,omitempty"`
+	Kty *JSONWebKeyType
 
 	// RSA modulus.
-	N []byte `json:"n,omitempty"`
+	N []byte
 
 	// RSA secret prime.
-	P []byte `json:"p,omitempty"`
+	P []byte
 
 	// RSA secret prime, with p < q.
-	Q []byte `json:"q,omitempty"`
+	Q []byte
 
 	// RSA private key parameter.
-	QI []byte `json:"qi,omitempty"`
+	QI []byte
 
 	// Protected Key, used with 'Bring Your Own Key'.
-	T []byte `json:"key_hsm,omitempty"`
+	T []byte
 
 	// X component of an EC public key.
-	X []byte `json:"x,omitempty"`
+	X []byte
 
 	// Y component of an EC public key.
-	Y []byte `json:"y,omitempty"`
+	Y []byte
 }
 
 // KeyAttributes - The attributes of a key managed by the key vault service.
 type KeyAttributes struct {
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	Expires *time.Time `json:"exp,omitempty"`
+	Expires *time.Time
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for keys in the current vault. If it contains 'Purgeable'
 	// the key can be permanently deleted by a privileged user; otherwise, only the system
 	// can purge the key, at the end of the retention interval.
-	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // KeyBundle - A KeyBundle consisting of a WebKey plus its attributes.
 type KeyBundle struct {
 	// The key management attributes.
-	Attributes *KeyAttributes `json:"attributes,omitempty"`
+	Attributes *KeyAttributes
 
 	// The Json web key.
-	Key *JSONWebKey `json:"key,omitempty"`
+	Key *JSONWebKey
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
 	// be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 }
 
 // KeyCreateParameters - The key create parameters.
 type KeyCreateParameters struct {
 	// REQUIRED; The type of key to create. For valid values, see JsonWebKeyType.
-	Kty *JSONWebKeyType `json:"kty,omitempty"`
+	Kty *JSONWebKeyType
 
 	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	Curve *JSONWebKeyCurveName `json:"crv,omitempty"`
+	Curve *JSONWebKeyCurveName
 
 	// The attributes of a key managed by the key vault service.
-	KeyAttributes *KeyAttributes         `json:"attributes,omitempty"`
-	KeyOps        []*JSONWebKeyOperation `json:"key_ops,omitempty"`
+	KeyAttributes *KeyAttributes
+	KeyOps        []*JSONWebKeyOperation
 
 	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
-	KeySize *int32 `json:"key_size,omitempty"`
+	KeySize *int32
 
 	// The public exponent for a RSA key.
-	PublicExponent *int32 `json:"public_exponent,omitempty"`
+	PublicExponent *int32
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // KeyImportParameters - The key import parameters.
 type KeyImportParameters struct {
 	// REQUIRED; The Json web key
-	Key *JSONWebKey `json:"key,omitempty"`
+	Key *JSONWebKey
 
 	// Whether to import as a hardware key (HSM) or software key.
-	Hsm *bool `json:"Hsm,omitempty"`
+	Hsm *bool
 
 	// The key management attributes.
-	KeyAttributes *KeyAttributes `json:"attributes,omitempty"`
+	KeyAttributes *KeyAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // KeyItem - The key item containing key metadata.
 type KeyItem struct {
 	// The key management attributes.
-	Attributes *KeyAttributes `json:"attributes,omitempty"`
+	Attributes *KeyAttributes
 
 	// Key identifier.
-	Kid *string `json:"kid,omitempty"`
+	Kid *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; True if the key's lifetime is managed by key vault. If this is a key backing a certificate, then managed will
 	// be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 }
 
 // KeyListResult - The key list result.
 type KeyListResult struct {
 	// READ-ONLY; The URL to get the next set of keys.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of keys in the key vault along with a link to the next page of keys.
-	Value []*KeyItem `json:"value,omitempty" azure:"ro"`
+	Value []*KeyItem
 }
 
 // KeyOperationResult - The key operation result.
 type KeyOperationResult struct {
 	// READ-ONLY
-	AdditionalAuthenticatedData []byte `json:"aad,omitempty" azure:"ro"`
+	AdditionalAuthenticatedData []byte
 
 	// READ-ONLY
-	AuthenticationTag []byte `json:"tag,omitempty" azure:"ro"`
+	AuthenticationTag []byte
 
 	// READ-ONLY
-	Iv []byte `json:"iv,omitempty" azure:"ro"`
+	Iv []byte
 
 	// READ-ONLY; Key identifier
-	Kid *string `json:"kid,omitempty" azure:"ro"`
+	Kid *string
 
 	// READ-ONLY
-	Result []byte `json:"value,omitempty" azure:"ro"`
+	Result []byte
 }
 
 // KeyOperationsParameters - The key operations parameters.
 type KeyOperationsParameters struct {
 	// REQUIRED; algorithm identifier
-	Algorithm *JSONWebKeyEncryptionAlgorithm `json:"alg,omitempty"`
+	Algorithm *JSONWebKeyEncryptionAlgorithm
 
 	// REQUIRED
-	Value []byte `json:"value,omitempty"`
+	Value []byte
 
 	// Additional data to authenticate but not encrypt/decrypt when using authenticated crypto algorithms.
-	AAD []byte `json:"aad,omitempty"`
+	AAD []byte
 
 	// Initialization vector for symmetric algorithms.
-	Iv []byte `json:"iv,omitempty"`
+	Iv []byte
 
 	// The tag to authenticate when performing decryption with an authenticated algorithm.
-	Tag []byte `json:"tag,omitempty"`
+	Tag []byte
 }
 
 // KeyProperties - Properties of the key pair backing a certificate.
 type KeyProperties struct {
 	// Elliptic curve name. For valid values, see JsonWebKeyCurveName.
-	Curve *JSONWebKeyCurveName `json:"crv,omitempty"`
+	Curve *JSONWebKeyCurveName
 
 	// Not supported in this version. Indicates if the private key can be exported.
-	Exportable *bool `json:"exportable,omitempty"`
+	Exportable *bool
 
 	// The key size in bits. For example: 2048, 3072, or 4096 for RSA.
-	KeySize *int32 `json:"key_size,omitempty"`
+	KeySize *int32
 
 	// The type of key pair to be used for the certificate.
-	KeyType *JSONWebKeyType `json:"kty,omitempty"`
+	KeyType *JSONWebKeyType
 
 	// Indicates if the same key pair will be used on certificate renewal.
-	ReuseKey *bool `json:"reuse_key,omitempty"`
+	ReuseKey *bool
 }
 
 // KeyRestoreParameters - The key restore parameters.
 type KeyRestoreParameters struct {
 	// REQUIRED; The backup blob associated with a key bundle.
-	KeyBundleBackup []byte `json:"value,omitempty"`
+	KeyBundleBackup []byte
 }
 
 // KeySignParameters - The key operations parameters.
 type KeySignParameters struct {
 	// REQUIRED; The signing/verification algorithm identifier. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
-	Algorithm *JSONWebKeySignatureAlgorithm `json:"alg,omitempty"`
+	Algorithm *JSONWebKeySignatureAlgorithm
 
 	// REQUIRED
-	Value []byte `json:"value,omitempty"`
+	Value []byte
 }
 
 // KeyUpdateParameters - The key update parameters.
 type KeyUpdateParameters struct {
 	// The attributes of a key managed by the key vault service.
-	KeyAttributes *KeyAttributes `json:"attributes,omitempty"`
+	KeyAttributes *KeyAttributes
 
 	// Json web key operations. For more information on possible key operations, see JsonWebKeyOperation.
-	KeyOps []*JSONWebKeyOperation `json:"key_ops,omitempty"`
+	KeyOps []*JSONWebKeyOperation
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // KeyVerifyParameters - The key verify parameters.
 type KeyVerifyParameters struct {
 	// REQUIRED; The signing/verification algorithm. For more information on possible algorithm types, see JsonWebKeySignatureAlgorithm.
-	Algorithm *JSONWebKeySignatureAlgorithm `json:"alg,omitempty"`
+	Algorithm *JSONWebKeySignatureAlgorithm
 
 	// REQUIRED; The digest used for signing.
-	Digest []byte `json:"digest,omitempty"`
+	Digest []byte
 
 	// REQUIRED; The signature to be verified.
-	Signature []byte `json:"value,omitempty"`
+	Signature []byte
 }
 
 // KeyVerifyResult - The key verify result.
 type KeyVerifyResult struct {
 	// READ-ONLY; True if the signature is verified, otherwise false.
-	Value *bool `json:"value,omitempty" azure:"ro"`
+	Value *bool
 }
 
 // LifetimeAction - Action and its trigger that will be performed by Key Vault over the lifetime of a certificate.
 type LifetimeAction struct {
 	// The action that will be executed.
-	Action *Action `json:"action,omitempty"`
+	Action *Action
 
 	// The condition that will execute the action.
-	Trigger *Trigger `json:"trigger,omitempty"`
+	Trigger *Trigger
 }
 
 // OrganizationDetails - Details of the organization of the certificate issuer.
 type OrganizationDetails struct {
 	// Details of the organization administrator.
-	AdminDetails []*AdministratorDetails `json:"admin_details,omitempty"`
+	AdminDetails []*AdministratorDetails
 
 	// Id of the organization.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // PendingCertificateSigningRequestResult - The pending certificate signing request result.
 type PendingCertificateSigningRequestResult struct {
 	// READ-ONLY; The pending certificate signing request as Base64 encoded string.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // Permission - Role definition permissions.
 type Permission struct {
 	// Action permissions that are granted.
-	Actions []*string `json:"actions,omitempty"`
+	Actions []*string
 
 	// Data action permissions that are granted.
-	DataActions []*DataAction `json:"dataActions,omitempty"`
+	DataActions []*DataAction
 
 	// Action permissions that are excluded but not denied. They may be granted by other role definitions assigned to a principal.
-	NotActions []*string `json:"notActions,omitempty"`
+	NotActions []*string
 
 	// Data action permissions that are excluded but not denied. They may be granted by other role definitions assigned to a principal.
-	NotDataActions []*DataAction `json:"notDataActions,omitempty"`
+	NotDataActions []*DataAction
 }
 
 // RestoreOperation - Restore operation
 type RestoreOperation struct {
 	// The end time of the restore operation
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Error encountered, if any, during the restore operation.
-	Error *ErrorInfo `json:"error,omitempty"`
+	Error *ErrorInfo
 
 	// Identifier for the restore operation.
-	JobID *string `json:"jobId,omitempty"`
+	JobID *string
 
 	// The start time of the restore operation
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Status of the restore operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// The status details of restore operation.
-	StatusDetails *string `json:"statusDetails,omitempty"`
+	StatusDetails *string
 }
 
 type RestoreOperationParameters struct {
 	// REQUIRED; The Folder name of the blob where the previous successful full backup was stored
-	FolderToRestore *string `json:"folderToRestore,omitempty"`
+	FolderToRestore *string
 
 	// REQUIRED; SAS token parameter object containing Azure storage resourceUri and token
-	SasTokenParameters *SASTokenParameter `json:"sasTokenParameters,omitempty"`
+	SasTokenParameters *SASTokenParameter
 }
 
 // RoleAssignment - Role Assignments
 type RoleAssignment struct {
 	// Role assignment properties.
-	Properties *RoleAssignmentPropertiesWithScope `json:"properties,omitempty"`
+	Properties *RoleAssignmentPropertiesWithScope
 
 	// READ-ONLY; The role assignment ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The role assignment name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The role assignment type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // RoleAssignmentCreateParameters - Role assignment create parameters.
 type RoleAssignmentCreateParameters struct {
 	// REQUIRED; Role assignment properties.
-	Properties *RoleAssignmentProperties `json:"properties,omitempty"`
+	Properties *RoleAssignmentProperties
 }
 
 // RoleAssignmentFilter - Role Assignments filter
 type RoleAssignmentFilter struct {
 	// Returns role assignment of the specific principal.
-	PrincipalID *string `json:"principalId,omitempty"`
+	PrincipalID *string
 }
 
 // RoleAssignmentListResult - Role assignment list operation result.
 type RoleAssignmentListResult struct {
 	// The URL to use for getting the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// Role assignment list.
-	Value []*RoleAssignment `json:"value,omitempty"`
+	Value []*RoleAssignment
 }
 
 // RoleAssignmentProperties - Role assignment properties.
 type RoleAssignmentProperties struct {
 	// REQUIRED; The principal ID assigned to the role. This maps to the ID inside the Active Directory. It can point to a user,
 	// service principal, or security group.
-	PrincipalID *string `json:"principalId,omitempty"`
+	PrincipalID *string
 
 	// REQUIRED; The role definition ID used in the role assignment.
-	RoleDefinitionID *string `json:"roleDefinitionId,omitempty"`
+	RoleDefinitionID *string
 }
 
 // RoleAssignmentPropertiesWithScope - Role assignment properties with scope.
 type RoleAssignmentPropertiesWithScope struct {
 	// The principal ID.
-	PrincipalID *string `json:"principalId,omitempty"`
+	PrincipalID *string
 
 	// The role definition ID.
-	RoleDefinitionID *string `json:"roleDefinitionId,omitempty"`
+	RoleDefinitionID *string
 
 	// The role scope.
-	Scope *RoleScope `json:"scope,omitempty"`
+	Scope *RoleScope
 }
 
 // RoleAssignmentsClientCreateOptions contains the optional parameters for the RoleAssignmentsClient.Create method.
@@ -1673,55 +1673,55 @@ type RoleAssignmentsClientListForScopeOptions struct {
 // RoleDefinition - Role definition.
 type RoleDefinition struct {
 	// Role definition properties.
-	Properties *RoleDefinitionProperties `json:"properties,omitempty"`
+	Properties *RoleDefinitionProperties
 
 	// READ-ONLY; The role definition ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The role definition name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The role definition type.
-	Type *RoleDefinitionType `json:"type,omitempty" azure:"ro"`
+	Type *RoleDefinitionType
 }
 
 // RoleDefinitionCreateParameters - Role definition create parameters.
 type RoleDefinitionCreateParameters struct {
 	// REQUIRED; Role definition properties.
-	Properties *RoleDefinitionProperties `json:"properties,omitempty"`
+	Properties *RoleDefinitionProperties
 }
 
 // RoleDefinitionFilter - Role Definitions filter
 type RoleDefinitionFilter struct {
 	// Returns role definition with the specific name.
-	RoleName *string `json:"roleName,omitempty"`
+	RoleName *string
 }
 
 // RoleDefinitionListResult - Role definition list operation result.
 type RoleDefinitionListResult struct {
 	// The URL to use for getting the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// Role definition list.
-	Value []*RoleDefinition `json:"value,omitempty"`
+	Value []*RoleDefinition
 }
 
 // RoleDefinitionProperties - Role definition properties.
 type RoleDefinitionProperties struct {
 	// Role definition assignable scopes.
-	AssignableScopes []*RoleScope `json:"assignableScopes,omitempty"`
+	AssignableScopes []*RoleScope
 
 	// The role definition description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Role definition permissions.
-	Permissions []*Permission `json:"permissions,omitempty"`
+	Permissions []*Permission
 
 	// The role name.
-	RoleName *string `json:"roleName,omitempty"`
+	RoleName *string
 
 	// The role type.
-	RoleType *RoleType `json:"type,omitempty"`
+	RoleType *RoleType
 }
 
 // RoleDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the RoleDefinitionsClient.CreateOrUpdate
@@ -1748,481 +1748,481 @@ type RoleDefinitionsClientListOptions struct {
 
 type SASTokenParameter struct {
 	// REQUIRED; Azure Blob storage container Uri
-	StorageResourceURI *string `json:"storageResourceUri,omitempty"`
+	StorageResourceURI *string
 
 	// REQUIRED; The SAS token pointing to an Azure Blob storage container
-	Token *string `json:"token,omitempty"`
+	Token *string
 }
 
 // SasDefinitionAttributes - The SAS definition management attributes.
 type SasDefinitionAttributes struct {
 	// the enabled state of the object.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for SAS definitions in the current vault. If it contains
 	// 'Purgeable' the SAS definition can be permanently deleted by a privileged user;
 	// otherwise, only the system can purge the SAS definition, at the end of the retention interval.
-	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // SasDefinitionBundle - A SAS definition bundle consists of key vault SAS definition details plus its attributes.
 type SasDefinitionBundle struct {
 	// READ-ONLY; The SAS definition attributes.
-	Attributes *SasDefinitionAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *SasDefinitionAttributes
 
 	// READ-ONLY; The SAS definition id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The type of SAS token the SAS definition will create.
-	SasType *SasTokenType `json:"sasType,omitempty" azure:"ro"`
+	SasType *SasTokenType
 
 	// READ-ONLY; Storage account SAS definition secret id.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 
 	// READ-ONLY; The SAS definition token template signed with an arbitrary key. Tokens created according to the SAS definition
 	// will have the same properties as the template.
-	TemplateURI *string `json:"templateUri,omitempty" azure:"ro"`
+	TemplateURI *string
 
 	// READ-ONLY; The validity period of SAS tokens created according to the SAS definition.
-	ValidityPeriod *string `json:"validityPeriod,omitempty" azure:"ro"`
+	ValidityPeriod *string
 }
 
 // SasDefinitionCreateParameters - The SAS definition create parameters.
 type SasDefinitionCreateParameters struct {
 	// REQUIRED; The type of SAS token the SAS definition will create.
-	SasType *SasTokenType `json:"sasType,omitempty"`
+	SasType *SasTokenType
 
 	// REQUIRED; The SAS definition token template signed with an arbitrary key. Tokens created according to the SAS definition
 	// will have the same properties as the template.
-	TemplateURI *string `json:"templateUri,omitempty"`
+	TemplateURI *string
 
 	// REQUIRED; The validity period of SAS tokens created according to the SAS definition.
-	ValidityPeriod *string `json:"validityPeriod,omitempty"`
+	ValidityPeriod *string
 
 	// The attributes of the SAS definition.
-	SasDefinitionAttributes *SasDefinitionAttributes `json:"attributes,omitempty"`
+	SasDefinitionAttributes *SasDefinitionAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // SasDefinitionItem - The SAS definition item containing storage SAS definition metadata.
 type SasDefinitionItem struct {
 	// READ-ONLY; The SAS definition management attributes.
-	Attributes *SasDefinitionAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *SasDefinitionAttributes
 
 	// READ-ONLY; The storage SAS identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The storage account SAS definition secret id.
-	SecretID *string `json:"sid,omitempty" azure:"ro"`
+	SecretID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // SasDefinitionListResult - The storage account SAS definition list result.
 type SasDefinitionListResult struct {
 	// READ-ONLY; The URL to get the next set of SAS definitions.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of SAS definitions along with a link to the next page of SAS definitions.
-	Value []*SasDefinitionItem `json:"value,omitempty" azure:"ro"`
+	Value []*SasDefinitionItem
 }
 
 // SasDefinitionUpdateParameters - The SAS definition update parameters.
 type SasDefinitionUpdateParameters struct {
 	// The attributes of the SAS definition.
-	SasDefinitionAttributes *SasDefinitionAttributes `json:"attributes,omitempty"`
+	SasDefinitionAttributes *SasDefinitionAttributes
 
 	// The type of SAS token the SAS definition will create.
-	SasType *SasTokenType `json:"sasType,omitempty"`
+	SasType *SasTokenType
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The SAS definition token template signed with an arbitrary key. Tokens created according to the SAS definition will have
 	// the same properties as the template.
-	TemplateURI *string `json:"templateUri,omitempty"`
+	TemplateURI *string
 
 	// The validity period of SAS tokens created according to the SAS definition.
-	ValidityPeriod *string `json:"validityPeriod,omitempty"`
+	ValidityPeriod *string
 }
 
 // SecretAttributes - The secret management attributes.
 type SecretAttributes struct {
 	// Determines whether the object is enabled.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Expiry date in UTC.
-	Expires *time.Time `json:"exp,omitempty"`
+	Expires *time.Time
 
 	// Not before date in UTC.
-	NotBefore *time.Time `json:"nbf,omitempty"`
+	NotBefore *time.Time
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for secrets in the current vault. If it contains 'Purgeable',
 	// the secret can be permanently deleted by a privileged user; otherwise, only the
 	// system can purge the secret, at the end of the retention interval.
-	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // SecretBundle - A secret consisting of a value, id and its attributes.
 type SecretBundle struct {
 	// The secret management attributes.
-	Attributes *SecretAttributes `json:"attributes,omitempty"`
+	Attributes *SecretAttributes
 
 	// The content type of the secret.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The secret id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The secret value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 
 	// READ-ONLY; If this is a secret backing a KV certificate, then this field specifies the corresponding key backing the KV
 	// certificate.
-	Kid *string `json:"kid,omitempty" azure:"ro"`
+	Kid *string
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a secret backing a certificate, then managed
 	// will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 }
 
 // SecretItem - The secret item containing secret metadata.
 type SecretItem struct {
 	// The secret management attributes.
-	Attributes *SecretAttributes `json:"attributes,omitempty"`
+	Attributes *SecretAttributes
 
 	// Type of the secret value such as a password.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// Secret identifier.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; True if the secret's lifetime is managed by key vault. If this is a key backing a certificate, then managed
 	// will be true.
-	Managed *bool `json:"managed,omitempty" azure:"ro"`
+	Managed *bool
 }
 
 // SecretListResult - The secret list result.
 type SecretListResult struct {
 	// READ-ONLY; The URL to get the next set of secrets.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of secrets in the key vault along with a link to the next page of secrets.
-	Value []*SecretItem `json:"value,omitempty" azure:"ro"`
+	Value []*SecretItem
 }
 
 // SecretProperties - Properties of the key backing a certificate.
 type SecretProperties struct {
 	// The media type (MIME type).
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 }
 
 // SecretRestoreParameters - The secret restore parameters.
 type SecretRestoreParameters struct {
 	// REQUIRED; The backup blob associated with a secret bundle.
-	SecretBundleBackup []byte `json:"value,omitempty"`
+	SecretBundleBackup []byte
 }
 
 // SecretSetParameters - The secret set parameters.
 type SecretSetParameters struct {
 	// REQUIRED; The value of the secret.
-	Value *string `json:"value,omitempty"`
+	Value *string
 
 	// Type of the secret value such as a password.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The secret management attributes.
-	SecretAttributes *SecretAttributes `json:"attributes,omitempty"`
+	SecretAttributes *SecretAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // SecretUpdateParameters - The secret update parameters.
 type SecretUpdateParameters struct {
 	// Type of the secret value such as a password.
-	ContentType *string `json:"contentType,omitempty"`
+	ContentType *string
 
 	// The secret management attributes.
-	SecretAttributes *SecretAttributes `json:"attributes,omitempty"`
+	SecretAttributes *SecretAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 type SecurityDomainCertificateItem struct {
 	// REQUIRED; Customer generated certificate containing public key in JWK format
-	Value *SecurityDomainJSONWebKey `json:"value,omitempty"`
+	Value *SecurityDomainJSONWebKey
 }
 
 type SecurityDomainJSONWebKey struct {
 	// REQUIRED; Algorithm intended for use with the key.
-	Alg *string `json:"alg,omitempty"`
+	Alg *string
 
 	// REQUIRED; RSA public exponent.
-	E *string `json:"e,omitempty"`
+	E *string
 
 	// REQUIRED
-	KeyOps []*string `json:"key_ops,omitempty"`
+	KeyOps []*string
 
 	// REQUIRED; Key identifier.
-	Kid *string `json:"kid,omitempty"`
+	Kid *string
 
 	// REQUIRED; JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
 	// For Security Domain this value must be RSA.
-	Kty *string `json:"kty,omitempty"`
+	Kty *string
 
 	// REQUIRED; RSA modulus.
-	N *string `json:"n,omitempty"`
+	N *string
 
 	// REQUIRED; X509 certificate chain parameter
-	X5C []*string `json:"x5c,omitempty"`
+	X5C []*string
 
 	// REQUIRED; X509 certificate SHA256 thumbprint.
-	X5TS256 *string `json:"x5t#S256,omitempty"`
+	X5TS256 *string
 
 	// Public Key Use Parameter. This is optional and if present must be enc.
-	Use *string `json:"use,omitempty"`
+	Use *string
 
 	// X509 certificate SHA1 thumbprint. This is optional.
-	X5T *string `json:"x5t,omitempty"`
+	X5T *string
 }
 
 // SecurityDomainObject - The Security Domain.
 type SecurityDomainObject struct {
 	// REQUIRED; The Security Domain.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 type SecurityDomainOperationStatus struct {
 	// operation status
-	Status        *OperationStatus `json:"status,omitempty"`
-	StatusDetails *string          `json:"status_details,omitempty"`
+	Status        *OperationStatus
+	StatusDetails *string
 }
 
 // SelectiveKeyRestoreOperation - Selective Key Restore operation
 type SelectiveKeyRestoreOperation struct {
 	// The end time of the restore operation
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Error encountered, if any, during the selective key restore operation.
-	Error *ErrorInfo `json:"error,omitempty"`
+	Error *ErrorInfo
 
 	// Identifier for the selective key restore operation.
-	JobID *string `json:"jobId,omitempty"`
+	JobID *string
 
 	// The start time of the restore operation
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Status of the restore operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// The status details of restore operation.
-	StatusDetails *string `json:"statusDetails,omitempty"`
+	StatusDetails *string
 }
 
 type SelectiveKeyRestoreOperationParameters struct {
 	// REQUIRED; The Folder name of the blob where the previous successful full backup was stored
-	Folder *string `json:"folder,omitempty"`
+	Folder *string
 
 	// REQUIRED; SAS token parameter object containing Azure storage resourceUri and token
-	SasTokenParameters *SASTokenParameter `json:"sasTokenParameters,omitempty"`
+	SasTokenParameters *SASTokenParameter
 }
 
 // StorageAccountAttributes - The storage account management attributes.
 type StorageAccountAttributes struct {
 	// the enabled state of the object.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// READ-ONLY; Creation time in UTC.
-	Created *time.Time `json:"created,omitempty" azure:"ro"`
+	Created *time.Time
 
 	// READ-ONLY; softDelete data retention days. Value should be >=7 and <=90 when softDelete enabled, otherwise 0.
-	RecoverableDays *int32 `json:"recoverableDays,omitempty" azure:"ro"`
+	RecoverableDays *int32
 
 	// READ-ONLY; Reflects the deletion recovery level currently in effect for storage accounts in the current vault. If it contains
 	// 'Purgeable' the storage account can be permanently deleted by a privileged user;
 	// otherwise, only the system can purge the storage account, at the end of the retention interval.
-	RecoveryLevel *DeletionRecoveryLevel `json:"recoveryLevel,omitempty" azure:"ro"`
+	RecoveryLevel *DeletionRecoveryLevel
 
 	// READ-ONLY; Last updated time in UTC.
-	Updated *time.Time `json:"updated,omitempty" azure:"ro"`
+	Updated *time.Time
 }
 
 // StorageAccountCreateParameters - The storage account create parameters.
 type StorageAccountCreateParameters struct {
 	// REQUIRED; Current active storage account key name.
-	ActiveKeyName *string `json:"activeKeyName,omitempty"`
+	ActiveKeyName *string
 
 	// REQUIRED; whether keyvault should manage the storage account for the user.
-	AutoRegenerateKey *bool `json:"autoRegenerateKey,omitempty"`
+	AutoRegenerateKey *bool
 
 	// REQUIRED; Storage account resource id.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 
 	// The key regeneration time duration specified in ISO-8601 format.
-	RegenerationPeriod *string `json:"regenerationPeriod,omitempty"`
+	RegenerationPeriod *string
 
 	// The attributes of the storage account.
-	StorageAccountAttributes *StorageAccountAttributes `json:"attributes,omitempty"`
+	StorageAccountAttributes *StorageAccountAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // StorageAccountItem - The storage account item containing storage account metadata.
 type StorageAccountItem struct {
 	// READ-ONLY; The storage account management attributes.
-	Attributes *StorageAccountAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *StorageAccountAttributes
 
 	// READ-ONLY; Storage identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Storage account resource Id.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // StorageAccountRegenerteKeyParameters - The storage account key regenerate parameters.
 type StorageAccountRegenerteKeyParameters struct {
 	// REQUIRED; The storage account key name.
-	KeyName *string `json:"keyName,omitempty"`
+	KeyName *string
 }
 
 // StorageAccountUpdateParameters - The storage account update parameters.
 type StorageAccountUpdateParameters struct {
 	// The current active storage account key name.
-	ActiveKeyName *string `json:"activeKeyName,omitempty"`
+	ActiveKeyName *string
 
 	// whether keyvault should manage the storage account for the user.
-	AutoRegenerateKey *bool `json:"autoRegenerateKey,omitempty"`
+	AutoRegenerateKey *bool
 
 	// The key regeneration time duration specified in ISO-8601 format.
-	RegenerationPeriod *string `json:"regenerationPeriod,omitempty"`
+	RegenerationPeriod *string
 
 	// The attributes of the storage account.
-	StorageAccountAttributes *StorageAccountAttributes `json:"attributes,omitempty"`
+	StorageAccountAttributes *StorageAccountAttributes
 
 	// Application specific metadata in the form of key-value pairs.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // StorageBundle - A Storage account bundle consists of key vault storage account details plus its attributes.
 type StorageBundle struct {
 	// READ-ONLY; The current active storage account key name.
-	ActiveKeyName *string `json:"activeKeyName,omitempty" azure:"ro"`
+	ActiveKeyName *string
 
 	// READ-ONLY; The storage account attributes.
-	Attributes *StorageAccountAttributes `json:"attributes,omitempty" azure:"ro"`
+	Attributes *StorageAccountAttributes
 
 	// READ-ONLY; whether keyvault should manage the storage account for the user.
-	AutoRegenerateKey *bool `json:"autoRegenerateKey,omitempty" azure:"ro"`
+	AutoRegenerateKey *bool
 
 	// READ-ONLY; The storage account id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The key regeneration time duration specified in ISO-8601 format.
-	RegenerationPeriod *string `json:"regenerationPeriod,omitempty" azure:"ro"`
+	RegenerationPeriod *string
 
 	// READ-ONLY; The storage account resource id.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; Application specific metadata in the form of key-value pairs
-	Tags map[string]*string `json:"tags,omitempty" azure:"ro"`
+	Tags map[string]*string
 }
 
 // StorageListResult - The storage accounts list result.
 type StorageListResult struct {
 	// READ-ONLY; The URL to get the next set of storage accounts.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; A response message containing a list of storage accounts in the key vault along with a link to the next page
 	// of storage accounts.
-	Value []*StorageAccountItem `json:"value,omitempty" azure:"ro"`
+	Value []*StorageAccountItem
 }
 
 // StorageRestoreParameters - The secret restore parameters.
 type StorageRestoreParameters struct {
 	// REQUIRED; The backup blob associated with a storage account.
-	StorageBundleBackup []byte `json:"value,omitempty"`
+	StorageBundleBackup []byte
 }
 
 // SubjectAlternativeNames - The subject alternate names of a X509 object.
 type SubjectAlternativeNames struct {
 	// Domain names.
-	DNSNames []*string `json:"dns_names,omitempty"`
+	DNSNames []*string
 
 	// Email addresses.
-	Emails []*string `json:"emails,omitempty"`
+	Emails []*string
 
 	// User principal names.
-	Upns []*string `json:"upns,omitempty"`
+	Upns []*string
 }
 
 type TransferKey struct {
 	// REQUIRED; Specifies the transfer key in JWK format
-	TransferKey *SecurityDomainJSONWebKey `json:"transfer_key,omitempty"`
+	TransferKey *SecurityDomainJSONWebKey
 
 	// Specifies the format of the transfer key
-	KeyFormat *string `json:"key_format,omitempty"`
+	KeyFormat *string
 }
 
 // Trigger - A condition to be satisfied for an action to be executed.
 type Trigger struct {
 	// Days before expiry to attempt renewal. Value should be between 1 and validityinmonths multiplied by 27. If validityinmonths
 	// is 36, then value should be between 1 and 972 (36 * 27).
-	DaysBeforeExpiry *int32 `json:"days_before_expiry,omitempty"`
+	DaysBeforeExpiry *int32
 
 	// Percentage of lifetime at which to trigger. Value should be between 1 and 99.
-	LifetimePercentage *int32 `json:"lifetime_percentage,omitempty"`
+	LifetimePercentage *int32
 }
 
 // X509CertificateProperties - Properties of the X509 component of a certificate.
 type X509CertificateProperties struct {
 	// The enhanced key usage.
-	Ekus []*string `json:"ekus,omitempty"`
+	Ekus []*string
 
 	// List of key usages.
-	KeyUsage []*KeyUsageType `json:"key_usage,omitempty"`
+	KeyUsage []*KeyUsageType
 
 	// The subject name. Should be a valid X509 distinguished Name.
-	Subject *string `json:"subject,omitempty"`
+	Subject *string
 
 	// The subject alternative names.
-	SubjectAlternativeNames *SubjectAlternativeNames `json:"sans,omitempty"`
+	SubjectAlternativeNames *SubjectAlternativeNames
 
 	// The duration that the certificate is valid in months.
-	ValidityInMonths *int32 `json:"validity_months,omitempty"`
+	ValidityInMonths *int32
 }

--- a/test/maps/azalias/zz_models.go
+++ b/test/maps/azalias/zz_models.go
@@ -14,16 +14,16 @@ import "time"
 // AliasesCreateResponse - The response model for the Alias Create API for the case when the alias was successfully created.
 type AliasesCreateResponse struct {
 	// READ-ONLY; The id for the alias.
-	AliasID *string `json:"aliasId,omitempty" azure:"ro"`
+	AliasID *string
 
 	// READ-ONLY; The created timestamp for the alias.
-	CreatedTimestamp *string `json:"createdTimestamp,omitempty" azure:"ro"`
+	CreatedTimestamp *string
 
 	// READ-ONLY; The id for the creator data item that this alias references (could be null if the alias has not been assigned).
-	CreatorDataItemID *string `json:"creatorDataItemId,omitempty" azure:"ro"`
+	CreatorDataItemID *string
 
 	// READ-ONLY; The timestamp of the last time the alias was assigned.
-	LastUpdatedTimestamp *string `json:"lastUpdatedTimestamp,omitempty" azure:"ro"`
+	LastUpdatedTimestamp *string
 }
 
 // ClientCreateOptions contains the optional parameters for the Client.Create method.
@@ -53,10 +53,10 @@ type ClientPolicyAssignmentOptions struct {
 // ErrorResponse - An error happened.
 type ErrorResponse struct {
 	// READ-ONLY; The error code.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The error message.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 }
 
 // GeoJSONFeature - A valid GeoJSON Feature object type. Please refer to RFC 7946 [https://tools.ietf.org/html/rfc7946#section-3.2]
@@ -65,20 +65,20 @@ type GeoJSONFeature struct {
 	// REQUIRED; Specifies the GeoJSON type. Must be one of the nine valid GeoJSON object types - Point, MultiPoint, LineString,
 	// MultiLineString, Polygon, MultiPolygon, GeometryCollection, Feature and
 	// FeatureCollection.
-	Type *GeoJSONObjectType `json:"type,omitempty"`
+	Type *GeoJSONObjectType
 
 	// The type of the feature. The value depends on the data model the current feature is part of. Some data models may have
 	// an empty value.
-	FeatureType *string `json:"featureType,omitempty"`
+	FeatureType *string
 
 	// Identifier for the feature.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties []byte `json:"properties,omitempty"`
+	Properties []byte
 
 	// test enum with a default
-	Setting *DataSetting `json:"setting,omitempty"`
+	Setting *DataSetting
 }
 
 // GetGeoJSONObject implements the GeoJSONObjectClassification interface for type GeoJSONFeature.
@@ -92,16 +92,16 @@ func (g *GeoJSONFeature) GetGeoJSONObject() *GeoJSONObject {
 type GeoJSONFeatureData struct {
 	// The type of the feature. The value depends on the data model the current feature is part of. Some data models may have
 	// an empty value.
-	FeatureType *string `json:"featureType,omitempty"`
+	FeatureType *string
 
 	// Identifier for the feature.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties []byte `json:"properties,omitempty"`
+	Properties []byte
 
 	// test enum with a default
-	Setting *DataSetting `json:"setting,omitempty"`
+	Setting *DataSetting
 }
 
 // GeoJSONObjectClassification provides polymorphic access to related types.
@@ -118,10 +118,10 @@ type GeoJSONObject struct {
 	// REQUIRED; Specifies the GeoJSON type. Must be one of the nine valid GeoJSON object types - Point, MultiPoint, LineString,
 	// MultiLineString, Polygon, MultiPolygon, GeometryCollection, Feature and
 	// FeatureCollection.
-	Type *GeoJSONObjectType `json:"type,omitempty"`
+	Type *GeoJSONObjectType
 
 	// Identifier for the feature.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // GetGeoJSONObject implements the GeoJSONObjectClassification interface for type GeoJSONObject.
@@ -130,68 +130,68 @@ func (g *GeoJSONObject) GetGeoJSONObject() *GeoJSONObject { return g }
 // ListItem - Detailed information for the alias.
 type ListItem struct {
 	// READ-ONLY; The id for the alias.
-	AliasID *string `json:"aliasId,omitempty" azure:"ro"`
+	AliasID *string
 
 	// READ-ONLY; The created timestamp for the alias.
-	CreatedTimestamp *string `json:"createdTimestamp,omitempty" azure:"ro"`
+	CreatedTimestamp *string
 
 	// READ-ONLY; The id for the creator data item that this alias references (could be null if the alias has not been assigned).
-	CreatorDataItemID *string `json:"creatorDataItemId,omitempty" azure:"ro"`
+	CreatorDataItemID *string
 
 	// READ-ONLY; The timestamp of the last time the alias was assigned.
-	LastUpdatedTimestamp *string `json:"lastUpdatedTimestamp,omitempty" azure:"ro"`
+	LastUpdatedTimestamp *string
 }
 
 // ListResponse - The response model for the List API. Returns a list of all the previously created aliases.
 type ListResponse struct {
 	// READ-ONLY; A list of all the previously created aliases.
-	Aliases []*ListItem `json:"aliases,omitempty" azure:"ro"`
+	Aliases []*ListItem
 
 	// READ-ONLY; If present, the location of the next page of data.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 type ParameterMetadataValue struct {
 	// a JSON object
-	Value []byte `json:"value,omitempty"`
+	Value []byte
 }
 
 // ParameterValuesValue - The value of a parameter.
 type ParameterValuesValue struct {
 	// The value of the parameter.
-	Value []byte `json:"value,omitempty"`
+	Value []byte
 }
 
 type PolicyAssignmentProperties struct {
 	// The display name of the policy assignment.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// Key-value pairs of extra info.
-	Metadata map[string]*ParameterMetadataValue `json:"metadata,omitempty"`
+	Metadata map[string]*ParameterMetadataValue
 
 	// The parameter values for the assigned policy rule. The keys are the parameter names.
-	Parameters map[string]*ParameterValuesValue `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterValuesValue
 }
 
 // ScheduleCreateOrUpdateProperties - The parameters supplied to the create or update schedule operation.
 type ScheduleCreateOrUpdateProperties struct {
 	// A list of all the previously created aliases.
-	Aliases []*string `json:"aliases,omitempty"`
+	Aliases []*string
 
 	// Gets or sets the description of the schedule.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Gets or sets the interval of the schedule.
-	Interval []byte `json:"interval,omitempty"`
+	Interval []byte
 
 	// Gets or sets the start time of the schedule.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 }
 
 type TypeWithRawJSON struct {
 	// any JSON object
-	AnyObject []byte `json:"anyObject,omitempty"`
+	AnyObject []byte
 
 	// any valid JSON
-	Anything []byte `json:"anything,omitempty"`
+	Anything []byte
 }

--- a/test/network/2020-03-01/armnetwork/zz_models.go
+++ b/test/network/2020-03-01/armnetwork/zz_models.go
@@ -14,1134 +14,1134 @@ import "time"
 // AADAuthenticationParameters - AAD Vpn authentication type related parameters.
 type AADAuthenticationParameters struct {
 	// AAD Vpn authentication parameter AAD audience.
-	AADAudience *string `json:"aadAudience,omitempty"`
+	AADAudience *string
 
 	// AAD Vpn authentication parameter AAD issuer.
-	AADIssuer *string `json:"aadIssuer,omitempty"`
+	AADIssuer *string
 
 	// AAD Vpn authentication parameter AAD tenant.
-	AADTenant *string `json:"aadTenant,omitempty"`
+	AADTenant *string
 }
 
 // AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.
 type AddressSpace struct {
 	// A list of address blocks reserved for this virtual network in CIDR notation.
-	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string
 }
 
 // ApplicationGateway - Application gateway resource.
 type ApplicationGateway struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The identity of the application gateway, if configured.
-	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
+	Identity *ManagedServiceIdentity
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the application gateway.
-	Properties *ApplicationGatewayPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayAuthenticationCertificate - Authentication certificates of an application gateway.
 type ApplicationGatewayAuthenticationCertificate struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the authentication certificate that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway authentication certificate.
-	Properties *ApplicationGatewayAuthenticationCertificatePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayAuthenticationCertificatePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayAuthenticationCertificatePropertiesFormat - Authentication certificates properties of an application
 // gateway.
 type ApplicationGatewayAuthenticationCertificatePropertiesFormat struct {
 	// Certificate public data.
-	Data *string `json:"data,omitempty"`
+	Data *string
 
 	// READ-ONLY; The provisioning state of the authentication certificate resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayAutoscaleConfiguration - Application Gateway autoscale configuration.
 type ApplicationGatewayAutoscaleConfiguration struct {
 	// REQUIRED; Lower bound on number of Application Gateway capacity.
-	MinCapacity *int32 `json:"minCapacity,omitempty"`
+	MinCapacity *int32
 
 	// Upper bound on number of Application Gateway capacity.
-	MaxCapacity *int32 `json:"maxCapacity,omitempty"`
+	MaxCapacity *int32
 }
 
 // ApplicationGatewayAvailableSSLOptions - Response for ApplicationGatewayAvailableSslOptions API service call.
 type ApplicationGatewayAvailableSSLOptions struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the application gateway available SSL options.
-	Properties *ApplicationGatewayAvailableSSLOptionsPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayAvailableSSLOptionsPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayAvailableSSLOptionsPropertiesFormat - Properties of ApplicationGatewayAvailableSslOptions.
 type ApplicationGatewayAvailableSSLOptionsPropertiesFormat struct {
 	// List of available Ssl cipher suites.
-	AvailableCipherSuites []*ApplicationGatewaySSLCipherSuite `json:"availableCipherSuites,omitempty"`
+	AvailableCipherSuites []*ApplicationGatewaySSLCipherSuite
 
 	// List of available Ssl protocols.
-	AvailableProtocols []*ApplicationGatewaySSLProtocol `json:"availableProtocols,omitempty"`
+	AvailableProtocols []*ApplicationGatewaySSLProtocol
 
 	// Name of the Ssl predefined policy applied by default to application gateway.
-	DefaultPolicy *ApplicationGatewaySSLPolicyName `json:"defaultPolicy,omitempty"`
+	DefaultPolicy *ApplicationGatewaySSLPolicyName
 
 	// List of available Ssl predefined policy.
-	PredefinedPolicies []*SubResource `json:"predefinedPolicies,omitempty"`
+	PredefinedPolicies []*SubResource
 }
 
 // ApplicationGatewayAvailableSSLPredefinedPolicies - Response for ApplicationGatewayAvailableSslOptions API service call.
 type ApplicationGatewayAvailableSSLPredefinedPolicies struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of available Ssl predefined policy.
-	Value []*ApplicationGatewaySSLPredefinedPolicy `json:"value,omitempty"`
+	Value []*ApplicationGatewaySSLPredefinedPolicy
 }
 
 // ApplicationGatewayAvailableWafRuleSetsResult - Response for ApplicationGatewayAvailableWafRuleSets API service call.
 type ApplicationGatewayAvailableWafRuleSetsResult struct {
 	// The list of application gateway rule sets.
-	Value []*ApplicationGatewayFirewallRuleSet `json:"value,omitempty"`
+	Value []*ApplicationGatewayFirewallRuleSet
 }
 
 // ApplicationGatewayBackendAddress - Backend address of an application gateway.
 type ApplicationGatewayBackendAddress struct {
 	// Fully qualified domain name (FQDN).
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// IP address.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 }
 
 // ApplicationGatewayBackendAddressPool - Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPool struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the backend address pool that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway backend address pool.
-	Properties *ApplicationGatewayBackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayBackendAddressPoolPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayBackendAddressPoolPropertiesFormat - Properties of Backend Address Pool of an application gateway.
 type ApplicationGatewayBackendAddressPoolPropertiesFormat struct {
 	// Backend addresses.
-	BackendAddresses []*ApplicationGatewayBackendAddress `json:"backendAddresses,omitempty"`
+	BackendAddresses []*ApplicationGatewayBackendAddress
 
 	// READ-ONLY; Collection of references to IPs defined in network interfaces.
-	BackendIPConfigurations []*InterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*InterfaceIPConfiguration
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayBackendHTTPSettings - Backend address pool settings of an application gateway.
 type ApplicationGatewayBackendHTTPSettings struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the backend http settings that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway backend HTTP settings.
-	Properties *ApplicationGatewayBackendHTTPSettingsPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayBackendHTTPSettingsPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayBackendHTTPSettingsPropertiesFormat - Properties of Backend address pool settings of an application gateway.
 type ApplicationGatewayBackendHTTPSettingsPropertiesFormat struct {
 	// Cookie name to use for the affinity cookie.
-	AffinityCookieName *string `json:"affinityCookieName,omitempty"`
+	AffinityCookieName *string
 
 	// Array of references to application gateway authentication certificates.
-	AuthenticationCertificates []*SubResource `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates []*SubResource
 
 	// Connection draining of the backend http settings resource.
-	ConnectionDraining *ApplicationGatewayConnectionDraining `json:"connectionDraining,omitempty"`
+	ConnectionDraining *ApplicationGatewayConnectionDraining
 
 	// Cookie based affinity.
-	CookieBasedAffinity *ApplicationGatewayCookieBasedAffinity `json:"cookieBasedAffinity,omitempty"`
+	CookieBasedAffinity *ApplicationGatewayCookieBasedAffinity
 
 	// Host header to be sent to the backend servers.
-	HostName *string `json:"hostName,omitempty"`
+	HostName *string
 
 	// Path which should be used as a prefix for all HTTP requests. Null means no path will be prefixed. Default value is null.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// Whether to pick host header should be picked from the host name of the backend server. Default value is false.
-	PickHostNameFromBackendAddress *bool `json:"pickHostNameFromBackendAddress,omitempty"`
+	PickHostNameFromBackendAddress *bool
 
 	// The destination port on the backend.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// Probe resource of an application gateway.
-	Probe *SubResource `json:"probe,omitempty"`
+	Probe *SubResource
 
 	// Whether the probe is enabled. Default value is false.
-	ProbeEnabled *bool `json:"probeEnabled,omitempty"`
+	ProbeEnabled *bool
 
 	// The protocol used to communicate with the backend.
-	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
+	Protocol *ApplicationGatewayProtocol
 
 	// Request timeout in seconds. Application Gateway will fail the request if response is not received within RequestTimeout.
 	// Acceptable values are from 1 second to 86400 seconds.
-	RequestTimeout *int32 `json:"requestTimeout,omitempty"`
+	RequestTimeout *int32
 
 	// Array of references to application gateway trusted root certificates.
-	TrustedRootCertificates []*SubResource `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates []*SubResource
 
 	// READ-ONLY; The provisioning state of the backend HTTP settings resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayBackendHealth - Response for ApplicationGatewayBackendHealth API service call.
 type ApplicationGatewayBackendHealth struct {
 	// A list of ApplicationGatewayBackendHealthPool resources.
-	BackendAddressPools []*ApplicationGatewayBackendHealthPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*ApplicationGatewayBackendHealthPool
 }
 
 // ApplicationGatewayBackendHealthHTTPSettings - Application gateway BackendHealthHttp settings.
 type ApplicationGatewayBackendHealthHTTPSettings struct {
 	// Reference to an ApplicationGatewayBackendHttpSettings resource.
-	BackendHTTPSettings *ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettings,omitempty"`
+	BackendHTTPSettings *ApplicationGatewayBackendHTTPSettings
 
 	// List of ApplicationGatewayBackendHealthServer resources.
-	Servers []*ApplicationGatewayBackendHealthServer `json:"servers,omitempty"`
+	Servers []*ApplicationGatewayBackendHealthServer
 }
 
 // ApplicationGatewayBackendHealthOnDemand - Result of on demand test probe.
 type ApplicationGatewayBackendHealthOnDemand struct {
 	// Reference to an ApplicationGatewayBackendAddressPool resource.
-	BackendAddressPool *ApplicationGatewayBackendAddressPool `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *ApplicationGatewayBackendAddressPool
 
 	// Application gateway BackendHealthHttp settings.
-	BackendHealthHTTPSettings *ApplicationGatewayBackendHealthHTTPSettings `json:"backendHealthHttpSettings,omitempty"`
+	BackendHealthHTTPSettings *ApplicationGatewayBackendHealthHTTPSettings
 }
 
 // ApplicationGatewayBackendHealthPool - Application gateway BackendHealth pool.
 type ApplicationGatewayBackendHealthPool struct {
 	// Reference to an ApplicationGatewayBackendAddressPool resource.
-	BackendAddressPool *ApplicationGatewayBackendAddressPool `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *ApplicationGatewayBackendAddressPool
 
 	// List of ApplicationGatewayBackendHealthHttpSettings resources.
-	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHealthHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHealthHTTPSettings
 }
 
 // ApplicationGatewayBackendHealthServer - Application gateway backendhealth http settings.
 type ApplicationGatewayBackendHealthServer struct {
 	// IP address or FQDN of backend server.
-	Address *string `json:"address,omitempty"`
+	Address *string
 
 	// Health of backend server.
-	Health *ApplicationGatewayBackendHealthServerHealth `json:"health,omitempty"`
+	Health *ApplicationGatewayBackendHealthServerHealth
 
 	// Health Probe Log.
-	HealthProbeLog *string `json:"healthProbeLog,omitempty"`
+	HealthProbeLog *string
 
 	// Reference to IP configuration of backend server.
-	IPConfiguration *InterfaceIPConfiguration `json:"ipConfiguration,omitempty"`
+	IPConfiguration *InterfaceIPConfiguration
 }
 
 // ApplicationGatewayConnectionDraining - Connection draining allows open connections to a backend server to be active for
 // a specified time after the backend server got removed from the configuration.
 type ApplicationGatewayConnectionDraining struct {
 	// REQUIRED; The number of seconds connection draining is active. Acceptable values are from 1 second to 3600 seconds.
-	DrainTimeoutInSec *int32 `json:"drainTimeoutInSec,omitempty"`
+	DrainTimeoutInSec *int32
 
 	// REQUIRED; Whether connection draining is enabled or not.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 }
 
 // ApplicationGatewayCustomError - Customer error of an application gateway.
 type ApplicationGatewayCustomError struct {
 	// Error page URL of the application gateway customer error.
-	CustomErrorPageURL *string `json:"customErrorPageUrl,omitempty"`
+	CustomErrorPageURL *string
 
 	// Status code of the application gateway customer error.
-	StatusCode *ApplicationGatewayCustomErrorStatusCode `json:"statusCode,omitempty"`
+	StatusCode *ApplicationGatewayCustomErrorStatusCode
 }
 
 // ApplicationGatewayFirewallDisabledRuleGroup - Allows to disable rules within a rule group or an entire rule group.
 type ApplicationGatewayFirewallDisabledRuleGroup struct {
 	// REQUIRED; The name of the rule group that will be disabled.
-	RuleGroupName *string `json:"ruleGroupName,omitempty"`
+	RuleGroupName *string
 
 	// The list of rules that will be disabled. If null, all rules of the rule group will be disabled.
-	Rules []*int32 `json:"rules,omitempty"`
+	Rules []*int32
 }
 
 // ApplicationGatewayFirewallExclusion - Allow to exclude some variable satisfy the condition for the WAF check.
 type ApplicationGatewayFirewallExclusion struct {
 	// REQUIRED; The variable to be excluded.
-	MatchVariable *string `json:"matchVariable,omitempty"`
+	MatchVariable *string
 
 	// REQUIRED; When matchVariable is a collection, operator used to specify which elements in the collection this exclusion
 	// applies to.
-	Selector *string `json:"selector,omitempty"`
+	Selector *string
 
 	// REQUIRED; When matchVariable is a collection, operate on the selector to specify which elements in the collection this
 	// exclusion applies to.
-	SelectorMatchOperator *string `json:"selectorMatchOperator,omitempty"`
+	SelectorMatchOperator *string
 }
 
 // ApplicationGatewayFirewallRule - A web application firewall rule.
 type ApplicationGatewayFirewallRule struct {
 	// REQUIRED; The identifier of the web application firewall rule.
-	RuleID *int32 `json:"ruleId,omitempty"`
+	RuleID *int32
 
 	// The description of the web application firewall rule.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // ApplicationGatewayFirewallRuleGroup - A web application firewall rule group.
 type ApplicationGatewayFirewallRuleGroup struct {
 	// REQUIRED; The name of the web application firewall rule group.
-	RuleGroupName *string `json:"ruleGroupName,omitempty"`
+	RuleGroupName *string
 
 	// REQUIRED; The rules of the web application firewall rule group.
-	Rules []*ApplicationGatewayFirewallRule `json:"rules,omitempty"`
+	Rules []*ApplicationGatewayFirewallRule
 
 	// The description of the web application firewall rule group.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // ApplicationGatewayFirewallRuleSet - A web application firewall rule set.
 type ApplicationGatewayFirewallRuleSet struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the application gateway firewall rule set.
-	Properties *ApplicationGatewayFirewallRuleSetPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayFirewallRuleSetPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayFirewallRuleSetPropertiesFormat - Properties of the web application firewall rule set.
 type ApplicationGatewayFirewallRuleSetPropertiesFormat struct {
 	// REQUIRED; The rule groups of the web application firewall rule set.
-	RuleGroups []*ApplicationGatewayFirewallRuleGroup `json:"ruleGroups,omitempty"`
+	RuleGroups []*ApplicationGatewayFirewallRuleGroup
 
 	// REQUIRED; The type of the web application firewall rule set.
-	RuleSetType *string `json:"ruleSetType,omitempty"`
+	RuleSetType *string
 
 	// REQUIRED; The version of the web application firewall rule set type.
-	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
+	RuleSetVersion *string
 
 	// READ-ONLY; The provisioning state of the web application firewall rule set.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayFrontendIPConfiguration - Frontend IP configuration of an application gateway.
 type ApplicationGatewayFrontendIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the frontend IP configuration that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway frontend IP configuration.
-	Properties *ApplicationGatewayFrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayFrontendIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayFrontendIPConfigurationPropertiesFormat - Properties of Frontend IP configuration of an application gateway.
 type ApplicationGatewayFrontendIPConfigurationPropertiesFormat struct {
 	// PrivateIPAddress of the network interface IP Configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// Reference to the PublicIP resource.
-	PublicIPAddress *SubResource `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *SubResource
 
 	// Reference to the subnet resource.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 
 	// READ-ONLY; The provisioning state of the frontend IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayFrontendPort - Frontend port of an application gateway.
 type ApplicationGatewayFrontendPort struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the frontend port that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway frontend port.
-	Properties *ApplicationGatewayFrontendPortPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayFrontendPortPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayFrontendPortPropertiesFormat - Properties of Frontend port of an application gateway.
 type ApplicationGatewayFrontendPortPropertiesFormat struct {
 	// Frontend port.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// READ-ONLY; The provisioning state of the frontend port resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayHTTPListener - Http listener of an application gateway.
 type ApplicationGatewayHTTPListener struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the HTTP listener that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway HTTP listener.
-	Properties *ApplicationGatewayHTTPListenerPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayHTTPListenerPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayHTTPListenerPropertiesFormat - Properties of HTTP listener of an application gateway.
 type ApplicationGatewayHTTPListenerPropertiesFormat struct {
 	// Custom error configurations of the HTTP listener.
-	CustomErrorConfigurations []*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations []*ApplicationGatewayCustomError
 
 	// Reference to the FirewallPolicy resource.
-	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
+	FirewallPolicy *SubResource
 
 	// Frontend IP configuration resource of an application gateway.
-	FrontendIPConfiguration *SubResource `json:"frontendIPConfiguration,omitempty"`
+	FrontendIPConfiguration *SubResource
 
 	// Frontend port resource of an application gateway.
-	FrontendPort *SubResource `json:"frontendPort,omitempty"`
+	FrontendPort *SubResource
 
 	// Host name of HTTP listener.
-	HostName *string `json:"hostName,omitempty"`
+	HostName *string
 
 	// List of Host names for HTTP Listener that allows special wildcard characters as well.
-	HostNames []*string `json:"hostNames,omitempty"`
+	HostNames []*string
 
 	// Protocol of the HTTP listener.
-	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
+	Protocol *ApplicationGatewayProtocol
 
 	// Applicable only if protocol is https. Enables SNI for multi-hosting.
-	RequireServerNameIndication *bool `json:"requireServerNameIndication,omitempty"`
+	RequireServerNameIndication *bool
 
 	// SSL certificate resource of an application gateway.
-	SSLCertificate *SubResource `json:"sslCertificate,omitempty"`
+	SSLCertificate *SubResource
 
 	// READ-ONLY; The provisioning state of the HTTP listener resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayHeaderConfiguration - Header configuration of the Actions set in Application Gateway.
 type ApplicationGatewayHeaderConfiguration struct {
 	// Header name of the header configuration.
-	HeaderName *string `json:"headerName,omitempty"`
+	HeaderName *string
 
 	// Header value of the header configuration.
-	HeaderValue *string `json:"headerValue,omitempty"`
+	HeaderValue *string
 }
 
 // ApplicationGatewayIPConfiguration - IP configuration of an application gateway. Currently 1 public and 1 private IP configuration
 // is allowed.
 type ApplicationGatewayIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the IP configuration that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway IP configuration.
-	Properties *ApplicationGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayIPConfigurationPropertiesFormat - Properties of IP configuration of an application gateway.
 type ApplicationGatewayIPConfigurationPropertiesFormat struct {
 	// Reference to the subnet resource. A subnet from where application gateway gets its private address.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 
 	// READ-ONLY; The provisioning state of the application gateway IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayListResult - Response for ListApplicationGateways API service call.
 type ApplicationGatewayListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of an application gateways in a resource group.
-	Value []*ApplicationGateway `json:"value,omitempty"`
+	Value []*ApplicationGateway
 }
 
 // ApplicationGatewayOnDemandProbe - Details of on demand test probe request.
 type ApplicationGatewayOnDemandProbe struct {
 	// Reference to backend pool of application gateway to which probe request will be sent.
-	BackendAddressPool *SubResource `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *SubResource
 
 	// Reference to backend http setting of application gateway to be used for test probe.
-	BackendHTTPSettings *SubResource `json:"backendHttpSettings,omitempty"`
+	BackendHTTPSettings *SubResource
 
 	// Host name to send the probe to.
-	Host *string `json:"host,omitempty"`
+	Host *string
 
 	// Criterion for classifying a healthy probe response.
-	Match *ApplicationGatewayProbeHealthResponseMatch `json:"match,omitempty"`
+	Match *ApplicationGatewayProbeHealthResponseMatch
 
 	// Relative path of probe. Valid path starts from '/'. Probe is sent to ://:.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// Whether the host header should be picked from the backend http settings. Default value is false.
-	PickHostNameFromBackendHTTPSettings *bool `json:"pickHostNameFromBackendHttpSettings,omitempty"`
+	PickHostNameFromBackendHTTPSettings *bool
 
 	// The protocol used for the probe.
-	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
+	Protocol *ApplicationGatewayProtocol
 
 	// The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable
 	// values are from 1 second to 86400 seconds.
-	Timeout *int32 `json:"timeout,omitempty"`
+	Timeout *int32
 }
 
 // ApplicationGatewayPathRule - Path rule of URL path map of an application gateway.
 type ApplicationGatewayPathRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the path rule that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway path rule.
-	Properties *ApplicationGatewayPathRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayPathRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayPathRulePropertiesFormat - Properties of path rule of an application gateway.
 type ApplicationGatewayPathRulePropertiesFormat struct {
 	// Backend address pool resource of URL path map path rule.
-	BackendAddressPool *SubResource `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *SubResource
 
 	// Backend http settings resource of URL path map path rule.
-	BackendHTTPSettings *SubResource `json:"backendHttpSettings,omitempty"`
+	BackendHTTPSettings *SubResource
 
 	// Reference to the FirewallPolicy resource.
-	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
+	FirewallPolicy *SubResource
 
 	// Path rules of URL path map.
-	Paths []*string `json:"paths,omitempty"`
+	Paths []*string
 
 	// Redirect configuration resource of URL path map path rule.
-	RedirectConfiguration *SubResource `json:"redirectConfiguration,omitempty"`
+	RedirectConfiguration *SubResource
 
 	// Rewrite rule set resource of URL path map path rule.
-	RewriteRuleSet *SubResource `json:"rewriteRuleSet,omitempty"`
+	RewriteRuleSet *SubResource
 
 	// READ-ONLY; The provisioning state of the path rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayProbe - Probe of the application gateway.
 type ApplicationGatewayProbe struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the probe that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway probe.
-	Properties *ApplicationGatewayProbePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayProbePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayProbeHealthResponseMatch - Application gateway probe health response match.
 type ApplicationGatewayProbeHealthResponseMatch struct {
 	// Body that must be contained in the health response. Default value is empty.
-	Body *string `json:"body,omitempty"`
+	Body *string
 
 	// Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399.
-	StatusCodes []*string `json:"statusCodes,omitempty"`
+	StatusCodes []*string
 }
 
 // ApplicationGatewayProbePropertiesFormat - Properties of probe of an application gateway.
 type ApplicationGatewayProbePropertiesFormat struct {
 	// Host name to send the probe to.
-	Host *string `json:"host,omitempty"`
+	Host *string
 
 	// The probing interval in seconds. This is the time interval between two consecutive probes. Acceptable values are from 1
 	// second to 86400 seconds.
-	Interval *int32 `json:"interval,omitempty"`
+	Interval *int32
 
 	// Criterion for classifying a healthy probe response.
-	Match *ApplicationGatewayProbeHealthResponseMatch `json:"match,omitempty"`
+	Match *ApplicationGatewayProbeHealthResponseMatch
 
 	// Minimum number of servers that are always marked healthy. Default value is 0.
-	MinServers *int32 `json:"minServers,omitempty"`
+	MinServers *int32
 
 	// Relative path of probe. Valid path starts from '/'. Probe is sent to ://:.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// Whether the host header should be picked from the backend http settings. Default value is false.
-	PickHostNameFromBackendHTTPSettings *bool `json:"pickHostNameFromBackendHttpSettings,omitempty"`
+	PickHostNameFromBackendHTTPSettings *bool
 
 	// Custom port which will be used for probing the backend servers. The valid value ranges from 1 to 65535. In case not set,
 	// port from http settings will be used. This property is valid for Standardv2 and
 	// WAFv2 only.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// The protocol used for the probe.
-	Protocol *ApplicationGatewayProtocol `json:"protocol,omitempty"`
+	Protocol *ApplicationGatewayProtocol
 
 	// The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable
 	// values are from 1 second to 86400 seconds.
-	Timeout *int32 `json:"timeout,omitempty"`
+	Timeout *int32
 
 	// The probe retry count. Backend server is marked down after consecutive probe failure count reaches UnhealthyThreshold.
 	// Acceptable values are from 1 second to 20.
-	UnhealthyThreshold *int32 `json:"unhealthyThreshold,omitempty"`
+	UnhealthyThreshold *int32
 
 	// READ-ONLY; The provisioning state of the probe resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayPropertiesFormat - Properties of the application gateway.
 type ApplicationGatewayPropertiesFormat struct {
 	// Authentication certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	AuthenticationCertificates []*ApplicationGatewayAuthenticationCertificate `json:"authenticationCertificates,omitempty"`
+	AuthenticationCertificates []*ApplicationGatewayAuthenticationCertificate
 
 	// Autoscale Configuration.
-	AutoscaleConfiguration *ApplicationGatewayAutoscaleConfiguration `json:"autoscaleConfiguration,omitempty"`
+	AutoscaleConfiguration *ApplicationGatewayAutoscaleConfiguration
 
 	// Backend address pool of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*ApplicationGatewayBackendAddressPool
 
 	// Backend http settings of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHTTPSettings `json:"backendHttpSettingsCollection,omitempty"`
+	BackendHTTPSettingsCollection []*ApplicationGatewayBackendHTTPSettings
 
 	// Custom error configurations of the application gateway resource.
-	CustomErrorConfigurations []*ApplicationGatewayCustomError `json:"customErrorConfigurations,omitempty"`
+	CustomErrorConfigurations []*ApplicationGatewayCustomError
 
 	// Whether FIPS is enabled on the application gateway resource.
-	EnableFips *bool `json:"enableFips,omitempty"`
+	EnableFips *bool
 
 	// Whether HTTP2 is enabled on the application gateway resource.
-	EnableHTTP2 *bool `json:"enableHttp2,omitempty"`
+	EnableHTTP2 *bool
 
 	// Reference to the FirewallPolicy resource.
-	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
+	FirewallPolicy *SubResource
 
 	// If true, associates a firewall policy with an application gateway regardless whether the policy differs from the WAF Config.
-	ForceFirewallPolicyAssociation *bool `json:"forceFirewallPolicyAssociation,omitempty"`
+	ForceFirewallPolicyAssociation *bool
 
 	// Frontend IP addresses of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendIPConfigurations []*ApplicationGatewayFrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*ApplicationGatewayFrontendIPConfiguration
 
 	// Frontend ports of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	FrontendPorts []*ApplicationGatewayFrontendPort `json:"frontendPorts,omitempty"`
+	FrontendPorts []*ApplicationGatewayFrontendPort
 
 	// Subnets of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	GatewayIPConfigurations []*ApplicationGatewayIPConfiguration `json:"gatewayIPConfigurations,omitempty"`
+	GatewayIPConfigurations []*ApplicationGatewayIPConfiguration
 
 	// Http listeners of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	HTTPListeners []*ApplicationGatewayHTTPListener `json:"httpListeners,omitempty"`
+	HTTPListeners []*ApplicationGatewayHTTPListener
 
 	// Probes of the application gateway resource.
-	Probes []*ApplicationGatewayProbe `json:"probes,omitempty"`
+	Probes []*ApplicationGatewayProbe
 
 	// Redirect configurations of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	RedirectConfigurations []*ApplicationGatewayRedirectConfiguration `json:"redirectConfigurations,omitempty"`
+	RedirectConfigurations []*ApplicationGatewayRedirectConfiguration
 
 	// Request routing rules of the application gateway resource.
-	RequestRoutingRules []*ApplicationGatewayRequestRoutingRule `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules []*ApplicationGatewayRequestRoutingRule
 
 	// Rewrite rules for the application gateway resource.
-	RewriteRuleSets []*ApplicationGatewayRewriteRuleSet `json:"rewriteRuleSets,omitempty"`
+	RewriteRuleSets []*ApplicationGatewayRewriteRuleSet
 
 	// SKU of the application gateway resource.
-	SKU *ApplicationGatewaySKU `json:"sku,omitempty"`
+	SKU *ApplicationGatewaySKU
 
 	// SSL certificates of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits]
 	// .
-	SSLCertificates []*ApplicationGatewaySSLCertificate `json:"sslCertificates,omitempty"`
+	SSLCertificates []*ApplicationGatewaySSLCertificate
 
 	// SSL policy of the application gateway resource.
-	SSLPolicy *ApplicationGatewaySSLPolicy `json:"sslPolicy,omitempty"`
+	SSLPolicy *ApplicationGatewaySSLPolicy
 
 	// Trusted Root certificates of the application gateway resource. For default limits, see Application Gateway limits
 	// [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	TrustedRootCertificates []*ApplicationGatewayTrustedRootCertificate `json:"trustedRootCertificates,omitempty"`
+	TrustedRootCertificates []*ApplicationGatewayTrustedRootCertificate
 
 	// URL path map of the application gateway resource. For default limits, see Application Gateway limits [https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits].
-	URLPathMaps []*ApplicationGatewayURLPathMap `json:"urlPathMaps,omitempty"`
+	URLPathMaps []*ApplicationGatewayURLPathMap
 
 	// Web application firewall configuration.
-	WebApplicationFirewallConfiguration *ApplicationGatewayWebApplicationFirewallConfiguration `json:"webApplicationFirewallConfiguration,omitempty"`
+	WebApplicationFirewallConfiguration *ApplicationGatewayWebApplicationFirewallConfiguration
 
 	// READ-ONLY; Operational state of the application gateway resource.
-	OperationalState *ApplicationGatewayOperationalState `json:"operationalState,omitempty" azure:"ro"`
+	OperationalState *ApplicationGatewayOperationalState
 
 	// READ-ONLY; The provisioning state of the application gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the application gateway resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // ApplicationGatewayRedirectConfiguration - Redirect configuration of an application gateway.
 type ApplicationGatewayRedirectConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the redirect configuration that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway redirect configuration.
-	Properties *ApplicationGatewayRedirectConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayRedirectConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayRedirectConfigurationPropertiesFormat - Properties of redirect configuration of the application gateway.
 type ApplicationGatewayRedirectConfigurationPropertiesFormat struct {
 	// Include path in the redirected url.
-	IncludePath *bool `json:"includePath,omitempty"`
+	IncludePath *bool
 
 	// Include query string in the redirected url.
-	IncludeQueryString *bool `json:"includeQueryString,omitempty"`
+	IncludeQueryString *bool
 
 	// Path rules specifying redirect configuration.
-	PathRules []*SubResource `json:"pathRules,omitempty"`
+	PathRules []*SubResource
 
 	// HTTP redirection type.
-	RedirectType *ApplicationGatewayRedirectType `json:"redirectType,omitempty"`
+	RedirectType *ApplicationGatewayRedirectType
 
 	// Request routing specifying redirect configuration.
-	RequestRoutingRules []*SubResource `json:"requestRoutingRules,omitempty"`
+	RequestRoutingRules []*SubResource
 
 	// Reference to a listener to redirect the request to.
-	TargetListener *SubResource `json:"targetListener,omitempty"`
+	TargetListener *SubResource
 
 	// Url to redirect the request to.
-	TargetURL *string `json:"targetUrl,omitempty"`
+	TargetURL *string
 
 	// Url path maps specifying default redirect configuration.
-	URLPathMaps []*SubResource `json:"urlPathMaps,omitempty"`
+	URLPathMaps []*SubResource
 }
 
 // ApplicationGatewayRequestRoutingRule - Request routing rule of an application gateway.
 type ApplicationGatewayRequestRoutingRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the request routing rule that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway request routing rule.
-	Properties *ApplicationGatewayRequestRoutingRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayRequestRoutingRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayRequestRoutingRulePropertiesFormat - Properties of request routing rule of the application gateway.
 type ApplicationGatewayRequestRoutingRulePropertiesFormat struct {
 	// Backend address pool resource of the application gateway.
-	BackendAddressPool *SubResource `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *SubResource
 
 	// Backend http settings resource of the application gateway.
-	BackendHTTPSettings *SubResource `json:"backendHttpSettings,omitempty"`
+	BackendHTTPSettings *SubResource
 
 	// Http listener resource of the application gateway.
-	HTTPListener *SubResource `json:"httpListener,omitempty"`
+	HTTPListener *SubResource
 
 	// Priority of the request routing rule.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Redirect configuration resource of the application gateway.
-	RedirectConfiguration *SubResource `json:"redirectConfiguration,omitempty"`
+	RedirectConfiguration *SubResource
 
 	// Rewrite Rule Set resource in Basic rule of the application gateway.
-	RewriteRuleSet *SubResource `json:"rewriteRuleSet,omitempty"`
+	RewriteRuleSet *SubResource
 
 	// Rule type.
-	RuleType *ApplicationGatewayRequestRoutingRuleType `json:"ruleType,omitempty"`
+	RuleType *ApplicationGatewayRequestRoutingRuleType
 
 	// URL path map resource of the application gateway.
-	URLPathMap *SubResource `json:"urlPathMap,omitempty"`
+	URLPathMap *SubResource
 
 	// READ-ONLY; The provisioning state of the request routing rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayRewriteRule - Rewrite rule of an application gateway.
 type ApplicationGatewayRewriteRule struct {
 	// Set of actions to be done as part of the rewrite Rule.
-	ActionSet *ApplicationGatewayRewriteRuleActionSet `json:"actionSet,omitempty"`
+	ActionSet *ApplicationGatewayRewriteRuleActionSet
 
 	// Conditions based on which the action set execution will be evaluated.
-	Conditions []*ApplicationGatewayRewriteRuleCondition `json:"conditions,omitempty"`
+	Conditions []*ApplicationGatewayRewriteRuleCondition
 
 	// Name of the rewrite rule that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Rule Sequence of the rewrite rule that determines the order of execution of a particular rule in a RewriteRuleSet.
-	RuleSequence *int32 `json:"ruleSequence,omitempty"`
+	RuleSequence *int32
 }
 
 // ApplicationGatewayRewriteRuleActionSet - Set of actions in the Rewrite Rule in Application Gateway.
 type ApplicationGatewayRewriteRuleActionSet struct {
 	// Request Header Actions in the Action Set.
-	RequestHeaderConfigurations []*ApplicationGatewayHeaderConfiguration `json:"requestHeaderConfigurations,omitempty"`
+	RequestHeaderConfigurations []*ApplicationGatewayHeaderConfiguration
 
 	// Response Header Actions in the Action Set.
-	ResponseHeaderConfigurations []*ApplicationGatewayHeaderConfiguration `json:"responseHeaderConfigurations,omitempty"`
+	ResponseHeaderConfigurations []*ApplicationGatewayHeaderConfiguration
 
 	// Url Configuration Action in the Action Set.
-	URLConfiguration *ApplicationGatewayURLConfiguration `json:"urlConfiguration,omitempty"`
+	URLConfiguration *ApplicationGatewayURLConfiguration
 }
 
 // ApplicationGatewayRewriteRuleCondition - Set of conditions in the Rewrite Rule in Application Gateway.
 type ApplicationGatewayRewriteRuleCondition struct {
 	// Setting this paramter to truth value with force the pattern to do a case in-sensitive comparison.
-	IgnoreCase *bool `json:"ignoreCase,omitempty"`
+	IgnoreCase *bool
 
 	// Setting this value as truth will force to check the negation of the condition given by the user.
-	Negate *bool `json:"negate,omitempty"`
+	Negate *bool
 
 	// The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition.
-	Pattern *string `json:"pattern,omitempty"`
+	Pattern *string
 
 	// The condition parameter of the RewriteRuleCondition.
-	Variable *string `json:"variable,omitempty"`
+	Variable *string
 }
 
 // ApplicationGatewayRewriteRuleSet - Rewrite rule set of an application gateway.
 type ApplicationGatewayRewriteRuleSet struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the rewrite rule set that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway rewrite rule set.
-	Properties *ApplicationGatewayRewriteRuleSetPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayRewriteRuleSetPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // ApplicationGatewayRewriteRuleSetPropertiesFormat - Properties of rewrite rule set of the application gateway.
 type ApplicationGatewayRewriteRuleSetPropertiesFormat struct {
 	// Rewrite rules in the rewrite rule set.
-	RewriteRules []*ApplicationGatewayRewriteRule `json:"rewriteRules,omitempty"`
+	RewriteRules []*ApplicationGatewayRewriteRule
 
 	// READ-ONLY; The provisioning state of the rewrite rule set resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewaySKU - SKU of an application gateway.
 type ApplicationGatewaySKU struct {
 	// Capacity (instance count) of an application gateway.
-	Capacity *int32 `json:"capacity,omitempty"`
+	Capacity *int32
 
 	// Name of an application gateway SKU.
-	Name *ApplicationGatewaySKUName `json:"name,omitempty"`
+	Name *ApplicationGatewaySKUName
 
 	// Tier of an application gateway.
-	Tier *ApplicationGatewayTier `json:"tier,omitempty"`
+	Tier *ApplicationGatewayTier
 }
 
 // ApplicationGatewaySSLCertificate - SSL certificates of an application gateway.
 type ApplicationGatewaySSLCertificate struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the SSL certificate that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway SSL certificate.
-	Properties *ApplicationGatewaySSLCertificatePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewaySSLCertificatePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewaySSLCertificatePropertiesFormat - Properties of SSL certificates of an application gateway.
 type ApplicationGatewaySSLCertificatePropertiesFormat struct {
 	// Base-64 encoded pfx certificate. Only applicable in PUT Request.
-	Data *string `json:"data,omitempty"`
+	Data *string
 
 	// Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.
-	KeyVaultSecretID *string `json:"keyVaultSecretId,omitempty"`
+	KeyVaultSecretID *string
 
 	// Password for the pfx file specified in data. Only applicable in PUT request.
-	Password *string `json:"password,omitempty"`
+	Password *string
 
 	// READ-ONLY; The provisioning state of the SSL certificate resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; Base-64 encoded Public cert data corresponding to pfx specified in data. Only applicable in GET request.
-	PublicCertData *string `json:"publicCertData,omitempty" azure:"ro"`
+	PublicCertData *string
 }
 
 // ApplicationGatewaySSLPolicy - Application Gateway Ssl policy.
 type ApplicationGatewaySSLPolicy struct {
 	// Ssl cipher suites to be enabled in the specified order to application gateway.
-	CipherSuites []*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites []*ApplicationGatewaySSLCipherSuite
 
 	// Ssl protocols to be disabled on application gateway.
-	DisabledSSLProtocols []*ApplicationGatewaySSLProtocol `json:"disabledSslProtocols,omitempty"`
+	DisabledSSLProtocols []*ApplicationGatewaySSLProtocol
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
-	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
+	MinProtocolVersion *ApplicationGatewaySSLProtocol
 
 	// Name of Ssl predefined policy.
-	PolicyName *ApplicationGatewaySSLPolicyName `json:"policyName,omitempty"`
+	PolicyName *ApplicationGatewaySSLPolicyName
 
 	// Type of Ssl Policy.
-	PolicyType *ApplicationGatewaySSLPolicyType `json:"policyType,omitempty"`
+	PolicyType *ApplicationGatewaySSLPolicyType
 }
 
 // ApplicationGatewaySSLPredefinedPolicy - An Ssl predefined policy.
 type ApplicationGatewaySSLPredefinedPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the Ssl predefined policy.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway SSL predefined policy.
-	Properties *ApplicationGatewaySSLPredefinedPolicyPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewaySSLPredefinedPolicyPropertiesFormat
 }
 
 // ApplicationGatewaySSLPredefinedPolicyPropertiesFormat - Properties of ApplicationGatewaySslPredefinedPolicy.
 type ApplicationGatewaySSLPredefinedPolicyPropertiesFormat struct {
 	// Ssl cipher suites to be enabled in the specified order for application gateway.
-	CipherSuites []*ApplicationGatewaySSLCipherSuite `json:"cipherSuites,omitempty"`
+	CipherSuites []*ApplicationGatewaySSLCipherSuite
 
 	// Minimum version of Ssl protocol to be supported on application gateway.
-	MinProtocolVersion *ApplicationGatewaySSLProtocol `json:"minProtocolVersion,omitempty"`
+	MinProtocolVersion *ApplicationGatewaySSLProtocol
 }
 
 // ApplicationGatewayTrustedRootCertificate - Trusted Root certificates of an application gateway.
 type ApplicationGatewayTrustedRootCertificate struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the trusted root certificate that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway trusted root certificate.
-	Properties *ApplicationGatewayTrustedRootCertificatePropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayTrustedRootCertificatePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayTrustedRootCertificatePropertiesFormat - Trusted Root certificates properties of an application gateway.
 type ApplicationGatewayTrustedRootCertificatePropertiesFormat struct {
 	// Certificate public data.
-	Data *string `json:"data,omitempty"`
+	Data *string
 
 	// Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault.
-	KeyVaultSecretID *string `json:"keyVaultSecretId,omitempty"`
+	KeyVaultSecretID *string
 
 	// READ-ONLY; The provisioning state of the trusted root certificate resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayURLConfiguration - Url configuration of the Actions set in Application Gateway.
 type ApplicationGatewayURLConfiguration struct {
 	// Url path which user has provided for url rewrite. Null means no path will be updated. Default value is null.
-	ModifiedPath *string `json:"modifiedPath,omitempty"`
+	ModifiedPath *string
 
 	// Query string which user has provided for url rewrite. Null means no query string will be updated. Default value is null.
-	ModifiedQueryString *string `json:"modifiedQueryString,omitempty"`
+	ModifiedQueryString *string
 
 	// If set as true, it will re-evaluate the url path map provided in path based request routing rules using modified path.
 	// Default value is false.
-	Reroute *bool `json:"reroute,omitempty"`
+	Reroute *bool
 }
 
 // ApplicationGatewayURLPathMap - UrlPathMaps give a url path to the backend mapping information for PathBasedRouting.
 type ApplicationGatewayURLPathMap struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the URL path map that is unique within an Application Gateway.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the application gateway URL path map.
-	Properties *ApplicationGatewayURLPathMapPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationGatewayURLPathMapPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationGatewayURLPathMapPropertiesFormat - Properties of UrlPathMap of the application gateway.
 type ApplicationGatewayURLPathMapPropertiesFormat struct {
 	// Default backend address pool resource of URL path map.
-	DefaultBackendAddressPool *SubResource `json:"defaultBackendAddressPool,omitempty"`
+	DefaultBackendAddressPool *SubResource
 
 	// Default backend http settings resource of URL path map.
-	DefaultBackendHTTPSettings *SubResource `json:"defaultBackendHttpSettings,omitempty"`
+	DefaultBackendHTTPSettings *SubResource
 
 	// Default redirect configuration resource of URL path map.
-	DefaultRedirectConfiguration *SubResource `json:"defaultRedirectConfiguration,omitempty"`
+	DefaultRedirectConfiguration *SubResource
 
 	// Default Rewrite rule set resource of URL path map.
-	DefaultRewriteRuleSet *SubResource `json:"defaultRewriteRuleSet,omitempty"`
+	DefaultRewriteRuleSet *SubResource
 
 	// Path rule of URL path map resource.
-	PathRules []*ApplicationGatewayPathRule `json:"pathRules,omitempty"`
+	PathRules []*ApplicationGatewayPathRule
 
 	// READ-ONLY; The provisioning state of the URL path map resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ApplicationGatewayWebApplicationFirewallConfiguration - Application gateway web application firewall configuration.
 type ApplicationGatewayWebApplicationFirewallConfiguration struct {
 	// REQUIRED; Whether the web application firewall is enabled or not.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// REQUIRED; Web application firewall mode.
-	FirewallMode *ApplicationGatewayFirewallMode `json:"firewallMode,omitempty"`
+	FirewallMode *ApplicationGatewayFirewallMode
 
 	// REQUIRED; The type of the web application firewall rule set. Possible values are: 'OWASP'.
-	RuleSetType *string `json:"ruleSetType,omitempty"`
+	RuleSetType *string
 
 	// REQUIRED; The version of the rule set type.
-	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
+	RuleSetVersion *string
 
 	// The disabled rule groups.
-	DisabledRuleGroups []*ApplicationGatewayFirewallDisabledRuleGroup `json:"disabledRuleGroups,omitempty"`
+	DisabledRuleGroups []*ApplicationGatewayFirewallDisabledRuleGroup
 
 	// The exclusion list.
-	Exclusions []*ApplicationGatewayFirewallExclusion `json:"exclusions,omitempty"`
+	Exclusions []*ApplicationGatewayFirewallExclusion
 
 	// Maximum file upload size in Mb for WAF.
-	FileUploadLimitInMb *int32 `json:"fileUploadLimitInMb,omitempty"`
+	FileUploadLimitInMb *int32
 
 	// Maximum request body size for WAF.
-	MaxRequestBodySize *int32 `json:"maxRequestBodySize,omitempty"`
+	MaxRequestBodySize *int32
 
 	// Maximum request body size in Kb for WAF.
-	MaxRequestBodySizeInKb *int32 `json:"maxRequestBodySizeInKb,omitempty"`
+	MaxRequestBodySizeInKb *int32
 
 	// Whether allow WAF to check request Body.
-	RequestBodyCheck *bool `json:"requestBodyCheck,omitempty"`
+	RequestBodyCheck *bool
 }
 
 // ApplicationGatewaysClientBeginBackendHealthOnDemandOptions contains the optional parameters for the ApplicationGatewaysClient.BeginBackendHealthOnDemand
@@ -1257,31 +1257,31 @@ type ApplicationGatewaysClientUpdateTagsOptions struct {
 // ApplicationRuleCondition - Rule condition of type application.
 type ApplicationRuleCondition struct {
 	// REQUIRED; Rule Condition Type.
-	RuleConditionType *FirewallPolicyRuleConditionType `json:"ruleConditionType,omitempty"`
+	RuleConditionType *FirewallPolicyRuleConditionType
 
 	// Description of the rule condition.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string
 
 	// List of FQDN Tags for this rule condition.
-	FqdnTags []*string `json:"fqdnTags,omitempty"`
+	FqdnTags []*string
 
 	// Name of the rule condition.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Array of Application Protocols.
-	Protocols []*FirewallPolicyRuleConditionApplicationProtocol `json:"protocols,omitempty"`
+	Protocols []*FirewallPolicyRuleConditionApplicationProtocol
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 
 	// List of FQDNs for this rule condition.
-	TargetFqdns []*string `json:"targetFqdns,omitempty"`
+	TargetFqdns []*string
 }
 
 // GetFirewallPolicyRuleCondition implements the FirewallPolicyRuleConditionClassification interface for type ApplicationRuleCondition.
@@ -1296,45 +1296,45 @@ func (a *ApplicationRuleCondition) GetFirewallPolicyRuleCondition() *FirewallPol
 // ApplicationSecurityGroup - An application security group in a resource group.
 type ApplicationSecurityGroup struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the application security group.
-	Properties *ApplicationSecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Properties *ApplicationSecurityGroupPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ApplicationSecurityGroupListResult - A list of application security groups.
 type ApplicationSecurityGroupListResult struct {
 	// A list of application security groups.
-	Value []*ApplicationSecurityGroup `json:"value,omitempty"`
+	Value []*ApplicationSecurityGroup
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ApplicationSecurityGroupPropertiesFormat - Application security group properties.
 type ApplicationSecurityGroupPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the application security group resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the application security group resource. It uniquely identifies a resource, even
 	// if the user changes its name or migrate the resource across subscriptions or resource
 	// groups.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // ApplicationSecurityGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the ApplicationSecurityGroupsClient.BeginCreateOrUpdate
@@ -1379,68 +1379,68 @@ type ApplicationSecurityGroupsClientUpdateTagsOptions struct {
 // an ExpressRouteCircuit.
 type AuthorizationListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The authorizations in an ExpressRoute Circuit.
-	Value []*ExpressRouteCircuitAuthorization `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitAuthorization
 }
 
 // AuthorizationPropertiesFormat - Properties of ExpressRouteCircuitAuthorization.
 type AuthorizationPropertiesFormat struct {
 	// The authorization key.
-	AuthorizationKey *string `json:"authorizationKey,omitempty"`
+	AuthorizationKey *string
 
 	// The authorization use status.
-	AuthorizationUseStatus *AuthorizationUseStatus `json:"authorizationUseStatus,omitempty"`
+	AuthorizationUseStatus *AuthorizationUseStatus
 
 	// READ-ONLY; The provisioning state of the authorization resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AutoApprovedPrivateLinkService - The information of an AutoApprovedPrivateLinkService.
 type AutoApprovedPrivateLinkService struct {
 	// The id of the private link service resource.
-	PrivateLinkService *string `json:"privateLinkService,omitempty"`
+	PrivateLinkService *string
 }
 
 // AutoApprovedPrivateLinkServicesResult - An array of private link service id that can be linked to a private end point with
 // auto approved.
 type AutoApprovedPrivateLinkServicesResult struct {
 	// An array of auto approved private link service.
-	Value []*AutoApprovedPrivateLinkService `json:"value,omitempty"`
+	Value []*AutoApprovedPrivateLinkService
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // Availability of the metric.
 type Availability struct {
 	// Duration of the availability blob.
-	BlobDuration *string `json:"blobDuration,omitempty"`
+	BlobDuration *string
 
 	// The retention of the availability.
-	Retention *string `json:"retention,omitempty"`
+	Retention *string
 
 	// The time grain of the availability.
-	TimeGrain *string `json:"timeGrain,omitempty"`
+	TimeGrain *string
 }
 
 // AvailableDelegation - The serviceName of an AvailableDelegation indicates a possible delegation for a subnet.
 type AvailableDelegation struct {
 	// The actions permitted to the service upon delegation.
-	Actions []*string `json:"actions,omitempty"`
+	Actions []*string
 
 	// A unique identifier of the AvailableDelegation resource.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the AvailableDelegation resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The name of the service and resource.
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName *string
 
 	// Resource type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // AvailableDelegationsClientListOptions contains the optional parameters for the AvailableDelegationsClient.NewListPager
@@ -1452,10 +1452,10 @@ type AvailableDelegationsClientListOptions struct {
 // AvailableDelegationsResult - An array of available delegations.
 type AvailableDelegationsResult struct {
 	// An array of available delegations.
-	Value []*AvailableDelegation `json:"value,omitempty"`
+	Value []*AvailableDelegation
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // AvailableEndpointServicesClientListOptions contains the optional parameters for the AvailableEndpointServicesClient.NewListPager
@@ -1467,16 +1467,16 @@ type AvailableEndpointServicesClientListOptions struct {
 // AvailablePrivateEndpointType - The information of an AvailablePrivateEndpointType.
 type AvailablePrivateEndpointType struct {
 	// A unique identifier of the AvailablePrivateEndpoint Type resource.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the service and resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The name of the service and resource.
-	ResourceName *string `json:"resourceName,omitempty"`
+	ResourceName *string
 
 	// Resource type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // AvailablePrivateEndpointTypesClientListByResourceGroupOptions contains the optional parameters for the AvailablePrivateEndpointTypesClient.NewListByResourceGroupPager
@@ -1494,64 +1494,64 @@ type AvailablePrivateEndpointTypesClientListOptions struct {
 // AvailablePrivateEndpointTypesResult - An array of available PrivateEndpoint types.
 type AvailablePrivateEndpointTypesResult struct {
 	// An array of available privateEndpoint type.
-	Value []*AvailablePrivateEndpointType `json:"value,omitempty"`
+	Value []*AvailablePrivateEndpointType
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // AvailableProvidersList - List of available countries with details.
 type AvailableProvidersList struct {
 	// REQUIRED; List of available countries.
-	Countries []*AvailableProvidersListCountry `json:"countries,omitempty"`
+	Countries []*AvailableProvidersListCountry
 }
 
 // AvailableProvidersListCity - City or town details.
 type AvailableProvidersListCity struct {
 	// The city or town name.
-	CityName *string `json:"cityName,omitempty"`
+	CityName *string
 
 	// A list of Internet service providers.
-	Providers []*string `json:"providers,omitempty"`
+	Providers []*string
 }
 
 // AvailableProvidersListCountry - Country details.
 type AvailableProvidersListCountry struct {
 	// The country name.
-	CountryName *string `json:"countryName,omitempty"`
+	CountryName *string
 
 	// A list of Internet service providers.
-	Providers []*string `json:"providers,omitempty"`
+	Providers []*string
 
 	// List of available states in the country.
-	States []*AvailableProvidersListState `json:"states,omitempty"`
+	States []*AvailableProvidersListState
 }
 
 // AvailableProvidersListParameters - Constraints that determine the list of available Internet service providers.
 type AvailableProvidersListParameters struct {
 	// A list of Azure regions.
-	AzureLocations []*string `json:"azureLocations,omitempty"`
+	AzureLocations []*string
 
 	// The city or town for available providers list.
-	City *string `json:"city,omitempty"`
+	City *string
 
 	// The country for available providers list.
-	Country *string `json:"country,omitempty"`
+	Country *string
 
 	// The state for available providers list.
-	State *string `json:"state,omitempty"`
+	State *string
 }
 
 // AvailableProvidersListState - State details.
 type AvailableProvidersListState struct {
 	// List of available cities or towns in the state.
-	Cities []*AvailableProvidersListCity `json:"cities,omitempty"`
+	Cities []*AvailableProvidersListCity
 
 	// A list of Internet service providers.
-	Providers []*string `json:"providers,omitempty"`
+	Providers []*string
 
 	// The state name.
-	StateName *string `json:"stateName,omitempty"`
+	StateName *string
 }
 
 // AvailableResourceGroupDelegationsClientListOptions contains the optional parameters for the AvailableResourceGroupDelegationsClient.NewListPager
@@ -1563,16 +1563,16 @@ type AvailableResourceGroupDelegationsClientListOptions struct {
 // AvailableServiceAlias - The available service alias.
 type AvailableServiceAlias struct {
 	// The ID of the service alias.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the service alias.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The resource name of the service alias.
-	ResourceName *string `json:"resourceName,omitempty"`
+	ResourceName *string
 
 	// The type of the resource.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // AvailableServiceAliasesClientListByResourceGroupOptions contains the optional parameters for the AvailableServiceAliasesClient.NewListByResourceGroupPager
@@ -1590,142 +1590,142 @@ type AvailableServiceAliasesClientListOptions struct {
 // AvailableServiceAliasesResult - An array of available service aliases.
 type AvailableServiceAliasesResult struct {
 	// An array of available service aliases.
-	Value []*AvailableServiceAlias `json:"value,omitempty"`
+	Value []*AvailableServiceAlias
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // AzureFirewall - Azure Firewall resource.
 type AzureFirewall struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the azure firewall.
-	Properties *AzureFirewallPropertiesFormat `json:"properties,omitempty"`
+	Properties *AzureFirewallPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// A list of availability zones denoting where the resource needs to come from.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AzureFirewallApplicationRule - Properties of an application rule.
 type AzureFirewallApplicationRule struct {
 	// Description of the rule.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of FQDN Tags for this rule.
-	FqdnTags []*string `json:"fqdnTags,omitempty"`
+	FqdnTags []*string
 
 	// Name of the application rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Array of ApplicationRuleProtocols.
-	Protocols []*AzureFirewallApplicationRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallApplicationRuleProtocol
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 
 	// List of FQDNs for this rule.
-	TargetFqdns []*string `json:"targetFqdns,omitempty"`
+	TargetFqdns []*string
 }
 
 // AzureFirewallApplicationRuleCollection - Application rule collection resource.
 type AzureFirewallApplicationRuleCollection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the Azure firewall. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the azure firewall application rule collection.
-	Properties *AzureFirewallApplicationRuleCollectionPropertiesFormat `json:"properties,omitempty"`
+	Properties *AzureFirewallApplicationRuleCollectionPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // AzureFirewallApplicationRuleCollectionPropertiesFormat - Properties of the application rule collection.
 type AzureFirewallApplicationRuleCollectionPropertiesFormat struct {
 	// The action type of a rule collection.
-	Action *AzureFirewallRCAction `json:"action,omitempty"`
+	Action *AzureFirewallRCAction
 
 	// Priority of the application rule collection resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Collection of rules used by a application rule collection.
-	Rules []*AzureFirewallApplicationRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallApplicationRule
 
 	// READ-ONLY; The provisioning state of the application rule collection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallApplicationRuleProtocol - Properties of the application rule protocol.
 type AzureFirewallApplicationRuleProtocol struct {
 	// Port number for the protocol, cannot be greater than 64000. This field is optional.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// Protocol type.
-	ProtocolType *AzureFirewallApplicationRuleProtocolType `json:"protocolType,omitempty"`
+	ProtocolType *AzureFirewallApplicationRuleProtocolType
 }
 
 // AzureFirewallFqdnTag - Azure Firewall FQDN Tag Resource.
 type AzureFirewallFqdnTag struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the azure firewall FQDN tag.
-	Properties *AzureFirewallFqdnTagPropertiesFormat `json:"properties,omitempty"`
+	Properties *AzureFirewallFqdnTagPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AzureFirewallFqdnTagListResult - Response for ListAzureFirewallFqdnTags API service call.
 type AzureFirewallFqdnTagListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Azure Firewall FQDN Tags in a resource group.
-	Value []*AzureFirewallFqdnTag `json:"value,omitempty"`
+	Value []*AzureFirewallFqdnTag
 }
 
 // AzureFirewallFqdnTagPropertiesFormat - Azure Firewall FQDN Tag Properties.
 type AzureFirewallFqdnTagPropertiesFormat struct {
 	// READ-ONLY; The name of this FQDN Tag.
-	FqdnTagName *string `json:"fqdnTagName,omitempty" azure:"ro"`
+	FqdnTagName *string
 
 	// READ-ONLY; The provisioning state of the Azure firewall FQDN tag resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallFqdnTagsClientListAllOptions contains the optional parameters for the AzureFirewallFqdnTagsClient.NewListAllPager
@@ -1737,244 +1737,244 @@ type AzureFirewallFqdnTagsClientListAllOptions struct {
 // AzureFirewallIPConfiguration - IP configuration of an Azure Firewall.
 type AzureFirewallIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the azure firewall IP configuration.
-	Properties *AzureFirewallIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *AzureFirewallIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AzureFirewallIPConfigurationPropertiesFormat - Properties of IP configuration of an Azure Firewall.
 type AzureFirewallIPConfigurationPropertiesFormat struct {
 	// Reference to the PublicIP resource. This field is a mandatory input if subnet is not null.
-	PublicIPAddress *SubResource `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *SubResource
 
 	// Reference to the subnet resource. This resource must be named 'AzureFirewallSubnet' or 'AzureFirewallManagementSubnet'.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 
 	// READ-ONLY; The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty" azure:"ro"`
+	PrivateIPAddress *string
 
 	// READ-ONLY; The provisioning state of the Azure firewall IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallIPGroups - IpGroups associated with azure firewall.
 type AzureFirewallIPGroups struct {
 	// READ-ONLY; The iteration number.
-	ChangeNumber *string `json:"changeNumber,omitempty" azure:"ro"`
+	ChangeNumber *string
 
 	// READ-ONLY; Resource ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // AzureFirewallListResult - Response for ListAzureFirewalls API service call.
 type AzureFirewallListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Azure Firewalls in a resource group.
-	Value []*AzureFirewall `json:"value,omitempty"`
+	Value []*AzureFirewall
 }
 
 // AzureFirewallNatRCAction - AzureFirewall NAT Rule Collection Action.
 type AzureFirewallNatRCAction struct {
 	// The type of action.
-	Type *AzureFirewallNatRCActionType `json:"type,omitempty"`
+	Type *AzureFirewallNatRCActionType
 }
 
 // AzureFirewallNatRule - Properties of a NAT rule.
 type AzureFirewallNatRule struct {
 	// Description of the rule.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of destination IP addresses for this rule. Supports IP ranges, prefixes, and service tags.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string
 
 	// List of destination ports.
-	DestinationPorts []*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string
 
 	// Name of the NAT rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule.
-	Protocols []*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallNetworkRuleProtocol
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 
 	// The translated address for this NAT rule.
-	TranslatedAddress *string `json:"translatedAddress,omitempty"`
+	TranslatedAddress *string
 
 	// The translated FQDN for this NAT rule.
-	TranslatedFqdn *string `json:"translatedFqdn,omitempty"`
+	TranslatedFqdn *string
 
 	// The translated port for this NAT rule.
-	TranslatedPort *string `json:"translatedPort,omitempty"`
+	TranslatedPort *string
 }
 
 // AzureFirewallNatRuleCollection - NAT rule collection resource.
 type AzureFirewallNatRuleCollection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the Azure firewall. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the azure firewall NAT rule collection.
-	Properties *AzureFirewallNatRuleCollectionProperties `json:"properties,omitempty"`
+	Properties *AzureFirewallNatRuleCollectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // AzureFirewallNatRuleCollectionProperties - Properties of the NAT rule collection.
 type AzureFirewallNatRuleCollectionProperties struct {
 	// The action type of a NAT rule collection.
-	Action *AzureFirewallNatRCAction `json:"action,omitempty"`
+	Action *AzureFirewallNatRCAction
 
 	// Priority of the NAT rule collection resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Collection of rules used by a NAT rule collection.
-	Rules []*AzureFirewallNatRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallNatRule
 
 	// READ-ONLY; The provisioning state of the NAT rule collection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallNetworkRule - Properties of the network rule.
 type AzureFirewallNetworkRule struct {
 	// Description of the rule.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of destination IP addresses.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string
 
 	// List of destination FQDNs.
-	DestinationFqdns []*string `json:"destinationFqdns,omitempty"`
+	DestinationFqdns []*string
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups []*string
 
 	// List of destination ports.
-	DestinationPorts []*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string
 
 	// Name of the network rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Array of AzureFirewallNetworkRuleProtocols.
-	Protocols []*AzureFirewallNetworkRuleProtocol `json:"protocols,omitempty"`
+	Protocols []*AzureFirewallNetworkRuleProtocol
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 }
 
 // AzureFirewallNetworkRuleCollection - Network rule collection resource.
 type AzureFirewallNetworkRuleCollection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the Azure firewall. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the azure firewall network rule collection.
-	Properties *AzureFirewallNetworkRuleCollectionPropertiesFormat `json:"properties,omitempty"`
+	Properties *AzureFirewallNetworkRuleCollectionPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // AzureFirewallNetworkRuleCollectionPropertiesFormat - Properties of the network rule collection.
 type AzureFirewallNetworkRuleCollectionPropertiesFormat struct {
 	// The action type of a rule collection.
-	Action *AzureFirewallRCAction `json:"action,omitempty"`
+	Action *AzureFirewallRCAction
 
 	// Priority of the network rule collection resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Collection of rules used by a network rule collection.
-	Rules []*AzureFirewallNetworkRule `json:"rules,omitempty"`
+	Rules []*AzureFirewallNetworkRule
 
 	// READ-ONLY; The provisioning state of the network rule collection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallPropertiesFormat - Properties of the Azure Firewall.
 type AzureFirewallPropertiesFormat struct {
 	// The additional properties used to further config this azure firewall.
-	AdditionalProperties map[string]*string `json:"additionalProperties,omitempty"`
+	AdditionalProperties map[string]*string
 
 	// Collection of application rule collections used by Azure Firewall.
-	ApplicationRuleCollections []*AzureFirewallApplicationRuleCollection `json:"applicationRuleCollections,omitempty"`
+	ApplicationRuleCollections []*AzureFirewallApplicationRuleCollection
 
 	// The firewallPolicy associated with this azure firewall.
-	FirewallPolicy *SubResource `json:"firewallPolicy,omitempty"`
+	FirewallPolicy *SubResource
 
 	// IP configuration of the Azure Firewall resource.
-	IPConfigurations []*AzureFirewallIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*AzureFirewallIPConfiguration
 
 	// IP configuration of the Azure Firewall used for management traffic.
-	ManagementIPConfiguration *AzureFirewallIPConfiguration `json:"managementIpConfiguration,omitempty"`
+	ManagementIPConfiguration *AzureFirewallIPConfiguration
 
 	// Collection of NAT rule collections used by Azure Firewall.
-	NatRuleCollections []*AzureFirewallNatRuleCollection `json:"natRuleCollections,omitempty"`
+	NatRuleCollections []*AzureFirewallNatRuleCollection
 
 	// Collection of network rule collections used by Azure Firewall.
-	NetworkRuleCollections []*AzureFirewallNetworkRuleCollection `json:"networkRuleCollections,omitempty"`
+	NetworkRuleCollections []*AzureFirewallNetworkRuleCollection
 
 	// The Azure Firewall Resource SKU.
-	SKU *AzureFirewallSKU `json:"sku,omitempty"`
+	SKU *AzureFirewallSKU
 
 	// The operation mode for Threat Intelligence.
-	ThreatIntelMode *AzureFirewallThreatIntelMode `json:"threatIntelMode,omitempty"`
+	ThreatIntelMode *AzureFirewallThreatIntelMode
 
 	// The virtualHub to which the firewall belongs.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+	VirtualHub *SubResource
 
 	// READ-ONLY; IP addresses associated with AzureFirewall.
-	HubIPAddresses *HubIPAddresses `json:"hubIpAddresses,omitempty" azure:"ro"`
+	HubIPAddresses *HubIPAddresses
 
 	// READ-ONLY; IpGroups associated with AzureFirewall.
-	IPGroups []*AzureFirewallIPGroups `json:"ipGroups,omitempty" azure:"ro"`
+	IPGroups []*AzureFirewallIPGroups
 
 	// READ-ONLY; The provisioning state of the Azure firewall resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // AzureFirewallPublicIPAddress - Public IP Address associated with azure firewall.
 type AzureFirewallPublicIPAddress struct {
 	// Public IP Address value.
-	Address *string `json:"address,omitempty"`
+	Address *string
 }
 
 // AzureFirewallRCAction - Properties of the AzureFirewallRCAction.
 type AzureFirewallRCAction struct {
 	// The type of action.
-	Type *AzureFirewallRCActionType `json:"type,omitempty"`
+	Type *AzureFirewallRCActionType
 }
 
 // AzureFirewallSKU - SKU of an Azure Firewall.
 type AzureFirewallSKU struct {
 	// Name of an Azure Firewall SKU.
-	Name *AzureFirewallSKUName `json:"name,omitempty"`
+	Name *AzureFirewallSKUName
 
 	// Tier of an Azure Firewall.
-	Tier *AzureFirewallSKUTier `json:"tier,omitempty"`
+	Tier *AzureFirewallSKUTier
 }
 
 // AzureFirewallsClientBeginCreateOrUpdateOptions contains the optional parameters for the AzureFirewallsClient.BeginCreateOrUpdate
@@ -2015,245 +2015,245 @@ type AzureFirewallsClientListOptions struct {
 // AzureReachabilityReport - Azure reachability report details.
 type AzureReachabilityReport struct {
 	// REQUIRED; The aggregation level of Azure reachability report. Can be Country, State or City.
-	AggregationLevel *string `json:"aggregationLevel,omitempty"`
+	AggregationLevel *string
 
 	// REQUIRED; Parameters that define a geographic location.
-	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
+	ProviderLocation *AzureReachabilityReportLocation
 
 	// REQUIRED; List of Azure reachability report items.
-	ReachabilityReport []*AzureReachabilityReportItem `json:"reachabilityReport,omitempty"`
+	ReachabilityReport []*AzureReachabilityReportItem
 }
 
 // AzureReachabilityReportItem - Azure reachability report details for a given provider location.
 type AzureReachabilityReportItem struct {
 	// The Azure region.
-	AzureLocation *string `json:"azureLocation,omitempty"`
+	AzureLocation *string
 
 	// List of latency details for each of the time series.
-	Latencies []*AzureReachabilityReportLatencyInfo `json:"latencies,omitempty"`
+	Latencies []*AzureReachabilityReportLatencyInfo
 
 	// The Internet service provider.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 }
 
 // AzureReachabilityReportLatencyInfo - Details on latency for a time series.
 type AzureReachabilityReportLatencyInfo struct {
 	// The relative latency score between 1 and 100, higher values indicating a faster connection.
-	Score *int32 `json:"score,omitempty"`
+	Score *int32
 
 	// The time stamp.
-	TimeStamp *time.Time `json:"timeStamp,omitempty"`
+	TimeStamp *time.Time
 }
 
 // AzureReachabilityReportLocation - Parameters that define a geographic location.
 type AzureReachabilityReportLocation struct {
 	// REQUIRED; The name of the country.
-	Country *string `json:"country,omitempty"`
+	Country *string
 
 	// The name of the city or town.
-	City *string `json:"city,omitempty"`
+	City *string
 
 	// The name of the state.
-	State *string `json:"state,omitempty"`
+	State *string
 }
 
 // AzureReachabilityReportParameters - Geographic and time constraints for Azure reachability report.
 type AzureReachabilityReportParameters struct {
 	// REQUIRED; The end time for the Azure reachability report.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// REQUIRED; Parameters that define a geographic location.
-	ProviderLocation *AzureReachabilityReportLocation `json:"providerLocation,omitempty"`
+	ProviderLocation *AzureReachabilityReportLocation
 
 	// REQUIRED; The start time for the Azure reachability report.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Optional Azure regions to scope the query to.
-	AzureLocations []*string `json:"azureLocations,omitempty"`
+	AzureLocations []*string
 
 	// List of Internet service providers.
-	Providers []*string `json:"providers,omitempty"`
+	Providers []*string
 }
 
 // BGPCommunity - Contains bgp community information offered in Service Community resources.
 type BGPCommunity struct {
 	// The name of the bgp community. e.g. Skype.
-	CommunityName *string `json:"communityName,omitempty"`
+	CommunityName *string
 
 	// The prefixes that the bgp community contains.
-	CommunityPrefixes []*string `json:"communityPrefixes,omitempty"`
+	CommunityPrefixes []*string
 
 	// The value of the bgp community. For more information: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing.
-	CommunityValue *string `json:"communityValue,omitempty"`
+	CommunityValue *string
 
 	// Customer is authorized to use bgp community or not.
-	IsAuthorizedToUse *bool `json:"isAuthorizedToUse,omitempty"`
+	IsAuthorizedToUse *bool
 
 	// The service group of the bgp community contains.
-	ServiceGroup *string `json:"serviceGroup,omitempty"`
+	ServiceGroup *string
 
 	// The region which the service support. e.g. For O365, region is Global.
-	ServiceSupportedRegion *string `json:"serviceSupportedRegion,omitempty"`
+	ServiceSupportedRegion *string
 }
 
 // BackendAddressPool - Pool of backend IP addresses.
 type BackendAddressPool struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of backend address pools used by the load balancer. This name can
 	// be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer backend address pool.
-	Properties *BackendAddressPoolPropertiesFormat `json:"properties,omitempty"`
+	Properties *BackendAddressPoolPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BackendAddressPoolPropertiesFormat - Properties of the backend address pool.
 type BackendAddressPoolPropertiesFormat struct {
 	// READ-ONLY; An array of references to IP addresses defined in network interfaces.
-	BackendIPConfigurations []*InterfaceIPConfiguration `json:"backendIPConfigurations,omitempty" azure:"ro"`
+	BackendIPConfigurations []*InterfaceIPConfiguration
 
 	// READ-ONLY; An array of references to load balancing rules that use this backend address pool.
-	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource
 
 	// READ-ONLY; A reference to an outbound rule that uses this backend address pool.
-	OutboundRule *SubResource `json:"outboundRule,omitempty" azure:"ro"`
+	OutboundRule *SubResource
 
 	// READ-ONLY; An array of references to outbound rules that use this backend address pool.
-	OutboundRules []*SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules []*SubResource
 
 	// READ-ONLY; The provisioning state of the backend address pool resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // BastionActiveSession - The session detail for a target.
 type BastionActiveSession struct {
 	// READ-ONLY; The protocol used to connect to the target.
-	Protocol *BastionConnectProtocol `json:"protocol,omitempty" azure:"ro"`
+	Protocol *BastionConnectProtocol
 
 	// READ-ONLY; The type of the resource.
-	ResourceType *string `json:"resourceType,omitempty" azure:"ro"`
+	ResourceType *string
 
 	// READ-ONLY; Duration in mins the session has been active.
-	SessionDurationInMins *float32 `json:"sessionDurationInMins,omitempty" azure:"ro"`
+	SessionDurationInMins *float32
 
 	// READ-ONLY; A unique id for the session.
-	SessionID *string `json:"sessionId,omitempty" azure:"ro"`
+	SessionID *string
 
 	// READ-ONLY; The time when the session started.
-	StartTime any `json:"startTime,omitempty" azure:"ro"`
+	StartTime any
 
 	// READ-ONLY; The host name of the target.
-	TargetHostName *string `json:"targetHostName,omitempty" azure:"ro"`
+	TargetHostName *string
 
 	// READ-ONLY; The IP Address of the target.
-	TargetIPAddress *string `json:"targetIpAddress,omitempty" azure:"ro"`
+	TargetIPAddress *string
 
 	// READ-ONLY; The resource group of the target.
-	TargetResourceGroup *string `json:"targetResourceGroup,omitempty" azure:"ro"`
+	TargetResourceGroup *string
 
 	// READ-ONLY; The resource id of the target.
-	TargetResourceID *string `json:"targetResourceId,omitempty" azure:"ro"`
+	TargetResourceID *string
 
 	// READ-ONLY; The subscription id for the target virtual machine.
-	TargetSubscriptionID *string `json:"targetSubscriptionId,omitempty" azure:"ro"`
+	TargetSubscriptionID *string
 
 	// READ-ONLY; The user name who is active on this session.
-	UserName *string `json:"userName,omitempty" azure:"ro"`
+	UserName *string
 }
 
 // BastionActiveSessionListResult - Response for GetActiveSessions.
 type BastionActiveSessionListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of active sessions on the bastion.
-	Value []*BastionActiveSession `json:"value,omitempty"`
+	Value []*BastionActiveSession
 }
 
 // BastionHost - Bastion Host resource.
 type BastionHost struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Represents the bastion host resource.
-	Properties *BastionHostPropertiesFormat `json:"properties,omitempty"`
+	Properties *BastionHostPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BastionHostIPConfiguration - IP configuration of an Bastion Host.
 type BastionHostIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Represents the ip configuration associated with the resource.
-	Properties *BastionHostIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *BastionHostIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Ip configuration type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BastionHostIPConfigurationPropertiesFormat - Properties of IP configuration of an Bastion Host.
 type BastionHostIPConfigurationPropertiesFormat struct {
 	// REQUIRED; Reference of the PublicIP resource.
-	PublicIPAddress *SubResource `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *SubResource
 
 	// REQUIRED; Reference of the subnet resource.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 
 	// Private IP allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// READ-ONLY; The provisioning state of the bastion host IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // BastionHostListResult - Response for ListBastionHosts API service call.
 type BastionHostListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Bastion Hosts in a resource group.
-	Value []*BastionHost `json:"value,omitempty"`
+	Value []*BastionHost
 }
 
 // BastionHostPropertiesFormat - Properties of the Bastion Host.
 type BastionHostPropertiesFormat struct {
 	// FQDN for the endpoint on which bastion host is accessible.
-	DNSName *string `json:"dnsName,omitempty"`
+	DNSName *string
 
 	// IP configuration of the Bastion Host resource.
-	IPConfigurations []*BastionHostIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*BastionHostIPConfiguration
 
 	// READ-ONLY; The provisioning state of the bastion host resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // BastionHostsClientBeginCreateOrUpdateOptions contains the optional parameters for the BastionHostsClient.BeginCreateOrUpdate
@@ -2288,85 +2288,85 @@ type BastionHostsClientListOptions struct {
 // BastionSessionDeleteResult - Response for DisconnectActiveSessions.
 type BastionSessionDeleteResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of sessions with their corresponding state.
-	Value []*BastionSessionState `json:"value,omitempty"`
+	Value []*BastionSessionState
 }
 
 // BastionSessionState - The session state detail for a target.
 type BastionSessionState struct {
 	// READ-ONLY; Used for extra information.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 
 	// READ-ONLY; A unique id for the session.
-	SessionID *string `json:"sessionId,omitempty" azure:"ro"`
+	SessionID *string
 
 	// READ-ONLY; The state of the session. Disconnected/Failed/NotFound.
-	State *string `json:"state,omitempty" azure:"ro"`
+	State *string
 }
 
 // BastionShareableLink - Bastion Shareable Link.
 type BastionShareableLink struct {
 	// REQUIRED; Reference of the virtual machine resource.
-	VM *VM `json:"vm,omitempty"`
+	VM *VM
 
 	// READ-ONLY; The unique Bastion Shareable Link to the virtual machine.
-	Bsl *string `json:"bsl,omitempty" azure:"ro"`
+	Bsl *string
 
 	// READ-ONLY; The time when the link was created.
-	CreatedAt *string `json:"createdAt,omitempty" azure:"ro"`
+	CreatedAt *string
 
 	// READ-ONLY; Optional field indicating the warning or error message related to the vm in case of partial failure.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 }
 
 // BastionShareableLinkListRequest - Post request for all the Bastion Shareable Link endpoints.
 type BastionShareableLinkListRequest struct {
 	// List of VM references.
-	VMs []*BastionShareableLink `json:"vms,omitempty"`
+	VMs []*BastionShareableLink
 }
 
 // BastionShareableLinkListResult - Response for all the Bastion Shareable Link endpoints.
 type BastionShareableLinkListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Bastion Shareable Links for the request.
-	Value []*BastionShareableLink `json:"value,omitempty"`
+	Value []*BastionShareableLink
 }
 
 // BgpPeerStatus - BGP peer status details.
 type BgpPeerStatus struct {
 	// READ-ONLY; The autonomous system number of the remote BGP peer.
-	Asn *int32 `json:"asn,omitempty" azure:"ro"`
+	Asn *int32
 
 	// READ-ONLY; For how long the peering has been up.
-	ConnectedDuration *string `json:"connectedDuration,omitempty" azure:"ro"`
+	ConnectedDuration *string
 
 	// READ-ONLY; The virtual network gateway's local address.
-	LocalAddress *string `json:"localAddress,omitempty" azure:"ro"`
+	LocalAddress *string
 
 	// READ-ONLY; The number of BGP messages received.
-	MessagesReceived *int64 `json:"messagesReceived,omitempty" azure:"ro"`
+	MessagesReceived *int64
 
 	// READ-ONLY; The number of BGP messages sent.
-	MessagesSent *int64 `json:"messagesSent,omitempty" azure:"ro"`
+	MessagesSent *int64
 
 	// READ-ONLY; The remote BGP peer.
-	Neighbor *string `json:"neighbor,omitempty" azure:"ro"`
+	Neighbor *string
 
 	// READ-ONLY; The number of routes learned from this peer.
-	RoutesReceived *int64 `json:"routesReceived,omitempty" azure:"ro"`
+	RoutesReceived *int64
 
 	// READ-ONLY; The BGP peer state.
-	State *BgpPeerState `json:"state,omitempty" azure:"ro"`
+	State *BgpPeerState
 }
 
 // BgpPeerStatusListResult - Response for list BGP peer status API service call.
 type BgpPeerStatusListResult struct {
 	// List of BGP peers.
-	Value []*BgpPeerStatus `json:"value,omitempty"`
+	Value []*BgpPeerStatus
 }
 
 // BgpServiceCommunitiesClientListOptions contains the optional parameters for the BgpServiceCommunitiesClient.NewListPager
@@ -2378,398 +2378,398 @@ type BgpServiceCommunitiesClientListOptions struct {
 // BgpServiceCommunity - Service Community Properties.
 type BgpServiceCommunity struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the BGP service community.
-	Properties *BgpServiceCommunityPropertiesFormat `json:"properties,omitempty"`
+	Properties *BgpServiceCommunityPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BgpServiceCommunityListResult - Response for the ListServiceCommunity API service call.
 type BgpServiceCommunityListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of service community resources.
-	Value []*BgpServiceCommunity `json:"value,omitempty"`
+	Value []*BgpServiceCommunity
 }
 
 // BgpServiceCommunityPropertiesFormat - Properties of Service Community.
 type BgpServiceCommunityPropertiesFormat struct {
 	// A list of bgp communities.
-	BgpCommunities []*BGPCommunity `json:"bgpCommunities,omitempty"`
+	BgpCommunities []*BGPCommunity
 
 	// The name of the bgp community. e.g. Skype.
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName *string
 }
 
 // BgpSettings - BGP settings details.
 type BgpSettings struct {
 	// The BGP speaker's ASN.
-	Asn *int64 `json:"asn,omitempty"`
+	Asn *int64
 
 	// The BGP peering address and BGP identifier of this BGP speaker.
-	BgpPeeringAddress *string `json:"bgpPeeringAddress,omitempty"`
+	BgpPeeringAddress *string
 
 	// BGP peering address with IP configuration ID for virtual network gateway.
-	BgpPeeringAddresses []*IPConfigurationBgpPeeringAddress `json:"bgpPeeringAddresses,omitempty"`
+	BgpPeeringAddresses []*IPConfigurationBgpPeeringAddress
 
 	// The weight added to routes learned from this BGP speaker.
-	PeerWeight *int32 `json:"peerWeight,omitempty"`
+	PeerWeight *int32
 }
 
 // CheckPrivateLinkServiceVisibilityRequest - Request body of the CheckPrivateLinkServiceVisibility API service call.
 type CheckPrivateLinkServiceVisibilityRequest struct {
 	// The alias of the private link service.
-	PrivateLinkServiceAlias *string `json:"privateLinkServiceAlias,omitempty"`
+	PrivateLinkServiceAlias *string
 }
 
 type Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties struct {
 	// READ-ONLY; The client id of user assigned identity.
-	ClientID *string `json:"clientId,omitempty" azure:"ro"`
+	ClientID *string
 
 	// READ-ONLY; The principal id of user assigned identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 }
 
 // ConfigurationDiagnosticParameters - Parameters to get network configuration diagnostic.
 type ConfigurationDiagnosticParameters struct {
 	// REQUIRED; List of network configuration diagnostic profiles.
-	Profiles []*ConfigurationDiagnosticProfile `json:"profiles,omitempty"`
+	Profiles []*ConfigurationDiagnosticProfile
 
 	// REQUIRED; The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface,
 	// VMSS/NetworkInterface and Application Gateway.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 
 	// Verbosity level.
-	VerbosityLevel *VerbosityLevel `json:"verbosityLevel,omitempty"`
+	VerbosityLevel *VerbosityLevel
 }
 
 // ConfigurationDiagnosticProfile - Parameters to compare with network configuration.
 type ConfigurationDiagnosticProfile struct {
 	// REQUIRED; Traffic destination. Accepted values are: '*', IP Address/CIDR, Service Tag.
-	Destination *string `json:"destination,omitempty"`
+	Destination *string
 
 	// REQUIRED; Traffic destination port. Accepted values are '*' and a single port in the range (0 - 65535).
-	DestinationPort *string `json:"destinationPort,omitempty"`
+	DestinationPort *string
 
 	// REQUIRED; The direction of the traffic.
-	Direction *Direction `json:"direction,omitempty"`
+	Direction *Direction
 
 	// REQUIRED; Protocol to be verified on. Accepted values are '*', TCP, UDP.
-	Protocol *string `json:"protocol,omitempty"`
+	Protocol *string
 
 	// REQUIRED; Traffic source. Accepted values are '*', IP Address/CIDR, Service Tag.
-	Source *string `json:"source,omitempty"`
+	Source *string
 }
 
 // ConfigurationDiagnosticResponse - Results of network configuration diagnostic on the target resource.
 type ConfigurationDiagnosticResponse struct {
 	// READ-ONLY; List of network configuration diagnostic results.
-	Results []*ConfigurationDiagnosticResult `json:"results,omitempty" azure:"ro"`
+	Results []*ConfigurationDiagnosticResult
 }
 
 // ConfigurationDiagnosticResult - Network configuration diagnostic result corresponded to provided traffic query.
 type ConfigurationDiagnosticResult struct {
 	// Network security group result.
-	NetworkSecurityGroupResult *SecurityGroupResult `json:"networkSecurityGroupResult,omitempty"`
+	NetworkSecurityGroupResult *SecurityGroupResult
 
 	// Network configuration diagnostic profile.
-	Profile *ConfigurationDiagnosticProfile `json:"profile,omitempty"`
+	Profile *ConfigurationDiagnosticProfile
 }
 
 // ConnectionMonitor - Parameters that define the operation to create a connection monitor.
 type ConnectionMonitor struct {
 	// REQUIRED; Properties of the connection monitor.
-	Properties *ConnectionMonitorParameters `json:"properties,omitempty"`
+	Properties *ConnectionMonitorParameters
 
 	// Connection monitor location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Connection monitor tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // ConnectionMonitorDestination - Describes the destination of connection monitor.
 type ConnectionMonitorDestination struct {
 	// Address of the connection monitor destination (IP or domain name).
-	Address *string `json:"address,omitempty"`
+	Address *string
 
 	// The destination port used by connection monitor.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// The ID of the resource used as the destination by connection monitor.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 }
 
 // ConnectionMonitorEndpoint - Describes the connection monitor endpoint.
 type ConnectionMonitorEndpoint struct {
 	// REQUIRED; The name of the connection monitor endpoint.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Address of the connection monitor endpoint (IP or domain name).
-	Address *string `json:"address,omitempty"`
+	Address *string
 
 	// Filter for sub-items within the endpoint.
-	Filter *ConnectionMonitorEndpointFilter `json:"filter,omitempty"`
+	Filter *ConnectionMonitorEndpointFilter
 
 	// Resource ID of the connection monitor endpoint.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 }
 
 // ConnectionMonitorEndpointFilter - Describes the connection monitor endpoint filter.
 type ConnectionMonitorEndpointFilter struct {
 	// List of items in the filter.
-	Items []*ConnectionMonitorEndpointFilterItem `json:"items,omitempty"`
+	Items []*ConnectionMonitorEndpointFilterItem
 
 	// The behavior of the endpoint filter. Currently only 'Include' is supported.
-	Type *ConnectionMonitorEndpointFilterType `json:"type,omitempty"`
+	Type *ConnectionMonitorEndpointFilterType
 }
 
 // ConnectionMonitorEndpointFilterItem - Describes the connection monitor endpoint filter item.
 type ConnectionMonitorEndpointFilterItem struct {
 	// The address of the filter item.
-	Address *string `json:"address,omitempty"`
+	Address *string
 
 	// The type of item included in the filter. Currently only 'AgentAddress' is supported.
-	Type *ConnectionMonitorEndpointFilterItemType `json:"type,omitempty"`
+	Type *ConnectionMonitorEndpointFilterItemType
 }
 
 // ConnectionMonitorHTTPConfiguration - Describes the HTTP configuration.
 type ConnectionMonitorHTTPConfiguration struct {
 	// The HTTP method to use.
-	Method *HTTPConfigurationMethod `json:"method,omitempty"`
+	Method *HTTPConfigurationMethod
 
 	// The path component of the URI. For instance, "/dir1/dir2".
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// The port to connect to.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// Value indicating whether HTTPS is preferred over HTTP in cases where the choice is not explicit.
-	PreferHTTPS *bool `json:"preferHTTPS,omitempty"`
+	PreferHTTPS *bool
 
 	// The HTTP headers to transmit with the request.
-	RequestHeaders []*HTTPHeader `json:"requestHeaders,omitempty"`
+	RequestHeaders []*HTTPHeader
 
 	// HTTP status codes to consider successful. For instance, "2xx,301-304,418".
-	ValidStatusCodeRanges []*string `json:"validStatusCodeRanges,omitempty"`
+	ValidStatusCodeRanges []*string
 }
 
 // ConnectionMonitorIcmpConfiguration - Describes the ICMP configuration.
 type ConnectionMonitorIcmpConfiguration struct {
 	// Value indicating whether path evaluation with trace route should be disabled.
-	DisableTraceRoute *bool `json:"disableTraceRoute,omitempty"`
+	DisableTraceRoute *bool
 }
 
 // ConnectionMonitorListResult - List of connection monitors.
 type ConnectionMonitorListResult struct {
 	// Information about connection monitors.
-	Value []*ConnectionMonitorResult `json:"value,omitempty"`
+	Value []*ConnectionMonitorResult
 }
 
 // ConnectionMonitorOutput - Describes a connection monitor output destination.
 type ConnectionMonitorOutput struct {
 	// Connection monitor output destination type. Currently, only "Workspace" is supported.
-	Type *OutputType `json:"type,omitempty"`
+	Type *OutputType
 
 	// Describes the settings for producing output into a log analytics workspace.
-	WorkspaceSettings *ConnectionMonitorWorkspaceSettings `json:"workspaceSettings,omitempty"`
+	WorkspaceSettings *ConnectionMonitorWorkspaceSettings
 }
 
 // ConnectionMonitorParameters - Parameters that define the operation to create a connection monitor.
 type ConnectionMonitorParameters struct {
 	// Determines if the connection monitor will start automatically once created.
-	AutoStart *bool `json:"autoStart,omitempty"`
+	AutoStart *bool
 
 	// Describes the destination of connection monitor.
-	Destination *ConnectionMonitorDestination `json:"destination,omitempty"`
+	Destination *ConnectionMonitorDestination
 
 	// List of connection monitor endpoints.
-	Endpoints []*ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
+	Endpoints []*ConnectionMonitorEndpoint
 
 	// Monitoring interval in seconds.
-	MonitoringIntervalInSeconds *int32 `json:"monitoringIntervalInSeconds,omitempty"`
+	MonitoringIntervalInSeconds *int32
 
 	// Optional notes to be associated with the connection monitor.
-	Notes *string `json:"notes,omitempty"`
+	Notes *string
 
 	// List of connection monitor outputs.
-	Outputs []*ConnectionMonitorOutput `json:"outputs,omitempty"`
+	Outputs []*ConnectionMonitorOutput
 
 	// Describes the source of connection monitor.
-	Source *ConnectionMonitorSource `json:"source,omitempty"`
+	Source *ConnectionMonitorSource
 
 	// List of connection monitor test configurations.
-	TestConfigurations []*ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
+	TestConfigurations []*ConnectionMonitorTestConfiguration
 
 	// List of connection monitor test groups.
-	TestGroups []*ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
+	TestGroups []*ConnectionMonitorTestGroup
 }
 
 // ConnectionMonitorQueryResult - List of connection states snapshots.
 type ConnectionMonitorQueryResult struct {
 	// Status of connection monitor source.
-	SourceStatus *ConnectionMonitorSourceStatus `json:"sourceStatus,omitempty"`
+	SourceStatus *ConnectionMonitorSourceStatus
 
 	// Information about connection states.
-	States []*ConnectionStateSnapshot `json:"states,omitempty"`
+	States []*ConnectionStateSnapshot
 }
 
 // ConnectionMonitorResult - Information about the connection monitor.
 type ConnectionMonitorResult struct {
 	// Connection monitor location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the connection monitor result.
-	Properties *ConnectionMonitorResultProperties `json:"properties,omitempty"`
+	Properties *ConnectionMonitorResultProperties
 
 	// Connection monitor tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; ID of the connection monitor.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Name of the connection monitor.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Connection monitor type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ConnectionMonitorResultProperties - Describes the properties of a connection monitor.
 type ConnectionMonitorResultProperties struct {
 	// Determines if the connection monitor will start automatically once created.
-	AutoStart *bool `json:"autoStart,omitempty"`
+	AutoStart *bool
 
 	// Describes the destination of connection monitor.
-	Destination *ConnectionMonitorDestination `json:"destination,omitempty"`
+	Destination *ConnectionMonitorDestination
 
 	// List of connection monitor endpoints.
-	Endpoints []*ConnectionMonitorEndpoint `json:"endpoints,omitempty"`
+	Endpoints []*ConnectionMonitorEndpoint
 
 	// Monitoring interval in seconds.
-	MonitoringIntervalInSeconds *int32 `json:"monitoringIntervalInSeconds,omitempty"`
+	MonitoringIntervalInSeconds *int32
 
 	// Optional notes to be associated with the connection monitor.
-	Notes *string `json:"notes,omitempty"`
+	Notes *string
 
 	// List of connection monitor outputs.
-	Outputs []*ConnectionMonitorOutput `json:"outputs,omitempty"`
+	Outputs []*ConnectionMonitorOutput
 
 	// Describes the source of connection monitor.
-	Source *ConnectionMonitorSource `json:"source,omitempty"`
+	Source *ConnectionMonitorSource
 
 	// List of connection monitor test configurations.
-	TestConfigurations []*ConnectionMonitorTestConfiguration `json:"testConfigurations,omitempty"`
+	TestConfigurations []*ConnectionMonitorTestConfiguration
 
 	// List of connection monitor test groups.
-	TestGroups []*ConnectionMonitorTestGroup `json:"testGroups,omitempty"`
+	TestGroups []*ConnectionMonitorTestGroup
 
 	// READ-ONLY; Type of connection monitor.
-	ConnectionMonitorType *ConnectionMonitorType `json:"connectionMonitorType,omitempty" azure:"ro"`
+	ConnectionMonitorType *ConnectionMonitorType
 
 	// READ-ONLY; The monitoring status of the connection monitor.
-	MonitoringStatus *string `json:"monitoringStatus,omitempty" azure:"ro"`
+	MonitoringStatus *string
 
 	// READ-ONLY; The provisioning state of the connection monitor.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The date and time when the connection monitor was started.
-	StartTime *time.Time `json:"startTime,omitempty" azure:"ro"`
+	StartTime *time.Time
 }
 
 // ConnectionMonitorSource - Describes the source of connection monitor.
 type ConnectionMonitorSource struct {
 	// REQUIRED; The ID of the resource used as the source by connection monitor.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 
 	// The source port used by connection monitor.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 }
 
 // ConnectionMonitorSuccessThreshold - Describes the threshold for declaring a test successful.
 type ConnectionMonitorSuccessThreshold struct {
 	// The maximum percentage of failed checks permitted for a test to evaluate as successful.
-	ChecksFailedPercent *int32 `json:"checksFailedPercent,omitempty"`
+	ChecksFailedPercent *int32
 
 	// The maximum round-trip time in milliseconds permitted for a test to evaluate as successful.
-	RoundTripTimeMs *int32 `json:"roundTripTimeMs,omitempty"`
+	RoundTripTimeMs *int32
 }
 
 // ConnectionMonitorTCPConfiguration - Describes the TCP configuration.
 type ConnectionMonitorTCPConfiguration struct {
 	// Value indicating whether path evaluation with trace route should be disabled.
-	DisableTraceRoute *bool `json:"disableTraceRoute,omitempty"`
+	DisableTraceRoute *bool
 
 	// The port to connect to.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 }
 
 // ConnectionMonitorTestConfiguration - Describes a connection monitor test configuration.
 type ConnectionMonitorTestConfiguration struct {
 	// REQUIRED; The name of the connection monitor test configuration.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The protocol to use in test evaluation.
-	Protocol *ConnectionMonitorTestConfigurationProtocol `json:"protocol,omitempty"`
+	Protocol *ConnectionMonitorTestConfigurationProtocol
 
 	// The parameters used to perform test evaluation over HTTP.
-	HTTPConfiguration *ConnectionMonitorHTTPConfiguration `json:"httpConfiguration,omitempty"`
+	HTTPConfiguration *ConnectionMonitorHTTPConfiguration
 
 	// The parameters used to perform test evaluation over ICMP.
-	IcmpConfiguration *ConnectionMonitorIcmpConfiguration `json:"icmpConfiguration,omitempty"`
+	IcmpConfiguration *ConnectionMonitorIcmpConfiguration
 
 	// The preferred IP version to use in test evaluation. The connection monitor may choose to use a different version depending
 	// on other parameters.
-	PreferredIPVersion *PreferredIPVersion `json:"preferredIPVersion,omitempty"`
+	PreferredIPVersion *PreferredIPVersion
 
 	// The threshold for declaring a test successful.
-	SuccessThreshold *ConnectionMonitorSuccessThreshold `json:"successThreshold,omitempty"`
+	SuccessThreshold *ConnectionMonitorSuccessThreshold
 
 	// The parameters used to perform test evaluation over TCP.
-	TCPConfiguration *ConnectionMonitorTCPConfiguration `json:"tcpConfiguration,omitempty"`
+	TCPConfiguration *ConnectionMonitorTCPConfiguration
 
 	// The frequency of test evaluation, in seconds.
-	TestFrequencySec *int32 `json:"testFrequencySec,omitempty"`
+	TestFrequencySec *int32
 }
 
 // ConnectionMonitorTestGroup - Describes the connection monitor test group.
 type ConnectionMonitorTestGroup struct {
 	// REQUIRED; List of destination endpoint names.
-	Destinations []*string `json:"destinations,omitempty"`
+	Destinations []*string
 
 	// REQUIRED; The name of the connection monitor test group.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; List of source endpoint names.
-	Sources []*string `json:"sources,omitempty"`
+	Sources []*string
 
 	// REQUIRED; List of test configuration names.
-	TestConfigurations []*string `json:"testConfigurations,omitempty"`
+	TestConfigurations []*string
 
 	// Value indicating whether test group is disabled.
-	Disable *bool `json:"disable,omitempty"`
+	Disable *bool
 }
 
 // ConnectionMonitorWorkspaceSettings - Describes the settings for producing output into a log analytics workspace.
 type ConnectionMonitorWorkspaceSettings struct {
 	// Log analytics workspace resource ID.
-	WorkspaceResourceID *string `json:"workspaceResourceId,omitempty"`
+	WorkspaceResourceID *string
 }
 
 // ConnectionMonitorsClientBeginCreateOrUpdateOptions contains the optional parameters for the ConnectionMonitorsClient.BeginCreateOrUpdate
@@ -2825,253 +2825,253 @@ type ConnectionMonitorsClientUpdateTagsOptions struct {
 // ConnectionResetSharedKey - The virtual network connection reset shared key.
 type ConnectionResetSharedKey struct {
 	// REQUIRED; The virtual network connection reset shared key length, should between 1 and 128.
-	KeyLength *int32 `json:"keyLength,omitempty"`
+	KeyLength *int32
 }
 
 // ConnectionSharedKey - Response for GetConnectionSharedKey API service call.
 type ConnectionSharedKey struct {
 	// REQUIRED; The virtual network connection shared key value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // ConnectionStateSnapshot - Connection state snapshot.
 type ConnectionStateSnapshot struct {
 	// Average latency in ms.
-	AvgLatencyInMs *int32 `json:"avgLatencyInMs,omitempty"`
+	AvgLatencyInMs *int32
 
 	// The connection state.
-	ConnectionState *ConnectionState `json:"connectionState,omitempty"`
+	ConnectionState *ConnectionState
 
 	// The end time of the connection snapshot.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Connectivity analysis evaluation state.
-	EvaluationState *EvaluationState `json:"evaluationState,omitempty"`
+	EvaluationState *EvaluationState
 
 	// Maximum latency in ms.
-	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty"`
+	MaxLatencyInMs *int32
 
 	// Minimum latency in ms.
-	MinLatencyInMs *int32 `json:"minLatencyInMs,omitempty"`
+	MinLatencyInMs *int32
 
 	// The number of failed probes.
-	ProbesFailed *int32 `json:"probesFailed,omitempty"`
+	ProbesFailed *int32
 
 	// The number of sent probes.
-	ProbesSent *int32 `json:"probesSent,omitempty"`
+	ProbesSent *int32
 
 	// The start time of the connection snapshot.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops []*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops []*ConnectivityHop
 }
 
 // ConnectivityDestination - Parameters that define destination of connection.
 type ConnectivityDestination struct {
 	// The IP address or URI the resource to which a connection attempt will be made.
-	Address *string `json:"address,omitempty"`
+	Address *string
 
 	// Port on which check connectivity will be performed.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// The ID of the resource to which a connection attempt will be made.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 }
 
 // ConnectivityHop - Information about a hop between the source and the destination.
 type ConnectivityHop struct {
 	// READ-ONLY; The IP address of the hop.
-	Address *string `json:"address,omitempty" azure:"ro"`
+	Address *string
 
 	// READ-ONLY; The ID of the hop.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; List of issues.
-	Issues []*ConnectivityIssue `json:"issues,omitempty" azure:"ro"`
+	Issues []*ConnectivityIssue
 
 	// READ-ONLY; List of next hop identifiers.
-	NextHopIDs []*string `json:"nextHopIds,omitempty" azure:"ro"`
+	NextHopIDs []*string
 
 	// READ-ONLY; The ID of the resource corresponding to this hop.
-	ResourceID *string `json:"resourceId,omitempty" azure:"ro"`
+	ResourceID *string
 
 	// READ-ONLY; The type of the hop.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ConnectivityInformation - Information on the connectivity status.
 type ConnectivityInformation struct {
 	// READ-ONLY; Average latency in milliseconds.
-	AvgLatencyInMs *int32 `json:"avgLatencyInMs,omitempty" azure:"ro"`
+	AvgLatencyInMs *int32
 
 	// READ-ONLY; The connection status.
-	ConnectionStatus *ConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *ConnectionStatus
 
 	// READ-ONLY; List of hops between the source and the destination.
-	Hops []*ConnectivityHop `json:"hops,omitempty" azure:"ro"`
+	Hops []*ConnectivityHop
 
 	// READ-ONLY; Maximum latency in milliseconds.
-	MaxLatencyInMs *int32 `json:"maxLatencyInMs,omitempty" azure:"ro"`
+	MaxLatencyInMs *int32
 
 	// READ-ONLY; Minimum latency in milliseconds.
-	MinLatencyInMs *int32 `json:"minLatencyInMs,omitempty" azure:"ro"`
+	MinLatencyInMs *int32
 
 	// READ-ONLY; Number of failed probes.
-	ProbesFailed *int32 `json:"probesFailed,omitempty" azure:"ro"`
+	ProbesFailed *int32
 
 	// READ-ONLY; Total number of probes sent.
-	ProbesSent *int32 `json:"probesSent,omitempty" azure:"ro"`
+	ProbesSent *int32
 }
 
 // ConnectivityIssue - Information about an issue encountered in the process of checking for connectivity.
 type ConnectivityIssue struct {
 	// READ-ONLY; Provides additional context on the issue.
-	Context []map[string]*string `json:"context,omitempty" azure:"ro"`
+	Context []map[string]*string
 
 	// READ-ONLY; The origin of the issue.
-	Origin *Origin `json:"origin,omitempty" azure:"ro"`
+	Origin *Origin
 
 	// READ-ONLY; The severity of the issue.
-	Severity *Severity `json:"severity,omitempty" azure:"ro"`
+	Severity *Severity
 
 	// READ-ONLY; The type of issue.
-	Type *IssueType `json:"type,omitempty" azure:"ro"`
+	Type *IssueType
 }
 
 // ConnectivityParameters - Parameters that determine how the connectivity check will be performed.
 type ConnectivityParameters struct {
 	// REQUIRED; The destination of connection.
-	Destination *ConnectivityDestination `json:"destination,omitempty"`
+	Destination *ConnectivityDestination
 
 	// REQUIRED; The source of the connection.
-	Source *ConnectivitySource `json:"source,omitempty"`
+	Source *ConnectivitySource
 
 	// Preferred IP version of the connection.
-	PreferredIPVersion *IPVersion `json:"preferredIPVersion,omitempty"`
+	PreferredIPVersion *IPVersion
 
 	// Network protocol.
-	Protocol *Protocol `json:"protocol,omitempty"`
+	Protocol *Protocol
 
 	// Configuration of the protocol.
-	ProtocolConfiguration *ProtocolConfiguration `json:"protocolConfiguration,omitempty"`
+	ProtocolConfiguration *ProtocolConfiguration
 }
 
 // ConnectivitySource - Parameters that define the source of the connection.
 type ConnectivitySource struct {
 	// REQUIRED; The ID of the resource from which a connectivity check will be initiated.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 
 	// The source port from which a connectivity check will be performed.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 }
 
 // Container - Reference to container resource in remote resource provider.
 type Container struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // ContainerNetworkInterface - Container network interface child resource.
 type ContainerNetworkInterface struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Container network interface properties.
-	Properties *ContainerNetworkInterfacePropertiesFormat `json:"properties,omitempty"`
+	Properties *ContainerNetworkInterfacePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ContainerNetworkInterfaceConfiguration - Container network interface configuration child resource.
 type ContainerNetworkInterfaceConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Container network interface configuration properties.
-	Properties *ContainerNetworkInterfaceConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ContainerNetworkInterfaceConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ContainerNetworkInterfaceConfigurationPropertiesFormat - Container network interface configuration properties.
 type ContainerNetworkInterfaceConfigurationPropertiesFormat struct {
 	// A list of container network interfaces created from this container network interface configuration.
-	ContainerNetworkInterfaces []*SubResource `json:"containerNetworkInterfaces,omitempty"`
+	ContainerNetworkInterfaces []*SubResource
 
 	// A list of ip configurations of the container network interface configuration.
-	IPConfigurations []*IPConfigurationProfile `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*IPConfigurationProfile
 
 	// READ-ONLY; The provisioning state of the container network interface configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ContainerNetworkInterfaceIPConfiguration - The ip configuration for a container network interface.
 type ContainerNetworkInterfaceIPConfiguration struct {
 	// The name of the resource. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the container network interface IP configuration.
-	Properties *ContainerNetworkInterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ContainerNetworkInterfaceIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ContainerNetworkInterfaceIPConfigurationPropertiesFormat - Properties of the container network interface IP configuration.
 type ContainerNetworkInterfaceIPConfigurationPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the container network interface IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ContainerNetworkInterfacePropertiesFormat - Properties of container network interface.
 type ContainerNetworkInterfacePropertiesFormat struct {
 	// Reference to the container to which this container network interface is attached.
-	Container *Container `json:"container,omitempty"`
+	Container *Container
 
 	// READ-ONLY; Container network interface configuration from which this container network interface is created.
-	ContainerNetworkInterfaceConfiguration *ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfiguration,omitempty" azure:"ro"`
+	ContainerNetworkInterfaceConfiguration *ContainerNetworkInterfaceConfiguration
 
 	// READ-ONLY; Reference to the ip configuration on this container nic.
-	IPConfigurations []*ContainerNetworkInterfaceIPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations []*ContainerNetworkInterfaceIPConfiguration
 
 	// READ-ONLY; The provisioning state of the container network interface resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // CustomDNSConfigPropertiesFormat - Contains custom Dns resolution configuration from customer.
 type CustomDNSConfigPropertiesFormat struct {
 	// Fqdn that resolves to private endpoint ip address.
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// A list of private ip addresses of the private endpoint.
-	IPAddresses []*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string
 }
 
 // DNSNameAvailabilityResult - Response for the CheckDnsNameAvailability API service call.
 type DNSNameAvailabilityResult struct {
 	// Domain availability (True/False).
-	Available *bool `json:"available,omitempty"`
+	Available *bool
 }
 
 // DdosCustomPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the DdosCustomPoliciesClient.BeginCreateOrUpdate
@@ -3102,87 +3102,87 @@ type DdosCustomPoliciesClientUpdateTagsOptions struct {
 // DdosCustomPolicy - A DDoS custom policy in a resource group.
 type DdosCustomPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the DDoS custom policy.
-	Properties *DdosCustomPolicyPropertiesFormat `json:"properties,omitempty"`
+	Properties *DdosCustomPolicyPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DdosCustomPolicyPropertiesFormat - DDoS custom policy properties.
 type DdosCustomPolicyPropertiesFormat struct {
 	// The protocol-specific DDoS policy customization parameters.
-	ProtocolCustomSettings []*ProtocolCustomSettingsFormat `json:"protocolCustomSettings,omitempty"`
+	ProtocolCustomSettings []*ProtocolCustomSettingsFormat
 
 	// READ-ONLY; The provisioning state of the DDoS custom policy resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The list of public IPs associated with the DDoS custom policy resource. This list is read-only.
-	PublicIPAddresses []*SubResource `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses []*SubResource
 
 	// READ-ONLY; The resource GUID property of the DDoS custom policy resource. It uniquely identifies the resource, even if
 	// the user changes its name or migrate the resource across subscriptions or resource groups.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // DdosProtectionPlan - A DDoS protection plan in a resource group.
 type DdosProtectionPlan struct {
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the DDoS protection plan.
-	Properties *DdosProtectionPlanPropertiesFormat `json:"properties,omitempty"`
+	Properties *DdosProtectionPlanPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DdosProtectionPlanListResult - A list of DDoS protection plans.
 type DdosProtectionPlanListResult struct {
 	// A list of DDoS protection plans.
-	Value []*DdosProtectionPlan `json:"value,omitempty"`
+	Value []*DdosProtectionPlan
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // DdosProtectionPlanPropertiesFormat - DDoS protection plan properties.
 type DdosProtectionPlanPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the DDoS protection plan resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the DDoS protection plan resource. It uniquely identifies the resource, even if
 	// the user changes its name or migrate the resource across subscriptions or resource groups.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; The list of virtual networks associated with the DDoS protection plan resource. This list is read-only.
-	VirtualNetworks []*SubResource `json:"virtualNetworks,omitempty" azure:"ro"`
+	VirtualNetworks []*SubResource
 }
 
 // DdosProtectionPlansClientBeginCreateOrUpdateOptions contains the optional parameters for the DdosProtectionPlansClient.BeginCreateOrUpdate
@@ -3224,13 +3224,13 @@ type DdosProtectionPlansClientUpdateTagsOptions struct {
 // DdosSettings - Contains the DDoS protection settings of the public IP.
 type DdosSettings struct {
 	// The DDoS custom policy associated with the public IP.
-	DdosCustomPolicy *SubResource `json:"ddosCustomPolicy,omitempty"`
+	DdosCustomPolicy *SubResource
 
 	// Enables DDoS protection on the public IP.
-	ProtectedIP *bool `json:"protectedIP,omitempty"`
+	ProtectedIP *bool
 
 	// The DDoS protection policy customizability of the public IP. Only standard coverage will have the ability to be customized.
-	ProtectionCoverage *DdosSettingsProtectionCoverage `json:"protectionCoverage,omitempty"`
+	ProtectionCoverage *DdosSettingsProtectionCoverage
 }
 
 // DefaultSecurityRulesClientGetOptions contains the optional parameters for the DefaultSecurityRulesClient.Get method.
@@ -3247,261 +3247,261 @@ type DefaultSecurityRulesClientListOptions struct {
 // Delegation - Details the service to which the subnet is delegated.
 type Delegation struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a subnet. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the subnet.
-	Properties *ServiceDelegationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ServiceDelegationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // DeviceProperties - List of properties of the device.
 type DeviceProperties struct {
 	// Model of the device.
-	DeviceModel *string `json:"deviceModel,omitempty"`
+	DeviceModel *string
 
 	// Name of the device Vendor.
-	DeviceVendor *string `json:"deviceVendor,omitempty"`
+	DeviceVendor *string
 
 	// Link speed.
-	LinkSpeedInMbps *int32 `json:"linkSpeedInMbps,omitempty"`
+	LinkSpeedInMbps *int32
 }
 
 // DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for
 // a subnet overrides VNET DHCP options.
 type DhcpOptions struct {
 	// The list of DNS servers IP addresses.
-	DNSServers []*string `json:"dnsServers,omitempty"`
+	DNSServers []*string
 }
 
 // Dimension of the metric.
 type Dimension struct {
 	// The display name of the dimension.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// The internal name of the dimension.
-	InternalName *string `json:"internalName,omitempty"`
+	InternalName *string
 
 	// The name of the dimension.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // EffectiveNetworkSecurityGroup - Effective network security group.
 type EffectiveNetworkSecurityGroup struct {
 	// Associated resources.
-	Association *EffectiveNetworkSecurityGroupAssociation `json:"association,omitempty"`
+	Association *EffectiveNetworkSecurityGroupAssociation
 
 	// A collection of effective security rules.
-	EffectiveSecurityRules []*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules []*EffectiveNetworkSecurityRule
 
 	// The ID of network security group that is applied.
-	NetworkSecurityGroup *SubResource `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SubResource
 
 	// Mapping of tags to list of IP Addresses included within the tag.
-	TagMap *string `json:"tagMap,omitempty"`
+	TagMap *string
 }
 
 // EffectiveNetworkSecurityGroupAssociation - The effective network security group association.
 type EffectiveNetworkSecurityGroupAssociation struct {
 	// The ID of the network interface if assigned.
-	NetworkInterface *SubResource `json:"networkInterface,omitempty"`
+	NetworkInterface *SubResource
 
 	// The ID of the subnet if assigned.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 }
 
 // EffectiveNetworkSecurityGroupListResult - Response for list effective network security groups API service call.
 type EffectiveNetworkSecurityGroupListResult struct {
 	// A list of effective network security groups.
-	Value []*EffectiveNetworkSecurityGroup `json:"value,omitempty"`
+	Value []*EffectiveNetworkSecurityGroup
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // EffectiveNetworkSecurityRule - Effective network security rules.
 type EffectiveNetworkSecurityRule struct {
 	// Whether network traffic is allowed or denied.
-	Access *SecurityRuleAccess `json:"access,omitempty"`
+	Access *SecurityRuleAccess
 
 	// The destination address prefix.
-	DestinationAddressPrefix *string `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefix *string
 
 	// The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer,
 	// Internet), System Tags, and the asterisk (*).
-	DestinationAddressPrefixes []*string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes []*string
 
 	// The destination port or range.
-	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
+	DestinationPortRange *string
 
 	// The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator
 	// (e.g. 100-400), or an asterisk (*).
-	DestinationPortRanges []*string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges []*string
 
 	// The direction of the rule.
-	Direction *SecurityRuleDirection `json:"direction,omitempty"`
+	Direction *SecurityRuleDirection
 
 	// Expanded destination address prefix.
-	ExpandedDestinationAddressPrefix []*string `json:"expandedDestinationAddressPrefix,omitempty"`
+	ExpandedDestinationAddressPrefix []*string
 
 	// The expanded source address prefix.
-	ExpandedSourceAddressPrefix []*string `json:"expandedSourceAddressPrefix,omitempty"`
+	ExpandedSourceAddressPrefix []*string
 
 	// The name of the security rule specified by the user (if created by the user).
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The priority of the rule.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// The network protocol this rule applies to.
-	Protocol *EffectiveSecurityRuleProtocol `json:"protocol,omitempty"`
+	Protocol *EffectiveSecurityRuleProtocol
 
 	// The source address prefix.
-	SourceAddressPrefix *string `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefix *string
 
 	// The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet),
 	// System Tags, and the asterisk (*).
-	SourceAddressPrefixes []*string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes []*string
 
 	// The source port or range.
-	SourcePortRange *string `json:"sourcePortRange,omitempty"`
+	SourcePortRange *string
 
 	// The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g.
 	// 100-400), or an asterisk (*).
-	SourcePortRanges []*string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges []*string
 }
 
 // EffectiveRoute - Effective Route.
 type EffectiveRoute struct {
 	// The address prefixes of the effective routes in CIDR notation.
-	AddressPrefix []*string `json:"addressPrefix,omitempty"`
+	AddressPrefix []*string
 
 	// If true, on-premises routes are not propagated to the network interfaces in the subnet.
-	DisableBgpRoutePropagation *bool `json:"disableBgpRoutePropagation,omitempty"`
+	DisableBgpRoutePropagation *bool
 
 	// The name of the user defined route. This is optional.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The IP address of the next hop of the effective route.
-	NextHopIPAddress []*string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress []*string
 
 	// The type of Azure hop the packet should be sent to.
-	NextHopType *RouteNextHopType `json:"nextHopType,omitempty"`
+	NextHopType *RouteNextHopType
 
 	// Who created the route.
-	Source *EffectiveRouteSource `json:"source,omitempty"`
+	Source *EffectiveRouteSource
 
 	// The value of effective route.
-	State *EffectiveRouteState `json:"state,omitempty"`
+	State *EffectiveRouteState
 }
 
 // EffectiveRouteListResult - Response for list effective route API service call.
 type EffectiveRouteListResult struct {
 	// A list of effective routes.
-	Value []*EffectiveRoute `json:"value,omitempty"`
+	Value []*EffectiveRoute
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // EndpointServiceResult - Endpoint service.
 type EndpointServiceResult struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// READ-ONLY; Name of the endpoint service.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Type of the endpoint service.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // EndpointServicesListResult - Response for the ListAvailableEndpointServices API service call.
 type EndpointServicesListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of available endpoint services in a region.
-	Value []*EndpointServiceResult `json:"value,omitempty"`
+	Value []*EndpointServiceResult
 }
 
 // EvaluatedNetworkSecurityGroup - Results of network security group evaluation.
 type EvaluatedNetworkSecurityGroup struct {
 	// Resource ID of nic or subnet to which network security group is applied.
-	AppliedTo *string `json:"appliedTo,omitempty"`
+	AppliedTo *string
 
 	// Matched network security rule.
-	MatchedRule *MatchedRule `json:"matchedRule,omitempty"`
+	MatchedRule *MatchedRule
 
 	// Network security group ID.
-	NetworkSecurityGroupID *string `json:"networkSecurityGroupId,omitempty"`
+	NetworkSecurityGroupID *string
 
 	// READ-ONLY; List of network security rules evaluation results.
-	RulesEvaluationResult []*SecurityRulesEvaluationResult `json:"rulesEvaluationResult,omitempty" azure:"ro"`
+	RulesEvaluationResult []*SecurityRulesEvaluationResult
 }
 
 // ExpressRouteCircuit resource.
 type ExpressRouteCircuit struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the express route circuit.
-	Properties *ExpressRouteCircuitPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRouteCircuitPropertiesFormat
 
 	// The SKU.
-	SKU *ExpressRouteCircuitSKU `json:"sku,omitempty"`
+	SKU *ExpressRouteCircuitSKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteCircuitArpTable - The ARP table associated with the ExpressRouteCircuit.
 type ExpressRouteCircuitArpTable struct {
 	// Entry age in minutes.
-	Age *int32 `json:"age,omitempty"`
+	Age *int32
 
 	// The IP address.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 
 	// Interface address.
-	Interface *string `json:"interface,omitempty"`
+	Interface *string
 
 	// The MAC address.
-	MacAddress *string `json:"macAddress,omitempty"`
+	MacAddress *string
 }
 
 // ExpressRouteCircuitAuthorization - Authorization in an ExpressRouteCircuit resource.
 type ExpressRouteCircuitAuthorization struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the express route circuit authorization.
-	Properties *AuthorizationPropertiesFormat `json:"properties,omitempty"`
+	Properties *AuthorizationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteCircuitAuthorizationsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitAuthorizationsClient.BeginCreateOrUpdate
@@ -3533,53 +3533,53 @@ type ExpressRouteCircuitAuthorizationsClientListOptions struct {
 // ExpressRouteCircuitConnection - Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.
 type ExpressRouteCircuitConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the express route circuit connection.
-	Properties *ExpressRouteCircuitConnectionPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRouteCircuitConnectionPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteCircuitConnectionListResult - Response for ListConnections API service call retrieves all global reach connections
 // that belongs to a Private Peering for an ExpressRouteCircuit.
 type ExpressRouteCircuitConnectionListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The global reach connection associated with Private Peering in an ExpressRoute Circuit.
-	Value []*ExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitConnection
 }
 
 // ExpressRouteCircuitConnectionPropertiesFormat - Properties of the express route circuit connection.
 type ExpressRouteCircuitConnectionPropertiesFormat struct {
 	// /29 IP address space to carve out Customer addresses for tunnels.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// The authorization key.
-	AuthorizationKey *string `json:"authorizationKey,omitempty"`
+	AuthorizationKey *string
 
 	// Reference to Express Route Circuit Private Peering Resource of the circuit initiating connection.
-	ExpressRouteCircuitPeering *SubResource `json:"expressRouteCircuitPeering,omitempty"`
+	ExpressRouteCircuitPeering *SubResource
 
 	// IPv6 Address PrefixProperties of the express route circuit connection.
-	IPv6CircuitConnectionConfig *IPv6CircuitConnectionConfig `json:"ipv6CircuitConnectionConfig,omitempty"`
+	IPv6CircuitConnectionConfig *IPv6CircuitConnectionConfig
 
 	// Reference to Express Route Circuit Private Peering Resource of the peered circuit.
-	PeerExpressRouteCircuitPeering *SubResource `json:"peerExpressRouteCircuitPeering,omitempty"`
+	PeerExpressRouteCircuitPeering *SubResource
 
 	// READ-ONLY; Express Route Circuit connection state.
-	CircuitConnectionStatus *CircuitConnectionStatus `json:"circuitConnectionStatus,omitempty" azure:"ro"`
+	CircuitConnectionStatus *CircuitConnectionStatus
 
 	// READ-ONLY; The provisioning state of the express route circuit connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRouteCircuitConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitConnectionsClient.BeginCreateOrUpdate
@@ -3611,128 +3611,128 @@ type ExpressRouteCircuitConnectionsClientListOptions struct {
 // ExpressRouteCircuitListResult - Response for ListExpressRouteCircuit API service call.
 type ExpressRouteCircuitListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of ExpressRouteCircuits in a resource group.
-	Value []*ExpressRouteCircuit `json:"value,omitempty"`
+	Value []*ExpressRouteCircuit
 }
 
 // ExpressRouteCircuitPeering - Peering in an ExpressRouteCircuit resource.
 type ExpressRouteCircuitPeering struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the express route circuit peering.
-	Properties *ExpressRouteCircuitPeeringPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRouteCircuitPeeringPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteCircuitPeeringConfig - Specifies the peering configuration.
 type ExpressRouteCircuitPeeringConfig struct {
 	// The communities of bgp peering. Specified for microsoft peering.
-	AdvertisedCommunities []*string `json:"advertisedCommunities,omitempty"`
+	AdvertisedCommunities []*string
 
 	// The reference to AdvertisedPublicPrefixes.
-	AdvertisedPublicPrefixes []*string `json:"advertisedPublicPrefixes,omitempty"`
+	AdvertisedPublicPrefixes []*string
 
 	// The CustomerASN of the peering.
-	CustomerASN *int32 `json:"customerASN,omitempty"`
+	CustomerASN *int32
 
 	// The legacy mode of the peering.
-	LegacyMode *int32 `json:"legacyMode,omitempty"`
+	LegacyMode *int32
 
 	// The RoutingRegistryName of the configuration.
-	RoutingRegistryName *string `json:"routingRegistryName,omitempty"`
+	RoutingRegistryName *string
 
 	// READ-ONLY; The advertised public prefix state of the Peering resource.
-	AdvertisedPublicPrefixesState *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState `json:"advertisedPublicPrefixesState,omitempty" azure:"ro"`
+	AdvertisedPublicPrefixesState *ExpressRouteCircuitPeeringAdvertisedPublicPrefixState
 }
 
 // ExpressRouteCircuitPeeringID - ExpressRoute circuit peering identifier.
 type ExpressRouteCircuitPeeringID struct {
 	// The ID of the ExpressRoute circuit peering.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // ExpressRouteCircuitPeeringListResult - Response for ListPeering API service call retrieves all peerings that belong to
 // an ExpressRouteCircuit.
 type ExpressRouteCircuitPeeringListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The peerings in an express route circuit.
-	Value []*ExpressRouteCircuitPeering `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitPeering
 }
 
 // ExpressRouteCircuitPeeringPropertiesFormat - Properties of the express route circuit peering.
 type ExpressRouteCircuitPeeringPropertiesFormat struct {
 	// The Azure ASN.
-	AzureASN *int32 `json:"azureASN,omitempty"`
+	AzureASN *int32
 
 	// The list of circuit connections associated with Azure Private Peering for this circuit.
-	Connections []*ExpressRouteCircuitConnection `json:"connections,omitempty"`
+	Connections []*ExpressRouteCircuitConnection
 
 	// The ExpressRoute connection.
-	ExpressRouteConnection *ExpressRouteConnectionID `json:"expressRouteConnection,omitempty"`
+	ExpressRouteConnection *ExpressRouteConnectionID
 
 	// The GatewayManager Etag.
-	GatewayManagerEtag *string `json:"gatewayManagerEtag,omitempty"`
+	GatewayManagerEtag *string
 
 	// The IPv6 peering configuration.
-	IPv6PeeringConfig *IPv6ExpressRouteCircuitPeeringConfig `json:"ipv6PeeringConfig,omitempty"`
+	IPv6PeeringConfig *IPv6ExpressRouteCircuitPeeringConfig
 
 	// The Microsoft peering configuration.
-	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig `json:"microsoftPeeringConfig,omitempty"`
+	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig
 
 	// The peer ASN.
-	PeerASN *int64 `json:"peerASN,omitempty"`
+	PeerASN *int64
 
 	// The peering type.
-	PeeringType *ExpressRoutePeeringType `json:"peeringType,omitempty"`
+	PeeringType *ExpressRoutePeeringType
 
 	// The primary port.
-	PrimaryAzurePort *string `json:"primaryAzurePort,omitempty"`
+	PrimaryAzurePort *string
 
 	// The primary address prefix.
-	PrimaryPeerAddressPrefix *string `json:"primaryPeerAddressPrefix,omitempty"`
+	PrimaryPeerAddressPrefix *string
 
 	// The reference to the RouteFilter resource.
-	RouteFilter *SubResource `json:"routeFilter,omitempty"`
+	RouteFilter *SubResource
 
 	// The secondary port.
-	SecondaryAzurePort *string `json:"secondaryAzurePort,omitempty"`
+	SecondaryAzurePort *string
 
 	// The secondary address prefix.
-	SecondaryPeerAddressPrefix *string `json:"secondaryPeerAddressPrefix,omitempty"`
+	SecondaryPeerAddressPrefix *string
 
 	// The shared key.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// The peering state.
-	State *ExpressRoutePeeringState `json:"state,omitempty"`
+	State *ExpressRoutePeeringState
 
 	// The peering stats of express route circuit.
-	Stats *ExpressRouteCircuitStats `json:"stats,omitempty"`
+	Stats *ExpressRouteCircuitStats
 
 	// The VLAN ID.
-	VlanID *int32 `json:"vlanId,omitempty"`
+	VlanID *int32
 
 	// READ-ONLY; Who was the last to modify the peering.
-	LastModifiedBy *string `json:"lastModifiedBy,omitempty" azure:"ro"`
+	LastModifiedBy *string
 
 	// READ-ONLY; The list of peered circuit connections associated with Azure Private Peering for this circuit.
-	PeeredConnections []*PeerExpressRouteCircuitConnection `json:"peeredConnections,omitempty" azure:"ro"`
+	PeeredConnections []*PeerExpressRouteCircuitConnection
 
 	// READ-ONLY; The provisioning state of the express route circuit peering resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRouteCircuitPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitPeeringsClient.BeginCreateOrUpdate
@@ -3764,137 +3764,137 @@ type ExpressRouteCircuitPeeringsClientListOptions struct {
 // ExpressRouteCircuitPropertiesFormat - Properties of ExpressRouteCircuit.
 type ExpressRouteCircuitPropertiesFormat struct {
 	// Allow classic operations.
-	AllowClassicOperations *bool `json:"allowClassicOperations,omitempty"`
+	AllowClassicOperations *bool
 
 	// The list of authorizations.
-	Authorizations []*ExpressRouteCircuitAuthorization `json:"authorizations,omitempty"`
+	Authorizations []*ExpressRouteCircuitAuthorization
 
 	// The bandwidth of the circuit when the circuit is provisioned on an ExpressRoutePort resource.
-	BandwidthInGbps *float32 `json:"bandwidthInGbps,omitempty"`
+	BandwidthInGbps *float32
 
 	// The CircuitProvisioningState state of the resource.
-	CircuitProvisioningState *string `json:"circuitProvisioningState,omitempty"`
+	CircuitProvisioningState *string
 
 	// The reference to the ExpressRoutePort resource when the circuit is provisioned on an ExpressRoutePort resource.
-	ExpressRoutePort *SubResource `json:"expressRoutePort,omitempty"`
+	ExpressRoutePort *SubResource
 
 	// The GatewayManager Etag.
-	GatewayManagerEtag *string `json:"gatewayManagerEtag,omitempty"`
+	GatewayManagerEtag *string
 
 	// Flag denoting global reach status.
-	GlobalReachEnabled *bool `json:"globalReachEnabled,omitempty"`
+	GlobalReachEnabled *bool
 
 	// The list of peerings.
-	Peerings []*ExpressRouteCircuitPeering `json:"peerings,omitempty"`
+	Peerings []*ExpressRouteCircuitPeering
 
 	// The ServiceKey.
-	ServiceKey *string `json:"serviceKey,omitempty"`
+	ServiceKey *string
 
 	// The ServiceProviderNotes.
-	ServiceProviderNotes *string `json:"serviceProviderNotes,omitempty"`
+	ServiceProviderNotes *string
 
 	// The ServiceProviderProperties.
-	ServiceProviderProperties *ExpressRouteCircuitServiceProviderProperties `json:"serviceProviderProperties,omitempty"`
+	ServiceProviderProperties *ExpressRouteCircuitServiceProviderProperties
 
 	// The ServiceProviderProvisioningState state of the resource.
-	ServiceProviderProvisioningState *ServiceProviderProvisioningState `json:"serviceProviderProvisioningState,omitempty"`
+	ServiceProviderProvisioningState *ServiceProviderProvisioningState
 
 	// READ-ONLY; The provisioning state of the express route circuit resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The identifier of the circuit traffic. Outer tag for QinQ encapsulation.
-	Stag *int32 `json:"stag,omitempty" azure:"ro"`
+	Stag *int32
 }
 
 // ExpressRouteCircuitReference - Reference to an express route circuit.
 type ExpressRouteCircuitReference struct {
 	// Corresponding Express Route Circuit Id.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // ExpressRouteCircuitRoutesTable - The routes table associated with the ExpressRouteCircuit.
 type ExpressRouteCircuitRoutesTable struct {
 	// Local preference value as set with the set local-preference route-map configuration command.
-	LocPrf *string `json:"locPrf,omitempty"`
+	LocPrf *string
 
 	// IP address of a network entity.
-	Network *string `json:"network,omitempty"`
+	Network *string
 
 	// NextHop address.
-	NextHop *string `json:"nextHop,omitempty"`
+	NextHop *string
 
 	// Autonomous system paths to the destination network.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// Route Weight.
-	Weight *int32 `json:"weight,omitempty"`
+	Weight *int32
 }
 
 // ExpressRouteCircuitRoutesTableSummary - The routes table associated with the ExpressRouteCircuit.
 type ExpressRouteCircuitRoutesTableSummary struct {
 	// Autonomous system number.
-	As *int32 `json:"as,omitempty"`
+	As *int32
 
 	// IP address of the neighbor.
-	Neighbor *string `json:"neighbor,omitempty"`
+	Neighbor *string
 
 	// Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group.
-	StatePfxRcd *string `json:"statePfxRcd,omitempty"`
+	StatePfxRcd *string
 
 	// The length of time that the BGP session has been in the Established state, or the current status if not in the Established
 	// state.
-	UpDown *string `json:"upDown,omitempty"`
+	UpDown *string
 
 	// BGP version number spoken to the neighbor.
-	V *int32 `json:"v,omitempty"`
+	V *int32
 }
 
 // ExpressRouteCircuitSKU - Contains SKU in an ExpressRouteCircuit.
 type ExpressRouteCircuitSKU struct {
 	// The family of the SKU.
-	Family *ExpressRouteCircuitSKUFamily `json:"family,omitempty"`
+	Family *ExpressRouteCircuitSKUFamily
 
 	// The name of the SKU.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The tier of the SKU.
-	Tier *ExpressRouteCircuitSKUTier `json:"tier,omitempty"`
+	Tier *ExpressRouteCircuitSKUTier
 }
 
 // ExpressRouteCircuitServiceProviderProperties - Contains ServiceProviderProperties in an ExpressRouteCircuit.
 type ExpressRouteCircuitServiceProviderProperties struct {
 	// The BandwidthInMbps.
-	BandwidthInMbps *int32 `json:"bandwidthInMbps,omitempty"`
+	BandwidthInMbps *int32
 
 	// The peering location.
-	PeeringLocation *string `json:"peeringLocation,omitempty"`
+	PeeringLocation *string
 
 	// The serviceProviderName.
-	ServiceProviderName *string `json:"serviceProviderName,omitempty"`
+	ServiceProviderName *string
 }
 
 // ExpressRouteCircuitStats - Contains stats associated with the peering.
 type ExpressRouteCircuitStats struct {
 	// The Primary BytesIn of the peering.
-	PrimarybytesIn *int64 `json:"primarybytesIn,omitempty"`
+	PrimarybytesIn *int64
 
 	// The primary BytesOut of the peering.
-	PrimarybytesOut *int64 `json:"primarybytesOut,omitempty"`
+	PrimarybytesOut *int64
 
 	// The secondary BytesIn of the peering.
-	SecondarybytesIn *int64 `json:"secondarybytesIn,omitempty"`
+	SecondarybytesIn *int64
 
 	// The secondary BytesOut of the peering.
-	SecondarybytesOut *int64 `json:"secondarybytesOut,omitempty"`
+	SecondarybytesOut *int64
 }
 
 // ExpressRouteCircuitsArpTableListResult - Response for ListArpTable associated with the Express Route Circuits API.
 type ExpressRouteCircuitsArpTableListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of the ARP tables.
-	Value []*ExpressRouteCircuitArpTable `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitArpTable
 }
 
 // ExpressRouteCircuitsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCircuitsClient.BeginCreateOrUpdate
@@ -3970,62 +3970,62 @@ type ExpressRouteCircuitsClientUpdateTagsOptions struct {
 // ExpressRouteCircuitsRoutesTableListResult - Response for ListRoutesTable associated with the Express Route Circuits API.
 type ExpressRouteCircuitsRoutesTableListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The list of routes table.
-	Value []*ExpressRouteCircuitRoutesTable `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitRoutesTable
 }
 
 // ExpressRouteCircuitsRoutesTableSummaryListResult - Response for ListRoutesTable associated with the Express Route Circuits
 // API.
 type ExpressRouteCircuitsRoutesTableSummaryListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of the routes table.
-	Value []*ExpressRouteCircuitRoutesTableSummary `json:"value,omitempty"`
+	Value []*ExpressRouteCircuitRoutesTableSummary
 }
 
 // ExpressRouteConnection resource.
 type ExpressRouteConnection struct {
 	// REQUIRED; The name of the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Properties of the express route connection.
-	Properties *ExpressRouteConnectionProperties `json:"properties,omitempty"`
+	Properties *ExpressRouteConnectionProperties
 }
 
 // ExpressRouteConnectionID - The ID of the ExpressRouteConnection.
 type ExpressRouteConnectionID struct {
 	// READ-ONLY; The ID of the ExpressRouteConnection.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // ExpressRouteConnectionList - ExpressRouteConnection list.
 type ExpressRouteConnectionList struct {
 	// The list of ExpressRoute connections.
-	Value []*ExpressRouteConnection `json:"value,omitempty"`
+	Value []*ExpressRouteConnection
 }
 
 // ExpressRouteConnectionProperties - Properties of the ExpressRouteConnection subresource.
 type ExpressRouteConnectionProperties struct {
 	// REQUIRED; The ExpressRoute circuit peering.
-	ExpressRouteCircuitPeering *ExpressRouteCircuitPeeringID `json:"expressRouteCircuitPeering,omitempty"`
+	ExpressRouteCircuitPeering *ExpressRouteCircuitPeeringID
 
 	// Authorization key to establish the connection.
-	AuthorizationKey *string `json:"authorizationKey,omitempty"`
+	AuthorizationKey *string
 
 	// Enable internet security.
-	EnableInternetSecurity *bool `json:"enableInternetSecurity,omitempty"`
+	EnableInternetSecurity *bool
 
 	// The routing weight associated to the connection.
-	RoutingWeight *int32 `json:"routingWeight,omitempty"`
+	RoutingWeight *int32
 
 	// READ-ONLY; The provisioning state of the express route connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRouteConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteConnectionsClient.BeginCreateOrUpdate
@@ -4055,107 +4055,107 @@ type ExpressRouteConnectionsClientListOptions struct {
 // ExpressRouteCrossConnection resource.
 type ExpressRouteCrossConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the express route cross connection.
-	Properties *ExpressRouteCrossConnectionProperties `json:"properties,omitempty"`
+	Properties *ExpressRouteCrossConnectionProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteCrossConnectionListResult - Response for ListExpressRouteCrossConnection API service call.
 type ExpressRouteCrossConnectionListResult struct {
 	// A list of ExpressRouteCrossConnection resources.
-	Value []*ExpressRouteCrossConnection `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnection
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ExpressRouteCrossConnectionPeering - Peering in an ExpressRoute Cross Connection resource.
 type ExpressRouteCrossConnectionPeering struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the express route cross connection peering.
-	Properties *ExpressRouteCrossConnectionPeeringProperties `json:"properties,omitempty"`
+	Properties *ExpressRouteCrossConnectionPeeringProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // ExpressRouteCrossConnectionPeeringList - Response for ListPeering API service call retrieves all peerings that belong to
 // an ExpressRouteCrossConnection.
 type ExpressRouteCrossConnectionPeeringList struct {
 	// The peerings in an express route cross connection.
-	Value []*ExpressRouteCrossConnectionPeering `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnectionPeering
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ExpressRouteCrossConnectionPeeringProperties - Properties of express route cross connection peering.
 type ExpressRouteCrossConnectionPeeringProperties struct {
 	// The GatewayManager Etag.
-	GatewayManagerEtag *string `json:"gatewayManagerEtag,omitempty"`
+	GatewayManagerEtag *string
 
 	// The IPv6 peering configuration.
-	IPv6PeeringConfig *IPv6ExpressRouteCircuitPeeringConfig `json:"ipv6PeeringConfig,omitempty"`
+	IPv6PeeringConfig *IPv6ExpressRouteCircuitPeeringConfig
 
 	// The Microsoft peering configuration.
-	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig `json:"microsoftPeeringConfig,omitempty"`
+	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig
 
 	// The peer ASN.
-	PeerASN *int64 `json:"peerASN,omitempty"`
+	PeerASN *int64
 
 	// The peering type.
-	PeeringType *ExpressRoutePeeringType `json:"peeringType,omitempty"`
+	PeeringType *ExpressRoutePeeringType
 
 	// The primary address prefix.
-	PrimaryPeerAddressPrefix *string `json:"primaryPeerAddressPrefix,omitempty"`
+	PrimaryPeerAddressPrefix *string
 
 	// The secondary address prefix.
-	SecondaryPeerAddressPrefix *string `json:"secondaryPeerAddressPrefix,omitempty"`
+	SecondaryPeerAddressPrefix *string
 
 	// The shared key.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// The peering state.
-	State *ExpressRoutePeeringState `json:"state,omitempty"`
+	State *ExpressRoutePeeringState
 
 	// The VLAN ID.
-	VlanID *int32 `json:"vlanId,omitempty"`
+	VlanID *int32
 
 	// READ-ONLY; The Azure ASN.
-	AzureASN *int32 `json:"azureASN,omitempty" azure:"ro"`
+	AzureASN *int32
 
 	// READ-ONLY; Who was the last to modify the peering.
-	LastModifiedBy *string `json:"lastModifiedBy,omitempty" azure:"ro"`
+	LastModifiedBy *string
 
 	// READ-ONLY; The primary port.
-	PrimaryAzurePort *string `json:"primaryAzurePort,omitempty" azure:"ro"`
+	PrimaryAzurePort *string
 
 	// READ-ONLY; The provisioning state of the express route cross connection peering resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The secondary port.
-	SecondaryAzurePort *string `json:"secondaryAzurePort,omitempty" azure:"ro"`
+	SecondaryAzurePort *string
 }
 
 // ExpressRouteCrossConnectionPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnectionPeeringsClient.BeginCreateOrUpdate
@@ -4187,50 +4187,50 @@ type ExpressRouteCrossConnectionPeeringsClientListOptions struct {
 // ExpressRouteCrossConnectionProperties - Properties of ExpressRouteCrossConnection.
 type ExpressRouteCrossConnectionProperties struct {
 	// The circuit bandwidth In Mbps.
-	BandwidthInMbps *int32 `json:"bandwidthInMbps,omitempty"`
+	BandwidthInMbps *int32
 
 	// The ExpressRouteCircuit.
-	ExpressRouteCircuit *ExpressRouteCircuitReference `json:"expressRouteCircuit,omitempty"`
+	ExpressRouteCircuit *ExpressRouteCircuitReference
 
 	// The peering location of the ExpressRoute circuit.
-	PeeringLocation *string `json:"peeringLocation,omitempty"`
+	PeeringLocation *string
 
 	// The list of peerings.
-	Peerings []*ExpressRouteCrossConnectionPeering `json:"peerings,omitempty"`
+	Peerings []*ExpressRouteCrossConnectionPeering
 
 	// Additional read only notes set by the connectivity provider.
-	ServiceProviderNotes *string `json:"serviceProviderNotes,omitempty"`
+	ServiceProviderNotes *string
 
 	// The provisioning state of the circuit in the connectivity provider system.
-	ServiceProviderProvisioningState *ServiceProviderProvisioningState `json:"serviceProviderProvisioningState,omitempty"`
+	ServiceProviderProvisioningState *ServiceProviderProvisioningState
 
 	// READ-ONLY; The name of the primary port.
-	PrimaryAzurePort *string `json:"primaryAzurePort,omitempty" azure:"ro"`
+	PrimaryAzurePort *string
 
 	// READ-ONLY; The provisioning state of the express route cross connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The identifier of the circuit traffic.
-	STag *int32 `json:"sTag,omitempty" azure:"ro"`
+	STag *int32
 
 	// READ-ONLY; The name of the secondary port.
-	SecondaryAzurePort *string `json:"secondaryAzurePort,omitempty" azure:"ro"`
+	SecondaryAzurePort *string
 }
 
 // ExpressRouteCrossConnectionRoutesTableSummary - The routes table associated with the ExpressRouteCircuit.
 type ExpressRouteCrossConnectionRoutesTableSummary struct {
 	// Autonomous system number.
-	Asn *int32 `json:"asn,omitempty"`
+	Asn *int32
 
 	// IP address of Neighbor router.
-	Neighbor *string `json:"neighbor,omitempty"`
+	Neighbor *string
 
 	// Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group.
-	StateOrPrefixesReceived *string `json:"stateOrPrefixesReceived,omitempty"`
+	StateOrPrefixesReceived *string
 
 	// The length of time that the BGP session has been in the Established state, or the current status if not in the Established
 	// state.
-	UpDown *string `json:"upDown,omitempty"`
+	UpDown *string
 }
 
 // ExpressRouteCrossConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteCrossConnectionsClient.BeginCreateOrUpdate
@@ -4289,70 +4289,70 @@ type ExpressRouteCrossConnectionsClientUpdateTagsOptions struct {
 // Cross Connections.
 type ExpressRouteCrossConnectionsRoutesTableSummaryListResult struct {
 	// A list of the routes table.
-	Value []*ExpressRouteCrossConnectionRoutesTableSummary `json:"value,omitempty"`
+	Value []*ExpressRouteCrossConnectionRoutesTableSummary
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ExpressRouteGateway - ExpressRoute gateway resource.
 type ExpressRouteGateway struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the express route gateway.
-	Properties *ExpressRouteGatewayProperties `json:"properties,omitempty"`
+	Properties *ExpressRouteGatewayProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteGatewayList - List of ExpressRoute gateways.
 type ExpressRouteGatewayList struct {
 	// List of ExpressRoute gateways.
-	Value []*ExpressRouteGateway `json:"value,omitempty"`
+	Value []*ExpressRouteGateway
 }
 
 // ExpressRouteGatewayProperties - ExpressRoute gateway resource properties.
 type ExpressRouteGatewayProperties struct {
 	// REQUIRED; The Virtual Hub where the ExpressRoute gateway is or will be deployed.
-	VirtualHub *VirtualHubID `json:"virtualHub,omitempty"`
+	VirtualHub *VirtualHubID
 
 	// Configuration for auto scaling.
-	AutoScaleConfiguration *ExpressRouteGatewayPropertiesAutoScaleConfiguration `json:"autoScaleConfiguration,omitempty"`
+	AutoScaleConfiguration *ExpressRouteGatewayPropertiesAutoScaleConfiguration
 
 	// READ-ONLY; List of ExpressRoute connections to the ExpressRoute gateway.
-	ExpressRouteConnections []*ExpressRouteConnection `json:"expressRouteConnections,omitempty" azure:"ro"`
+	ExpressRouteConnections []*ExpressRouteConnection
 
 	// READ-ONLY; The provisioning state of the express route gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRouteGatewayPropertiesAutoScaleConfiguration - Configuration for auto scaling.
 type ExpressRouteGatewayPropertiesAutoScaleConfiguration struct {
 	// Minimum and maximum number of scale units to deploy.
-	Bounds *ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds `json:"bounds,omitempty"`
+	Bounds *ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds
 }
 
 // ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds - Minimum and maximum number of scale units to deploy.
 type ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds struct {
 	// Maximum number of scale units deployed for ExpressRoute gateway.
-	Max *int32 `json:"max,omitempty"`
+	Max *int32
 
 	// Minimum number of scale units deployed for ExpressRoute gateway.
-	Min *int32 `json:"min,omitempty"`
+	Min *int32
 }
 
 // ExpressRouteGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRouteGatewaysClient.BeginCreateOrUpdate
@@ -4389,64 +4389,64 @@ type ExpressRouteGatewaysClientListBySubscriptionOptions struct {
 // ExpressRouteLink child resource definition.
 type ExpressRouteLink struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of child port resource that is unique among child port resources of the parent.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// ExpressRouteLink properties.
-	Properties *ExpressRouteLinkPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRouteLinkPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // ExpressRouteLinkListResult - Response for ListExpressRouteLinks API service call.
 type ExpressRouteLinkListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The list of ExpressRouteLink sub-resources.
-	Value []*ExpressRouteLink `json:"value,omitempty"`
+	Value []*ExpressRouteLink
 }
 
 // ExpressRouteLinkMacSecConfig - ExpressRouteLink Mac Security Configuration.
 type ExpressRouteLinkMacSecConfig struct {
 	// Keyvault Secret Identifier URL containing Mac security CAK key.
-	CakSecretIdentifier *string `json:"cakSecretIdentifier,omitempty"`
+	CakSecretIdentifier *string
 
 	// Mac security cipher.
-	Cipher *ExpressRouteLinkMacSecCipher `json:"cipher,omitempty"`
+	Cipher *ExpressRouteLinkMacSecCipher
 
 	// Keyvault Secret Identifier URL containing Mac security CKN key.
-	CknSecretIdentifier *string `json:"cknSecretIdentifier,omitempty"`
+	CknSecretIdentifier *string
 }
 
 // ExpressRouteLinkPropertiesFormat - Properties specific to ExpressRouteLink resources.
 type ExpressRouteLinkPropertiesFormat struct {
 	// Administrative state of the physical port.
-	AdminState *ExpressRouteLinkAdminState `json:"adminState,omitempty"`
+	AdminState *ExpressRouteLinkAdminState
 
 	// MacSec configuration.
-	MacSecConfig *ExpressRouteLinkMacSecConfig `json:"macSecConfig,omitempty"`
+	MacSecConfig *ExpressRouteLinkMacSecConfig
 
 	// READ-ONLY; Physical fiber port type.
-	ConnectorType *ExpressRouteLinkConnectorType `json:"connectorType,omitempty" azure:"ro"`
+	ConnectorType *ExpressRouteLinkConnectorType
 
 	// READ-ONLY; Name of Azure router interface.
-	InterfaceName *string `json:"interfaceName,omitempty" azure:"ro"`
+	InterfaceName *string
 
 	// READ-ONLY; Mapping between physical port to patch panel port.
-	PatchPanelID *string `json:"patchPanelId,omitempty" azure:"ro"`
+	PatchPanelID *string
 
 	// READ-ONLY; The provisioning state of the express route link resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; Mapping of physical patch panel to rack.
-	RackID *string `json:"rackId,omitempty" azure:"ro"`
+	RackID *string
 
 	// READ-ONLY; Name of Azure router associated with physical port.
-	RouterName *string `json:"routerName,omitempty" azure:"ro"`
+	RouterName *string
 }
 
 // ExpressRouteLinksClientGetOptions contains the optional parameters for the ExpressRouteLinksClient.Get method.
@@ -4462,73 +4462,73 @@ type ExpressRouteLinksClientListOptions struct {
 // ExpressRoutePort resource definition.
 type ExpressRoutePort struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The identity of ExpressRoutePort, if configured.
-	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
+	Identity *ManagedServiceIdentity
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// ExpressRoutePort properties.
-	Properties *ExpressRoutePortPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRoutePortPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRoutePortListResult - Response for ListExpressRoutePorts API service call.
 type ExpressRoutePortListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of ExpressRoutePort resources.
-	Value []*ExpressRoutePort `json:"value,omitempty"`
+	Value []*ExpressRoutePort
 }
 
 // ExpressRoutePortPropertiesFormat - Properties specific to ExpressRoutePort resources.
 type ExpressRoutePortPropertiesFormat struct {
 	// Bandwidth of procured ports in Gbps.
-	BandwidthInGbps *int32 `json:"bandwidthInGbps,omitempty"`
+	BandwidthInGbps *int32
 
 	// Encapsulation method on physical ports.
-	Encapsulation *ExpressRoutePortsEncapsulation `json:"encapsulation,omitempty"`
+	Encapsulation *ExpressRoutePortsEncapsulation
 
 	// The set of physical links of the ExpressRoutePort resource.
-	Links []*ExpressRouteLink `json:"links,omitempty"`
+	Links []*ExpressRouteLink
 
 	// The name of the peering location that the ExpressRoutePort is mapped to physically.
-	PeeringLocation *string `json:"peeringLocation,omitempty"`
+	PeeringLocation *string
 
 	// READ-ONLY; Date of the physical port allocation to be used in Letter of Authorization.
-	AllocationDate *string `json:"allocationDate,omitempty" azure:"ro"`
+	AllocationDate *string
 
 	// READ-ONLY; Reference the ExpressRoute circuit(s) that are provisioned on this ExpressRoutePort resource.
-	Circuits []*SubResource `json:"circuits,omitempty" azure:"ro"`
+	Circuits []*SubResource
 
 	// READ-ONLY; Ether type of the physical port.
-	EtherType *string `json:"etherType,omitempty" azure:"ro"`
+	EtherType *string
 
 	// READ-ONLY; Maximum transmission unit of the physical port pair(s).
-	Mtu *string `json:"mtu,omitempty" azure:"ro"`
+	Mtu *string
 
 	// READ-ONLY; Aggregate Gbps of associated circuit bandwidths.
-	ProvisionedBandwidthInGbps *float32 `json:"provisionedBandwidthInGbps,omitempty" azure:"ro"`
+	ProvisionedBandwidthInGbps *float32
 
 	// READ-ONLY; The provisioning state of the express route port resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the express route port resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // ExpressRoutePortsClientBeginCreateOrUpdateOptions contains the optional parameters for the ExpressRoutePortsClient.BeginCreateOrUpdate
@@ -4569,55 +4569,55 @@ type ExpressRoutePortsClientUpdateTagsOptions struct {
 // ExpressRoutePortsLocation - Definition of the ExpressRoutePorts peering location resource.
 type ExpressRoutePortsLocation struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// ExpressRoutePort peering location properties.
-	Properties *ExpressRoutePortsLocationPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRoutePortsLocationPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRoutePortsLocationBandwidths - Real-time inventory of available ExpressRoute port bandwidths.
 type ExpressRoutePortsLocationBandwidths struct {
 	// READ-ONLY; Bandwidth descriptive name.
-	OfferName *string `json:"offerName,omitempty" azure:"ro"`
+	OfferName *string
 
 	// READ-ONLY; Bandwidth value in Gbps.
-	ValueInGbps *int32 `json:"valueInGbps,omitempty" azure:"ro"`
+	ValueInGbps *int32
 }
 
 // ExpressRoutePortsLocationListResult - Response for ListExpressRoutePortsLocations API service call.
 type ExpressRoutePortsLocationListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The list of all ExpressRoutePort peering locations.
-	Value []*ExpressRoutePortsLocation `json:"value,omitempty"`
+	Value []*ExpressRoutePortsLocation
 }
 
 // ExpressRoutePortsLocationPropertiesFormat - Properties specific to ExpressRoutePorts peering location resources.
 type ExpressRoutePortsLocationPropertiesFormat struct {
 	// The inventory of available ExpressRoutePort bandwidths.
-	AvailableBandwidths []*ExpressRoutePortsLocationBandwidths `json:"availableBandwidths,omitempty"`
+	AvailableBandwidths []*ExpressRoutePortsLocationBandwidths
 
 	// READ-ONLY; Address of peering location.
-	Address *string `json:"address,omitempty" azure:"ro"`
+	Address *string
 
 	// READ-ONLY; Contact details of peering locations.
-	Contact *string `json:"contact,omitempty" azure:"ro"`
+	Contact *string
 
 	// READ-ONLY; The provisioning state of the express route port location resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRoutePortsLocationsClientGetOptions contains the optional parameters for the ExpressRoutePortsLocationsClient.Get
@@ -4635,52 +4635,52 @@ type ExpressRoutePortsLocationsClientListOptions struct {
 // ExpressRouteServiceProvider - A ExpressRouteResourceProvider object.
 type ExpressRouteServiceProvider struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the express route service provider.
-	Properties *ExpressRouteServiceProviderPropertiesFormat `json:"properties,omitempty"`
+	Properties *ExpressRouteServiceProviderPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ExpressRouteServiceProviderBandwidthsOffered - Contains bandwidths offered in ExpressRouteServiceProvider resources.
 type ExpressRouteServiceProviderBandwidthsOffered struct {
 	// The OfferName.
-	OfferName *string `json:"offerName,omitempty"`
+	OfferName *string
 
 	// The ValueInMbps.
-	ValueInMbps *int32 `json:"valueInMbps,omitempty"`
+	ValueInMbps *int32
 }
 
 // ExpressRouteServiceProviderListResult - Response for the ListExpressRouteServiceProvider API service call.
 type ExpressRouteServiceProviderListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of ExpressRouteResourceProvider resources.
-	Value []*ExpressRouteServiceProvider `json:"value,omitempty"`
+	Value []*ExpressRouteServiceProvider
 }
 
 // ExpressRouteServiceProviderPropertiesFormat - Properties of ExpressRouteServiceProvider.
 type ExpressRouteServiceProviderPropertiesFormat struct {
 	// A list of bandwidths offered.
-	BandwidthsOffered []*ExpressRouteServiceProviderBandwidthsOffered `json:"bandwidthsOffered,omitempty"`
+	BandwidthsOffered []*ExpressRouteServiceProviderBandwidthsOffered
 
 	// A list of peering locations.
-	PeeringLocations []*string `json:"peeringLocations,omitempty"`
+	PeeringLocations []*string
 
 	// READ-ONLY; The provisioning state of the express route service provider resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ExpressRouteServiceProvidersClientListOptions contains the optional parameters for the ExpressRouteServiceProvidersClient.NewListPager
@@ -4721,43 +4721,43 @@ type FirewallPoliciesClientListOptions struct {
 // FirewallPolicy Resource.
 type FirewallPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the firewall policy.
-	Properties *FirewallPolicyPropertiesFormat `json:"properties,omitempty"`
+	Properties *FirewallPolicyPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // FirewallPolicyFilterRule - Firewall Policy Filter Rule.
 type FirewallPolicyFilterRule struct {
 	// REQUIRED; The type of the rule.
-	RuleType *FirewallPolicyRuleType `json:"ruleType,omitempty"`
+	RuleType *FirewallPolicyRuleType
 
 	// The action type of a Filter rule.
-	Action *FirewallPolicyFilterRuleAction `json:"action,omitempty"`
+	Action *FirewallPolicyFilterRuleAction
 
 	// The name of the rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Priority of the Firewall Policy Rule resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Collection of rule conditions used by a rule.
-	RuleConditions []FirewallPolicyRuleConditionClassification `json:"ruleConditions,omitempty"`
+	RuleConditions []FirewallPolicyRuleConditionClassification
 }
 
 // GetFirewallPolicyRule implements the FirewallPolicyRuleClassification interface for type FirewallPolicyFilterRule.
@@ -4772,40 +4772,40 @@ func (f *FirewallPolicyFilterRule) GetFirewallPolicyRule() *FirewallPolicyRule {
 // FirewallPolicyFilterRuleAction - Properties of the FirewallPolicyFilterRuleAction.
 type FirewallPolicyFilterRuleAction struct {
 	// The type of action.
-	Type *FirewallPolicyFilterRuleActionType `json:"type,omitempty"`
+	Type *FirewallPolicyFilterRuleActionType
 }
 
 // FirewallPolicyListResult - Response for ListFirewallPolicies API service call.
 type FirewallPolicyListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Firewall Policies in a resource group.
-	Value []*FirewallPolicy `json:"value,omitempty"`
+	Value []*FirewallPolicy
 }
 
 // FirewallPolicyNatRule - Firewall Policy NAT Rule.
 type FirewallPolicyNatRule struct {
 	// REQUIRED; The type of the rule.
-	RuleType *FirewallPolicyRuleType `json:"ruleType,omitempty"`
+	RuleType *FirewallPolicyRuleType
 
 	// The action type of a Nat rule.
-	Action *FirewallPolicyNatRuleAction `json:"action,omitempty"`
+	Action *FirewallPolicyNatRuleAction
 
 	// The name of the rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Priority of the Firewall Policy Rule resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// The match conditions for incoming traffic.
-	RuleCondition FirewallPolicyRuleConditionClassification `json:"ruleCondition,omitempty"`
+	RuleCondition FirewallPolicyRuleConditionClassification
 
 	// The translated address for this NAT rule.
-	TranslatedAddress *string `json:"translatedAddress,omitempty"`
+	TranslatedAddress *string
 
 	// The translated port for this NAT rule.
-	TranslatedPort *string `json:"translatedPort,omitempty"`
+	TranslatedPort *string
 }
 
 // GetFirewallPolicyRule implements the FirewallPolicyRuleClassification interface for type FirewallPolicyNatRule.
@@ -4820,28 +4820,28 @@ func (f *FirewallPolicyNatRule) GetFirewallPolicyRule() *FirewallPolicyRule {
 // FirewallPolicyNatRuleAction - Properties of the FirewallPolicyNatRuleAction.
 type FirewallPolicyNatRuleAction struct {
 	// The type of action.
-	Type *FirewallPolicyNatRuleActionType `json:"type,omitempty"`
+	Type *FirewallPolicyNatRuleActionType
 }
 
 // FirewallPolicyPropertiesFormat - Firewall Policy definition.
 type FirewallPolicyPropertiesFormat struct {
 	// The parent firewall policy from which rules are inherited.
-	BasePolicy *SubResource `json:"basePolicy,omitempty"`
+	BasePolicy *SubResource
 
 	// The operation mode for Threat Intelligence.
-	ThreatIntelMode *AzureFirewallThreatIntelMode `json:"threatIntelMode,omitempty"`
+	ThreatIntelMode *AzureFirewallThreatIntelMode
 
 	// READ-ONLY; List of references to Child Firewall Policies.
-	ChildPolicies []*SubResource `json:"childPolicies,omitempty" azure:"ro"`
+	ChildPolicies []*SubResource
 
 	// READ-ONLY; List of references to Azure Firewalls that this Firewall Policy is associated with.
-	Firewalls []*SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls []*SubResource
 
 	// READ-ONLY; The provisioning state of the firewall policy resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; List of references to FirewallPolicyRuleGroups.
-	RuleGroups []*SubResource `json:"ruleGroups,omitempty" azure:"ro"`
+	RuleGroups []*SubResource
 }
 
 // FirewallPolicyRuleClassification provides polymorphic access to related types.
@@ -4856,13 +4856,13 @@ type FirewallPolicyRuleClassification interface {
 // FirewallPolicyRule - Properties of the rule.
 type FirewallPolicyRule struct {
 	// REQUIRED; The type of the rule.
-	RuleType *FirewallPolicyRuleType `json:"ruleType,omitempty"`
+	RuleType *FirewallPolicyRuleType
 
 	// The name of the rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Priority of the Firewall Policy Rule resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 }
 
 // GetFirewallPolicyRule implements the FirewallPolicyRuleClassification interface for type FirewallPolicyRule.
@@ -4880,13 +4880,13 @@ type FirewallPolicyRuleConditionClassification interface {
 // FirewallPolicyRuleCondition - Properties of a rule.
 type FirewallPolicyRuleCondition struct {
 	// REQUIRED; Rule Condition Type.
-	RuleConditionType *FirewallPolicyRuleConditionType `json:"ruleConditionType,omitempty"`
+	RuleConditionType *FirewallPolicyRuleConditionType
 
 	// Description of the rule condition.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Name of the rule condition.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // GetFirewallPolicyRuleCondition implements the FirewallPolicyRuleConditionClassification interface for type FirewallPolicyRuleCondition.
@@ -4897,49 +4897,49 @@ func (f *FirewallPolicyRuleCondition) GetFirewallPolicyRuleCondition() *Firewall
 // FirewallPolicyRuleConditionApplicationProtocol - Properties of the application rule protocol.
 type FirewallPolicyRuleConditionApplicationProtocol struct {
 	// Port number for the protocol, cannot be greater than 64000.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// Protocol type.
-	ProtocolType *FirewallPolicyRuleConditionApplicationProtocolType `json:"protocolType,omitempty"`
+	ProtocolType *FirewallPolicyRuleConditionApplicationProtocolType
 }
 
 // FirewallPolicyRuleGroup - Rule Group resource.
 type FirewallPolicyRuleGroup struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The properties of the firewall policy rule group.
-	Properties *FirewallPolicyRuleGroupProperties `json:"properties,omitempty"`
+	Properties *FirewallPolicyRuleGroupProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Rule Group type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // FirewallPolicyRuleGroupListResult - Response for ListFirewallPolicyRuleGroups API service call.
 type FirewallPolicyRuleGroupListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of FirewallPolicyRuleGroups in a FirewallPolicy.
-	Value []*FirewallPolicyRuleGroup `json:"value,omitempty"`
+	Value []*FirewallPolicyRuleGroup
 }
 
 // FirewallPolicyRuleGroupProperties - Properties of the rule group.
 type FirewallPolicyRuleGroupProperties struct {
 	// Priority of the Firewall Policy Rule Group resource.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// Group of Firewall Policy rules.
-	Rules []FirewallPolicyRuleClassification `json:"rules,omitempty"`
+	Rules []FirewallPolicyRuleClassification
 
 	// READ-ONLY; The provisioning state of the firewall policy rule group resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // FirewallPolicyRuleGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the FirewallPolicyRuleGroupsClient.BeginCreateOrUpdate
@@ -4970,103 +4970,103 @@ type FirewallPolicyRuleGroupsClientListOptions struct {
 // FlowLog - A flow log resource.
 type FlowLog struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the flow log.
-	Properties *FlowLogPropertiesFormat `json:"properties,omitempty"`
+	Properties *FlowLogPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // FlowLogFormatParameters - Parameters that define the flow log format.
 type FlowLogFormatParameters struct {
 	// The file type of flow log.
-	Type *FlowLogFormatType `json:"type,omitempty"`
+	Type *FlowLogFormatType
 
 	// The version (revision) of the flow log.
-	Version *int32 `json:"version,omitempty"`
+	Version *int32
 }
 
 // FlowLogInformation - Information on the configuration of flow log and traffic analytics (optional) .
 type FlowLogInformation struct {
 	// REQUIRED; Properties of the flow log.
-	Properties *FlowLogProperties `json:"properties,omitempty"`
+	Properties *FlowLogProperties
 
 	// REQUIRED; The ID of the resource to configure for flow log and traffic analytics (optional) .
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 
 	// Parameters that define the configuration of traffic analytics.
-	FlowAnalyticsConfiguration *TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
+	FlowAnalyticsConfiguration *TrafficAnalyticsProperties
 }
 
 // FlowLogListResult - List of flow logs.
 type FlowLogListResult struct {
 	// Information about flow log resource.
-	Value []*FlowLog `json:"value,omitempty"`
+	Value []*FlowLog
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // FlowLogProperties - Parameters that define the configuration of flow log.
 type FlowLogProperties struct {
 	// REQUIRED; Flag to enable/disable flow logging.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// REQUIRED; ID of the storage account which is used to store the flow log.
-	StorageID *string `json:"storageId,omitempty"`
+	StorageID *string
 
 	// Parameters that define the flow log format.
-	Format *FlowLogFormatParameters `json:"format,omitempty"`
+	Format *FlowLogFormatParameters
 
 	// Parameters that define the retention policy for flow log.
-	RetentionPolicy *RetentionPolicyParameters `json:"retentionPolicy,omitempty"`
+	RetentionPolicy *RetentionPolicyParameters
 }
 
 // FlowLogPropertiesFormat - Parameters that define the configuration of flow log.
 type FlowLogPropertiesFormat struct {
 	// REQUIRED; ID of the storage account which is used to store the flow log.
-	StorageID *string `json:"storageId,omitempty"`
+	StorageID *string
 
 	// REQUIRED; ID of network security group to which flow log will be applied.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 
 	// Flag to enable/disable flow logging.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// Parameters that define the configuration of traffic analytics.
-	FlowAnalyticsConfiguration *TrafficAnalyticsProperties `json:"flowAnalyticsConfiguration,omitempty"`
+	FlowAnalyticsConfiguration *TrafficAnalyticsProperties
 
 	// Parameters that define the flow log format.
-	Format *FlowLogFormatParameters `json:"format,omitempty"`
+	Format *FlowLogFormatParameters
 
 	// Parameters that define the retention policy for flow log.
-	RetentionPolicy *RetentionPolicyParameters `json:"retentionPolicy,omitempty"`
+	RetentionPolicy *RetentionPolicyParameters
 
 	// READ-ONLY; The provisioning state of the flow log.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; Guid of network security group to which flow log will be applied.
-	TargetResourceGUID *string `json:"targetResourceGuid,omitempty" azure:"ro"`
+	TargetResourceGUID *string
 }
 
 // FlowLogStatusParameters - Parameters that define a resource to query flow log and traffic analytics (optional) status.
 type FlowLogStatusParameters struct {
 	// REQUIRED; The target resource where getting the flow log and traffic analytics (optional) status.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 }
 
 // FlowLogsClientBeginCreateOrUpdateOptions contains the optional parameters for the FlowLogsClient.BeginCreateOrUpdate method.
@@ -5094,161 +5094,161 @@ type FlowLogsClientListOptions struct {
 // FrontendIPConfiguration - Frontend IP address of the load balancer.
 type FrontendIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of frontend IP configurations used by the load balancer. This name
 	// can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the load balancer probe.
-	Properties *FrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *FrontendIPConfigurationPropertiesFormat
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // FrontendIPConfigurationPropertiesFormat - Properties of Frontend IP Configuration of the load balancer.
 type FrontendIPConfigurationPropertiesFormat struct {
 	// The private IP address of the IP configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// Whether the specific ipconfiguration is IPv4 or IPv6. Default is taken as IPv4.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAddressVersion *IPVersion
 
 	// The Private IP allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// The reference to the Public IP resource.
-	PublicIPAddress *PublicIPAddress `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *PublicIPAddress
 
 	// The reference to the Public IP Prefix resource.
-	PublicIPPrefix *SubResource `json:"publicIPPrefix,omitempty"`
+	PublicIPPrefix *SubResource
 
 	// The reference to the subnet resource.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// READ-ONLY; An array of references to inbound pools that use this frontend IP.
-	InboundNatPools []*SubResource `json:"inboundNatPools,omitempty" azure:"ro"`
+	InboundNatPools []*SubResource
 
 	// READ-ONLY; An array of references to inbound rules that use this frontend IP.
-	InboundNatRules []*SubResource `json:"inboundNatRules,omitempty" azure:"ro"`
+	InboundNatRules []*SubResource
 
 	// READ-ONLY; An array of references to load balancing rules that use this frontend IP.
-	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource
 
 	// READ-ONLY; An array of references to outbound rules that use this frontend IP.
-	OutboundRules []*SubResource `json:"outboundRules,omitempty" azure:"ro"`
+	OutboundRules []*SubResource
 
 	// READ-ONLY; The provisioning state of the frontend IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // GatewayRoute - Gateway routing details.
 type GatewayRoute struct {
 	// READ-ONLY; The route's AS path sequence.
-	AsPath *string `json:"asPath,omitempty" azure:"ro"`
+	AsPath *string
 
 	// READ-ONLY; The gateway's local address.
-	LocalAddress *string `json:"localAddress,omitempty" azure:"ro"`
+	LocalAddress *string
 
 	// READ-ONLY; The route's network prefix.
-	Network *string `json:"network,omitempty" azure:"ro"`
+	Network *string
 
 	// READ-ONLY; The route's next hop.
-	NextHop *string `json:"nextHop,omitempty" azure:"ro"`
+	NextHop *string
 
 	// READ-ONLY; The source this route was learned from.
-	Origin *string `json:"origin,omitempty" azure:"ro"`
+	Origin *string
 
 	// READ-ONLY; The peer this route was learned from.
-	SourcePeer *string `json:"sourcePeer,omitempty" azure:"ro"`
+	SourcePeer *string
 
 	// READ-ONLY; The route's weight.
-	Weight *int32 `json:"weight,omitempty" azure:"ro"`
+	Weight *int32
 }
 
 // GatewayRouteListResult - List of virtual network gateway routes.
 type GatewayRouteListResult struct {
 	// List of gateway routes.
-	Value []*GatewayRoute `json:"value,omitempty"`
+	Value []*GatewayRoute
 }
 
 // GetVPNSitesConfigurationRequest - List of Vpn-Sites.
 type GetVPNSitesConfigurationRequest struct {
 	// REQUIRED; The sas-url to download the configurations for vpn-sites.
-	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
+	OutputBlobSasURL *string
 
 	// List of resource-ids of the vpn-sites for which config is to be downloaded.
-	VPNSites []*string `json:"vpnSites,omitempty"`
+	VPNSites []*string
 }
 
 // HTTPConfiguration - HTTP configuration of the connectivity check.
 type HTTPConfiguration struct {
 	// List of HTTP headers.
-	Headers []*HTTPHeader `json:"headers,omitempty"`
+	Headers []*HTTPHeader
 
 	// HTTP method.
-	Method *HTTPMethod `json:"method,omitempty"`
+	Method *HTTPMethod
 
 	// Valid status codes.
-	ValidStatusCodes []*int32 `json:"validStatusCodes,omitempty"`
+	ValidStatusCodes []*int32
 }
 
 // HTTPHeader - The HTTP header.
 type HTTPHeader struct {
 	// The name in HTTP header.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The value in HTTP header.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // HubIPAddresses - IP addresses associated with azure firewall.
 type HubIPAddresses struct {
 	// Private IP Address associated with azure firewall.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// List of Public IP addresses associated with azure firewall.
-	PublicIPAddresses []*AzureFirewallPublicIPAddress `json:"publicIPAddresses,omitempty"`
+	PublicIPAddresses []*AzureFirewallPublicIPAddress
 }
 
 // HubVirtualNetworkConnection Resource.
 type HubVirtualNetworkConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the hub virtual network connection.
-	Properties *HubVirtualNetworkConnectionProperties `json:"properties,omitempty"`
+	Properties *HubVirtualNetworkConnectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // HubVirtualNetworkConnectionProperties - Parameters for HubVirtualNetworkConnection.
 type HubVirtualNetworkConnectionProperties struct {
 	// VirtualHub to RemoteVnet transit to enabled or not.
-	AllowHubToRemoteVnetTransit *bool `json:"allowHubToRemoteVnetTransit,omitempty"`
+	AllowHubToRemoteVnetTransit *bool
 
 	// Allow RemoteVnet to use Virtual Hub's gateways.
-	AllowRemoteVnetToUseHubVnetGateways *bool `json:"allowRemoteVnetToUseHubVnetGateways,omitempty"`
+	AllowRemoteVnetToUseHubVnetGateways *bool
 
 	// Enable internet security.
-	EnableInternetSecurity *bool `json:"enableInternetSecurity,omitempty"`
+	EnableInternetSecurity *bool
 
 	// Reference to the remote virtual network.
-	RemoteVirtualNetwork *SubResource `json:"remoteVirtualNetwork,omitempty"`
+	RemoteVirtualNetwork *SubResource
 
 	// READ-ONLY; The provisioning state of the hub virtual network connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // HubVirtualNetworkConnectionsClientGetOptions contains the optional parameters for the HubVirtualNetworkConnectionsClient.Get
@@ -5266,70 +5266,70 @@ type HubVirtualNetworkConnectionsClientListOptions struct {
 // IPAddressAvailabilityResult - Response for CheckIPAddressAvailability API service call.
 type IPAddressAvailabilityResult struct {
 	// Private IP address availability.
-	Available *bool `json:"available,omitempty"`
+	Available *bool
 
 	// Contains other available private IP addresses if the asked for address is taken.
-	AvailableIPAddresses []*string `json:"availableIPAddresses,omitempty"`
+	AvailableIPAddresses []*string
 }
 
 // IPAllocation - IpAllocation resource.
 type IPAllocation struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the IpAllocation.
-	Properties *IPAllocationPropertiesFormat `json:"properties,omitempty"`
+	Properties *IPAllocationPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // IPAllocationListResult - Response for the ListIpAllocations API service call.
 type IPAllocationListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of IpAllocation resources.
-	Value []*IPAllocation `json:"value,omitempty"`
+	Value []*IPAllocation
 }
 
 // IPAllocationPropertiesFormat - Properties of the IpAllocation.
 type IPAllocationPropertiesFormat struct {
 	// IpAllocation tags.
-	AllocationTags map[string]*string `json:"allocationTags,omitempty"`
+	AllocationTags map[string]*string
 
 	// The IPAM allocation ID.
-	IpamAllocationID *string `json:"ipamAllocationId,omitempty"`
+	IpamAllocationID *string
 
 	// The address prefix for the IpAllocation.
-	Prefix *string `json:"prefix,omitempty"`
+	Prefix *string
 
 	// The address prefix length for the IpAllocation.
-	PrefixLength *int32 `json:"prefixLength,omitempty"`
+	PrefixLength *int32
 
 	// The address prefix Type for the IpAllocation.
-	PrefixType *IPVersion `json:"prefixType,omitempty"`
+	PrefixType *IPVersion
 
 	// The type for the IpAllocation.
-	Type *IPAllocationType `json:"type,omitempty"`
+	Type *IPAllocationType
 
 	// READ-ONLY; The Subnet that using the prefix of this IpAllocation resource.
-	Subnet *SubResource `json:"subnet,omitempty" azure:"ro"`
+	Subnet *SubResource
 
 	// READ-ONLY; The VirtualNetwork that using the prefix of this IpAllocation resource.
-	VirtualNetwork *SubResource `json:"virtualNetwork,omitempty" azure:"ro"`
+	VirtualNetwork *SubResource
 }
 
 // IPAllocationsClientBeginCreateOrUpdateOptions contains the optional parameters for the IPAllocationsClient.BeginCreateOrUpdate
@@ -5370,121 +5370,121 @@ type IPAllocationsClientUpdateTagsOptions struct {
 // IPConfiguration - IP configuration.
 type IPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the IP configuration.
-	Properties *IPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *IPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // IPConfigurationBgpPeeringAddress - Properties of IPConfigurationBgpPeeringAddress.
 type IPConfigurationBgpPeeringAddress struct {
 	// The list of custom BGP peering addresses which belong to IP configuration.
-	CustomBgpIPAddresses []*string `json:"customBgpIpAddresses,omitempty"`
+	CustomBgpIPAddresses []*string
 
 	// The ID of IP configuration which belongs to gateway.
-	IPConfigurationID *string `json:"ipconfigurationId,omitempty"`
+	IPConfigurationID *string
 
 	// READ-ONLY; The list of default BGP peering addresses which belong to IP configuration.
-	DefaultBgpIPAddresses []*string `json:"defaultBgpIpAddresses,omitempty" azure:"ro"`
+	DefaultBgpIPAddresses []*string
 
 	// READ-ONLY; The list of tunnel public IP addresses which belong to IP configuration.
-	TunnelIPAddresses []*string `json:"tunnelIpAddresses,omitempty" azure:"ro"`
+	TunnelIPAddresses []*string
 }
 
 // IPConfigurationProfile - IP configuration profile child resource.
 type IPConfigurationProfile struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the IP configuration profile.
-	Properties *IPConfigurationProfilePropertiesFormat `json:"properties,omitempty"`
+	Properties *IPConfigurationProfilePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // IPConfigurationProfilePropertiesFormat - IP configuration profile properties.
 type IPConfigurationProfilePropertiesFormat struct {
 	// The reference to the subnet resource to create a container network interface ip configuration.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// READ-ONLY; The provisioning state of the IP configuration profile resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // IPConfigurationPropertiesFormat - Properties of IP configuration.
 type IPConfigurationPropertiesFormat struct {
 	// The private IP address of the IP configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// The reference to the public IP resource.
-	PublicIPAddress *PublicIPAddress `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *PublicIPAddress
 
 	// The reference to the subnet resource.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// READ-ONLY; The provisioning state of the IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // IPGroup - The IpGroups resource information.
 type IPGroup struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the IpGroups.
-	Properties *IPGroupPropertiesFormat `json:"properties,omitempty"`
+	Properties *IPGroupPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // IPGroupListResult - Response for the ListIpGroups API service call.
 type IPGroupListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The list of IpGroups information resources.
-	Value []*IPGroup `json:"value,omitempty"`
+	Value []*IPGroup
 }
 
 // IPGroupPropertiesFormat - The IpGroups property information.
 type IPGroupPropertiesFormat struct {
 	// IpAddresses/IpAddressPrefixes in the IpGroups resource.
-	IPAddresses []*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string
 
 	// READ-ONLY; List of references to Azure resources that this IpGroups is associated with.
-	Firewalls []*SubResource `json:"firewalls,omitempty" azure:"ro"`
+	Firewalls []*SubResource
 
 	// READ-ONLY; The provisioning state of the IpGroups resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // IPGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the IPGroupsClient.BeginCreateOrUpdate method.
@@ -5524,185 +5524,185 @@ type IPGroupsClientUpdateGroupsOptions struct {
 // IPSecPolicy - An IPSec Policy configuration for a virtual network gateway connection.
 type IPSecPolicy struct {
 	// REQUIRED; The DH Group used in IKE Phase 1 for initial SA.
-	DhGroup *DhGroup `json:"dhGroup,omitempty"`
+	DhGroup *DhGroup
 
 	// REQUIRED; The IPSec encryption algorithm (IKE phase 1).
-	IPSecEncryption *IPSecEncryption `json:"ipsecEncryption,omitempty"`
+	IPSecEncryption *IPSecEncryption
 
 	// REQUIRED; The IPSec integrity algorithm (IKE phase 1).
-	IPSecIntegrity *IPSecIntegrity `json:"ipsecIntegrity,omitempty"`
+	IPSecIntegrity *IPSecIntegrity
 
 	// REQUIRED; The IKE encryption algorithm (IKE phase 2).
-	IkeEncryption *IkeEncryption `json:"ikeEncryption,omitempty"`
+	IkeEncryption *IkeEncryption
 
 	// REQUIRED; The IKE integrity algorithm (IKE phase 2).
-	IkeIntegrity *IkeIntegrity `json:"ikeIntegrity,omitempty"`
+	IkeIntegrity *IkeIntegrity
 
 	// REQUIRED; The Pfs Group used in IKE Phase 2 for new child SA.
-	PfsGroup *PfsGroup `json:"pfsGroup,omitempty"`
+	PfsGroup *PfsGroup
 
 	// REQUIRED; The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN
 	// tunnel.
-	SaDataSizeKilobytes *int32 `json:"saDataSizeKilobytes,omitempty"`
+	SaDataSizeKilobytes *int32
 
 	// REQUIRED; The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site
 	// VPN tunnel.
-	SaLifeTimeSeconds *int32 `json:"saLifeTimeSeconds,omitempty"`
+	SaLifeTimeSeconds *int32
 }
 
 // IPTag - Contains the IpTag associated with the object.
 type IPTag struct {
 	// The IP tag type. Example: FirstPartyUsage.
-	IPTagType *string `json:"ipTagType,omitempty"`
+	IPTagType *string
 
 	// The value of the IP tag associated with the public IP. Example: SQL.
-	Tag *string `json:"tag,omitempty"`
+	Tag *string
 }
 
 // IPv6CircuitConnectionConfig - IPv6 Circuit Connection properties for global reach.
 type IPv6CircuitConnectionConfig struct {
 	// /125 IP address space to carve out customer addresses for global reach.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// READ-ONLY; Express Route Circuit connection state.
-	CircuitConnectionStatus *CircuitConnectionStatus `json:"circuitConnectionStatus,omitempty" azure:"ro"`
+	CircuitConnectionStatus *CircuitConnectionStatus
 }
 
 // IPv6ExpressRouteCircuitPeeringConfig - Contains IPv6 peering config.
 type IPv6ExpressRouteCircuitPeeringConfig struct {
 	// The Microsoft peering configuration.
-	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig `json:"microsoftPeeringConfig,omitempty"`
+	MicrosoftPeeringConfig *ExpressRouteCircuitPeeringConfig
 
 	// The primary address prefix.
-	PrimaryPeerAddressPrefix *string `json:"primaryPeerAddressPrefix,omitempty"`
+	PrimaryPeerAddressPrefix *string
 
 	// The reference to the RouteFilter resource.
-	RouteFilter *SubResource `json:"routeFilter,omitempty"`
+	RouteFilter *SubResource
 
 	// The secondary address prefix.
-	SecondaryPeerAddressPrefix *string `json:"secondaryPeerAddressPrefix,omitempty"`
+	SecondaryPeerAddressPrefix *string
 
 	// The state of peering.
-	State *ExpressRouteCircuitPeeringState `json:"state,omitempty"`
+	State *ExpressRouteCircuitPeeringState
 }
 
 // InboundNatPool - Inbound NAT pool of the load balancer.
 type InboundNatPool struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of inbound NAT pools used by the load balancer. This name can be
 	// used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer inbound nat pool.
-	Properties *InboundNatPoolPropertiesFormat `json:"properties,omitempty"`
+	Properties *InboundNatPoolPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // InboundNatPoolPropertiesFormat - Properties of Inbound NAT pool.
 type InboundNatPoolPropertiesFormat struct {
 	// REQUIRED; The port used for internal connections on the endpoint. Acceptable values are between 1 and 65535.
-	BackendPort *int32 `json:"backendPort,omitempty"`
+	BackendPort *int32
 
 	// REQUIRED; The last port number in the range of external ports that will be used to provide Inbound Nat to NICs associated
 	// with a load balancer. Acceptable values range between 1 and 65535.
-	FrontendPortRangeEnd *int32 `json:"frontendPortRangeEnd,omitempty"`
+	FrontendPortRangeEnd *int32
 
 	// REQUIRED; The first port number in the range of external ports that will be used to provide Inbound Nat to NICs associated
 	// with a load balancer. Acceptable values range between 1 and 65534.
-	FrontendPortRangeStart *int32 `json:"frontendPortRangeStart,omitempty"`
+	FrontendPortRangeStart *int32
 
 	// REQUIRED; The reference to the transport protocol used by the inbound NAT pool.
-	Protocol *TransportProtocol `json:"protocol,omitempty"`
+	Protocol *TransportProtocol
 
 	// Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability
 	// Group. This setting is required when using the SQL AlwaysOn Availability Groups
 	// in SQL server. This setting can't be changed after you create the endpoint.
-	EnableFloatingIP *bool `json:"enableFloatingIP,omitempty"`
+	EnableFloatingIP *bool
 
 	// Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used
 	// when the protocol is set to TCP.
-	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
+	EnableTCPReset *bool
 
 	// A reference to frontend IP addresses.
-	FrontendIPConfiguration *SubResource `json:"frontendIPConfiguration,omitempty"`
+	FrontendIPConfiguration *SubResource
 
 	// The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes.
 	// This element is only used when the protocol is set to TCP.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// READ-ONLY; The provisioning state of the inbound NAT pool resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // InboundNatRule - Inbound NAT rule of the load balancer.
 type InboundNatRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of inbound NAT rules used by the load balancer. This name can be
 	// used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer inbound nat rule.
-	Properties *InboundNatRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *InboundNatRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // InboundNatRuleListResult - Response for ListInboundNatRule API service call.
 type InboundNatRuleListResult struct {
 	// A list of inbound nat rules in a load balancer.
-	Value []*InboundNatRule `json:"value,omitempty"`
+	Value []*InboundNatRule
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // InboundNatRulePropertiesFormat - Properties of the inbound NAT rule.
 type InboundNatRulePropertiesFormat struct {
 	// The port used for the internal endpoint. Acceptable values range from 1 to 65535.
-	BackendPort *int32 `json:"backendPort,omitempty"`
+	BackendPort *int32
 
 	// Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability
 	// Group. This setting is required when using the SQL AlwaysOn Availability Groups
 	// in SQL server. This setting can't be changed after you create the endpoint.
-	EnableFloatingIP *bool `json:"enableFloatingIP,omitempty"`
+	EnableFloatingIP *bool
 
 	// Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used
 	// when the protocol is set to TCP.
-	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
+	EnableTCPReset *bool
 
 	// A reference to frontend IP addresses.
-	FrontendIPConfiguration *SubResource `json:"frontendIPConfiguration,omitempty"`
+	FrontendIPConfiguration *SubResource
 
 	// The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values
 	// range from 1 to 65534.
-	FrontendPort *int32 `json:"frontendPort,omitempty"`
+	FrontendPort *int32
 
 	// The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes.
 	// This element is only used when the protocol is set to TCP.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// The reference to the transport protocol used by the load balancing rule.
-	Protocol *TransportProtocol `json:"protocol,omitempty"`
+	Protocol *TransportProtocol
 
 	// READ-ONLY; A reference to a private IP address defined on a network interface of a VM. Traffic sent to the frontend port
 	// of each of the frontend IP configurations is forwarded to the backend IP.
-	BackendIPConfiguration *InterfaceIPConfiguration `json:"backendIPConfiguration,omitempty" azure:"ro"`
+	BackendIPConfiguration *InterfaceIPConfiguration
 
 	// READ-ONLY; The provisioning state of the inbound NAT rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // InboundNatRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the InboundNatRulesClient.BeginCreateOrUpdate
@@ -5732,64 +5732,64 @@ type InboundNatRulesClientListOptions struct {
 // IntentPolicy - Network Intent Policy resource.
 type IntentPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // IntentPolicyConfiguration - Details of NetworkIntentPolicyConfiguration for PrepareNetworkPoliciesRequest.
 type IntentPolicyConfiguration struct {
 	// The name of the Network Intent Policy for storing in target subscription.
-	NetworkIntentPolicyName *string `json:"networkIntentPolicyName,omitempty"`
+	NetworkIntentPolicyName *string
 
 	// Source network intent policy.
-	SourceNetworkIntentPolicy *IntentPolicy `json:"sourceNetworkIntentPolicy,omitempty"`
+	SourceNetworkIntentPolicy *IntentPolicy
 }
 
 // Interface - A network interface in a resource group.
 type Interface struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the network interface.
-	Properties *InterfacePropertiesFormat `json:"properties,omitempty"`
+	Properties *InterfacePropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // InterfaceAssociation - Network interface and its custom security rules.
 type InterfaceAssociation struct {
 	// Collection of custom security rules.
-	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule
 
 	// READ-ONLY; Network interface ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // InterfaceDNSSettings - DNS settings of a network interface.
@@ -5797,101 +5797,101 @@ type InterfaceDNSSettings struct {
 	// List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS'
 	// value cannot be combined with other IPs, it must be the only value in dnsServers
 	// collection.
-	DNSServers []*string `json:"dnsServers,omitempty"`
+	DNSServers []*string
 
 	// Relative DNS name for this NIC used for internal communications between VMs in the same virtual network.
-	InternalDNSNameLabel *string `json:"internalDnsNameLabel,omitempty"`
+	InternalDNSNameLabel *string
 
 	// READ-ONLY; If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers
 	// from all NICs that are part of the Availability Set. This property is what is
 	// configured on each of those VMs.
-	AppliedDNSServers []*string `json:"appliedDnsServers,omitempty" azure:"ro"`
+	AppliedDNSServers []*string
 
 	// READ-ONLY; Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS
 	// name can be constructed by concatenating the VM name with the value of
 	// internalDomainNameSuffix.
-	InternalDomainNameSuffix *string `json:"internalDomainNameSuffix,omitempty" azure:"ro"`
+	InternalDomainNameSuffix *string
 
 	// READ-ONLY; Fully qualified DNS name supporting internal communications between VMs in the same virtual network.
-	InternalFqdn *string `json:"internalFqdn,omitempty" azure:"ro"`
+	InternalFqdn *string
 }
 
 // InterfaceIPConfiguration - IPConfiguration in a network interface.
 type InterfaceIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Network interface IP configuration properties.
-	Properties *InterfaceIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *InterfaceIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // InterfaceIPConfigurationListResult - Response for list ip configurations API service call.
 type InterfaceIPConfigurationListResult struct {
 	// A list of ip configurations.
-	Value []*InterfaceIPConfiguration `json:"value,omitempty"`
+	Value []*InterfaceIPConfiguration
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // InterfaceIPConfigurationPrivateLinkConnectionProperties - PrivateLinkConnection properties for the network interface.
 type InterfaceIPConfigurationPrivateLinkConnectionProperties struct {
 	// READ-ONLY; List of FQDNs for current private link connection.
-	Fqdns []*string `json:"fqdns,omitempty" azure:"ro"`
+	Fqdns []*string
 
 	// READ-ONLY; The group ID for current private link connection.
-	GroupID *string `json:"groupId,omitempty" azure:"ro"`
+	GroupID *string
 
 	// READ-ONLY; The required member name for current private link connection.
-	RequiredMemberName *string `json:"requiredMemberName,omitempty" azure:"ro"`
+	RequiredMemberName *string
 }
 
 // InterfaceIPConfigurationPropertiesFormat - Properties of IP configuration.
 type InterfaceIPConfigurationPropertiesFormat struct {
 	// The reference to ApplicationGatewayBackendAddressPool resource.
-	ApplicationGatewayBackendAddressPools []*ApplicationGatewayBackendAddressPool `json:"applicationGatewayBackendAddressPools,omitempty"`
+	ApplicationGatewayBackendAddressPools []*ApplicationGatewayBackendAddressPool
 
 	// Application security groups in which the IP configuration is included.
-	ApplicationSecurityGroups []*ApplicationSecurityGroup `json:"applicationSecurityGroups,omitempty"`
+	ApplicationSecurityGroups []*ApplicationSecurityGroup
 
 	// The reference to LoadBalancerBackendAddressPool resource.
-	LoadBalancerBackendAddressPools []*BackendAddressPool `json:"loadBalancerBackendAddressPools,omitempty"`
+	LoadBalancerBackendAddressPools []*BackendAddressPool
 
 	// A list of references of LoadBalancerInboundNatRules.
-	LoadBalancerInboundNatRules []*InboundNatRule `json:"loadBalancerInboundNatRules,omitempty"`
+	LoadBalancerInboundNatRules []*InboundNatRule
 
 	// Whether this is a primary customer address on the network interface.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 
 	// Private IP address of the IP configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAddressVersion *IPVersion
 
 	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// Public IP address bound to the IP configuration.
-	PublicIPAddress *PublicIPAddress `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *PublicIPAddress
 
 	// Subnet bound to the IP configuration.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// The reference to Virtual Network Taps.
-	VirtualNetworkTaps []*VirtualNetworkTap `json:"virtualNetworkTaps,omitempty"`
+	VirtualNetworkTaps []*VirtualNetworkTap
 
 	// READ-ONLY; PrivateLinkConnection properties for the network interface.
-	PrivateLinkConnectionProperties *InterfaceIPConfigurationPrivateLinkConnectionProperties `json:"privateLinkConnectionProperties,omitempty" azure:"ro"`
+	PrivateLinkConnectionProperties *InterfaceIPConfigurationPrivateLinkConnectionProperties
 
 	// READ-ONLY; The provisioning state of the network interface IP configuration.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // InterfaceIPConfigurationsClientGetOptions contains the optional parameters for the InterfaceIPConfigurationsClient.Get
@@ -5909,19 +5909,19 @@ type InterfaceIPConfigurationsClientListOptions struct {
 // InterfaceListResult - Response for the ListNetworkInterface API service call.
 type InterfaceListResult struct {
 	// A list of network interfaces in a resource group.
-	Value []*Interface `json:"value,omitempty"`
+	Value []*Interface
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // InterfaceLoadBalancerListResult - Response for list ip configurations API service call.
 type InterfaceLoadBalancerListResult struct {
 	// A list of load balancers.
-	Value []*LoadBalancer `json:"value,omitempty"`
+	Value []*LoadBalancer
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // InterfaceLoadBalancersClientListOptions contains the optional parameters for the InterfaceLoadBalancersClient.NewListPager
@@ -5933,79 +5933,79 @@ type InterfaceLoadBalancersClientListOptions struct {
 // InterfacePropertiesFormat - NetworkInterface properties.
 type InterfacePropertiesFormat struct {
 	// The DNS settings in network interface.
-	DNSSettings *InterfaceDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *InterfaceDNSSettings
 
 	// If the network interface is accelerated networking enabled.
-	EnableAcceleratedNetworking *bool `json:"enableAcceleratedNetworking,omitempty"`
+	EnableAcceleratedNetworking *bool
 
 	// Indicates whether IP forwarding is enabled on this network interface.
-	EnableIPForwarding *bool `json:"enableIPForwarding,omitempty"`
+	EnableIPForwarding *bool
 
 	// A list of IPConfigurations of the network interface.
-	IPConfigurations []*InterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*InterfaceIPConfiguration
 
 	// The reference to the NetworkSecurityGroup resource.
-	NetworkSecurityGroup *SecurityGroup `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SecurityGroup
 
 	// READ-ONLY; A list of references to linked BareMetal resources.
-	HostedWorkloads []*string `json:"hostedWorkloads,omitempty" azure:"ro"`
+	HostedWorkloads []*string
 
 	// READ-ONLY; The MAC address of the network interface.
-	MacAddress *string `json:"macAddress,omitempty" azure:"ro"`
+	MacAddress *string
 
 	// READ-ONLY; Whether this is a primary network interface on a virtual machine.
-	Primary *bool `json:"primary,omitempty" azure:"ro"`
+	Primary *bool
 
 	// READ-ONLY; A reference to the private endpoint to which the network interface is linked.
-	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty" azure:"ro"`
+	PrivateEndpoint *PrivateEndpoint
 
 	// READ-ONLY; The provisioning state of the network interface resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the network interface resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; A list of TapConfigurations of the network interface.
-	TapConfigurations []*InterfaceTapConfiguration `json:"tapConfigurations,omitempty" azure:"ro"`
+	TapConfigurations []*InterfaceTapConfiguration
 
 	// READ-ONLY; The reference to a virtual machine.
-	VirtualMachine *SubResource `json:"virtualMachine,omitempty" azure:"ro"`
+	VirtualMachine *SubResource
 }
 
 // InterfaceTapConfiguration - Tap configuration in a Network Interface.
 type InterfaceTapConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the Virtual Network Tap configuration.
-	Properties *InterfaceTapConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *InterfaceTapConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Sub Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // InterfaceTapConfigurationListResult - Response for list tap configurations API service call.
 type InterfaceTapConfigurationListResult struct {
 	// A list of tap configurations.
-	Value []*InterfaceTapConfiguration `json:"value,omitempty"`
+	Value []*InterfaceTapConfiguration
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // InterfaceTapConfigurationPropertiesFormat - Properties of Virtual Network Tap configuration.
 type InterfaceTapConfigurationPropertiesFormat struct {
 	// The reference to the Virtual Network Tap resource.
-	VirtualNetworkTap *VirtualNetworkTap `json:"virtualNetworkTap,omitempty"`
+	VirtualNetworkTap *VirtualNetworkTap
 
 	// READ-ONLY; The provisioning state of the network interface tap configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // InterfaceTapConfigurationsClientBeginCreateOrUpdateOptions contains the optional parameters for the InterfaceTapConfigurationsClient.BeginCreateOrUpdate
@@ -6119,145 +6119,145 @@ type InterfacesClientUpdateTagsOptions struct {
 // results.
 type ListHubVirtualNetworkConnectionsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of HubVirtualNetworkConnections.
-	Value []*HubVirtualNetworkConnection `json:"value,omitempty"`
+	Value []*HubVirtualNetworkConnection
 }
 
 // ListP2SVPNGatewaysResult - Result of the request to list P2SVpnGateways. It contains a list of P2SVpnGateways and a URL
 // nextLink to get the next set of results.
 type ListP2SVPNGatewaysResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of P2SVpnGateways.
-	Value []*P2SVPNGateway `json:"value,omitempty"`
+	Value []*P2SVPNGateway
 }
 
 // ListVPNConnectionsResult - Result of the request to list all vpn connections to a virtual wan vpn gateway. It contains
 // a list of Vpn Connections and a URL nextLink to get the next set of results.
 type ListVPNConnectionsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Vpn Connections.
-	Value []*VPNConnection `json:"value,omitempty"`
+	Value []*VPNConnection
 }
 
 // ListVPNGatewaysResult - Result of the request to list VpnGateways. It contains a list of VpnGateways and a URL nextLink
 // to get the next set of results.
 type ListVPNGatewaysResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VpnGateways.
-	Value []*VPNGateway `json:"value,omitempty"`
+	Value []*VPNGateway
 }
 
 // ListVPNServerConfigurationsResult - Result of the request to list all VpnServerConfigurations. It contains a list of VpnServerConfigurations
 // and a URL nextLink to get the next set of results.
 type ListVPNServerConfigurationsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VpnServerConfigurations.
-	Value []*VPNServerConfiguration `json:"value,omitempty"`
+	Value []*VPNServerConfiguration
 }
 
 // ListVPNSiteLinkConnectionsResult - Result of the request to list all vpn connections to a virtual wan vpn gateway. It contains
 // a list of Vpn Connections and a URL nextLink to get the next set of results.
 type ListVPNSiteLinkConnectionsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VpnSiteLinkConnections.
-	Value []*VPNSiteLinkConnection `json:"value,omitempty"`
+	Value []*VPNSiteLinkConnection
 }
 
 // ListVPNSiteLinksResult - Result of the request to list VpnSiteLinks. It contains a list of VpnSiteLinks and a URL nextLink
 // to get the next set of results.
 type ListVPNSiteLinksResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VpnSitesLinks.
-	Value []*VPNSiteLink `json:"value,omitempty"`
+	Value []*VPNSiteLink
 }
 
 // ListVPNSitesResult - Result of the request to list VpnSites. It contains a list of VpnSites and a URL nextLink to get the
 // next set of results.
 type ListVPNSitesResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VpnSites.
-	Value []*VPNSite `json:"value,omitempty"`
+	Value []*VPNSite
 }
 
 // ListVirtualHubRouteTableV2SResult - List of VirtualHubRouteTableV2s and a URL nextLink to get the next set of results.
 type ListVirtualHubRouteTableV2SResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VirtualHubRouteTableV2s.
-	Value []*VirtualHubRouteTableV2 `json:"value,omitempty"`
+	Value []*VirtualHubRouteTableV2
 }
 
 // ListVirtualHubsResult - Result of the request to list VirtualHubs. It contains a list of VirtualHubs and a URL nextLink
 // to get the next set of results.
 type ListVirtualHubsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VirtualHubs.
-	Value []*VirtualHub `json:"value,omitempty"`
+	Value []*VirtualHub
 }
 
 // ListVirtualWANsResult - Result of the request to list VirtualWANs. It contains a list of VirtualWANs and a URL nextLink
 // to get the next set of results.
 type ListVirtualWANsResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VirtualWANs.
-	Value []*VirtualWAN `json:"value,omitempty"`
+	Value []*VirtualWAN
 }
 
 // LoadBalancer resource.
 type LoadBalancer struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of load balancer.
-	Properties *LoadBalancerPropertiesFormat `json:"properties,omitempty"`
+	Properties *LoadBalancerPropertiesFormat
 
 	// The load balancer SKU.
-	SKU *LoadBalancerSKU `json:"sku,omitempty"`
+	SKU *LoadBalancerSKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LoadBalancerBackendAddressPoolListResult - Response for ListBackendAddressPool API service call.
 type LoadBalancerBackendAddressPoolListResult struct {
 	// A list of backend address pools in a load balancer.
-	Value []*BackendAddressPool `json:"value,omitempty"`
+	Value []*BackendAddressPool
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerBackendAddressPoolsClientGetOptions contains the optional parameters for the LoadBalancerBackendAddressPoolsClient.Get
@@ -6275,10 +6275,10 @@ type LoadBalancerBackendAddressPoolsClientListOptions struct {
 // LoadBalancerFrontendIPConfigurationListResult - Response for ListFrontendIPConfiguration API service call.
 type LoadBalancerFrontendIPConfigurationListResult struct {
 	// A list of frontend IP configurations in a load balancer.
-	Value []*FrontendIPConfiguration `json:"value,omitempty"`
+	Value []*FrontendIPConfiguration
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerFrontendIPConfigurationsClientGetOptions contains the optional parameters for the LoadBalancerFrontendIPConfigurationsClient.Get
@@ -6296,19 +6296,19 @@ type LoadBalancerFrontendIPConfigurationsClientListOptions struct {
 // LoadBalancerListResult - Response for ListLoadBalancers API service call.
 type LoadBalancerListResult struct {
 	// A list of load balancers in a resource group.
-	Value []*LoadBalancer `json:"value,omitempty"`
+	Value []*LoadBalancer
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerLoadBalancingRuleListResult - Response for ListLoadBalancingRule API service call.
 type LoadBalancerLoadBalancingRuleListResult struct {
 	// A list of load balancing rules in a load balancer.
-	Value []*LoadBalancingRule `json:"value,omitempty"`
+	Value []*LoadBalancingRule
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerLoadBalancingRulesClientGetOptions contains the optional parameters for the LoadBalancerLoadBalancingRulesClient.Get
@@ -6332,10 +6332,10 @@ type LoadBalancerNetworkInterfacesClientListOptions struct {
 // LoadBalancerOutboundRuleListResult - Response for ListOutboundRule API service call.
 type LoadBalancerOutboundRuleListResult struct {
 	// A list of outbound rules in a load balancer.
-	Value []*OutboundRule `json:"value,omitempty"`
+	Value []*OutboundRule
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerOutboundRulesClientGetOptions contains the optional parameters for the LoadBalancerOutboundRulesClient.Get
@@ -6353,10 +6353,10 @@ type LoadBalancerOutboundRulesClientListOptions struct {
 // LoadBalancerProbeListResult - Response for ListProbe API service call.
 type LoadBalancerProbeListResult struct {
 	// A list of probes in a load balancer.
-	Value []*Probe `json:"value,omitempty"`
+	Value []*Probe
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LoadBalancerProbesClientGetOptions contains the optional parameters for the LoadBalancerProbesClient.Get method.
@@ -6372,10 +6372,10 @@ type LoadBalancerProbesClientListOptions struct {
 // LoadBalancerPropertiesFormat - Properties of the load balancer.
 type LoadBalancerPropertiesFormat struct {
 	// Collection of backend address pools used by a load balancer.
-	BackendAddressPools []*BackendAddressPool `json:"backendAddressPools,omitempty"`
+	BackendAddressPools []*BackendAddressPool
 
 	// Object representing the frontend IPs to be used for the load balancer.
-	FrontendIPConfigurations []*FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*FrontendIPConfiguration
 
 	// Defines an external port range for inbound NAT to a single backend port on NICs associated with a load balancer. Inbound
 	// NAT rules are created automatically for each NIC associated with the Load
@@ -6383,34 +6383,34 @@ type LoadBalancerPropertiesFormat struct {
 	// with defining inbound Nat rules. Inbound NAT pools are referenced from virtual
 	// machine scale sets. NICs that are associated with individual virtual machines cannot reference an inbound NAT pool. They
 	// have to reference individual inbound NAT rules.
-	InboundNatPools []*InboundNatPool `json:"inboundNatPools,omitempty"`
+	InboundNatPools []*InboundNatPool
 
 	// Collection of inbound NAT Rules used by a load balancer. Defining inbound NAT rules on your load balancer is mutually exclusive
 	// with defining an inbound NAT pool. Inbound NAT pools are referenced from
 	// virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an Inbound NAT pool.
 	// They have to reference individual inbound NAT rules.
-	InboundNatRules []*InboundNatRule `json:"inboundNatRules,omitempty"`
+	InboundNatRules []*InboundNatRule
 
 	// Object collection representing the load balancing rules Gets the provisioning.
-	LoadBalancingRules []*LoadBalancingRule `json:"loadBalancingRules,omitempty"`
+	LoadBalancingRules []*LoadBalancingRule
 
 	// The outbound rules.
-	OutboundRules []*OutboundRule `json:"outboundRules,omitempty"`
+	OutboundRules []*OutboundRule
 
 	// Collection of probe objects used in the load balancer.
-	Probes []*Probe `json:"probes,omitempty"`
+	Probes []*Probe
 
 	// READ-ONLY; The provisioning state of the load balancer resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the load balancer resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // LoadBalancerSKU - SKU of a load balancer.
 type LoadBalancerSKU struct {
 	// Name of a load balancer SKU.
-	Name *LoadBalancerSKUName `json:"name,omitempty"`
+	Name *LoadBalancerSKUName
 }
 
 // LoadBalancersClientBeginCreateOrUpdateOptions contains the optional parameters for the LoadBalancersClient.BeginCreateOrUpdate
@@ -6450,120 +6450,120 @@ type LoadBalancersClientUpdateTagsOptions struct {
 // LoadBalancingRule - A load balancing rule for a load balancer.
 type LoadBalancingRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of load balancing rules used by the load balancer. This name can
 	// be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer load balancing rule.
-	Properties *LoadBalancingRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *LoadBalancingRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LoadBalancingRulePropertiesFormat - Properties of the load balancer.
 type LoadBalancingRulePropertiesFormat struct {
 	// REQUIRED; The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable
 	// values are between 0 and 65534. Note that value 0 enables "Any Port".
-	FrontendPort *int32 `json:"frontendPort,omitempty"`
+	FrontendPort *int32
 
 	// REQUIRED; The reference to the transport protocol used by the load balancing rule.
-	Protocol *TransportProtocol `json:"protocol,omitempty"`
+	Protocol *TransportProtocol
 
 	// A reference to a pool of DIPs. Inbound traffic is randomly load balanced across IPs in the backend IPs.
-	BackendAddressPool *SubResource `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *SubResource
 
 	// The port used for internal connections on the endpoint. Acceptable values are between 0 and 65535. Note that value 0 enables
 	// "Any Port".
-	BackendPort *int32 `json:"backendPort,omitempty"`
+	BackendPort *int32
 
 	// Configures SNAT for the VMs in the backend pool to use the publicIP address specified in the frontend of the load balancing
 	// rule.
-	DisableOutboundSnat *bool `json:"disableOutboundSnat,omitempty"`
+	DisableOutboundSnat *bool
 
 	// Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability
 	// Group. This setting is required when using the SQL AlwaysOn Availability Groups
 	// in SQL server. This setting can't be changed after you create the endpoint.
-	EnableFloatingIP *bool `json:"enableFloatingIP,omitempty"`
+	EnableFloatingIP *bool
 
 	// Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used
 	// when the protocol is set to TCP.
-	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
+	EnableTCPReset *bool
 
 	// A reference to frontend IP addresses.
-	FrontendIPConfiguration *SubResource `json:"frontendIPConfiguration,omitempty"`
+	FrontendIPConfiguration *SubResource
 
 	// The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes.
 	// This element is only used when the protocol is set to TCP.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// The load distribution policy for this rule.
-	LoadDistribution *LoadDistribution `json:"loadDistribution,omitempty"`
+	LoadDistribution *LoadDistribution
 
 	// The reference to the load balancer probe used by the load balancing rule.
-	Probe *SubResource `json:"probe,omitempty"`
+	Probe *SubResource
 
 	// READ-ONLY; The provisioning state of the load balancing rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // LocalNetworkGateway - A common class for general resource information.
 type LocalNetworkGateway struct {
 	// REQUIRED; Properties of the local network gateway.
-	Properties *LocalNetworkGatewayPropertiesFormat `json:"properties,omitempty"`
+	Properties *LocalNetworkGatewayPropertiesFormat
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LocalNetworkGatewayListResult - Response for ListLocalNetworkGateways API service call.
 type LocalNetworkGatewayListResult struct {
 	// A list of local network gateways that exists in a resource group.
-	Value []*LocalNetworkGateway `json:"value,omitempty"`
+	Value []*LocalNetworkGateway
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // LocalNetworkGatewayPropertiesFormat - LocalNetworkGateway properties.
 type LocalNetworkGatewayPropertiesFormat struct {
 	// Local network gateway's BGP speaker settings.
-	BgpSettings *BgpSettings `json:"bgpSettings,omitempty"`
+	BgpSettings *BgpSettings
 
 	// FQDN of local network gateway.
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// IP address of local network gateway.
-	GatewayIPAddress *string `json:"gatewayIpAddress,omitempty"`
+	GatewayIPAddress *string
 
 	// Local network site address space.
-	LocalNetworkAddressSpace *AddressSpace `json:"localNetworkAddressSpace,omitempty"`
+	LocalNetworkAddressSpace *AddressSpace
 
 	// READ-ONLY; The provisioning state of the local network gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the local network gateway resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // LocalNetworkGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the LocalNetworkGatewaysClient.BeginCreateOrUpdate
@@ -6600,52 +6600,52 @@ type LocalNetworkGatewaysClientUpdateTagsOptions struct {
 // LogSpecification - Description of logging specification.
 type LogSpecification struct {
 	// Duration of the blob.
-	BlobDuration *string `json:"blobDuration,omitempty"`
+	BlobDuration *string
 
 	// The display name of the specification.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// The name of the specification.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // ManagedRuleGroupOverride - Defines a managed rule group override setting.
 type ManagedRuleGroupOverride struct {
 	// REQUIRED; The managed rule group to override.
-	RuleGroupName *string `json:"ruleGroupName,omitempty"`
+	RuleGroupName *string
 
 	// List of rules that will be disabled. If none specified, all rules in the group will be disabled.
-	Rules []*ManagedRuleOverride `json:"rules,omitempty"`
+	Rules []*ManagedRuleOverride
 }
 
 // ManagedRuleOverride - Defines a managed rule group override setting.
 type ManagedRuleOverride struct {
 	// REQUIRED; Identifier for the managed rule.
-	RuleID *string `json:"ruleId,omitempty"`
+	RuleID *string
 
 	// The state of the managed rule. Defaults to Disabled if not specified.
-	State *ManagedRuleEnabledState `json:"state,omitempty"`
+	State *ManagedRuleEnabledState
 }
 
 // ManagedRuleSet - Defines a managed rule set.
 type ManagedRuleSet struct {
 	// REQUIRED; Defines the rule set type to use.
-	RuleSetType *string `json:"ruleSetType,omitempty"`
+	RuleSetType *string
 
 	// REQUIRED; Defines the version of the rule set to use.
-	RuleSetVersion *string `json:"ruleSetVersion,omitempty"`
+	RuleSetVersion *string
 
 	// Defines the rule group overrides to apply to the rule set.
-	RuleGroupOverrides []*ManagedRuleGroupOverride `json:"ruleGroupOverrides,omitempty"`
+	RuleGroupOverrides []*ManagedRuleGroupOverride
 }
 
 // ManagedRulesDefinition - Allow to exclude some variable satisfy the condition for the WAF check.
 type ManagedRulesDefinition struct {
 	// REQUIRED; The managed rule sets that are associated with the policy.
-	ManagedRuleSets []*ManagedRuleSet `json:"managedRuleSets,omitempty"`
+	ManagedRuleSets []*ManagedRuleSet
 
 	// The Exclusions that are applied on the policy.
-	Exclusions []*OwaspCrsExclusionEntry `json:"exclusions,omitempty"`
+	Exclusions []*OwaspCrsExclusionEntry
 }
 
 // ManagedServiceIdentity - Identity for the resource.
@@ -6653,19 +6653,19 @@ type ManagedServiceIdentity struct {
 	// The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created
 	// identity and a set of user assigned identities. The type 'None' will remove any
 	// identities from the virtual machine.
-	Type *ResourceIdentityType `json:"type,omitempty"`
+	Type *ResourceIdentityType
 
 	// The list of user identities associated with resource. The user identity dictionary key references will be ARM resource
 	// ids in the form:
 	// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
-	UserAssignedIdentities map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties `json:"userAssignedIdentities,omitempty"`
+	UserAssignedIdentities map[string]*Components1Jq1T4ISchemasManagedserviceidentityPropertiesUserassignedidentitiesAdditionalproperties
 
 	// READ-ONLY; The principal id of the system assigned identity. This property will only be provided for a system assigned
 	// identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The tenant id of the system assigned identity. This property will only be provided for a system assigned identity.
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 // ManagementClientBeginDeleteBastionShareableLinkOptions contains the optional parameters for the ManagementClient.BeginDeleteBastionShareableLink
@@ -6723,148 +6723,148 @@ type ManagementClientSupportedSecurityProvidersOptions struct {
 // MatchCondition - Define match conditions.
 type MatchCondition struct {
 	// REQUIRED; Match value.
-	MatchValues []*string `json:"matchValues,omitempty"`
+	MatchValues []*string
 
 	// REQUIRED; List of match variables.
-	MatchVariables []*MatchVariable `json:"matchVariables,omitempty"`
+	MatchVariables []*MatchVariable
 
 	// REQUIRED; The operator to be matched.
-	Operator *WebApplicationFirewallOperator `json:"operator,omitempty"`
+	Operator *WebApplicationFirewallOperator
 
 	// Whether this is negate condition or not.
-	NegationConditon *bool `json:"negationConditon,omitempty"`
+	NegationConditon *bool
 
 	// List of transforms.
-	Transforms []*WebApplicationFirewallTransform `json:"transforms,omitempty"`
+	Transforms []*WebApplicationFirewallTransform
 }
 
 // MatchVariable - Define match variables.
 type MatchVariable struct {
 	// REQUIRED; Match Variable.
-	VariableName *WebApplicationFirewallMatchVariable `json:"variableName,omitempty"`
+	VariableName *WebApplicationFirewallMatchVariable
 
 	// The selector of match variable.
-	Selector *string `json:"selector,omitempty"`
+	Selector *string
 }
 
 // MatchedRule - Matched rule.
 type MatchedRule struct {
 	// The network traffic is allowed or denied. Possible values are 'Allow' and 'Deny'.
-	Action *string `json:"action,omitempty"`
+	Action *string
 
 	// Name of the matched network security rule.
-	RuleName *string `json:"ruleName,omitempty"`
+	RuleName *string
 }
 
 // MetricSpecification - Description of metrics specification.
 type MetricSpecification struct {
 	// The aggregation type.
-	AggregationType *string `json:"aggregationType,omitempty"`
+	AggregationType *string
 
 	// List of availability.
-	Availabilities []*Availability `json:"availabilities,omitempty"`
+	Availabilities []*Availability
 
 	// List of dimensions.
-	Dimensions []*Dimension `json:"dimensions,omitempty"`
+	Dimensions []*Dimension
 
 	// The description of the metric.
-	DisplayDescription *string `json:"displayDescription,omitempty"`
+	DisplayDescription *string
 
 	// The display name of the metric.
-	DisplayName *string `json:"displayName,omitempty"`
+	DisplayName *string
 
 	// Whether regional MDM account enabled.
-	EnableRegionalMdmAccount *bool `json:"enableRegionalMdmAccount,omitempty"`
+	EnableRegionalMdmAccount *bool
 
 	// Whether gaps would be filled with zeros.
-	FillGapWithZero *bool `json:"fillGapWithZero,omitempty"`
+	FillGapWithZero *bool
 
 	// Whether the metric is internal.
-	IsInternal *bool `json:"isInternal,omitempty"`
+	IsInternal *bool
 
 	// Pattern for the filter of the metric.
-	MetricFilterPattern *string `json:"metricFilterPattern,omitempty"`
+	MetricFilterPattern *string
 
 	// The name of the metric.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The resource Id dimension name override.
-	ResourceIDDimensionNameOverride *string `json:"resourceIdDimensionNameOverride,omitempty"`
+	ResourceIDDimensionNameOverride *string
 
 	// The source MDM account.
-	SourceMdmAccount *string `json:"sourceMdmAccount,omitempty"`
+	SourceMdmAccount *string
 
 	// The source MDM namespace.
-	SourceMdmNamespace *string `json:"sourceMdmNamespace,omitempty"`
+	SourceMdmNamespace *string
 
 	// Units the metric to be displayed in.
-	Unit *string `json:"unit,omitempty"`
+	Unit *string
 }
 
 // NatGateway - Nat Gateway resource.
 type NatGateway struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Nat Gateway properties.
-	Properties *NatGatewayPropertiesFormat `json:"properties,omitempty"`
+	Properties *NatGatewayPropertiesFormat
 
 	// The nat gateway SKU.
-	SKU *NatGatewaySKU `json:"sku,omitempty"`
+	SKU *NatGatewaySKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// A list of availability zones denoting the zone in which Nat Gateway should be deployed.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // NatGatewayListResult - Response for ListNatGateways API service call.
 type NatGatewayListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of Nat Gateways that exists in a resource group.
-	Value []*NatGateway `json:"value,omitempty"`
+	Value []*NatGateway
 }
 
 // NatGatewayPropertiesFormat - Nat Gateway properties.
 type NatGatewayPropertiesFormat struct {
 	// The idle timeout of the nat gateway.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// An array of public ip addresses associated with the nat gateway resource.
-	PublicIPAddresses []*SubResource `json:"publicIpAddresses,omitempty"`
+	PublicIPAddresses []*SubResource
 
 	// An array of public ip prefixes associated with the nat gateway resource.
-	PublicIPPrefixes []*SubResource `json:"publicIpPrefixes,omitempty"`
+	PublicIPPrefixes []*SubResource
 
 	// READ-ONLY; The provisioning state of the NAT gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the NAT gateway resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; An array of references to the subnets using this nat gateway resource.
-	Subnets []*SubResource `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*SubResource
 }
 
 // NatGatewaySKU - SKU of nat gateway.
 type NatGatewaySKU struct {
 	// Name of Nat Gateway SKU.
-	Name *NatGatewaySKUName `json:"name,omitempty"`
+	Name *NatGatewaySKUName
 }
 
 // NatGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the NatGatewaysClient.BeginCreateOrUpdate
@@ -6904,28 +6904,28 @@ type NatGatewaysClientUpdateTagsOptions struct {
 // NatRuleCondition - Rule condition of type nat.
 type NatRuleCondition struct {
 	// REQUIRED; Rule Condition Type.
-	RuleConditionType *FirewallPolicyRuleConditionType `json:"ruleConditionType,omitempty"`
+	RuleConditionType *FirewallPolicyRuleConditionType
 
 	// Description of the rule condition.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string
 
 	// List of destination ports.
-	DestinationPorts []*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol
 
 	// Name of the rule condition.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 }
 
 // GetFirewallPolicyRuleCondition implements the FirewallPolicyRuleConditionClassification interface for type NatRuleCondition.
@@ -6940,86 +6940,86 @@ func (n *NatRuleCondition) GetFirewallPolicyRuleCondition() *FirewallPolicyRuleC
 // NextHopParameters - Parameters that define the source and destination endpoint.
 type NextHopParameters struct {
 	// REQUIRED; The destination IP address.
-	DestinationIPAddress *string `json:"destinationIPAddress,omitempty"`
+	DestinationIPAddress *string
 
 	// REQUIRED; The source IP address.
-	SourceIPAddress *string `json:"sourceIPAddress,omitempty"`
+	SourceIPAddress *string
 
 	// REQUIRED; The resource identifier of the target resource against which the action is to be performed.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 
 	// The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of the nics, then this parameter must be specified.
 	// Otherwise optional).
-	TargetNicResourceID *string `json:"targetNicResourceId,omitempty"`
+	TargetNicResourceID *string
 }
 
 // NextHopResult - The information about next hop from the specified VM.
 type NextHopResult struct {
 	// Next hop IP Address.
-	NextHopIPAddress *string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress *string
 
 	// Next hop type.
-	NextHopType *NextHopType `json:"nextHopType,omitempty"`
+	NextHopType *NextHopType
 
 	// The resource identifier for the route table associated with the route being returned. If the route being returned does
 	// not correspond to any user created routes then this field will be the string
 	// 'System Route'.
-	RouteTableID *string `json:"routeTableId,omitempty"`
+	RouteTableID *string
 }
 
 // Operation - Network REST API operation definition.
 type Operation struct {
 	// Display metadata associated with the operation.
-	Display *OperationDisplay `json:"display,omitempty"`
+	Display *OperationDisplay
 
 	// Operation name: {provider}/{resource}/{operation}.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Origin of the operation.
-	Origin *string `json:"origin,omitempty"`
+	Origin *string
 
 	// Operation properties format.
-	Properties *OperationPropertiesFormat `json:"properties,omitempty"`
+	Properties *OperationPropertiesFormat
 }
 
 // OperationDisplay - Display metadata associated with the operation.
 type OperationDisplay struct {
 	// Description of the operation.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Type of the operation: get, read, delete, etc.
-	Operation *string `json:"operation,omitempty"`
+	Operation *string
 
 	// Service provider: Microsoft Network.
-	Provider *string `json:"provider,omitempty"`
+	Provider *string
 
 	// Resource on which the operation is performed.
-	Resource *string `json:"resource,omitempty"`
+	Resource *string
 }
 
 // OperationListResult - Result of the request to list Network operations. It contains a list of operations and a URL link
 // to get the next set of results.
 type OperationListResult struct {
 	// URL to get the next set of operation list results if there are any.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Network operations supported by the Network resource provider.
-	Value []*Operation `json:"value,omitempty"`
+	Value []*Operation
 }
 
 // OperationPropertiesFormat - Description of operation properties format.
 type OperationPropertiesFormat struct {
 	// Specification of the service.
-	ServiceSpecification *OperationPropertiesFormatServiceSpecification `json:"serviceSpecification,omitempty"`
+	ServiceSpecification *OperationPropertiesFormatServiceSpecification
 }
 
 // OperationPropertiesFormatServiceSpecification - Specification of the service.
 type OperationPropertiesFormatServiceSpecification struct {
 	// Operation log specification.
-	LogSpecifications []*LogSpecification `json:"logSpecifications,omitempty"`
+	LogSpecifications []*LogSpecification
 
 	// Operation service specification.
-	MetricSpecifications []*MetricSpecification `json:"metricSpecifications,omitempty"`
+	MetricSpecifications []*MetricSpecification
 }
 
 // OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
@@ -7030,149 +7030,149 @@ type OperationsClientListOptions struct {
 // OutboundRule - Outbound rule of the load balancer.
 type OutboundRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of outbound rules used by the load balancer. This name can be used
 	// to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer outbound rule.
-	Properties *OutboundRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *OutboundRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // OutboundRulePropertiesFormat - Outbound rule of the load balancer.
 type OutboundRulePropertiesFormat struct {
 	// REQUIRED; A reference to a pool of DIPs. Outbound traffic is randomly load balanced across IPs in the backend IPs.
-	BackendAddressPool *SubResource `json:"backendAddressPool,omitempty"`
+	BackendAddressPool *SubResource
 
 	// REQUIRED; The Frontend IP addresses of the load balancer.
-	FrontendIPConfigurations []*SubResource `json:"frontendIPConfigurations,omitempty"`
+	FrontendIPConfigurations []*SubResource
 
 	// REQUIRED; The protocol for the outbound rule in load balancer.
-	Protocol *LoadBalancerOutboundRuleProtocol `json:"protocol,omitempty"`
+	Protocol *LoadBalancerOutboundRuleProtocol
 
 	// The number of outbound ports to be used for NAT.
-	AllocatedOutboundPorts *int32 `json:"allocatedOutboundPorts,omitempty"`
+	AllocatedOutboundPorts *int32
 
 	// Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used
 	// when the protocol is set to TCP.
-	EnableTCPReset *bool `json:"enableTcpReset,omitempty"`
+	EnableTCPReset *bool
 
 	// The timeout for the TCP idle connection.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// READ-ONLY; The provisioning state of the outbound rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // OwaspCrsExclusionEntry - Allow to exclude some variable satisfy the condition for the WAF check.
 type OwaspCrsExclusionEntry struct {
 	// REQUIRED; The variable to be excluded.
-	MatchVariable *OwaspCrsExclusionEntryMatchVariable `json:"matchVariable,omitempty"`
+	MatchVariable *OwaspCrsExclusionEntryMatchVariable
 
 	// REQUIRED; When matchVariable is a collection, operator used to specify which elements in the collection this exclusion
 	// applies to.
-	Selector *string `json:"selector,omitempty"`
+	Selector *string
 
 	// REQUIRED; When matchVariable is a collection, operate on the selector to specify which elements in the collection this
 	// exclusion applies to.
-	SelectorMatchOperator *OwaspCrsExclusionEntrySelectorMatchOperator `json:"selectorMatchOperator,omitempty"`
+	SelectorMatchOperator *OwaspCrsExclusionEntrySelectorMatchOperator
 }
 
 // P2SConnectionConfiguration Resource.
 type P2SConnectionConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the P2S connection configuration.
-	Properties *P2SConnectionConfigurationProperties `json:"properties,omitempty"`
+	Properties *P2SConnectionConfigurationProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // P2SConnectionConfigurationProperties - Parameters for P2SConnectionConfiguration.
 type P2SConnectionConfigurationProperties struct {
 	// The reference to the address space resource which represents Address space for P2S VpnClient.
-	VPNClientAddressPool *AddressSpace `json:"vpnClientAddressPool,omitempty"`
+	VPNClientAddressPool *AddressSpace
 
 	// READ-ONLY; The provisioning state of the P2SConnectionConfiguration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // P2SVPNConnectionHealth - P2S Vpn connection detailed health written to sas url.
 type P2SVPNConnectionHealth struct {
 	// Returned sas url of the blob to which the p2s vpn connection detailed health will be written.
-	SasURL *string `json:"sasUrl,omitempty"`
+	SasURL *string
 }
 
 // P2SVPNConnectionHealthRequest - List of P2S Vpn connection health request.
 type P2SVPNConnectionHealthRequest struct {
 	// The sas-url to download the P2S Vpn connection health detail.
-	OutputBlobSasURL *string `json:"outputBlobSasUrl,omitempty"`
+	OutputBlobSasURL *string
 
 	// The list of p2s vpn user names whose p2s vpn connection detailed health to retrieve for.
-	VPNUserNamesFilter []*string `json:"vpnUserNamesFilter,omitempty"`
+	VPNUserNamesFilter []*string
 }
 
 // P2SVPNConnectionRequest - List of p2s vpn connections to be disconnected.
 type P2SVPNConnectionRequest struct {
 	// List of p2s vpn connection Ids.
-	VPNConnectionIDs []*string `json:"vpnConnectionIds,omitempty"`
+	VPNConnectionIDs []*string
 }
 
 // P2SVPNGateway - P2SVpnGateway Resource.
 type P2SVPNGateway struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the P2SVpnGateway.
-	Properties *P2SVPNGatewayProperties `json:"properties,omitempty"`
+	Properties *P2SVPNGatewayProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // P2SVPNGatewayProperties - Parameters for P2SVpnGateway.
 type P2SVPNGatewayProperties struct {
 	// List of all p2s connection configurations of the gateway.
-	P2SConnectionConfigurations []*P2SConnectionConfiguration `json:"p2SConnectionConfigurations,omitempty"`
+	P2SConnectionConfigurations []*P2SConnectionConfiguration
 
 	// The scale unit for this p2s vpn gateway.
-	VPNGatewayScaleUnit *int32 `json:"vpnGatewayScaleUnit,omitempty"`
+	VPNGatewayScaleUnit *int32
 
 	// The VpnServerConfiguration to which the p2sVpnGateway is attached to.
-	VPNServerConfiguration *SubResource `json:"vpnServerConfiguration,omitempty"`
+	VPNServerConfiguration *SubResource
 
 	// The VirtualHub to which the gateway belongs.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+	VirtualHub *SubResource
 
 	// READ-ONLY; The provisioning state of the P2S VPN gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; All P2S VPN clients' connection health status.
-	VPNClientConnectionHealth *VPNClientConnectionHealth `json:"vpnClientConnectionHealth,omitempty" azure:"ro"`
+	VPNClientConnectionHealth *VPNClientConnectionHealth
 }
 
 // P2SVPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the P2SVPNGatewaysClient.BeginCreateOrUpdate
@@ -7240,13 +7240,13 @@ type P2SVPNGatewaysClientUpdateTagsOptions struct {
 // P2SVPNProfileParameters - Vpn Client Parameters for package generation.
 type P2SVPNProfileParameters struct {
 	// VPN client authentication method.
-	AuthenticationMethod *AuthenticationMethod `json:"authenticationMethod,omitempty"`
+	AuthenticationMethod *AuthenticationMethod
 }
 
 // PacketCapture - Parameters that define the create packet capture operation.
 type PacketCapture struct {
 	// REQUIRED; Properties of the packet capture.
-	Properties *PacketCaptureParameters `json:"properties,omitempty"`
+	Properties *PacketCaptureParameters
 }
 
 // PacketCaptureFilter - Filter that is applied to packet capture request. Multiple filters can be applied.
@@ -7254,112 +7254,112 @@ type PacketCaptureFilter struct {
 	// Local IP Address to be filtered on. Notation: "127.0.0.1" for single address entry. "127.0.0.1-127.0.0.255" for range.
 	// "127.0.0.1;127.0.0.5"? for multiple entries. Multiple ranges not currently
 	// supported. Mixing ranges with multiple entries not currently supported. Default = null.
-	LocalIPAddress *string `json:"localIPAddress,omitempty"`
+	LocalIPAddress *string
 
 	// Local port to be filtered on. Notation: "80" for single port entry."80-85" for range. "80;443;" for multiple entries. Multiple
 	// ranges not currently supported. Mixing ranges with multiple entries not
 	// currently supported. Default = null.
-	LocalPort *string `json:"localPort,omitempty"`
+	LocalPort *string
 
 	// Protocol to be filtered on.
-	Protocol *PcProtocol `json:"protocol,omitempty"`
+	Protocol *PcProtocol
 
 	// Local IP Address to be filtered on. Notation: "127.0.0.1" for single address entry. "127.0.0.1-127.0.0.255" for range.
 	// "127.0.0.1;127.0.0.5;" for multiple entries. Multiple ranges not currently
 	// supported. Mixing ranges with multiple entries not currently supported. Default = null.
-	RemoteIPAddress *string `json:"remoteIPAddress,omitempty"`
+	RemoteIPAddress *string
 
 	// Remote port to be filtered on. Notation: "80" for single port entry."80-85" for range. "80;443;" for multiple entries.
 	// Multiple ranges not currently supported. Mixing ranges with multiple entries not
 	// currently supported. Default = null.
-	RemotePort *string `json:"remotePort,omitempty"`
+	RemotePort *string
 }
 
 // PacketCaptureListResult - List of packet capture sessions.
 type PacketCaptureListResult struct {
 	// Information about packet capture sessions.
-	Value []*PacketCaptureResult `json:"value,omitempty"`
+	Value []*PacketCaptureResult
 }
 
 // PacketCaptureParameters - Parameters that define the create packet capture operation.
 type PacketCaptureParameters struct {
 	// REQUIRED; The storage location for a packet capture session.
-	StorageLocation *PacketCaptureStorageLocation `json:"storageLocation,omitempty"`
+	StorageLocation *PacketCaptureStorageLocation
 
 	// REQUIRED; The ID of the targeted resource, only VM is currently supported.
-	Target *string `json:"target,omitempty"`
+	Target *string
 
 	// Number of bytes captured per packet, the remaining bytes are truncated.
-	BytesToCapturePerPacket *int32 `json:"bytesToCapturePerPacket,omitempty"`
+	BytesToCapturePerPacket *int32
 
 	// A list of packet capture filters.
-	Filters []*PacketCaptureFilter `json:"filters,omitempty"`
+	Filters []*PacketCaptureFilter
 
 	// Maximum duration of the capture session in seconds.
-	TimeLimitInSeconds *int32 `json:"timeLimitInSeconds,omitempty"`
+	TimeLimitInSeconds *int32
 
 	// Maximum size of the capture output.
-	TotalBytesPerSession *int32 `json:"totalBytesPerSession,omitempty"`
+	TotalBytesPerSession *int32
 }
 
 // PacketCaptureQueryStatusResult - Status of packet capture session.
 type PacketCaptureQueryStatusResult struct {
 	// The start time of the packet capture session.
-	CaptureStartTime *time.Time `json:"captureStartTime,omitempty"`
+	CaptureStartTime *time.Time
 
 	// The ID of the packet capture resource.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the packet capture resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// List of errors of packet capture session.
-	PacketCaptureError []*PcError `json:"packetCaptureError,omitempty"`
+	PacketCaptureError []*PcError
 
 	// The status of the packet capture session.
-	PacketCaptureStatus *PcStatus `json:"packetCaptureStatus,omitempty"`
+	PacketCaptureStatus *PcStatus
 
 	// The reason the current packet capture session was stopped.
-	StopReason *string `json:"stopReason,omitempty"`
+	StopReason *string
 }
 
 // PacketCaptureResult - Information about packet capture session.
 type PacketCaptureResult struct {
 	// Properties of the packet capture result.
-	Properties *PacketCaptureResultProperties `json:"properties,omitempty"`
+	Properties *PacketCaptureResultProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; ID of the packet capture operation.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Name of the packet capture session.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 }
 
 // PacketCaptureResultProperties - The properties of a packet capture session.
 type PacketCaptureResultProperties struct {
 	// REQUIRED; The storage location for a packet capture session.
-	StorageLocation *PacketCaptureStorageLocation `json:"storageLocation,omitempty"`
+	StorageLocation *PacketCaptureStorageLocation
 
 	// REQUIRED; The ID of the targeted resource, only VM is currently supported.
-	Target *string `json:"target,omitempty"`
+	Target *string
 
 	// Number of bytes captured per packet, the remaining bytes are truncated.
-	BytesToCapturePerPacket *int32 `json:"bytesToCapturePerPacket,omitempty"`
+	BytesToCapturePerPacket *int32
 
 	// A list of packet capture filters.
-	Filters []*PacketCaptureFilter `json:"filters,omitempty"`
+	Filters []*PacketCaptureFilter
 
 	// Maximum duration of the capture session in seconds.
-	TimeLimitInSeconds *int32 `json:"timeLimitInSeconds,omitempty"`
+	TimeLimitInSeconds *int32
 
 	// Maximum size of the capture output.
-	TotalBytesPerSession *int32 `json:"totalBytesPerSession,omitempty"`
+	TotalBytesPerSession *int32
 
 	// READ-ONLY; The provisioning state of the packet capture session.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PacketCaptureStorageLocation - The storage location for a packet capture session.
@@ -7367,14 +7367,14 @@ type PacketCaptureStorageLocation struct {
 	// A valid local path on the targeting VM. Must include the name of the capture file (*.cap). For linux virtual machine it
 	// must start with /var/captures. Required if no storage ID is provided, otherwise
 	// optional.
-	FilePath *string `json:"filePath,omitempty"`
+	FilePath *string
 
 	// The ID of the storage account to save the packet capture session. Required if no local file path is provided.
-	StorageID *string `json:"storageId,omitempty"`
+	StorageID *string
 
 	// The URI of the storage path to save the packet capture. Must be a well-formed URI describing the location to save the packet
 	// capture.
-	StoragePath *string `json:"storagePath,omitempty"`
+	StoragePath *string
 }
 
 // PacketCapturesClientBeginCreateOptions contains the optional parameters for the PacketCapturesClient.BeginCreate method.
@@ -7415,53 +7415,53 @@ type PacketCapturesClientListOptions struct {
 // PeerExpressRouteCircuitConnection - Peer Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.
 type PeerExpressRouteCircuitConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the peer express route circuit connection.
-	Properties *PeerExpressRouteCircuitConnectionPropertiesFormat `json:"properties,omitempty"`
+	Properties *PeerExpressRouteCircuitConnectionPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PeerExpressRouteCircuitConnectionListResult - Response for ListPeeredConnections API service call retrieves all global
 // reach peer circuit connections that belongs to a Private Peering for an ExpressRouteCircuit.
 type PeerExpressRouteCircuitConnectionListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The global reach peer circuit connection associated with Private Peering in an ExpressRoute Circuit.
-	Value []*PeerExpressRouteCircuitConnection `json:"value,omitempty"`
+	Value []*PeerExpressRouteCircuitConnection
 }
 
 // PeerExpressRouteCircuitConnectionPropertiesFormat - Properties of the peer express route circuit connection.
 type PeerExpressRouteCircuitConnectionPropertiesFormat struct {
 	// /29 IP address space to carve out Customer addresses for tunnels.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// The resource guid of the authorization used for the express route circuit connection.
-	AuthResourceGUID *string `json:"authResourceGuid,omitempty"`
+	AuthResourceGUID *string
 
 	// The name of the express route circuit connection resource.
-	ConnectionName *string `json:"connectionName,omitempty"`
+	ConnectionName *string
 
 	// Reference to Express Route Circuit Private Peering Resource of the circuit.
-	ExpressRouteCircuitPeering *SubResource `json:"expressRouteCircuitPeering,omitempty"`
+	ExpressRouteCircuitPeering *SubResource
 
 	// Reference to Express Route Circuit Private Peering Resource of the peered circuit.
-	PeerExpressRouteCircuitPeering *SubResource `json:"peerExpressRouteCircuitPeering,omitempty"`
+	PeerExpressRouteCircuitPeering *SubResource
 
 	// READ-ONLY; Express Route Circuit connection state.
-	CircuitConnectionStatus *CircuitConnectionStatus `json:"circuitConnectionStatus,omitempty" azure:"ro"`
+	CircuitConnectionStatus *CircuitConnectionStatus
 
 	// READ-ONLY; The provisioning state of the peer express route circuit connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PeerExpressRouteCircuitConnectionsClientGetOptions contains the optional parameters for the PeerExpressRouteCircuitConnectionsClient.Get
@@ -7479,70 +7479,70 @@ type PeerExpressRouteCircuitConnectionsClientListOptions struct {
 // PolicySettings - Defines contents of a web application firewall global configuration.
 type PolicySettings struct {
 	// Maximum file upload size in Mb for WAF.
-	FileUploadLimitInMb *int32 `json:"fileUploadLimitInMb,omitempty"`
+	FileUploadLimitInMb *int32
 
 	// Maximum request body size in Kb for WAF.
-	MaxRequestBodySizeInKb *int32 `json:"maxRequestBodySizeInKb,omitempty"`
+	MaxRequestBodySizeInKb *int32
 
 	// The mode of the policy.
-	Mode *WebApplicationFirewallMode `json:"mode,omitempty"`
+	Mode *WebApplicationFirewallMode
 
 	// Whether to allow WAF to check request Body.
-	RequestBodyCheck *bool `json:"requestBodyCheck,omitempty"`
+	RequestBodyCheck *bool
 
 	// The state of the policy.
-	State *WebApplicationFirewallEnabledState `json:"state,omitempty"`
+	State *WebApplicationFirewallEnabledState
 }
 
 // PrepareNetworkPoliciesRequest - Details of PrepareNetworkPolicies for Subnet.
 type PrepareNetworkPoliciesRequest struct {
 	// A list of NetworkIntentPolicyConfiguration.
-	NetworkIntentPolicyConfigurations []*IntentPolicyConfiguration `json:"networkIntentPolicyConfigurations,omitempty"`
+	NetworkIntentPolicyConfigurations []*IntentPolicyConfiguration
 
 	// The name of the service for which subnet is being prepared for.
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName *string
 }
 
 // PrivateDNSZoneConfig - PrivateDnsZoneConfig resource.
 type PrivateDNSZoneConfig struct {
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the private dns zone configuration.
-	Properties *PrivateDNSZonePropertiesFormat `json:"properties,omitempty"`
+	Properties *PrivateDNSZonePropertiesFormat
 }
 
 // PrivateDNSZoneGroup - Private dns zone group resource.
 type PrivateDNSZoneGroup struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the private dns zone group.
-	Properties *PrivateDNSZoneGroupPropertiesFormat `json:"properties,omitempty"`
+	Properties *PrivateDNSZoneGroupPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // PrivateDNSZoneGroupListResult - Response for the ListPrivateDnsZoneGroups API service call.
 type PrivateDNSZoneGroupListResult struct {
 	// A list of private dns zone group resources in a private endpoint.
-	Value []*PrivateDNSZoneGroup `json:"value,omitempty"`
+	Value []*PrivateDNSZoneGroup
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // PrivateDNSZoneGroupPropertiesFormat - Properties of the private dns zone group.
 type PrivateDNSZoneGroupPropertiesFormat struct {
 	// A collection of private dns zone configurations of the private dns zone group.
-	PrivateDNSZoneConfigs []*PrivateDNSZoneConfig `json:"privateDnsZoneConfigs,omitempty"`
+	PrivateDNSZoneConfigs []*PrivateDNSZoneConfig
 
 	// READ-ONLY; The provisioning state of the private dns zone group resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateDNSZoneGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateDNSZoneGroupsClient.BeginCreateOrUpdate
@@ -7573,107 +7573,107 @@ type PrivateDNSZoneGroupsClientListOptions struct {
 // PrivateDNSZonePropertiesFormat - Properties of the private dns zone configuration resource.
 type PrivateDNSZonePropertiesFormat struct {
 	// The resource id of the private dns zone.
-	PrivateDNSZoneID *string `json:"privateDnsZoneId,omitempty"`
+	PrivateDNSZoneID *string
 
 	// READ-ONLY; A collection of information regarding a recordSet, holding information to identify private resources.
-	RecordSets []*RecordSet `json:"recordSets,omitempty" azure:"ro"`
+	RecordSets []*RecordSet
 }
 
 // PrivateEndpoint - Private endpoint resource.
 type PrivateEndpoint struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the private endpoint.
-	Properties *PrivateEndpointProperties `json:"properties,omitempty"`
+	Properties *PrivateEndpointProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateEndpointConnection resource.
 type PrivateEndpointConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the private end point connection.
-	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Properties *PrivateEndpointConnectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; The resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateEndpointConnectionListResult - Response for the ListPrivateEndpointConnection API service call.
 type PrivateEndpointConnectionListResult struct {
 	// A list of PrivateEndpointConnection resources for a specific private link service.
-	Value []*PrivateEndpointConnection `json:"value,omitempty"`
+	Value []*PrivateEndpointConnection
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // PrivateEndpointConnectionProperties - Properties of the PrivateEndpointConnectProperties.
 type PrivateEndpointConnectionProperties struct {
 	// A collection of information about the state of the connection between service consumer and provider.
-	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState
 
 	// READ-ONLY; The consumer link id.
-	LinkIdentifier *string `json:"linkIdentifier,omitempty" azure:"ro"`
+	LinkIdentifier *string
 
 	// READ-ONLY; The resource of private end point.
-	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty" azure:"ro"`
+	PrivateEndpoint *PrivateEndpoint
 
 	// READ-ONLY; The provisioning state of the private endpoint connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateEndpointListResult - Response for the ListPrivateEndpoints API service call.
 type PrivateEndpointListResult struct {
 	// A list of private endpoint resources in a resource group.
-	Value []*PrivateEndpoint `json:"value,omitempty"`
+	Value []*PrivateEndpoint
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // PrivateEndpointProperties - Properties of the private endpoint.
 type PrivateEndpointProperties struct {
 	// An array of custom dns configurations.
-	CustomDNSConfigs []*CustomDNSConfigPropertiesFormat `json:"customDnsConfigs,omitempty"`
+	CustomDNSConfigs []*CustomDNSConfigPropertiesFormat
 
 	// A grouping of information about the connection to the remote resource. Used when the network admin does not have access
 	// to approve connections to the remote resource.
-	ManualPrivateLinkServiceConnections []*PrivateLinkServiceConnection `json:"manualPrivateLinkServiceConnections,omitempty"`
+	ManualPrivateLinkServiceConnections []*PrivateLinkServiceConnection
 
 	// A grouping of information about the connection to the remote resource.
-	PrivateLinkServiceConnections []*PrivateLinkServiceConnection `json:"privateLinkServiceConnections,omitempty"`
+	PrivateLinkServiceConnections []*PrivateLinkServiceConnection
 
 	// The ID of the subnet from which the private IP will be allocated.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// READ-ONLY; An array of references to the network interfaces created for this private endpoint.
-	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*Interface
 
 	// READ-ONLY; The provisioning state of the private endpoint resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateEndpointsClientBeginCreateOrUpdateOptions contains the optional parameters for the PrivateEndpointsClient.BeginCreateOrUpdate
@@ -7709,173 +7709,173 @@ type PrivateEndpointsClientListOptions struct {
 // PrivateLinkService - Private link service resource.
 type PrivateLinkService struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the private link service.
-	Properties *PrivateLinkServiceProperties `json:"properties,omitempty"`
+	Properties *PrivateLinkServiceProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateLinkServiceConnection resource.
 type PrivateLinkServiceConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the private link service connection.
-	Properties *PrivateLinkServiceConnectionProperties `json:"properties,omitempty"`
+	Properties *PrivateLinkServiceConnectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; The resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateLinkServiceConnectionProperties - Properties of the PrivateLinkServiceConnection.
 type PrivateLinkServiceConnectionProperties struct {
 	// The ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.
-	GroupIDs []*string `json:"groupIds,omitempty"`
+	GroupIDs []*string
 
 	// A collection of read-only information about the state of the connection to the remote resource.
-	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState
 
 	// The resource id of private link service.
-	PrivateLinkServiceID *string `json:"privateLinkServiceId,omitempty"`
+	PrivateLinkServiceID *string
 
 	// A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars.
-	RequestMessage *string `json:"requestMessage,omitempty"`
+	RequestMessage *string
 
 	// READ-ONLY; The provisioning state of the private link service connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateLinkServiceConnectionState - A collection of information about the state of the connection between service consumer
 // and provider.
 type PrivateLinkServiceConnectionState struct {
 	// A message indicating if changes on the service provider require any updates on the consumer.
-	ActionsRequired *string `json:"actionsRequired,omitempty"`
+	ActionsRequired *string
 
 	// The reason for approval/rejection of the connection.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
-	Status *string `json:"status,omitempty"`
+	Status *string
 }
 
 // PrivateLinkServiceIPConfiguration - The private link service ip configuration.
 type PrivateLinkServiceIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of private link service ip configuration.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the private link service ip configuration.
-	Properties *PrivateLinkServiceIPConfigurationProperties `json:"properties,omitempty"`
+	Properties *PrivateLinkServiceIPConfigurationProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; The resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateLinkServiceIPConfigurationProperties - Properties of private link service IP configuration.
 type PrivateLinkServiceIPConfigurationProperties struct {
 	// Whether the ip configuration is primary or not.
-	Primary *bool `json:"primary,omitempty"`
+	Primary *bool
 
 	// The private IP address of the IP configuration.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+	PrivateIPAddress *string
 
 	// Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4.
-	PrivateIPAddressVersion *IPVersion `json:"privateIPAddressVersion,omitempty"`
+	PrivateIPAddressVersion *IPVersion
 
 	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// The reference to the subnet resource.
-	Subnet *Subnet `json:"subnet,omitempty"`
+	Subnet *Subnet
 
 	// READ-ONLY; The provisioning state of the private link service IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateLinkServiceListResult - Response for the ListPrivateLinkService API service call.
 type PrivateLinkServiceListResult struct {
 	// A list of PrivateLinkService resources in a resource group.
-	Value []*PrivateLinkService `json:"value,omitempty"`
+	Value []*PrivateLinkService
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // PrivateLinkServiceProperties - Properties of the private link service.
 type PrivateLinkServiceProperties struct {
 	// The auto-approval list of the private link service.
-	AutoApproval *PrivateLinkServicePropertiesAutoApproval `json:"autoApproval,omitempty"`
+	AutoApproval *PrivateLinkServicePropertiesAutoApproval
 
 	// Whether the private link service is enabled for proxy protocol or not.
-	EnableProxyProtocol *bool `json:"enableProxyProtocol,omitempty"`
+	EnableProxyProtocol *bool
 
 	// The list of Fqdn.
-	Fqdns []*string `json:"fqdns,omitempty"`
+	Fqdns []*string
 
 	// An array of private link service IP configurations.
-	IPConfigurations []*PrivateLinkServiceIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*PrivateLinkServiceIPConfiguration
 
 	// An array of references to the load balancer IP configurations.
-	LoadBalancerFrontendIPConfigurations []*FrontendIPConfiguration `json:"loadBalancerFrontendIpConfigurations,omitempty"`
+	LoadBalancerFrontendIPConfigurations []*FrontendIPConfiguration
 
 	// The visibility list of the private link service.
-	Visibility *PrivateLinkServicePropertiesVisibility `json:"visibility,omitempty"`
+	Visibility *PrivateLinkServicePropertiesVisibility
 
 	// READ-ONLY; The alias of the private link service.
-	Alias *string `json:"alias,omitempty" azure:"ro"`
+	Alias *string
 
 	// READ-ONLY; An array of references to the network interfaces created for this private link service.
-	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*Interface
 
 	// READ-ONLY; An array of list about connections to the private endpoint.
-	PrivateEndpointConnections []*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty" azure:"ro"`
+	PrivateEndpointConnections []*PrivateEndpointConnection
 
 	// READ-ONLY; The provisioning state of the private link service resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // PrivateLinkServicePropertiesAutoApproval - The auto-approval list of the private link service.
 type PrivateLinkServicePropertiesAutoApproval struct {
 	// The list of subscriptions.
-	Subscriptions []*string `json:"subscriptions,omitempty"`
+	Subscriptions []*string
 }
 
 // PrivateLinkServicePropertiesVisibility - The visibility list of the private link service.
 type PrivateLinkServicePropertiesVisibility struct {
 	// The list of subscriptions.
-	Subscriptions []*string `json:"subscriptions,omitempty"`
+	Subscriptions []*string
 }
 
 // PrivateLinkServiceVisibility - Response for the CheckPrivateLinkServiceVisibility API service call.
 type PrivateLinkServiceVisibility struct {
 	// Private Link Service Visibility (True/False).
-	Visible *bool `json:"visible,omitempty"`
+	Visible *bool
 }
 
 // PrivateLinkServicesClientBeginCheckPrivateLinkServiceVisibilityByResourceGroupOptions contains the optional parameters
@@ -7964,99 +7964,99 @@ type PrivateLinkServicesClientUpdatePrivateEndpointConnectionOptions struct {
 // Probe - A load balancer probe.
 type Probe struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within the set of probes used by the load balancer. This name can be used to access
 	// the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of load balancer probe.
-	Properties *ProbePropertiesFormat `json:"properties,omitempty"`
+	Properties *ProbePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Type of the resource.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ProbePropertiesFormat - Load balancer probe resource.
 type ProbePropertiesFormat struct {
 	// REQUIRED; The port for communicating the probe. Possible values range from 1 to 65535, inclusive.
-	Port *int32 `json:"port,omitempty"`
+	Port *int32
 
 	// REQUIRED; The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful.
 	// If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required
 	// for the probe to be successful.
-	Protocol *ProbeProtocol `json:"protocol,omitempty"`
+	Protocol *ProbeProtocol
 
 	// The interval, in seconds, for how frequently to probe the endpoint for health status. Typically, the interval is slightly
 	// less than half the allocated timeout period (in seconds) which allows two full
 	// probes before taking the instance out of rotation. The default value is 15, the minimum value is 5.
-	IntervalInSeconds *int32 `json:"intervalInSeconds,omitempty"`
+	IntervalInSeconds *int32
 
 	// The number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint.
 	// This values allows endpoints to be taken out of rotation faster or slower than
 	// the typical times used in Azure.
-	NumberOfProbes *int32 `json:"numberOfProbes,omitempty"`
+	NumberOfProbes *int32
 
 	// The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is
 	// not allowed. There is no default value.
-	RequestPath *string `json:"requestPath,omitempty"`
+	RequestPath *string
 
 	// READ-ONLY; The load balancer rules that use this probe.
-	LoadBalancingRules []*SubResource `json:"loadBalancingRules,omitempty" azure:"ro"`
+	LoadBalancingRules []*SubResource
 
 	// READ-ONLY; The provisioning state of the probe resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // Profile - Network profile resource.
 type Profile struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Network profile properties.
-	Properties *ProfilePropertiesFormat `json:"properties,omitempty"`
+	Properties *ProfilePropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ProfileListResult - Response for ListNetworkProfiles API service call.
 type ProfileListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of network profiles that exist in a resource group.
-	Value []*Profile `json:"value,omitempty"`
+	Value []*Profile
 }
 
 // ProfilePropertiesFormat - Network profile properties.
 type ProfilePropertiesFormat struct {
 	// List of chid container network interface configurations.
-	ContainerNetworkInterfaceConfigurations []*ContainerNetworkInterfaceConfiguration `json:"containerNetworkInterfaceConfigurations,omitempty"`
+	ContainerNetworkInterfaceConfigurations []*ContainerNetworkInterfaceConfiguration
 
 	// READ-ONLY; List of child container network interfaces.
-	ContainerNetworkInterfaces []*ContainerNetworkInterface `json:"containerNetworkInterfaces,omitempty" azure:"ro"`
+	ContainerNetworkInterfaces []*ContainerNetworkInterface
 
 	// READ-ONLY; The provisioning state of the network profile resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the network profile resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // ProfilesClientBeginDeleteOptions contains the optional parameters for the ProfilesClient.BeginDelete method.
@@ -8094,55 +8094,55 @@ type ProfilesClientUpdateTagsOptions struct {
 // ProtocolConfiguration - Configuration of the protocol.
 type ProtocolConfiguration struct {
 	// HTTP configuration of the connectivity check.
-	HTTPConfiguration *HTTPConfiguration `json:"HTTPConfiguration,omitempty"`
+	HTTPConfiguration *HTTPConfiguration
 }
 
 // ProtocolCustomSettingsFormat - DDoS custom policy properties.
 type ProtocolCustomSettingsFormat struct {
 	// The protocol for which the DDoS protection policy is being customized.
-	Protocol *DdosCustomPolicyProtocol `json:"protocol,omitempty"`
+	Protocol *DdosCustomPolicyProtocol
 
 	// The customized DDoS protection source rate.
-	SourceRateOverride *string `json:"sourceRateOverride,omitempty"`
+	SourceRateOverride *string
 
 	// The customized DDoS protection trigger rate.
-	TriggerRateOverride *string `json:"triggerRateOverride,omitempty"`
+	TriggerRateOverride *string
 
 	// The customized DDoS protection trigger rate sensitivity degrees. High: Trigger rate set with most sensitivity w.r.t. normal
 	// traffic. Default: Trigger rate set with moderate sensitivity w.r.t. normal
 	// traffic. Low: Trigger rate set with less sensitivity w.r.t. normal traffic. Relaxed: Trigger rate set with least sensitivity
 	// w.r.t. normal traffic.
-	TriggerSensitivityOverride *DdosCustomPolicyTriggerSensitivityOverride `json:"triggerSensitivityOverride,omitempty"`
+	TriggerSensitivityOverride *DdosCustomPolicyTriggerSensitivityOverride
 }
 
 // PublicIPAddress - Public IP address resource.
 type PublicIPAddress struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Public IP address properties.
-	Properties *PublicIPAddressPropertiesFormat `json:"properties,omitempty"`
+	Properties *PublicIPAddressPropertiesFormat
 
 	// The public IP address SKU.
-	SKU *PublicIPAddressSKU `json:"sku,omitempty"`
+	SKU *PublicIPAddressSKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PublicIPAddressDNSSettings - Contains FQDN of the DNS record associated with the public IP address.
@@ -8150,67 +8150,67 @@ type PublicIPAddressDNSSettings struct {
 	// The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified
 	// domain name associated with the public IP address. If a domain name label is
 	// specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system.
-	DomainNameLabel *string `json:"domainNameLabel,omitempty"`
+	DomainNameLabel *string
 
 	// The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel
 	// and the regionalized DNS zone.
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn
 	// is specified, then a PTR DNS record is created pointing from the IP address in
 	// the in-addr.arpa domain to the reverse FQDN.
-	ReverseFqdn *string `json:"reverseFqdn,omitempty"`
+	ReverseFqdn *string
 }
 
 // PublicIPAddressListResult - Response for ListPublicIpAddresses API service call.
 type PublicIPAddressListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of public IP addresses that exists in a resource group.
-	Value []*PublicIPAddress `json:"value,omitempty"`
+	Value []*PublicIPAddress
 }
 
 // PublicIPAddressPropertiesFormat - Public IP address properties.
 type PublicIPAddressPropertiesFormat struct {
 	// The FQDN of the DNS record associated with the public IP address.
-	DNSSettings *PublicIPAddressDNSSettings `json:"dnsSettings,omitempty"`
+	DNSSettings *PublicIPAddressDNSSettings
 
 	// The DDoS protection custom policy associated with the public IP address.
-	DdosSettings *DdosSettings `json:"ddosSettings,omitempty"`
+	DdosSettings *DdosSettings
 
 	// The IP address associated with the public IP address resource.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 
 	// The list of tags associated with the public IP address.
-	IPTags []*IPTag `json:"ipTags,omitempty"`
+	IPTags []*IPTag
 
 	// The idle timeout of the public IP address.
-	IdleTimeoutInMinutes *int32 `json:"idleTimeoutInMinutes,omitempty"`
+	IdleTimeoutInMinutes *int32
 
 	// The public IP address version.
-	PublicIPAddressVersion *IPVersion `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAddressVersion *IPVersion
 
 	// The public IP address allocation method.
-	PublicIPAllocationMethod *IPAllocationMethod `json:"publicIPAllocationMethod,omitempty"`
+	PublicIPAllocationMethod *IPAllocationMethod
 
 	// The Public IP Prefix this Public IP Address should be allocated from.
-	PublicIPPrefix *SubResource `json:"publicIPPrefix,omitempty"`
+	PublicIPPrefix *SubResource
 
 	// READ-ONLY; The IP configuration associated with the public IP address.
-	IPConfiguration *IPConfiguration `json:"ipConfiguration,omitempty" azure:"ro"`
+	IPConfiguration *IPConfiguration
 
 	// READ-ONLY; The provisioning state of the public IP address resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the public IP address resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // PublicIPAddressSKU - SKU of a public IP address.
 type PublicIPAddressSKU struct {
 	// Name of a public IP address SKU.
-	Name *PublicIPAddressSKUName `json:"name,omitempty"`
+	Name *PublicIPAddressSKUName
 }
 
 // PublicIPAddressesClientBeginCreateOrUpdateOptions contains the optional parameters for the PublicIPAddressesClient.BeginCreateOrUpdate
@@ -8271,73 +8271,73 @@ type PublicIPAddressesClientUpdateTagsOptions struct {
 // PublicIPPrefix - Public IP prefix resource.
 type PublicIPPrefix struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Public IP prefix properties.
-	Properties *PublicIPPrefixPropertiesFormat `json:"properties,omitempty"`
+	Properties *PublicIPPrefixPropertiesFormat
 
 	// The public IP prefix SKU.
-	SKU *PublicIPPrefixSKU `json:"sku,omitempty"`
+	SKU *PublicIPPrefixSKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// A list of availability zones denoting the IP allocated for the resource needs to come from.
-	Zones []*string `json:"zones,omitempty"`
+	Zones []*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PublicIPPrefixListResult - Response for ListPublicIpPrefixes API service call.
 type PublicIPPrefixListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of public IP prefixes that exists in a resource group.
-	Value []*PublicIPPrefix `json:"value,omitempty"`
+	Value []*PublicIPPrefix
 }
 
 // PublicIPPrefixPropertiesFormat - Public IP prefix properties.
 type PublicIPPrefixPropertiesFormat struct {
 	// The list of tags associated with the public IP prefix.
-	IPTags []*IPTag `json:"ipTags,omitempty"`
+	IPTags []*IPTag
 
 	// The Length of the Public IP Prefix.
-	PrefixLength *int32 `json:"prefixLength,omitempty"`
+	PrefixLength *int32
 
 	// The public IP address version.
-	PublicIPAddressVersion *IPVersion `json:"publicIPAddressVersion,omitempty"`
+	PublicIPAddressVersion *IPVersion
 
 	// READ-ONLY; The allocated Prefix.
-	IPPrefix *string `json:"ipPrefix,omitempty" azure:"ro"`
+	IPPrefix *string
 
 	// READ-ONLY; The reference to load balancer frontend IP configuration associated with the public IP prefix.
-	LoadBalancerFrontendIPConfiguration *SubResource `json:"loadBalancerFrontendIpConfiguration,omitempty" azure:"ro"`
+	LoadBalancerFrontendIPConfiguration *SubResource
 
 	// READ-ONLY; The provisioning state of the public IP prefix resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The list of all referenced PublicIPAddresses.
-	PublicIPAddresses []*ReferencedPublicIPAddress `json:"publicIPAddresses,omitempty" azure:"ro"`
+	PublicIPAddresses []*ReferencedPublicIPAddress
 
 	// READ-ONLY; The resource GUID property of the public IP prefix resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // PublicIPPrefixSKU - SKU of a public IP prefix.
 type PublicIPPrefixSKU struct {
 	// Name of a public IP prefix SKU.
-	Name *PublicIPPrefixSKUName `json:"name,omitempty"`
+	Name *PublicIPPrefixSKUName
 }
 
 // PublicIPPrefixesClientBeginCreateOrUpdateOptions contains the optional parameters for the PublicIPPrefixesClient.BeginCreateOrUpdate
@@ -8377,76 +8377,76 @@ type PublicIPPrefixesClientUpdateTagsOptions struct {
 // QueryTroubleshootingParameters - Parameters that define the resource to query the troubleshooting result.
 type QueryTroubleshootingParameters struct {
 	// REQUIRED; The target resource ID to query the troubleshooting result.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 }
 
 // RadiusServer - Radius Server Settings.
 type RadiusServer struct {
 	// REQUIRED; The address of this radius server.
-	RadiusServerAddress *string `json:"radiusServerAddress,omitempty"`
+	RadiusServerAddress *string
 
 	// The initial score assigned to this radius server.
-	RadiusServerScore *int64 `json:"radiusServerScore,omitempty"`
+	RadiusServerScore *int64
 
 	// The secret used for this radius server.
-	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
+	RadiusServerSecret *string
 }
 
 // RecordSet - A collective group of information about the record set information.
 type RecordSet struct {
 	// Fqdn that resolves to private endpoint ip address.
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// The private ip address of the private endpoint.
-	IPAddresses []*string `json:"ipAddresses,omitempty"`
+	IPAddresses []*string
 
 	// Recordset name.
-	RecordSetName *string `json:"recordSetName,omitempty"`
+	RecordSetName *string
 
 	// Resource record type.
-	RecordType *string `json:"recordType,omitempty"`
+	RecordType *string
 
 	// Recordset time to live.
-	TTL *int32 `json:"ttl,omitempty"`
+	TTL *int32
 
 	// READ-ONLY; The provisioning state of the recordset.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ReferencedPublicIPAddress - Reference to a public IP address.
 type ReferencedPublicIPAddress struct {
 	// The PublicIPAddress Reference.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // ResourceNavigationLink resource.
 type ResourceNavigationLink struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource navigation link properties format.
-	Properties *ResourceNavigationLinkFormat `json:"properties,omitempty"`
+	Properties *ResourceNavigationLinkFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ResourceNavigationLinkFormat - Properties of ResourceNavigationLink.
 type ResourceNavigationLinkFormat struct {
 	// Link to the external resource.
-	Link *string `json:"link,omitempty"`
+	Link *string
 
 	// Resource type of the linked resource.
-	LinkedResourceType *string `json:"linkedResourceType,omitempty"`
+	LinkedResourceType *string
 
 	// READ-ONLY; The provisioning state of the resource navigation link resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ResourceNavigationLinksClientListOptions contains the optional parameters for the ResourceNavigationLinksClient.List method.
@@ -8457,124 +8457,124 @@ type ResourceNavigationLinksClientListOptions struct {
 // ResourceNavigationLinksListResult - Response for ResourceNavigationLinks_List operation.
 type ResourceNavigationLinksListResult struct {
 	// The resource navigation links in a subnet.
-	Value []*ResourceNavigationLink `json:"value,omitempty"`
+	Value []*ResourceNavigationLink
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // RetentionPolicyParameters - Parameters that define the retention policy for flow log.
 type RetentionPolicyParameters struct {
 	// Number of days to retain flow log records.
-	Days *int32 `json:"days,omitempty"`
+	Days *int32
 
 	// Flag to enable/disable retention.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 }
 
 // Route resource.
 type Route struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the route.
-	Properties *RoutePropertiesFormat `json:"properties,omitempty"`
+	Properties *RoutePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // RouteFilter - Route Filter Resource.
 type RouteFilter struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the route filter.
-	Properties *RouteFilterPropertiesFormat `json:"properties,omitempty"`
+	Properties *RouteFilterPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // RouteFilterListResult - Response for the ListRouteFilters API service call.
 type RouteFilterListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of route filters in a resource group.
-	Value []*RouteFilter `json:"value,omitempty"`
+	Value []*RouteFilter
 }
 
 // RouteFilterPropertiesFormat - Route Filter Resource.
 type RouteFilterPropertiesFormat struct {
 	// Collection of RouteFilterRules contained within a route filter.
-	Rules []*RouteFilterRule `json:"rules,omitempty"`
+	Rules []*RouteFilterRule
 
 	// READ-ONLY; A collection of references to express route circuit ipv6 peerings.
-	IPv6Peerings []*ExpressRouteCircuitPeering `json:"ipv6Peerings,omitempty" azure:"ro"`
+	IPv6Peerings []*ExpressRouteCircuitPeering
 
 	// READ-ONLY; A collection of references to express route circuit peerings.
-	Peerings []*ExpressRouteCircuitPeering `json:"peerings,omitempty" azure:"ro"`
+	Peerings []*ExpressRouteCircuitPeering
 
 	// READ-ONLY; The provisioning state of the route filter resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // RouteFilterRule - Route Filter Rule Resource.
 type RouteFilterRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the route filter rule.
-	Properties *RouteFilterRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *RouteFilterRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // RouteFilterRuleListResult - Response for the ListRouteFilterRules API service call.
 type RouteFilterRuleListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of RouteFilterRules in a resource group.
-	Value []*RouteFilterRule `json:"value,omitempty"`
+	Value []*RouteFilterRule
 }
 
 // RouteFilterRulePropertiesFormat - Route Filter Rule Resource.
 type RouteFilterRulePropertiesFormat struct {
 	// REQUIRED; The access type of the rule.
-	Access *Access `json:"access,omitempty"`
+	Access *Access
 
 	// REQUIRED; The collection for bgp community values to filter on. e.g. ['12076:5010','12076:5020'].
-	Communities []*string `json:"communities,omitempty"`
+	Communities []*string
 
 	// REQUIRED; The rule type of the rule.
-	RouteFilterRuleType *RouteFilterRuleType `json:"routeFilterRuleType,omitempty"`
+	RouteFilterRuleType *RouteFilterRuleType
 
 	// READ-ONLY; The provisioning state of the route filter rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // RouteFilterRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteFilterRulesClient.BeginCreateOrUpdate
@@ -8639,73 +8639,73 @@ type RouteFiltersClientUpdateTagsOptions struct {
 // RouteListResult - Response for the ListRoute API service call.
 type RouteListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of routes in a resource group.
-	Value []*Route `json:"value,omitempty"`
+	Value []*Route
 }
 
 // RoutePropertiesFormat - Route resource.
 type RoutePropertiesFormat struct {
 	// REQUIRED; The type of Azure hop the packet should be sent to.
-	NextHopType *RouteNextHopType `json:"nextHopType,omitempty"`
+	NextHopType *RouteNextHopType
 
 	// The destination CIDR to which the route applies.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance.
-	NextHopIPAddress *string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress *string
 
 	// READ-ONLY; The provisioning state of the route resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // RouteTable - Route table resource.
 type RouteTable struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the route table.
-	Properties *RouteTablePropertiesFormat `json:"properties,omitempty"`
+	Properties *RouteTablePropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // RouteTableListResult - Response for the ListRouteTable API service call.
 type RouteTableListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of route tables in a resource group.
-	Value []*RouteTable `json:"value,omitempty"`
+	Value []*RouteTable
 }
 
 // RouteTablePropertiesFormat - Route Table resource.
 type RouteTablePropertiesFormat struct {
 	// Whether to disable the routes learned by BGP on that route table. True means disable.
-	DisableBgpRoutePropagation *bool `json:"disableBgpRoutePropagation,omitempty"`
+	DisableBgpRoutePropagation *bool
 
 	// Collection of routes contained within a route table.
-	Routes []*Route `json:"routes,omitempty"`
+	Routes []*Route
 
 	// READ-ONLY; The provisioning state of the route table resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet
 }
 
 // RouteTablesClientBeginCreateOrUpdateOptions contains the optional parameters for the RouteTablesClient.BeginCreateOrUpdate
@@ -8767,31 +8767,31 @@ type RoutesClientListOptions struct {
 // RuleCondition - Rule condition of type network.
 type RuleCondition struct {
 	// REQUIRED; Rule Condition Type.
-	RuleConditionType *FirewallPolicyRuleConditionType `json:"ruleConditionType,omitempty"`
+	RuleConditionType *FirewallPolicyRuleConditionType
 
 	// Description of the rule condition.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of destination IP addresses or Service Tags.
-	DestinationAddresses []*string `json:"destinationAddresses,omitempty"`
+	DestinationAddresses []*string
 
 	// List of destination IpGroups for this rule.
-	DestinationIPGroups []*string `json:"destinationIpGroups,omitempty"`
+	DestinationIPGroups []*string
 
 	// List of destination ports.
-	DestinationPorts []*string `json:"destinationPorts,omitempty"`
+	DestinationPorts []*string
 
 	// Array of FirewallPolicyRuleConditionNetworkProtocols.
-	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol `json:"ipProtocols,omitempty"`
+	IPProtocols []*FirewallPolicyRuleConditionNetworkProtocol
 
 	// Name of the rule condition.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// List of source IP addresses for this rule.
-	SourceAddresses []*string `json:"sourceAddresses,omitempty"`
+	SourceAddresses []*string
 
 	// List of source IpGroups for this rule.
-	SourceIPGroups []*string `json:"sourceIpGroups,omitempty"`
+	SourceIPGroups []*string
 }
 
 // GetFirewallPolicyRuleCondition implements the FirewallPolicyRuleConditionClassification interface for type RuleCondition.
@@ -8806,88 +8806,88 @@ func (r *RuleCondition) GetFirewallPolicyRuleCondition() *FirewallPolicyRuleCond
 // SecurityGroup - NetworkSecurityGroup resource.
 type SecurityGroup struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the network security group.
-	Properties *SecurityGroupPropertiesFormat `json:"properties,omitempty"`
+	Properties *SecurityGroupPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SecurityGroupListResult - Response for ListNetworkSecurityGroups API service call.
 type SecurityGroupListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of NetworkSecurityGroup resources.
-	Value []*SecurityGroup `json:"value,omitempty"`
+	Value []*SecurityGroup
 }
 
 // SecurityGroupNetworkInterface - Network interface and all its associated security rules.
 type SecurityGroupNetworkInterface struct {
 	// ID of the network interface.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// All security rules associated with the network interface.
-	SecurityRuleAssociations *SecurityRuleAssociations `json:"securityRuleAssociations,omitempty"`
+	SecurityRuleAssociations *SecurityRuleAssociations
 }
 
 // SecurityGroupPropertiesFormat - Network Security Group resource.
 type SecurityGroupPropertiesFormat struct {
 	// A collection of security rules of the network security group.
-	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule
 
 	// READ-ONLY; The default security rules of network security group.
-	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty" azure:"ro"`
+	DefaultSecurityRules []*SecurityRule
 
 	// READ-ONLY; A collection of references to flow log resources.
-	FlowLogs []*FlowLog `json:"flowLogs,omitempty" azure:"ro"`
+	FlowLogs []*FlowLog
 
 	// READ-ONLY; A collection of references to network interfaces.
-	NetworkInterfaces []*Interface `json:"networkInterfaces,omitempty" azure:"ro"`
+	NetworkInterfaces []*Interface
 
 	// READ-ONLY; The provisioning state of the network security group resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the network security group resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet
 }
 
 // SecurityGroupResult - Network configuration diagnostic result corresponded provided traffic query.
 type SecurityGroupResult struct {
 	// The network traffic is allowed or denied.
-	SecurityRuleAccessResult *SecurityRuleAccess `json:"securityRuleAccessResult,omitempty"`
+	SecurityRuleAccessResult *SecurityRuleAccess
 
 	// READ-ONLY; List of results network security groups diagnostic.
-	EvaluatedNetworkSecurityGroups []*EvaluatedNetworkSecurityGroup `json:"evaluatedNetworkSecurityGroups,omitempty" azure:"ro"`
+	EvaluatedNetworkSecurityGroups []*EvaluatedNetworkSecurityGroup
 }
 
 // SecurityGroupViewParameters - Parameters that define the VM to check security groups for.
 type SecurityGroupViewParameters struct {
 	// REQUIRED; ID of the target VM.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 }
 
 // SecurityGroupViewResult - The information about security rules applied to the specified VM.
 type SecurityGroupViewResult struct {
 	// List of network interfaces on the specified VM.
-	NetworkInterfaces []*SecurityGroupNetworkInterface `json:"networkInterfaces,omitempty"`
+	NetworkInterfaces []*SecurityGroupNetworkInterface
 }
 
 // SecurityGroupsClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityGroupsClient.BeginCreateOrUpdate
@@ -8927,49 +8927,49 @@ type SecurityGroupsClientUpdateTagsOptions struct {
 // SecurityPartnerProvider - Security Partner Provider resource.
 type SecurityPartnerProvider struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the Security Partner Provider.
-	Properties *SecurityPartnerProviderPropertiesFormat `json:"properties,omitempty"`
+	Properties *SecurityPartnerProviderPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SecurityPartnerProviderListResult - Response for ListSecurityPartnerProviders API service call.
 type SecurityPartnerProviderListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Security Partner Providers in a resource group.
-	Value []*SecurityPartnerProvider `json:"value,omitempty"`
+	Value []*SecurityPartnerProvider
 }
 
 // SecurityPartnerProviderPropertiesFormat - Properties of the Security Partner Provider.
 type SecurityPartnerProviderPropertiesFormat struct {
 	// The security provider name.
-	SecurityProviderName *SecurityProviderName `json:"securityProviderName,omitempty"`
+	SecurityProviderName *SecurityProviderName
 
 	// The virtualHub to which the Security Partner Provider belongs.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+	VirtualHub *SubResource
 
 	// READ-ONLY; The connection status with the Security Partner Provider.
-	ConnectionStatus *SecurityPartnerProviderConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *SecurityPartnerProviderConnectionStatus
 
 	// READ-ONLY; The provisioning state of the Security Partner Provider resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // SecurityPartnerProvidersClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityPartnerProvidersClient.BeginCreateOrUpdate
@@ -9012,97 +9012,97 @@ type SecurityPartnerProvidersClientUpdateTagsOptions struct {
 // SecurityRule - Network security rule.
 type SecurityRule struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the security rule.
-	Properties *SecurityRulePropertiesFormat `json:"properties,omitempty"`
+	Properties *SecurityRulePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // SecurityRuleAssociations - All security rules associated with the network interface.
 type SecurityRuleAssociations struct {
 	// Collection of default security rules of the network security group.
-	DefaultSecurityRules []*SecurityRule `json:"defaultSecurityRules,omitempty"`
+	DefaultSecurityRules []*SecurityRule
 
 	// Collection of effective security rules.
-	EffectiveSecurityRules []*EffectiveNetworkSecurityRule `json:"effectiveSecurityRules,omitempty"`
+	EffectiveSecurityRules []*EffectiveNetworkSecurityRule
 
 	// Network interface and it's custom security rules.
-	NetworkInterfaceAssociation *InterfaceAssociation `json:"networkInterfaceAssociation,omitempty"`
+	NetworkInterfaceAssociation *InterfaceAssociation
 
 	// Subnet and it's custom security rules.
-	SubnetAssociation *SubnetAssociation `json:"subnetAssociation,omitempty"`
+	SubnetAssociation *SubnetAssociation
 }
 
 // SecurityRuleListResult - Response for ListSecurityRule API service call. Retrieves all security rules that belongs to a
 // network security group.
 type SecurityRuleListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The security rules in a network security group.
-	Value []*SecurityRule `json:"value,omitempty"`
+	Value []*SecurityRule
 }
 
 // SecurityRulePropertiesFormat - Security rule resource.
 type SecurityRulePropertiesFormat struct {
 	// REQUIRED; The network traffic is allowed or denied.
-	Access *SecurityRuleAccess `json:"access,omitempty"`
+	Access *SecurityRuleAccess
 
 	// REQUIRED; The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.
-	Direction *SecurityRuleDirection `json:"direction,omitempty"`
+	Direction *SecurityRuleDirection
 
 	// REQUIRED; Network protocol this rule applies to.
-	Protocol *SecurityRuleProtocol `json:"protocol,omitempty"`
+	Protocol *SecurityRuleProtocol
 
 	// A description for this rule. Restricted to 140 chars.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default
 	// tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also
 	// be used.
-	DestinationAddressPrefix *string `json:"destinationAddressPrefix,omitempty"`
+	DestinationAddressPrefix *string
 
 	// The destination address prefixes. CIDR or destination IP ranges.
-	DestinationAddressPrefixes []*string `json:"destinationAddressPrefixes,omitempty"`
+	DestinationAddressPrefixes []*string
 
 	// The application security group specified as destination.
-	DestinationApplicationSecurityGroups []*ApplicationSecurityGroup `json:"destinationApplicationSecurityGroups,omitempty"`
+	DestinationApplicationSecurityGroups []*ApplicationSecurityGroup
 
 	// The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
-	DestinationPortRange *string `json:"destinationPortRange,omitempty"`
+	DestinationPortRange *string
 
 	// The destination port ranges.
-	DestinationPortRanges []*string `json:"destinationPortRanges,omitempty"`
+	DestinationPortRanges []*string
 
 	// The priority of the rule. The value can be between 100 and 4096. The priority number must be unique for each rule in the
 	// collection. The lower the priority number, the higher the priority of the rule.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork',
 	// 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress
 	// rule, specifies where network traffic originates from.
-	SourceAddressPrefix *string `json:"sourceAddressPrefix,omitempty"`
+	SourceAddressPrefix *string
 
 	// The CIDR or source IP ranges.
-	SourceAddressPrefixes []*string `json:"sourceAddressPrefixes,omitempty"`
+	SourceAddressPrefixes []*string
 
 	// The application security group specified as source.
-	SourceApplicationSecurityGroups []*ApplicationSecurityGroup `json:"sourceApplicationSecurityGroups,omitempty"`
+	SourceApplicationSecurityGroups []*ApplicationSecurityGroup
 
 	// The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports.
-	SourcePortRange *string `json:"sourcePortRange,omitempty"`
+	SourcePortRange *string
 
 	// The source port ranges.
-	SourcePortRanges []*string `json:"sourcePortRanges,omitempty"`
+	SourcePortRanges []*string
 
 	// READ-ONLY; The provisioning state of the security rule resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // SecurityRulesClientBeginCreateOrUpdateOptions contains the optional parameters for the SecurityRulesClient.BeginCreateOrUpdate
@@ -9131,58 +9131,58 @@ type SecurityRulesClientListOptions struct {
 // SecurityRulesEvaluationResult - Network security rules evaluation result.
 type SecurityRulesEvaluationResult struct {
 	// Value indicating whether destination is matched.
-	DestinationMatched *bool `json:"destinationMatched,omitempty"`
+	DestinationMatched *bool
 
 	// Value indicating whether destination port is matched.
-	DestinationPortMatched *bool `json:"destinationPortMatched,omitempty"`
+	DestinationPortMatched *bool
 
 	// Name of the network security rule.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Value indicating whether protocol is matched.
-	ProtocolMatched *bool `json:"protocolMatched,omitempty"`
+	ProtocolMatched *bool
 
 	// Value indicating whether source is matched.
-	SourceMatched *bool `json:"sourceMatched,omitempty"`
+	SourceMatched *bool
 
 	// Value indicating whether source port is matched.
-	SourcePortMatched *bool `json:"sourcePortMatched,omitempty"`
+	SourcePortMatched *bool
 }
 
 // ServiceAssociationLink resource.
 type ServiceAssociationLink struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Resource navigation link properties format.
-	Properties *ServiceAssociationLinkPropertiesFormat `json:"properties,omitempty"`
+	Properties *ServiceAssociationLinkPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ServiceAssociationLinkPropertiesFormat - Properties of ServiceAssociationLink.
 type ServiceAssociationLinkPropertiesFormat struct {
 	// If true, the resource can be deleted.
-	AllowDelete *bool `json:"allowDelete,omitempty"`
+	AllowDelete *bool
 
 	// Link to the external resource.
-	Link *string `json:"link,omitempty"`
+	Link *string
 
 	// Resource type of the linked resource.
-	LinkedResourceType *string `json:"linkedResourceType,omitempty"`
+	LinkedResourceType *string
 
 	// A list of locations.
-	Locations []*string `json:"locations,omitempty"`
+	Locations []*string
 
 	// READ-ONLY; The provisioning state of the service association link resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ServiceAssociationLinksClientListOptions contains the optional parameters for the ServiceAssociationLinksClient.List method.
@@ -9193,22 +9193,22 @@ type ServiceAssociationLinksClientListOptions struct {
 // ServiceAssociationLinksListResult - Response for ServiceAssociationLinks_List operation.
 type ServiceAssociationLinksListResult struct {
 	// The service association links in a subnet.
-	Value []*ServiceAssociationLink `json:"value,omitempty"`
+	Value []*ServiceAssociationLink
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ServiceDelegationPropertiesFormat - Properties of a service delegation.
 type ServiceDelegationPropertiesFormat struct {
 	// The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers).
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName *string
 
 	// READ-ONLY; The actions permitted to the service upon delegation.
-	Actions []*string `json:"actions,omitempty" azure:"ro"`
+	Actions []*string
 
 	// READ-ONLY; The provisioning state of the service delegation resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ServiceEndpointPoliciesClientBeginCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPoliciesClient.BeginCreateOrUpdate
@@ -9252,65 +9252,65 @@ type ServiceEndpointPoliciesClientUpdateTagsOptions struct {
 // ServiceEndpointPolicy - Service End point policy resource.
 type ServiceEndpointPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the service end point policy.
-	Properties *ServiceEndpointPolicyPropertiesFormat `json:"properties,omitempty"`
+	Properties *ServiceEndpointPolicyPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ServiceEndpointPolicyDefinition - Service Endpoint policy definitions.
 type ServiceEndpointPolicyDefinition struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the service endpoint policy definition.
-	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat `json:"properties,omitempty"`
+	Properties *ServiceEndpointPolicyDefinitionPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // ServiceEndpointPolicyDefinitionListResult - Response for ListServiceEndpointPolicyDefinition API service call. Retrieves
 // all service endpoint policy definition that belongs to a service endpoint policy.
 type ServiceEndpointPolicyDefinitionListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The service endpoint policy definition in a service endpoint policy.
-	Value []*ServiceEndpointPolicyDefinition `json:"value,omitempty"`
+	Value []*ServiceEndpointPolicyDefinition
 }
 
 // ServiceEndpointPolicyDefinitionPropertiesFormat - Service Endpoint policy definition resource.
 type ServiceEndpointPolicyDefinitionPropertiesFormat struct {
 	// A description for this rule. Restricted to 140 chars.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Service endpoint name.
-	Service *string `json:"service,omitempty"`
+	Service *string
 
 	// A list of service resources.
-	ServiceResources []*string `json:"serviceResources,omitempty"`
+	ServiceResources []*string
 
 	// READ-ONLY; The provisioning state of the service endpoint policy definition resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ServiceEndpointPolicyDefinitionsClientBeginCreateOrUpdateOptions contains the optional parameters for the ServiceEndpointPolicyDefinitionsClient.BeginCreateOrUpdate
@@ -9342,64 +9342,64 @@ type ServiceEndpointPolicyDefinitionsClientListByResourceGroupOptions struct {
 // ServiceEndpointPolicyListResult - Response for ListServiceEndpointPolicies API service call.
 type ServiceEndpointPolicyListResult struct {
 	// A list of ServiceEndpointPolicy resources.
-	Value []*ServiceEndpointPolicy `json:"value,omitempty"`
+	Value []*ServiceEndpointPolicy
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // ServiceEndpointPolicyPropertiesFormat - Service Endpoint Policy resource.
 type ServiceEndpointPolicyPropertiesFormat struct {
 	// A collection of service endpoint policy definitions of the service endpoint policy.
-	ServiceEndpointPolicyDefinitions []*ServiceEndpointPolicyDefinition `json:"serviceEndpointPolicyDefinitions,omitempty"`
+	ServiceEndpointPolicyDefinitions []*ServiceEndpointPolicyDefinition
 
 	// READ-ONLY; The provisioning state of the service endpoint policy resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the service endpoint policy resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; A collection of references to subnets.
-	Subnets []*Subnet `json:"subnets,omitempty" azure:"ro"`
+	Subnets []*Subnet
 }
 
 // ServiceEndpointPropertiesFormat - The service endpoint properties.
 type ServiceEndpointPropertiesFormat struct {
 	// A list of locations.
-	Locations []*string `json:"locations,omitempty"`
+	Locations []*string
 
 	// The type of the endpoint service.
-	Service *string `json:"service,omitempty"`
+	Service *string
 
 	// READ-ONLY; The provisioning state of the service endpoint resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // ServiceTagInformation - The service tag information.
 type ServiceTagInformation struct {
 	// READ-ONLY; The ID of service tag.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of service tag.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Properties of the service tag information.
-	Properties *ServiceTagInformationPropertiesFormat `json:"properties,omitempty" azure:"ro"`
+	Properties *ServiceTagInformationPropertiesFormat
 }
 
 // ServiceTagInformationPropertiesFormat - Properties of the service tag information.
 type ServiceTagInformationPropertiesFormat struct {
 	// READ-ONLY; The list of IP address prefixes.
-	AddressPrefixes []*string `json:"addressPrefixes,omitempty" azure:"ro"`
+	AddressPrefixes []*string
 
 	// READ-ONLY; The iteration number of service tag.
-	ChangeNumber *string `json:"changeNumber,omitempty" azure:"ro"`
+	ChangeNumber *string
 
 	// READ-ONLY; The region of service tag.
-	Region *string `json:"region,omitempty" azure:"ro"`
+	Region *string
 
 	// READ-ONLY; The name of system service.
-	SystemService *string `json:"systemService,omitempty" azure:"ro"`
+	SystemService *string
 }
 
 // ServiceTagsClientListOptions contains the optional parameters for the ServiceTagsClient.List method.
@@ -9410,125 +9410,125 @@ type ServiceTagsClientListOptions struct {
 // ServiceTagsListResult - Response for the ListServiceTags API service call.
 type ServiceTagsListResult struct {
 	// READ-ONLY; The iteration number.
-	ChangeNumber *string `json:"changeNumber,omitempty" azure:"ro"`
+	ChangeNumber *string
 
 	// READ-ONLY; The name of the cloud.
-	Cloud *string `json:"cloud,omitempty" azure:"ro"`
+	Cloud *string
 
 	// READ-ONLY; The ID of the cloud.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the cloud.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The azure resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; The list of service tag information resources.
-	Values []*ServiceTagInformation `json:"values,omitempty" azure:"ro"`
+	Values []*ServiceTagInformation
 }
 
 // SessionIDs - List of session IDs.
 type SessionIDs struct {
 	// List of session IDs.
-	SessionIDs []*string `json:"sessionIds,omitempty"`
+	SessionIDs []*string
 }
 
 // SubResource - Reference to another subresource.
 type SubResource struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // Subnet in a virtual network resource.
 type Subnet struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the subnet.
-	Properties *SubnetPropertiesFormat `json:"properties,omitempty"`
+	Properties *SubnetPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // SubnetAssociation - Subnet and it's custom security rules.
 type SubnetAssociation struct {
 	// Collection of custom security rules.
-	SecurityRules []*SecurityRule `json:"securityRules,omitempty"`
+	SecurityRules []*SecurityRule
 
 	// READ-ONLY; Subnet ID.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // SubnetListResult - Response for ListSubnets API service callRetrieves all subnet that belongs to a virtual network.
 type SubnetListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The subnets in a virtual network.
-	Value []*Subnet `json:"value,omitempty"`
+	Value []*Subnet
 }
 
 // SubnetPropertiesFormat - Properties of the subnet.
 type SubnetPropertiesFormat struct {
 	// The address prefix for the subnet.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// List of address prefixes for the subnet.
-	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string
 
 	// An array of references to the delegations on the subnet.
-	Delegations []*Delegation `json:"delegations,omitempty"`
+	Delegations []*Delegation
 
 	// Array of IpAllocation which reference this subnet.
-	IPAllocations []*SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations []*SubResource
 
 	// Nat gateway associated with this subnet.
-	NatGateway *SubResource `json:"natGateway,omitempty"`
+	NatGateway *SubResource
 
 	// The reference to the NetworkSecurityGroup resource.
-	NetworkSecurityGroup *SecurityGroup `json:"networkSecurityGroup,omitempty"`
+	NetworkSecurityGroup *SecurityGroup
 
 	// Enable or Disable apply network policies on private end point in the subnet.
-	PrivateEndpointNetworkPolicies *string `json:"privateEndpointNetworkPolicies,omitempty"`
+	PrivateEndpointNetworkPolicies *string
 
 	// Enable or Disable apply network policies on private link service in the subnet.
-	PrivateLinkServiceNetworkPolicies *string `json:"privateLinkServiceNetworkPolicies,omitempty"`
+	PrivateLinkServiceNetworkPolicies *string
 
 	// The reference to the RouteTable resource.
-	RouteTable *RouteTable `json:"routeTable,omitempty"`
+	RouteTable *RouteTable
 
 	// An array of service endpoint policies.
-	ServiceEndpointPolicies []*ServiceEndpointPolicy `json:"serviceEndpointPolicies,omitempty"`
+	ServiceEndpointPolicies []*ServiceEndpointPolicy
 
 	// An array of service endpoints.
-	ServiceEndpoints []*ServiceEndpointPropertiesFormat `json:"serviceEndpoints,omitempty"`
+	ServiceEndpoints []*ServiceEndpointPropertiesFormat
 
 	// READ-ONLY; Array of IP configuration profiles which reference this subnet.
-	IPConfigurationProfiles []*IPConfigurationProfile `json:"ipConfigurationProfiles,omitempty" azure:"ro"`
+	IPConfigurationProfiles []*IPConfigurationProfile
 
 	// READ-ONLY; An array of references to the network interface IP configurations using subnet.
-	IPConfigurations []*IPConfiguration `json:"ipConfigurations,omitempty" azure:"ro"`
+	IPConfigurations []*IPConfiguration
 
 	// READ-ONLY; An array of references to private endpoints.
-	PrivateEndpoints []*PrivateEndpoint `json:"privateEndpoints,omitempty" azure:"ro"`
+	PrivateEndpoints []*PrivateEndpoint
 
 	// READ-ONLY; The provisioning state of the subnet resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; A read-only string identifying the intention of use for this subnet based on delegations and other user-defined
 	// properties.
-	Purpose *string `json:"purpose,omitempty" azure:"ro"`
+	Purpose *string
 
 	// READ-ONLY; An array of references to the external resources using subnet.
-	ResourceNavigationLinks []*ResourceNavigationLink `json:"resourceNavigationLinks,omitempty" azure:"ro"`
+	ResourceNavigationLinks []*ResourceNavigationLink
 
 	// READ-ONLY; An array of references to services injecting into this subnet.
-	ServiceAssociationLinks []*ServiceAssociationLink `json:"serviceAssociationLinks,omitempty" azure:"ro"`
+	ServiceAssociationLinks []*ServiceAssociationLink
 }
 
 // SubnetsClientBeginCreateOrUpdateOptions contains the optional parameters for the SubnetsClient.BeginCreateOrUpdate method.
@@ -9571,211 +9571,211 @@ type SubnetsClientListOptions struct {
 // TagsObject - Tags object for patch operations.
 type TagsObject struct {
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // Topology of the specified resource group.
 type Topology struct {
 	// A list of topology resources.
-	Resources []*TopologyResource `json:"resources,omitempty"`
+	Resources []*TopologyResource
 
 	// READ-ONLY; The datetime when the topology was initially created for the resource group.
-	CreatedDateTime *time.Time `json:"createdDateTime,omitempty" azure:"ro"`
+	CreatedDateTime *time.Time
 
 	// READ-ONLY; GUID representing the operation id.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The datetime when the topology was last modified.
-	LastModified *time.Time `json:"lastModified,omitempty" azure:"ro"`
+	LastModified *time.Time
 }
 
 // TopologyAssociation - Resources that have an association with the parent resource.
 type TopologyAssociation struct {
 	// The association type of the child resource to the parent resource.
-	AssociationType *AssociationType `json:"associationType,omitempty"`
+	AssociationType *AssociationType
 
 	// The name of the resource that is associated with the parent resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The ID of the resource that is associated with the parent resource.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 }
 
 // TopologyParameters - Parameters that define the representation of topology.
 type TopologyParameters struct {
 	// The name of the target resource group to perform topology on.
-	TargetResourceGroupName *string `json:"targetResourceGroupName,omitempty"`
+	TargetResourceGroupName *string
 
 	// The reference to the Subnet resource.
-	TargetSubnet *SubResource `json:"targetSubnet,omitempty"`
+	TargetSubnet *SubResource
 
 	// The reference to the Virtual Network resource.
-	TargetVirtualNetwork *SubResource `json:"targetVirtualNetwork,omitempty"`
+	TargetVirtualNetwork *SubResource
 }
 
 // TopologyResource - The network resource topology information for the given resource group.
 type TopologyResource struct {
 	// Holds the associations the resource has with other resources in the resource group.
-	Associations []*TopologyAssociation `json:"associations,omitempty"`
+	Associations []*TopologyAssociation
 
 	// ID of the resource.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Name of the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // TrafficAnalyticsConfigurationProperties - Parameters that define the configuration of traffic analytics.
 type TrafficAnalyticsConfigurationProperties struct {
 	// Flag to enable/disable traffic analytics.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// The interval in minutes which would decide how frequently TA service should do flow analytics.
-	TrafficAnalyticsInterval *int32 `json:"trafficAnalyticsInterval,omitempty"`
+	TrafficAnalyticsInterval *int32
 
 	// The resource guid of the attached workspace.
-	WorkspaceID *string `json:"workspaceId,omitempty"`
+	WorkspaceID *string
 
 	// The location of the attached workspace.
-	WorkspaceRegion *string `json:"workspaceRegion,omitempty"`
+	WorkspaceRegion *string
 
 	// Resource Id of the attached workspace.
-	WorkspaceResourceID *string `json:"workspaceResourceId,omitempty"`
+	WorkspaceResourceID *string
 }
 
 // TrafficAnalyticsProperties - Parameters that define the configuration of traffic analytics.
 type TrafficAnalyticsProperties struct {
 	// Parameters that define the configuration of traffic analytics.
-	NetworkWatcherFlowAnalyticsConfiguration *TrafficAnalyticsConfigurationProperties `json:"networkWatcherFlowAnalyticsConfiguration,omitempty"`
+	NetworkWatcherFlowAnalyticsConfiguration *TrafficAnalyticsConfigurationProperties
 }
 
 // TrafficSelectorPolicy - An traffic selector policy for a virtual network gateway connection.
 type TrafficSelectorPolicy struct {
 	// REQUIRED; A collection of local address spaces in CIDR format.
-	LocalAddressRanges []*string `json:"localAddressRanges,omitempty"`
+	LocalAddressRanges []*string
 
 	// REQUIRED; A collection of remote address spaces in CIDR format.
-	RemoteAddressRanges []*string `json:"remoteAddressRanges,omitempty"`
+	RemoteAddressRanges []*string
 }
 
 // TroubleshootingDetails - Information gained from troubleshooting of specified resource.
 type TroubleshootingDetails struct {
 	// Details on troubleshooting results.
-	Detail *string `json:"detail,omitempty"`
+	Detail *string
 
 	// The id of the get troubleshoot operation.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Reason type of failure.
-	ReasonType *string `json:"reasonType,omitempty"`
+	ReasonType *string
 
 	// List of recommended actions.
-	RecommendedActions []*TroubleshootingRecommendedActions `json:"recommendedActions,omitempty"`
+	RecommendedActions []*TroubleshootingRecommendedActions
 
 	// A summary of troubleshooting.
-	Summary *string `json:"summary,omitempty"`
+	Summary *string
 }
 
 // TroubleshootingParameters - Parameters that define the resource to troubleshoot.
 type TroubleshootingParameters struct {
 	// REQUIRED; Properties of the troubleshooting resource.
-	Properties *TroubleshootingProperties `json:"properties,omitempty"`
+	Properties *TroubleshootingProperties
 
 	// REQUIRED; The target resource to troubleshoot.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 }
 
 // TroubleshootingProperties - Storage location provided for troubleshoot.
 type TroubleshootingProperties struct {
 	// REQUIRED; The ID for the storage account to save the troubleshoot result.
-	StorageID *string `json:"storageId,omitempty"`
+	StorageID *string
 
 	// REQUIRED; The path to the blob to save the troubleshoot result in.
-	StoragePath *string `json:"storagePath,omitempty"`
+	StoragePath *string
 }
 
 // TroubleshootingRecommendedActions - Recommended actions based on discovered issues.
 type TroubleshootingRecommendedActions struct {
 	// ID of the recommended action.
-	ActionID *string `json:"actionId,omitempty"`
+	ActionID *string
 
 	// Description of recommended actions.
-	ActionText *string `json:"actionText,omitempty"`
+	ActionText *string
 
 	// The uri linking to a documentation for the recommended troubleshooting actions.
-	ActionURI *string `json:"actionUri,omitempty"`
+	ActionURI *string
 
 	// The information from the URI for the recommended troubleshooting actions.
-	ActionURIText *string `json:"actionUriText,omitempty"`
+	ActionURIText *string
 }
 
 // TroubleshootingResult - Troubleshooting information gained from specified resource.
 type TroubleshootingResult struct {
 	// The result code of the troubleshooting.
-	Code *string `json:"code,omitempty"`
+	Code *string
 
 	// The end time of the troubleshooting.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Information from troubleshooting.
-	Results []*TroubleshootingDetails `json:"results,omitempty"`
+	Results []*TroubleshootingDetails
 
 	// The start time of the troubleshooting.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 }
 
 // TunnelConnectionHealth - VirtualNetworkGatewayConnection properties.
 type TunnelConnectionHealth struct {
 	// READ-ONLY; Virtual Network Gateway connection status.
-	ConnectionStatus *VirtualNetworkGatewayConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *VirtualNetworkGatewayConnectionStatus
 
 	// READ-ONLY; The Egress Bytes Transferred in this connection.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; The Ingress Bytes Transferred in this connection.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The time at which connection was established in Utc format.
-	LastConnectionEstablishedUTCTime *string `json:"lastConnectionEstablishedUtcTime,omitempty" azure:"ro"`
+	LastConnectionEstablishedUTCTime *string
 
 	// READ-ONLY; Tunnel name.
-	Tunnel *string `json:"tunnel,omitempty" azure:"ro"`
+	Tunnel *string
 }
 
 // UnprepareNetworkPoliciesRequest - Details of UnprepareNetworkPolicies for Subnet.
 type UnprepareNetworkPoliciesRequest struct {
 	// The name of the service for which subnet is being unprepared for.
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName *string
 }
 
 // Usage - The network resource usage.
 type Usage struct {
 	// REQUIRED; The current value of the usage.
-	CurrentValue *int64 `json:"currentValue,omitempty"`
+	CurrentValue *int64
 
 	// REQUIRED; The limit of usage.
-	Limit *int64 `json:"limit,omitempty"`
+	Limit *int64
 
 	// REQUIRED; The name of the type of usage.
-	Name *UsageName `json:"name,omitempty"`
+	Name *UsageName
 
 	// REQUIRED; An enum describing the unit of measurement.
-	Unit *UsageUnit `json:"unit,omitempty"`
+	Unit *UsageUnit
 
 	// READ-ONLY; Resource identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // UsageName - The usage names.
 type UsageName struct {
 	// A localized string describing the resource name.
-	LocalizedValue *string `json:"localizedValue,omitempty"`
+	LocalizedValue *string
 
 	// A string describing the resource name.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // UsagesClientListOptions contains the optional parameters for the UsagesClient.NewListPager method.
@@ -9786,286 +9786,286 @@ type UsagesClientListOptions struct {
 // UsagesListResult - The list usages operation response.
 type UsagesListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The list network resource usages.
-	Value []*Usage `json:"value,omitempty"`
+	Value []*Usage
 }
 
 // VM - Describes a Virtual Machine.
 type VM struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNClientConfiguration - VpnClientConfiguration for P2S client.
 type VPNClientConfiguration struct {
 	// The AADAudience property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication.
-	AADAudience *string `json:"aadAudience,omitempty"`
+	AADAudience *string
 
 	// The AADIssuer property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication.
-	AADIssuer *string `json:"aadIssuer,omitempty"`
+	AADIssuer *string
 
 	// The AADTenant property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication.
-	AADTenant *string `json:"aadTenant,omitempty"`
+	AADTenant *string
 
 	// The radius server address property of the VirtualNetworkGateway resource for vpn client connection.
-	RadiusServerAddress *string `json:"radiusServerAddress,omitempty"`
+	RadiusServerAddress *string
 
 	// The radius secret property of the VirtualNetworkGateway resource for vpn client connection.
-	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
+	RadiusServerSecret *string
 
 	// The radiusServers property for multiple radius server configuration.
-	RadiusServers []*RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers []*RadiusServer
 
 	// The reference to the address space resource which represents Address space for P2S VpnClient.
-	VPNClientAddressPool *AddressSpace `json:"vpnClientAddressPool,omitempty"`
+	VPNClientAddressPool *AddressSpace
 
 	// VpnClientIpsecPolicies for virtual network gateway P2S client.
-	VPNClientIPSecPolicies []*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies []*IPSecPolicy
 
 	// VpnClientProtocols for Virtual network gateway.
-	VPNClientProtocols []*VPNClientProtocol `json:"vpnClientProtocols,omitempty"`
+	VPNClientProtocols []*VPNClientProtocol
 
 	// VpnClientRevokedCertificate for Virtual network gateway.
-	VPNClientRevokedCertificates []*VPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates []*VPNClientRevokedCertificate
 
 	// VpnClientRootCertificate for virtual network gateway.
-	VPNClientRootCertificates []*VPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates []*VPNClientRootCertificate
 }
 
 // VPNClientConnectionHealth - VpnClientConnectionHealth properties.
 type VPNClientConnectionHealth struct {
 	// List of allocated ip addresses to the connected p2s vpn clients.
-	AllocatedIPAddresses []*string `json:"allocatedIpAddresses,omitempty"`
+	AllocatedIPAddresses []*string
 
 	// The total of p2s vpn clients connected at this time to this P2SVpnGateway.
-	VPNClientConnectionsCount *int32 `json:"vpnClientConnectionsCount,omitempty"`
+	VPNClientConnectionsCount *int32
 
 	// READ-ONLY; Total of the Egress Bytes Transferred in this connection.
-	TotalEgressBytesTransferred *int64 `json:"totalEgressBytesTransferred,omitempty" azure:"ro"`
+	TotalEgressBytesTransferred *int64
 
 	// READ-ONLY; Total of the Ingress Bytes Transferred in this P2S Vpn connection.
-	TotalIngressBytesTransferred *int64 `json:"totalIngressBytesTransferred,omitempty" azure:"ro"`
+	TotalIngressBytesTransferred *int64
 }
 
 // VPNClientConnectionHealthDetail - VPN client connection health detail.
 type VPNClientConnectionHealthDetail struct {
 	// READ-ONLY; The egress bytes per second.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; The egress packets per second.
-	EgressPacketsTransferred *int64 `json:"egressPacketsTransferred,omitempty" azure:"ro"`
+	EgressPacketsTransferred *int64
 
 	// READ-ONLY; The ingress bytes per second.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The ingress packets per second.
-	IngressPacketsTransferred *int64 `json:"ingressPacketsTransferred,omitempty" azure:"ro"`
+	IngressPacketsTransferred *int64
 
 	// READ-ONLY; The max band width.
-	MaxBandwidth *int64 `json:"maxBandwidth,omitempty" azure:"ro"`
+	MaxBandwidth *int64
 
 	// READ-ONLY; The max packets transferred per second.
-	MaxPacketsPerSecond *int64 `json:"maxPacketsPerSecond,omitempty" azure:"ro"`
+	MaxPacketsPerSecond *int64
 
 	// READ-ONLY; The assigned private Ip of a connected vpn client.
-	PrivateIPAddress *string `json:"privateIpAddress,omitempty" azure:"ro"`
+	PrivateIPAddress *string
 
 	// READ-ONLY; The public Ip of a connected vpn client.
-	PublicIPAddress *string `json:"publicIpAddress,omitempty" azure:"ro"`
+	PublicIPAddress *string
 
 	// READ-ONLY; The duration time of a connected vpn client.
-	VPNConnectionDuration *int64 `json:"vpnConnectionDuration,omitempty" azure:"ro"`
+	VPNConnectionDuration *int64
 
 	// READ-ONLY; The vpn client Id.
-	VPNConnectionID *string `json:"vpnConnectionId,omitempty" azure:"ro"`
+	VPNConnectionID *string
 
 	// READ-ONLY; The start time of a connected vpn client.
-	VPNConnectionTime *string `json:"vpnConnectionTime,omitempty" azure:"ro"`
+	VPNConnectionTime *string
 
 	// READ-ONLY; The user name of a connected vpn client.
-	VPNUserName *string `json:"vpnUserName,omitempty" azure:"ro"`
+	VPNUserName *string
 }
 
 // VPNClientConnectionHealthDetailListResult - List of virtual network gateway vpn client connection health.
 type VPNClientConnectionHealthDetailListResult struct {
 	// List of vpn client connection health.
-	Value []*VPNClientConnectionHealthDetail `json:"value,omitempty"`
+	Value []*VPNClientConnectionHealthDetail
 }
 
 // VPNClientIPsecParameters - An IPSec parameters for a virtual network gateway P2S connection.
 type VPNClientIPsecParameters struct {
 	// REQUIRED; The DH Group used in IKE Phase 1 for initial SA.
-	DhGroup *DhGroup `json:"dhGroup,omitempty"`
+	DhGroup *DhGroup
 
 	// REQUIRED; The IPSec encryption algorithm (IKE phase 1).
-	IPSecEncryption *IPSecEncryption `json:"ipsecEncryption,omitempty"`
+	IPSecEncryption *IPSecEncryption
 
 	// REQUIRED; The IPSec integrity algorithm (IKE phase 1).
-	IPSecIntegrity *IPSecIntegrity `json:"ipsecIntegrity,omitempty"`
+	IPSecIntegrity *IPSecIntegrity
 
 	// REQUIRED; The IKE encryption algorithm (IKE phase 2).
-	IkeEncryption *IkeEncryption `json:"ikeEncryption,omitempty"`
+	IkeEncryption *IkeEncryption
 
 	// REQUIRED; The IKE integrity algorithm (IKE phase 2).
-	IkeIntegrity *IkeIntegrity `json:"ikeIntegrity,omitempty"`
+	IkeIntegrity *IkeIntegrity
 
 	// REQUIRED; The Pfs Group used in IKE Phase 2 for new child SA.
-	PfsGroup *PfsGroup `json:"pfsGroup,omitempty"`
+	PfsGroup *PfsGroup
 
 	// REQUIRED; The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for P2S client..
-	SaDataSizeKilobytes *int32 `json:"saDataSizeKilobytes,omitempty"`
+	SaDataSizeKilobytes *int32
 
 	// REQUIRED; The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for P2S client.
-	SaLifeTimeSeconds *int32 `json:"saLifeTimeSeconds,omitempty"`
+	SaLifeTimeSeconds *int32
 }
 
 // VPNClientParameters - Vpn Client Parameters for package generation.
 type VPNClientParameters struct {
 	// VPN client authentication method.
-	AuthenticationMethod *AuthenticationMethod `json:"authenticationMethod,omitempty"`
+	AuthenticationMethod *AuthenticationMethod
 
 	// A list of client root certificates public certificate data encoded as Base-64 strings. Optional parameter for external
 	// radius based authentication with EAPTLS.
-	ClientRootCertificates []*string `json:"clientRootCertificates,omitempty"`
+	ClientRootCertificates []*string
 
 	// VPN client Processor Architecture.
-	ProcessorArchitecture *ProcessorArchitecture `json:"processorArchitecture,omitempty"`
+	ProcessorArchitecture *ProcessorArchitecture
 
 	// The public certificate data for the radius server authentication certificate as a Base-64 encoded string. Required only
 	// if external radius authentication has been configured with EAPTLS
 	// authentication.
-	RadiusServerAuthCertificate *string `json:"radiusServerAuthCertificate,omitempty"`
+	RadiusServerAuthCertificate *string
 }
 
 // VPNClientRevokedCertificate - VPN client revoked certificate of virtual network gateway.
 type VPNClientRevokedCertificate struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the vpn client revoked certificate.
-	Properties *VPNClientRevokedCertificatePropertiesFormat `json:"properties,omitempty"`
+	Properties *VPNClientRevokedCertificatePropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VPNClientRevokedCertificatePropertiesFormat - Properties of the revoked VPN client certificate of virtual network gateway.
 type VPNClientRevokedCertificatePropertiesFormat struct {
 	// The revoked VPN client certificate thumbprint.
-	Thumbprint *string `json:"thumbprint,omitempty"`
+	Thumbprint *string
 
 	// READ-ONLY; The provisioning state of the VPN client revoked certificate resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNClientRootCertificate - VPN client root certificate of virtual network gateway.
 type VPNClientRootCertificate struct {
 	// REQUIRED; Properties of the vpn client root certificate.
-	Properties *VPNClientRootCertificatePropertiesFormat `json:"properties,omitempty"`
+	Properties *VPNClientRootCertificatePropertiesFormat
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VPNClientRootCertificatePropertiesFormat - Properties of SSL certificates of application gateway.
 type VPNClientRootCertificatePropertiesFormat struct {
 	// REQUIRED; The certificate public data.
-	PublicCertData *string `json:"publicCertData,omitempty"`
+	PublicCertData *string
 
 	// READ-ONLY; The provisioning state of the VPN client root certificate resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNConnection - VpnConnection Resource.
 type VPNConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the VPN connection.
-	Properties *VPNConnectionProperties `json:"properties,omitempty"`
+	Properties *VPNConnectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VPNConnectionProperties - Parameters for VpnConnection.
 type VPNConnectionProperties struct {
 	// Expected bandwidth in MBPS.
-	ConnectionBandwidth *int32 `json:"connectionBandwidth,omitempty"`
+	ConnectionBandwidth *int32
 
 	// The dead peer detection timeout for a vpn connection in seconds.
-	DpdTimeoutSeconds *int32 `json:"dpdTimeoutSeconds,omitempty"`
+	DpdTimeoutSeconds *int32
 
 	// EnableBgp flag.
-	EnableBgp *bool `json:"enableBgp,omitempty"`
+	EnableBgp *bool
 
 	// Enable internet security.
-	EnableInternetSecurity *bool `json:"enableInternetSecurity,omitempty"`
+	EnableInternetSecurity *bool
 
 	// EnableBgp flag.
-	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
+	EnableRateLimiting *bool
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy
 
 	// Id of the connected vpn site.
-	RemoteVPNSite *SubResource `json:"remoteVpnSite,omitempty"`
+	RemoteVPNSite *SubResource
 
 	// Routing weight for vpn connection.
-	RoutingWeight *int32 `json:"routingWeight,omitempty"`
+	RoutingWeight *int32
 
 	// SharedKey for the vpn connection.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// Use local azure ip to initiate connection.
-	UseLocalAzureIPAddress *bool `json:"useLocalAzureIpAddress,omitempty"`
+	UseLocalAzureIPAddress *bool
 
 	// Enable policy-based traffic selectors.
-	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
+	UsePolicyBasedTrafficSelectors *bool
 
 	// Connection protocol used for this connection.
-	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol `json:"vpnConnectionProtocolType,omitempty"`
+	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol
 
 	// List of all vpn site link connections to the gateway.
-	VPNLinkConnections []*VPNSiteLinkConnection `json:"vpnLinkConnections,omitempty"`
+	VPNLinkConnections []*VPNSiteLinkConnection
 
 	// READ-ONLY; The connection status.
-	ConnectionStatus *VPNConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *VPNConnectionStatus
 
 	// READ-ONLY; Egress bytes transferred.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; Ingress bytes transferred.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The provisioning state of the VPN connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNConnectionsClient.BeginCreateOrUpdate
@@ -10095,55 +10095,55 @@ type VPNConnectionsClientListByVPNGatewayOptions struct {
 // VPNDeviceScriptParameters - Vpn device configuration script generation parameters.
 type VPNDeviceScriptParameters struct {
 	// The device family for the vpn device.
-	DeviceFamily *string `json:"deviceFamily,omitempty"`
+	DeviceFamily *string
 
 	// The firmware version for the vpn device.
-	FirmwareVersion *string `json:"firmwareVersion,omitempty"`
+	FirmwareVersion *string
 
 	// The vendor for the vpn device.
-	Vendor *string `json:"vendor,omitempty"`
+	Vendor *string
 }
 
 // VPNGateway - VpnGateway Resource.
 type VPNGateway struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the VPN gateway.
-	Properties *VPNGatewayProperties `json:"properties,omitempty"`
+	Properties *VPNGatewayProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNGatewayProperties - Parameters for VpnGateway.
 type VPNGatewayProperties struct {
 	// Local network gateway's BGP speaker settings.
-	BgpSettings *BgpSettings `json:"bgpSettings,omitempty"`
+	BgpSettings *BgpSettings
 
 	// List of all vpn connections to the gateway.
-	Connections []*VPNConnection `json:"connections,omitempty"`
+	Connections []*VPNConnection
 
 	// The scale unit for this vpn gateway.
-	VPNGatewayScaleUnit *int32 `json:"vpnGatewayScaleUnit,omitempty"`
+	VPNGatewayScaleUnit *int32
 
 	// The VirtualHub to which the gateway belongs.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+	VirtualHub *SubResource
 
 	// READ-ONLY; The provisioning state of the VPN gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNGatewaysClient.BeginCreateOrUpdate
@@ -10189,10 +10189,10 @@ type VPNGatewaysClientUpdateTagsOptions struct {
 // VPNLinkBgpSettings - BGP settings details for a link.
 type VPNLinkBgpSettings struct {
 	// The BGP speaker's ASN.
-	Asn *int64 `json:"asn,omitempty"`
+	Asn *int64
 
 	// The BGP peering address and BGP identifier of this BGP speaker.
-	BgpPeeringAddress *string `json:"bgpPeeringAddress,omitempty"`
+	BgpPeeringAddress *string
 }
 
 // VPNLinkConnectionsClientListByVPNConnectionOptions contains the optional parameters for the VPNLinkConnectionsClient.NewListByVPNConnectionPager
@@ -10204,137 +10204,137 @@ type VPNLinkConnectionsClientListByVPNConnectionOptions struct {
 // VPNLinkProviderProperties - List of properties of a link provider.
 type VPNLinkProviderProperties struct {
 	// Name of the link provider.
-	LinkProviderName *string `json:"linkProviderName,omitempty"`
+	LinkProviderName *string
 
 	// Link speed.
-	LinkSpeedInMbps *int32 `json:"linkSpeedInMbps,omitempty"`
+	LinkSpeedInMbps *int32
 }
 
 // VPNPacketCaptureStartParameters - Start packet capture parameters on virtual network gateway.
 type VPNPacketCaptureStartParameters struct {
 	// Start Packet capture parameters.
-	FilterData *string `json:"filterData,omitempty"`
+	FilterData *string
 }
 
 // VPNPacketCaptureStopParameters - Stop packet capture parameters.
 type VPNPacketCaptureStopParameters struct {
 	// SAS url for packet capture on virtual network gateway.
-	SasURL *string `json:"sasUrl,omitempty"`
+	SasURL *string
 }
 
 // VPNProfileResponse - Vpn Profile Response for package generation.
 type VPNProfileResponse struct {
 	// URL to the VPN profile.
-	ProfileURL *string `json:"profileUrl,omitempty"`
+	ProfileURL *string
 }
 
 // VPNServerConfigRadiusClientRootCertificate - Properties of the Radius client root certificate of VpnServerConfiguration.
 type VPNServerConfigRadiusClientRootCertificate struct {
 	// The certificate name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The Radius client root certificate thumbprint.
-	Thumbprint *string `json:"thumbprint,omitempty"`
+	Thumbprint *string
 }
 
 // VPNServerConfigRadiusServerRootCertificate - Properties of Radius Server root certificate of VpnServerConfiguration.
 type VPNServerConfigRadiusServerRootCertificate struct {
 	// The certificate name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The certificate public data.
-	PublicCertData *string `json:"publicCertData,omitempty"`
+	PublicCertData *string
 }
 
 // VPNServerConfigVPNClientRevokedCertificate - Properties of the revoked VPN client certificate of VpnServerConfiguration.
 type VPNServerConfigVPNClientRevokedCertificate struct {
 	// The certificate name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The revoked VPN client certificate thumbprint.
-	Thumbprint *string `json:"thumbprint,omitempty"`
+	Thumbprint *string
 }
 
 // VPNServerConfigVPNClientRootCertificate - Properties of VPN client root certificate of VpnServerConfiguration.
 type VPNServerConfigVPNClientRootCertificate struct {
 	// The certificate name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The certificate public data.
-	PublicCertData *string `json:"publicCertData,omitempty"`
+	PublicCertData *string
 }
 
 // VPNServerConfiguration - VpnServerConfiguration Resource.
 type VPNServerConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the P2SVpnServer configuration.
-	Properties *VPNServerConfigurationProperties `json:"properties,omitempty"`
+	Properties *VPNServerConfigurationProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNServerConfigurationProperties - Parameters for VpnServerConfiguration.
 type VPNServerConfigurationProperties struct {
 	// The set of aad vpn authentication parameters.
-	AADAuthenticationParameters *AADAuthenticationParameters `json:"aadAuthenticationParameters,omitempty"`
+	AADAuthenticationParameters *AADAuthenticationParameters
 
 	// The name of the VpnServerConfiguration that is unique within a resource group.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Radius client root certificate of VpnServerConfiguration.
-	RadiusClientRootCertificates []*VPNServerConfigRadiusClientRootCertificate `json:"radiusClientRootCertificates,omitempty"`
+	RadiusClientRootCertificates []*VPNServerConfigRadiusClientRootCertificate
 
 	// The radius server address property of the VpnServerConfiguration resource for point to site client connection.
-	RadiusServerAddress *string `json:"radiusServerAddress,omitempty"`
+	RadiusServerAddress *string
 
 	// Radius Server root certificate of VpnServerConfiguration.
-	RadiusServerRootCertificates []*VPNServerConfigRadiusServerRootCertificate `json:"radiusServerRootCertificates,omitempty"`
+	RadiusServerRootCertificates []*VPNServerConfigRadiusServerRootCertificate
 
 	// The radius secret property of the VpnServerConfiguration resource for point to site client connection.
-	RadiusServerSecret *string `json:"radiusServerSecret,omitempty"`
+	RadiusServerSecret *string
 
 	// Multiple Radius Server configuration for VpnServerConfiguration.
-	RadiusServers []*RadiusServer `json:"radiusServers,omitempty"`
+	RadiusServers []*RadiusServer
 
 	// VPN authentication types for the VpnServerConfiguration.
-	VPNAuthenticationTypes []*VPNAuthenticationType `json:"vpnAuthenticationTypes,omitempty"`
+	VPNAuthenticationTypes []*VPNAuthenticationType
 
 	// VpnClientIpsecPolicies for VpnServerConfiguration.
-	VPNClientIPSecPolicies []*IPSecPolicy `json:"vpnClientIpsecPolicies,omitempty"`
+	VPNClientIPSecPolicies []*IPSecPolicy
 
 	// VPN client revoked certificate of VpnServerConfiguration.
-	VPNClientRevokedCertificates []*VPNServerConfigVPNClientRevokedCertificate `json:"vpnClientRevokedCertificates,omitempty"`
+	VPNClientRevokedCertificates []*VPNServerConfigVPNClientRevokedCertificate
 
 	// VPN client root certificate of VpnServerConfiguration.
-	VPNClientRootCertificates []*VPNServerConfigVPNClientRootCertificate `json:"vpnClientRootCertificates,omitempty"`
+	VPNClientRootCertificates []*VPNServerConfigVPNClientRootCertificate
 
 	// VPN protocols for the VpnServerConfiguration.
-	VPNProtocols []*VPNGatewayTunnelingProtocol `json:"vpnProtocols,omitempty"`
+	VPNProtocols []*VPNGatewayTunnelingProtocol
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; List of references to P2SVpnGateways.
-	P2SVPNGateways []*P2SVPNGateway `json:"p2SVpnGateways,omitempty" azure:"ro"`
+	P2SVPNGateways []*P2SVPNGateway
 
 	// READ-ONLY; The provisioning state of the VpnServerConfiguration resource. Possible values are: 'Updating', 'Deleting',
 	// and 'Failed'.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanClientBeginListOptions contains the optional parameters for the VPNServerConfigurationsAssociatedWithVirtualWanClient.BeginList
@@ -10384,112 +10384,112 @@ type VPNServerConfigurationsClientUpdateTagsOptions struct {
 // VPNServerConfigurationsResponse - VpnServerConfigurations list associated with VirtualWan Response.
 type VPNServerConfigurationsResponse struct {
 	// List of VpnServerConfigurations associated with VirtualWan.
-	VPNServerConfigurationResourceIDs []*string `json:"vpnServerConfigurationResourceIds,omitempty"`
+	VPNServerConfigurationResourceIDs []*string
 }
 
 // VPNSite - VpnSite Resource.
 type VPNSite struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the VPN site.
-	Properties *VPNSiteProperties `json:"properties,omitempty"`
+	Properties *VPNSiteProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNSiteLink - VpnSiteLink Resource.
 type VPNSiteLink struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the VPN site link.
-	Properties *VPNSiteLinkProperties `json:"properties,omitempty"`
+	Properties *VPNSiteLinkProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNSiteLinkConnection - VpnSiteLinkConnection Resource.
 type VPNSiteLinkConnection struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the VPN site link connection.
-	Properties *VPNSiteLinkConnectionProperties `json:"properties,omitempty"`
+	Properties *VPNSiteLinkConnectionProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VPNSiteLinkConnectionProperties - Parameters for VpnConnection.
 type VPNSiteLinkConnectionProperties struct {
 	// Expected bandwidth in MBPS.
-	ConnectionBandwidth *int32 `json:"connectionBandwidth,omitempty"`
+	ConnectionBandwidth *int32
 
 	// EnableBgp flag.
-	EnableBgp *bool `json:"enableBgp,omitempty"`
+	EnableBgp *bool
 
 	// EnableBgp flag.
-	EnableRateLimiting *bool `json:"enableRateLimiting,omitempty"`
+	EnableRateLimiting *bool
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy
 
 	// Routing weight for vpn connection.
-	RoutingWeight *int32 `json:"routingWeight,omitempty"`
+	RoutingWeight *int32
 
 	// SharedKey for the vpn connection.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// Use local azure ip to initiate connection.
-	UseLocalAzureIPAddress *bool `json:"useLocalAzureIpAddress,omitempty"`
+	UseLocalAzureIPAddress *bool
 
 	// Enable policy-based traffic selectors.
-	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
+	UsePolicyBasedTrafficSelectors *bool
 
 	// Connection protocol used for this connection.
-	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol `json:"vpnConnectionProtocolType,omitempty"`
+	VPNConnectionProtocolType *VirtualNetworkGatewayConnectionProtocol
 
 	// Id of the connected vpn site link.
-	VPNSiteLink *SubResource `json:"vpnSiteLink,omitempty"`
+	VPNSiteLink *SubResource
 
 	// READ-ONLY; The connection status.
-	ConnectionStatus *VPNConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *VPNConnectionStatus
 
 	// READ-ONLY; Egress bytes transferred.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; Ingress bytes transferred.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The provisioning state of the VPN site link connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNSiteLinkConnectionsClientGetOptions contains the optional parameters for the VPNSiteLinkConnectionsClient.Get method.
@@ -10500,19 +10500,19 @@ type VPNSiteLinkConnectionsClientGetOptions struct {
 // VPNSiteLinkProperties - Parameters for VpnSite.
 type VPNSiteLinkProperties struct {
 	// The set of bgp properties.
-	BgpProperties *VPNLinkBgpSettings `json:"bgpProperties,omitempty"`
+	BgpProperties *VPNLinkBgpSettings
 
 	// FQDN of vpn-site-link.
-	Fqdn *string `json:"fqdn,omitempty"`
+	Fqdn *string
 
 	// The ip-address for the vpn-site-link.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 
 	// The link provider properties.
-	LinkProperties *VPNLinkProviderProperties `json:"linkProperties,omitempty"`
+	LinkProperties *VPNLinkProviderProperties
 
 	// READ-ONLY; The provisioning state of the VPN site link resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNSiteLinksClientGetOptions contains the optional parameters for the VPNSiteLinksClient.Get method.
@@ -10529,31 +10529,31 @@ type VPNSiteLinksClientListByVPNSiteOptions struct {
 // VPNSiteProperties - Parameters for VpnSite.
 type VPNSiteProperties struct {
 	// The AddressSpace that contains an array of IP address ranges.
-	AddressSpace *AddressSpace `json:"addressSpace,omitempty"`
+	AddressSpace *AddressSpace
 
 	// The set of bgp properties.
-	BgpProperties *BgpSettings `json:"bgpProperties,omitempty"`
+	BgpProperties *BgpSettings
 
 	// The device properties.
-	DeviceProperties *DeviceProperties `json:"deviceProperties,omitempty"`
+	DeviceProperties *DeviceProperties
 
 	// The ip-address for the vpn-site.
-	IPAddress *string `json:"ipAddress,omitempty"`
+	IPAddress *string
 
 	// IsSecuritySite flag.
-	IsSecuritySite *bool `json:"isSecuritySite,omitempty"`
+	IsSecuritySite *bool
 
 	// The key for vpn-site that can be used for connections.
-	SiteKey *string `json:"siteKey,omitempty"`
+	SiteKey *string
 
 	// List of all vpn site links.
-	VPNSiteLinks []*VPNSiteLink `json:"vpnSiteLinks,omitempty"`
+	VPNSiteLinks []*VPNSiteLink
 
 	// The VirtualWAN to which the vpnSite belongs.
-	VirtualWan *SubResource `json:"virtualWan,omitempty"`
+	VirtualWan *SubResource
 
 	// READ-ONLY; The provisioning state of the VPN site resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VPNSitesClientBeginCreateOrUpdateOptions contains the optional parameters for the VPNSitesClient.BeginCreateOrUpdate method.
@@ -10599,124 +10599,124 @@ type VPNSitesConfigurationClientBeginDownloadOptions struct {
 // VerificationIPFlowParameters - Parameters that define the IP flow to be verified.
 type VerificationIPFlowParameters struct {
 	// REQUIRED; The direction of the packet represented as a 5-tuple.
-	Direction *Direction `json:"direction,omitempty"`
+	Direction *Direction
 
 	// REQUIRED; The local IP address. Acceptable values are valid IPv4 addresses.
-	LocalIPAddress *string `json:"localIPAddress,omitempty"`
+	LocalIPAddress *string
 
 	// REQUIRED; The local port. Acceptable values are a single integer in the range (0-65535). Support for * for the source port,
 	// which depends on the direction.
-	LocalPort *string `json:"localPort,omitempty"`
+	LocalPort *string
 
 	// REQUIRED; Protocol to be verified on.
-	Protocol *IPFlowProtocol `json:"protocol,omitempty"`
+	Protocol *IPFlowProtocol
 
 	// REQUIRED; The remote IP address. Acceptable values are valid IPv4 addresses.
-	RemoteIPAddress *string `json:"remoteIPAddress,omitempty"`
+	RemoteIPAddress *string
 
 	// REQUIRED; The remote port. Acceptable values are a single integer in the range (0-65535). Support for * for the source
 	// port, which depends on the direction.
-	RemotePort *string `json:"remotePort,omitempty"`
+	RemotePort *string
 
 	// REQUIRED; The ID of the target resource to perform next-hop on.
-	TargetResourceID *string `json:"targetResourceId,omitempty"`
+	TargetResourceID *string
 
 	// The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of them, then this parameter must be specified.
 	// Otherwise optional).
-	TargetNicResourceID *string `json:"targetNicResourceId,omitempty"`
+	TargetNicResourceID *string
 }
 
 // VerificationIPFlowResult - Results of IP flow verification on the target resource.
 type VerificationIPFlowResult struct {
 	// Indicates whether the traffic is allowed or denied.
-	Access *Access `json:"access,omitempty"`
+	Access *Access
 
 	// Name of the rule. If input is not matched against any security rule, it is not displayed.
-	RuleName *string `json:"ruleName,omitempty"`
+	RuleName *string
 }
 
 // VirtualAppliance - NetworkVirtualAppliance Resource.
 type VirtualAppliance struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The service principal that has read access to cloud-init and config blob.
-	Identity *ManagedServiceIdentity `json:"identity,omitempty"`
+	Identity *ManagedServiceIdentity
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the Network Virtual Appliance.
-	Properties *VirtualAppliancePropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualAppliancePropertiesFormat
 
 	// Network Virtual Appliance SKU.
-	SKU *VirtualApplianceSKUProperties `json:"sku,omitempty"`
+	SKU *VirtualApplianceSKUProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualApplianceListResult - Response for ListNetworkVirtualAppliances API service call.
 type VirtualApplianceListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Network Virtual Appliances.
-	Value []*VirtualAppliance `json:"value,omitempty"`
+	Value []*VirtualAppliance
 }
 
 // VirtualApplianceNicProperties - Network Virtual Appliance NIC properties.
 type VirtualApplianceNicProperties struct {
 	// READ-ONLY; NIC name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Private IP address.
-	PrivateIPAddress *string `json:"privateIpAddress,omitempty" azure:"ro"`
+	PrivateIPAddress *string
 
 	// READ-ONLY; Public IP address.
-	PublicIPAddress *string `json:"publicIpAddress,omitempty" azure:"ro"`
+	PublicIPAddress *string
 }
 
 // VirtualAppliancePropertiesFormat - Network Virtual Appliance definition.
 type VirtualAppliancePropertiesFormat struct {
 	// BootStrapConfigurationBlob storage URLs.
-	BootStrapConfigurationBlob []*string `json:"bootStrapConfigurationBlob,omitempty"`
+	BootStrapConfigurationBlob []*string
 
 	// CloudInitConfigurationBlob storage URLs.
-	CloudInitConfigurationBlob []*string `json:"cloudInitConfigurationBlob,omitempty"`
+	CloudInitConfigurationBlob []*string
 
 	// VirtualAppliance ASN.
-	VirtualApplianceAsn *int64 `json:"virtualApplianceAsn,omitempty"`
+	VirtualApplianceAsn *int64
 
 	// The Virtual Hub where Network Virtual Appliance is being deployed.
-	VirtualHub *SubResource `json:"virtualHub,omitempty"`
+	VirtualHub *SubResource
 
 	// READ-ONLY; The provisioning state of the resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; List of Virtual Appliance Network Interfaces.
-	VirtualApplianceNics []*VirtualApplianceNicProperties `json:"virtualApplianceNics,omitempty" azure:"ro"`
+	VirtualApplianceNics []*VirtualApplianceNicProperties
 }
 
 // VirtualApplianceSKUProperties - Network Virtual Appliance Sku Properties.
 type VirtualApplianceSKUProperties struct {
 	// Virtual Appliance Scale Unit.
-	BundledScaleUnit *string `json:"bundledScaleUnit,omitempty"`
+	BundledScaleUnit *string
 
 	// Virtual Appliance Version.
-	MarketPlaceVersion *string `json:"marketPlaceVersion,omitempty"`
+	MarketPlaceVersion *string
 
 	// Virtual Appliance Vendor.
-	Vendor *string `json:"vendor,omitempty"`
+	Vendor *string
 }
 
 // VirtualAppliancesClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualAppliancesClient.BeginCreateOrUpdate
@@ -10758,116 +10758,116 @@ type VirtualAppliancesClientUpdateTagsOptions struct {
 // VirtualHub Resource.
 type VirtualHub struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the virtual hub.
-	Properties *VirtualHubProperties `json:"properties,omitempty"`
+	Properties *VirtualHubProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualHubID - Virtual Hub identifier.
 type VirtualHubID struct {
 	// The resource URI for the Virtual Hub where the ExpressRoute gateway is or will be deployed. The Virtual Hub resource and
 	// the ExpressRoute gateway resource reside in the same subscription.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // VirtualHubProperties - Parameters for VirtualHub.
 type VirtualHubProperties struct {
 	// Address-prefix for this VirtualHub.
-	AddressPrefix *string `json:"addressPrefix,omitempty"`
+	AddressPrefix *string
 
 	// The azureFirewall associated with this VirtualHub.
-	AzureFirewall *SubResource `json:"azureFirewall,omitempty"`
+	AzureFirewall *SubResource
 
 	// The expressRouteGateway associated with this VirtualHub.
-	ExpressRouteGateway *SubResource `json:"expressRouteGateway,omitempty"`
+	ExpressRouteGateway *SubResource
 
 	// The P2SVpnGateway associated with this VirtualHub.
-	P2SVPNGateway *SubResource `json:"p2SVpnGateway,omitempty"`
+	P2SVPNGateway *SubResource
 
 	// The routeTable associated with this virtual hub.
-	RouteTable *VirtualHubRouteTable `json:"routeTable,omitempty"`
+	RouteTable *VirtualHubRouteTable
 
 	// The sku of this VirtualHub.
-	SKU *string `json:"sku,omitempty"`
+	SKU *string
 
 	// The securityPartnerProvider associated with this VirtualHub.
-	SecurityPartnerProvider *SubResource `json:"securityPartnerProvider,omitempty"`
+	SecurityPartnerProvider *SubResource
 
 	// The Security Provider name.
-	SecurityProviderName *string `json:"securityProviderName,omitempty"`
+	SecurityProviderName *string
 
 	// The VpnGateway associated with this VirtualHub.
-	VPNGateway *SubResource `json:"vpnGateway,omitempty"`
+	VPNGateway *SubResource
 
 	// List of all virtual hub route table v2s associated with this VirtualHub.
-	VirtualHubRouteTableV2S []*VirtualHubRouteTableV2 `json:"virtualHubRouteTableV2s,omitempty"`
+	VirtualHubRouteTableV2S []*VirtualHubRouteTableV2
 
 	// List of all vnet connections with this VirtualHub.
-	VirtualNetworkConnections []*HubVirtualNetworkConnection `json:"virtualNetworkConnections,omitempty"`
+	VirtualNetworkConnections []*HubVirtualNetworkConnection
 
 	// The VirtualWAN to which the VirtualHub belongs.
-	VirtualWan *SubResource `json:"virtualWan,omitempty"`
+	VirtualWan *SubResource
 
 	// READ-ONLY; The provisioning state of the virtual hub resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualHubRoute - VirtualHub route.
 type VirtualHubRoute struct {
 	// List of all addressPrefixes.
-	AddressPrefixes []*string `json:"addressPrefixes,omitempty"`
+	AddressPrefixes []*string
 
 	// NextHop ip address.
-	NextHopIPAddress *string `json:"nextHopIpAddress,omitempty"`
+	NextHopIPAddress *string
 }
 
 // VirtualHubRouteTable - VirtualHub route table.
 type VirtualHubRouteTable struct {
 	// List of all routes.
-	Routes []*VirtualHubRoute `json:"routes,omitempty"`
+	Routes []*VirtualHubRoute
 }
 
 // VirtualHubRouteTableV2 Resource.
 type VirtualHubRouteTableV2 struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the virtual hub route table v2.
-	Properties *VirtualHubRouteTableV2Properties `json:"properties,omitempty"`
+	Properties *VirtualHubRouteTableV2Properties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VirtualHubRouteTableV2Properties - Parameters for VirtualHubRouteTableV2.
 type VirtualHubRouteTableV2Properties struct {
 	// List of all connections attached to this route table v2.
-	AttachedConnections []*string `json:"attachedConnections,omitempty"`
+	AttachedConnections []*string
 
 	// List of all routes.
-	Routes []*VirtualHubRouteV2 `json:"routes,omitempty"`
+	Routes []*VirtualHubRouteV2
 
 	// READ-ONLY; The provisioning state of the virtual hub route table v2 resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualHubRouteTableV2SClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubRouteTableV2SClient.BeginCreateOrUpdate
@@ -10898,16 +10898,16 @@ type VirtualHubRouteTableV2SClientListOptions struct {
 // VirtualHubRouteV2 - VirtualHubRouteTableV2 route.
 type VirtualHubRouteV2 struct {
 	// The type of destinations.
-	DestinationType *string `json:"destinationType,omitempty"`
+	DestinationType *string
 
 	// List of all destinations.
-	Destinations []*string `json:"destinations,omitempty"`
+	Destinations []*string
 
 	// The type of next hops.
-	NextHopType *string `json:"nextHopType,omitempty"`
+	NextHopType *string
 
 	// NextHops ip address.
-	NextHops []*string `json:"nextHops,omitempty"`
+	NextHops []*string
 }
 
 // VirtualHubsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualHubsClient.BeginCreateOrUpdate
@@ -10947,254 +10947,254 @@ type VirtualHubsClientUpdateTagsOptions struct {
 // VirtualNetwork - Virtual Network resource.
 type VirtualNetwork struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the virtual network.
-	Properties *VirtualNetworkPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualNetworkBgpCommunities - Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this
 // VNET.
 type VirtualNetworkBgpCommunities struct {
 	// REQUIRED; The BGP community associated with the virtual network.
-	VirtualNetworkCommunity *string `json:"virtualNetworkCommunity,omitempty"`
+	VirtualNetworkCommunity *string
 
 	// READ-ONLY; The BGP community associated with the region of the virtual network.
-	RegionalCommunity *string `json:"regionalCommunity,omitempty" azure:"ro"`
+	RegionalCommunity *string
 }
 
 // VirtualNetworkConnectionGatewayReference - A reference to VirtualNetworkGateway or LocalNetworkGateway resource.
 type VirtualNetworkConnectionGatewayReference struct {
 	// REQUIRED; The ID of VirtualNetworkGateway or LocalNetworkGateway resource.
-	ID *string `json:"id,omitempty"`
+	ID *string
 }
 
 // VirtualNetworkGateway - A common class for general resource information.
 type VirtualNetworkGateway struct {
 	// REQUIRED; Properties of the virtual network gateway.
-	Properties *VirtualNetworkGatewayPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkGatewayPropertiesFormat
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualNetworkGatewayConnection - A common class for general resource information.
 type VirtualNetworkGatewayConnection struct {
 	// REQUIRED; Properties of the virtual network gateway connection.
-	Properties *VirtualNetworkGatewayConnectionPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkGatewayConnectionPropertiesFormat
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualNetworkGatewayConnectionListEntity - A common class for general resource information.
 type VirtualNetworkGatewayConnectionListEntity struct {
 	// REQUIRED; Properties of the virtual network gateway connection.
-	Properties *VirtualNetworkGatewayConnectionListEntityPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkGatewayConnectionListEntityPropertiesFormat
 
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualNetworkGatewayConnectionListEntityPropertiesFormat - VirtualNetworkGatewayConnection properties.
 type VirtualNetworkGatewayConnectionListEntityPropertiesFormat struct {
 	// REQUIRED; Gateway connection type.
-	ConnectionType *VirtualNetworkGatewayConnectionType `json:"connectionType,omitempty"`
+	ConnectionType *VirtualNetworkGatewayConnectionType
 
 	// REQUIRED; The reference to virtual network gateway resource.
-	VirtualNetworkGateway1 *VirtualNetworkConnectionGatewayReference `json:"virtualNetworkGateway1,omitempty"`
+	VirtualNetworkGateway1 *VirtualNetworkConnectionGatewayReference
 
 	// The authorizationKey.
-	AuthorizationKey *string `json:"authorizationKey,omitempty"`
+	AuthorizationKey *string
 
 	// Connection protocol used for this connection.
-	ConnectionProtocol *VirtualNetworkGatewayConnectionProtocol `json:"connectionProtocol,omitempty"`
+	ConnectionProtocol *VirtualNetworkGatewayConnectionProtocol
 
 	// EnableBgp flag.
-	EnableBgp *bool `json:"enableBgp,omitempty"`
+	EnableBgp *bool
 
 	// Bypass ExpressRoute Gateway for data forwarding.
-	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
+	ExpressRouteGatewayBypass *bool
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy
 
 	// The reference to local network gateway resource.
-	LocalNetworkGateway2 *VirtualNetworkConnectionGatewayReference `json:"localNetworkGateway2,omitempty"`
+	LocalNetworkGateway2 *VirtualNetworkConnectionGatewayReference
 
 	// The reference to peerings resource.
-	Peer *SubResource `json:"peer,omitempty"`
+	Peer *SubResource
 
 	// The routing weight.
-	RoutingWeight *int32 `json:"routingWeight,omitempty"`
+	RoutingWeight *int32
 
 	// The IPSec shared key.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies []*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies []*TrafficSelectorPolicy
 
 	// Enable policy-based traffic selectors.
-	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
+	UsePolicyBasedTrafficSelectors *bool
 
 	// The reference to virtual network gateway resource.
-	VirtualNetworkGateway2 *VirtualNetworkConnectionGatewayReference `json:"virtualNetworkGateway2,omitempty"`
+	VirtualNetworkGateway2 *VirtualNetworkConnectionGatewayReference
 
 	// READ-ONLY; Virtual Network Gateway connection status.
-	ConnectionStatus *VirtualNetworkGatewayConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *VirtualNetworkGatewayConnectionStatus
 
 	// READ-ONLY; The egress bytes transferred in this connection.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The provisioning state of the virtual network gateway connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the virtual network gateway connection resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus []*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus []*TunnelConnectionHealth
 }
 
 // VirtualNetworkGatewayConnectionListResult - Response for the ListVirtualNetworkGatewayConnections API service call.
 type VirtualNetworkGatewayConnectionListResult struct {
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value []*VirtualNetworkGatewayConnection `json:"value,omitempty"`
+	Value []*VirtualNetworkGatewayConnection
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // VirtualNetworkGatewayConnectionPropertiesFormat - VirtualNetworkGatewayConnection properties.
 type VirtualNetworkGatewayConnectionPropertiesFormat struct {
 	// REQUIRED; Gateway connection type.
-	ConnectionType *VirtualNetworkGatewayConnectionType `json:"connectionType,omitempty"`
+	ConnectionType *VirtualNetworkGatewayConnectionType
 
 	// REQUIRED; The reference to virtual network gateway resource.
-	VirtualNetworkGateway1 *VirtualNetworkGateway `json:"virtualNetworkGateway1,omitempty"`
+	VirtualNetworkGateway1 *VirtualNetworkGateway
 
 	// The authorizationKey.
-	AuthorizationKey *string `json:"authorizationKey,omitempty"`
+	AuthorizationKey *string
 
 	// Connection protocol used for this connection.
-	ConnectionProtocol *VirtualNetworkGatewayConnectionProtocol `json:"connectionProtocol,omitempty"`
+	ConnectionProtocol *VirtualNetworkGatewayConnectionProtocol
 
 	// The dead peer detection timeout of this connection in seconds.
-	DpdTimeoutSeconds *int32 `json:"dpdTimeoutSeconds,omitempty"`
+	DpdTimeoutSeconds *int32
 
 	// EnableBgp flag.
-	EnableBgp *bool `json:"enableBgp,omitempty"`
+	EnableBgp *bool
 
 	// Bypass ExpressRoute Gateway for data forwarding.
-	ExpressRouteGatewayBypass *bool `json:"expressRouteGatewayBypass,omitempty"`
+	ExpressRouteGatewayBypass *bool
 
 	// The IPSec Policies to be considered by this connection.
-	IPSecPolicies []*IPSecPolicy `json:"ipsecPolicies,omitempty"`
+	IPSecPolicies []*IPSecPolicy
 
 	// The reference to local network gateway resource.
-	LocalNetworkGateway2 *LocalNetworkGateway `json:"localNetworkGateway2,omitempty"`
+	LocalNetworkGateway2 *LocalNetworkGateway
 
 	// The reference to peerings resource.
-	Peer *SubResource `json:"peer,omitempty"`
+	Peer *SubResource
 
 	// The routing weight.
-	RoutingWeight *int32 `json:"routingWeight,omitempty"`
+	RoutingWeight *int32
 
 	// The IPSec shared key.
-	SharedKey *string `json:"sharedKey,omitempty"`
+	SharedKey *string
 
 	// The Traffic Selector Policies to be considered by this connection.
-	TrafficSelectorPolicies []*TrafficSelectorPolicy `json:"trafficSelectorPolicies,omitempty"`
+	TrafficSelectorPolicies []*TrafficSelectorPolicy
 
 	// Use private local Azure IP for the connection.
-	UseLocalAzureIPAddress *bool `json:"useLocalAzureIpAddress,omitempty"`
+	UseLocalAzureIPAddress *bool
 
 	// Enable policy-based traffic selectors.
-	UsePolicyBasedTrafficSelectors *bool `json:"usePolicyBasedTrafficSelectors,omitempty"`
+	UsePolicyBasedTrafficSelectors *bool
 
 	// The reference to virtual network gateway resource.
-	VirtualNetworkGateway2 *VirtualNetworkGateway `json:"virtualNetworkGateway2,omitempty"`
+	VirtualNetworkGateway2 *VirtualNetworkGateway
 
 	// READ-ONLY; Virtual Network Gateway connection status.
-	ConnectionStatus *VirtualNetworkGatewayConnectionStatus `json:"connectionStatus,omitempty" azure:"ro"`
+	ConnectionStatus *VirtualNetworkGatewayConnectionStatus
 
 	// READ-ONLY; The egress bytes transferred in this connection.
-	EgressBytesTransferred *int64 `json:"egressBytesTransferred,omitempty" azure:"ro"`
+	EgressBytesTransferred *int64
 
 	// READ-ONLY; The ingress bytes transferred in this connection.
-	IngressBytesTransferred *int64 `json:"ingressBytesTransferred,omitempty" azure:"ro"`
+	IngressBytesTransferred *int64
 
 	// READ-ONLY; The provisioning state of the virtual network gateway connection resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the virtual network gateway connection resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 
 	// READ-ONLY; Collection of all tunnels' connection health status.
-	TunnelConnectionStatus []*TunnelConnectionHealth `json:"tunnelConnectionStatus,omitempty" azure:"ro"`
+	TunnelConnectionStatus []*TunnelConnectionHealth
 }
 
 // VirtualNetworkGatewayConnectionsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewayConnectionsClient.BeginCreateOrUpdate
@@ -11269,117 +11269,117 @@ type VirtualNetworkGatewayConnectionsClientListOptions struct {
 // VirtualNetworkGatewayIPConfiguration - IP configuration for virtual network gateway.
 type VirtualNetworkGatewayIPConfiguration struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the virtual network gateway ip configuration.
-	Properties *VirtualNetworkGatewayIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkGatewayIPConfigurationPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VirtualNetworkGatewayIPConfigurationPropertiesFormat - Properties of VirtualNetworkGatewayIPConfiguration.
 type VirtualNetworkGatewayIPConfigurationPropertiesFormat struct {
 	// The private IP address allocation method.
-	PrivateIPAllocationMethod *IPAllocationMethod `json:"privateIPAllocationMethod,omitempty"`
+	PrivateIPAllocationMethod *IPAllocationMethod
 
 	// The reference to the public IP resource.
-	PublicIPAddress *SubResource `json:"publicIPAddress,omitempty"`
+	PublicIPAddress *SubResource
 
 	// The reference to the subnet resource.
-	Subnet *SubResource `json:"subnet,omitempty"`
+	Subnet *SubResource
 
 	// READ-ONLY; Private IP Address for this gateway.
-	PrivateIPAddress *string `json:"privateIPAddress,omitempty" azure:"ro"`
+	PrivateIPAddress *string
 
 	// READ-ONLY; The provisioning state of the virtual network gateway IP configuration resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualNetworkGatewayListConnectionsResult - Response for the VirtualNetworkGatewayListConnections API service call.
 type VirtualNetworkGatewayListConnectionsResult struct {
 	// A list of VirtualNetworkGatewayConnection resources that exists in a resource group.
-	Value []*VirtualNetworkGatewayConnectionListEntity `json:"value,omitempty"`
+	Value []*VirtualNetworkGatewayConnectionListEntity
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // VirtualNetworkGatewayListResult - Response for the ListVirtualNetworkGateways API service call.
 type VirtualNetworkGatewayListResult struct {
 	// A list of VirtualNetworkGateway resources that exists in a resource group.
-	Value []*VirtualNetworkGateway `json:"value,omitempty"`
+	Value []*VirtualNetworkGateway
 
 	// READ-ONLY; The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // VirtualNetworkGatewayPropertiesFormat - VirtualNetworkGateway properties.
 type VirtualNetworkGatewayPropertiesFormat struct {
 	// ActiveActive flag.
-	Active *bool `json:"activeActive,omitempty"`
+	Active *bool
 
 	// Virtual network gateway's BGP speaker settings.
-	BgpSettings *BgpSettings `json:"bgpSettings,omitempty"`
+	BgpSettings *BgpSettings
 
 	// The reference to the address space resource which represents the custom routes address space specified by the customer
 	// for virtual network gateway and VpnClient.
-	CustomRoutes *AddressSpace `json:"customRoutes,omitempty"`
+	CustomRoutes *AddressSpace
 
 	// Whether BGP is enabled for this virtual network gateway or not.
-	EnableBgp *bool `json:"enableBgp,omitempty"`
+	EnableBgp *bool
 
 	// Whether dns forwarding is enabled or not.
-	EnableDNSForwarding *bool `json:"enableDnsForwarding,omitempty"`
+	EnableDNSForwarding *bool
 
 	// Whether private IP needs to be enabled on this gateway for connections or not.
-	EnablePrivateIPAddress *bool `json:"enablePrivateIpAddress,omitempty"`
+	EnablePrivateIPAddress *bool
 
 	// The reference to the LocalNetworkGateway resource which represents local network site having default routes. Assign Null
 	// value in case of removing existing default site setting.
-	GatewayDefaultSite *SubResource `json:"gatewayDefaultSite,omitempty"`
+	GatewayDefaultSite *SubResource
 
 	// The type of this virtual network gateway.
-	GatewayType *VirtualNetworkGatewayType `json:"gatewayType,omitempty"`
+	GatewayType *VirtualNetworkGatewayType
 
 	// IP configurations for virtual network gateway.
-	IPConfigurations []*VirtualNetworkGatewayIPConfiguration `json:"ipConfigurations,omitempty"`
+	IPConfigurations []*VirtualNetworkGatewayIPConfiguration
 
 	// The reference to the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway.
-	SKU *VirtualNetworkGatewaySKU `json:"sku,omitempty"`
+	SKU *VirtualNetworkGatewaySKU
 
 	// The reference to the VpnClientConfiguration resource which represents the P2S VpnClient configurations.
-	VPNClientConfiguration *VPNClientConfiguration `json:"vpnClientConfiguration,omitempty"`
+	VPNClientConfiguration *VPNClientConfiguration
 
 	// The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.
-	VPNGatewayGeneration *VPNGatewayGeneration `json:"vpnGatewayGeneration,omitempty"`
+	VPNGatewayGeneration *VPNGatewayGeneration
 
 	// The type of this virtual network gateway.
-	VPNType *VPNType `json:"vpnType,omitempty"`
+	VPNType *VPNType
 
 	// READ-ONLY; The IP address allocated by the gateway to which dns requests can be sent.
-	InboundDNSForwardingEndpoint *string `json:"inboundDnsForwardingEndpoint,omitempty" azure:"ro"`
+	InboundDNSForwardingEndpoint *string
 
 	// READ-ONLY; The provisioning state of the virtual network gateway resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the virtual network gateway resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // VirtualNetworkGatewaySKU - VirtualNetworkGatewaySku details.
 type VirtualNetworkGatewaySKU struct {
 	// Gateway SKU name.
-	Name *VirtualNetworkGatewaySKUName `json:"name,omitempty"`
+	Name *VirtualNetworkGatewaySKUName
 
 	// Gateway SKU tier.
-	Tier *VirtualNetworkGatewaySKUTier `json:"tier,omitempty"`
+	Tier *VirtualNetworkGatewaySKUTier
 
 	// READ-ONLY; The capacity.
-	Capacity *int32 `json:"capacity,omitempty" azure:"ro"`
+	Capacity *int32
 }
 
 // VirtualNetworkGatewaysClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkGatewaysClient.BeginCreateOrUpdate
@@ -11539,76 +11539,76 @@ type VirtualNetworkGatewaysClientVPNDeviceConfigurationScriptOptions struct {
 // VirtualNetworkListResult - Response for the ListVirtualNetworks API service call.
 type VirtualNetworkListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of VirtualNetwork resources in a resource group.
-	Value []*VirtualNetwork `json:"value,omitempty"`
+	Value []*VirtualNetwork
 }
 
 // VirtualNetworkListUsageResult - Response for the virtual networks GetUsage API service call.
 type VirtualNetworkListUsageResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// READ-ONLY; VirtualNetwork usage stats.
-	Value []*VirtualNetworkUsage `json:"value,omitempty" azure:"ro"`
+	Value []*VirtualNetworkUsage
 }
 
 // VirtualNetworkPeering - Peerings in a virtual network resource.
 type VirtualNetworkPeering struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// The name of the resource that is unique within a resource group. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Properties of the virtual network peering.
-	Properties *VirtualNetworkPeeringPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkPeeringPropertiesFormat
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // VirtualNetworkPeeringListResult - Response for ListSubnets API service call. Retrieves all subnets that belong to a virtual
 // network.
 type VirtualNetworkPeeringListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// The peerings in a virtual network.
-	Value []*VirtualNetworkPeering `json:"value,omitempty"`
+	Value []*VirtualNetworkPeering
 }
 
 // VirtualNetworkPeeringPropertiesFormat - Properties of the virtual network peering.
 type VirtualNetworkPeeringPropertiesFormat struct {
 	// Whether the forwarded traffic from the VMs in the local virtual network will be allowed/disallowed in remote virtual network.
-	AllowForwardedTraffic *bool `json:"allowForwardedTraffic,omitempty"`
+	AllowForwardedTraffic *bool
 
 	// If gateway links can be used in remote virtual networking to link to this virtual network.
-	AllowGatewayTransit *bool `json:"allowGatewayTransit,omitempty"`
+	AllowGatewayTransit *bool
 
 	// Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space.
-	AllowVirtualNetworkAccess *bool `json:"allowVirtualNetworkAccess,omitempty"`
+	AllowVirtualNetworkAccess *bool
 
 	// The status of the virtual network peering.
-	PeeringState *VirtualNetworkPeeringState `json:"peeringState,omitempty"`
+	PeeringState *VirtualNetworkPeeringState
 
 	// The reference to the remote virtual network address space.
-	RemoteAddressSpace *AddressSpace `json:"remoteAddressSpace,omitempty"`
+	RemoteAddressSpace *AddressSpace
 
 	// The reference to the remote virtual network. The remote virtual network can be in the same or different region (preview).
 	// See here to register for the preview and learn more
 	// (https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-create-peering).
-	RemoteVirtualNetwork *SubResource `json:"remoteVirtualNetwork,omitempty"`
+	RemoteVirtualNetwork *SubResource
 
 	// If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering
 	// is also true, virtual network will use gateways of remote virtual network
 	// for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a
 	// gateway.
-	UseRemoteGateways *bool `json:"useRemoteGateways,omitempty"`
+	UseRemoteGateways *bool
 
 	// READ-ONLY; The provisioning state of the virtual network peering resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkPeeringsClient.BeginCreateOrUpdate
@@ -11639,92 +11639,92 @@ type VirtualNetworkPeeringsClientListOptions struct {
 // VirtualNetworkPropertiesFormat - Properties of the virtual network.
 type VirtualNetworkPropertiesFormat struct {
 	// The AddressSpace that contains an array of IP address ranges that can be used by subnets.
-	AddressSpace *AddressSpace `json:"addressSpace,omitempty"`
+	AddressSpace *AddressSpace
 
 	// Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.
-	BgpCommunities *VirtualNetworkBgpCommunities `json:"bgpCommunities,omitempty"`
+	BgpCommunities *VirtualNetworkBgpCommunities
 
 	// The DDoS protection plan associated with the virtual network.
-	DdosProtectionPlan *SubResource `json:"ddosProtectionPlan,omitempty"`
+	DdosProtectionPlan *SubResource
 
 	// The dhcpOptions that contains an array of DNS servers available to VMs deployed in the virtual network.
-	DhcpOptions *DhcpOptions `json:"dhcpOptions,omitempty"`
+	DhcpOptions *DhcpOptions
 
 	// Indicates if DDoS protection is enabled for all the protected resources in the virtual network. It requires a DDoS protection
 	// plan associated with the resource.
-	EnableDdosProtection *bool `json:"enableDdosProtection,omitempty"`
+	EnableDdosProtection *bool
 
 	// Indicates if VM protection is enabled for all the subnets in the virtual network.
-	EnableVMProtection *bool `json:"enableVmProtection,omitempty"`
+	EnableVMProtection *bool
 
 	// Array of IpAllocation which reference this VNET.
-	IPAllocations []*SubResource `json:"ipAllocations,omitempty"`
+	IPAllocations []*SubResource
 
 	// A list of subnets in a Virtual Network.
-	Subnets []*Subnet `json:"subnets,omitempty"`
+	Subnets []*Subnet
 
 	// A list of peerings in a Virtual Network.
-	VirtualNetworkPeerings []*VirtualNetworkPeering `json:"virtualNetworkPeerings,omitempty"`
+	VirtualNetworkPeerings []*VirtualNetworkPeering
 
 	// READ-ONLY; The provisioning state of the virtual network resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resourceGuid property of the Virtual Network resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // VirtualNetworkTap - Virtual Network Tap resource.
 type VirtualNetworkTap struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Virtual Network Tap Properties.
-	Properties *VirtualNetworkTapPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualNetworkTapPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualNetworkTapListResult - Response for ListVirtualNetworkTap API service call.
 type VirtualNetworkTapListResult struct {
 	// The URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// A list of VirtualNetworkTaps in a resource group.
-	Value []*VirtualNetworkTap `json:"value,omitempty"`
+	Value []*VirtualNetworkTap
 }
 
 // VirtualNetworkTapPropertiesFormat - Virtual Network Tap properties.
 type VirtualNetworkTapPropertiesFormat struct {
 	// The reference to the private IP address on the internal Load Balancer that will receive the tap.
-	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration `json:"destinationLoadBalancerFrontEndIPConfiguration,omitempty"`
+	DestinationLoadBalancerFrontEndIPConfiguration *FrontendIPConfiguration
 
 	// The reference to the private IP Address of the collector nic that will receive the tap.
-	DestinationNetworkInterfaceIPConfiguration *InterfaceIPConfiguration `json:"destinationNetworkInterfaceIPConfiguration,omitempty"`
+	DestinationNetworkInterfaceIPConfiguration *InterfaceIPConfiguration
 
 	// The VXLAN destination port that will receive the tapped traffic.
-	DestinationPort *int32 `json:"destinationPort,omitempty"`
+	DestinationPort *int32
 
 	// READ-ONLY; Specifies the list of resource IDs for the network interface IP configuration that needs to be tapped.
-	NetworkInterfaceTapConfigurations []*InterfaceTapConfiguration `json:"networkInterfaceTapConfigurations,omitempty" azure:"ro"`
+	NetworkInterfaceTapConfigurations []*InterfaceTapConfiguration
 
 	// READ-ONLY; The provisioning state of the virtual network tap resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; The resource GUID property of the virtual network tap resource.
-	ResourceGUID *string `json:"resourceGuid,omitempty" azure:"ro"`
+	ResourceGUID *string
 }
 
 // VirtualNetworkTapsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworkTapsClient.BeginCreateOrUpdate
@@ -11767,28 +11767,28 @@ type VirtualNetworkTapsClientUpdateTagsOptions struct {
 // VirtualNetworkUsage - Usage details for subnet.
 type VirtualNetworkUsage struct {
 	// READ-ONLY; Indicates number of IPs used from the Subnet.
-	CurrentValue *float64 `json:"currentValue,omitempty" azure:"ro"`
+	CurrentValue *float64
 
 	// READ-ONLY; Subnet identifier.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Indicates the size of the subnet.
-	Limit *float64 `json:"limit,omitempty" azure:"ro"`
+	Limit *float64
 
 	// READ-ONLY; The name containing common and localized value for usage.
-	Name *VirtualNetworkUsageName `json:"name,omitempty" azure:"ro"`
+	Name *VirtualNetworkUsageName
 
 	// READ-ONLY; Usage units. Returns 'Count'.
-	Unit *string `json:"unit,omitempty" azure:"ro"`
+	Unit *string
 }
 
 // VirtualNetworkUsageName - Usage strings container.
 type VirtualNetworkUsageName struct {
 	// READ-ONLY; Localized subnet size and usage string.
-	LocalizedValue *string `json:"localizedValue,omitempty" azure:"ro"`
+	LocalizedValue *string
 
 	// READ-ONLY; Subnet size and usage string.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // VirtualNetworksClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualNetworksClient.BeginCreateOrUpdate
@@ -11840,73 +11840,73 @@ type VirtualNetworksClientUpdateTagsOptions struct {
 // VirtualRouter Resource.
 type VirtualRouter struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the Virtual Router.
-	Properties *VirtualRouterPropertiesFormat `json:"properties,omitempty"`
+	Properties *VirtualRouterPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualRouterListResult - Response for ListVirtualRouters API service call.
 type VirtualRouterListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Virtual Routers.
-	Value []*VirtualRouter `json:"value,omitempty"`
+	Value []*VirtualRouter
 }
 
 // VirtualRouterPeering - Virtual Router Peering resource.
 type VirtualRouterPeering struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Name of the virtual router peering that is unique within a virtual router.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The properties of the Virtual Router Peering.
-	Properties *VirtualRouterPeeringProperties `json:"properties,omitempty"`
+	Properties *VirtualRouterPeeringProperties
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Peering type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualRouterPeeringListResult - Response for ListVirtualRouterPeerings API service call.
 type VirtualRouterPeeringListResult struct {
 	// URL to get the next set of results.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of VirtualRouterPeerings in a VirtualRouter.
-	Value []*VirtualRouterPeering `json:"value,omitempty"`
+	Value []*VirtualRouterPeering
 }
 
 // VirtualRouterPeeringProperties - Properties of the rule group.
 type VirtualRouterPeeringProperties struct {
 	// Peer ASN.
-	PeerAsn *int64 `json:"peerAsn,omitempty"`
+	PeerAsn *int64
 
 	// Peer IP.
-	PeerIP *string `json:"peerIp,omitempty"`
+	PeerIP *string
 
 	// READ-ONLY; The provisioning state of the resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualRouterPeeringsClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualRouterPeeringsClient.BeginCreateOrUpdate
@@ -11937,22 +11937,22 @@ type VirtualRouterPeeringsClientListOptions struct {
 // VirtualRouterPropertiesFormat - Virtual Router definition.
 type VirtualRouterPropertiesFormat struct {
 	// The Gateway on which VirtualRouter is hosted.
-	HostedGateway *SubResource `json:"hostedGateway,omitempty"`
+	HostedGateway *SubResource
 
 	// The Subnet on which VirtualRouter is hosted.
-	HostedSubnet *SubResource `json:"hostedSubnet,omitempty"`
+	HostedSubnet *SubResource
 
 	// VirtualRouter ASN.
-	VirtualRouterAsn *int64 `json:"virtualRouterAsn,omitempty"`
+	VirtualRouterAsn *int64
 
 	// VirtualRouter IPs.
-	VirtualRouterIPs []*string `json:"virtualRouterIps,omitempty"`
+	VirtualRouterIPs []*string
 
 	// READ-ONLY; List of references to VirtualRouterPeerings.
-	Peerings []*SubResource `json:"peerings,omitempty" azure:"ro"`
+	Peerings []*SubResource
 
 	// READ-ONLY; The provisioning state of the resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // VirtualRoutersClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualRoutersClient.BeginCreateOrUpdate
@@ -11988,79 +11988,79 @@ type VirtualRoutersClientListOptions struct {
 // VirtualWAN Resource.
 type VirtualWAN struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the virtual WAN.
-	Properties *VirtualWanProperties `json:"properties,omitempty"`
+	Properties *VirtualWanProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // VirtualWanProperties - Parameters for VirtualWAN.
 type VirtualWanProperties struct {
 	// True if branch to branch traffic is allowed.
-	AllowBranchToBranchTraffic *bool `json:"allowBranchToBranchTraffic,omitempty"`
+	AllowBranchToBranchTraffic *bool
 
 	// True if Vnet to Vnet traffic is allowed.
-	AllowVnetToVnetTraffic *bool `json:"allowVnetToVnetTraffic,omitempty"`
+	AllowVnetToVnetTraffic *bool
 
 	// Vpn encryption to be disabled or not.
-	DisableVPNEncryption *bool `json:"disableVpnEncryption,omitempty"`
+	DisableVPNEncryption *bool
 
 	// The type of the VirtualWAN.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// READ-ONLY; The office local breakout category.
-	Office365LocalBreakoutCategory *OfficeTrafficCategory `json:"office365LocalBreakoutCategory,omitempty" azure:"ro"`
+	Office365LocalBreakoutCategory *OfficeTrafficCategory
 
 	// READ-ONLY; The provisioning state of the virtual WAN resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; List of VpnSites in the VirtualWAN.
-	VPNSites []*SubResource `json:"vpnSites,omitempty" azure:"ro"`
+	VPNSites []*SubResource
 
 	// READ-ONLY; List of VirtualHubs in the VirtualWAN.
-	VirtualHubs []*SubResource `json:"virtualHubs,omitempty" azure:"ro"`
+	VirtualHubs []*SubResource
 }
 
 // VirtualWanSecurityProvider - Collection of SecurityProviders.
 type VirtualWanSecurityProvider struct {
 	// Name of the security provider.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Url of the security provider.
-	URL *string `json:"url,omitempty"`
+	URL *string
 
 	// READ-ONLY; Name of the security provider.
-	Type *VirtualWanSecurityProviderType `json:"type,omitempty" azure:"ro"`
+	Type *VirtualWanSecurityProviderType
 }
 
 // VirtualWanSecurityProviders - Collection of SecurityProviders.
 type VirtualWanSecurityProviders struct {
 	// List of VirtualWAN security providers.
-	SupportedProviders []*VirtualWanSecurityProvider `json:"supportedProviders,omitempty"`
+	SupportedProviders []*VirtualWanSecurityProvider
 }
 
 // VirtualWanVPNProfileParameters - Virtual Wan Vpn profile parameters Vpn profile generation.
 type VirtualWanVPNProfileParameters struct {
 	// VPN client authentication method.
-	AuthenticationMethod *AuthenticationMethod `json:"authenticationMethod,omitempty"`
+	AuthenticationMethod *AuthenticationMethod
 
 	// VpnServerConfiguration partial resource uri with which VirtualWan is associated to.
-	VPNServerConfigurationResourceID *string `json:"vpnServerConfigurationResourceId,omitempty"`
+	VPNServerConfigurationResourceID *string
 }
 
 // VirtualWansClientBeginCreateOrUpdateOptions contains the optional parameters for the VirtualWansClient.BeginCreateOrUpdate
@@ -12100,37 +12100,37 @@ type VirtualWansClientUpdateTagsOptions struct {
 // Watcher - Network watcher in a resource group.
 type Watcher struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the network watcher.
-	Properties *WatcherPropertiesFormat `json:"properties,omitempty"`
+	Properties *WatcherPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // WatcherListResult - Response for ListNetworkWatchers API service call.
 type WatcherListResult struct {
 	// List of network watcher resources.
-	Value []*Watcher `json:"value,omitempty"`
+	Value []*Watcher
 }
 
 // WatcherPropertiesFormat - The network watcher properties.
 type WatcherPropertiesFormat struct {
 	// READ-ONLY; The provisioning state of the network watcher resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 }
 
 // WatchersClientBeginCheckConnectivityOptions contains the optional parameters for the WatchersClient.BeginCheckConnectivity
@@ -12247,22 +12247,22 @@ type WatchersClientUpdateTagsOptions struct {
 // WebApplicationFirewallCustomRule - Defines contents of a web application rule.
 type WebApplicationFirewallCustomRule struct {
 	// REQUIRED; Type of Actions.
-	Action *WebApplicationFirewallAction `json:"action,omitempty"`
+	Action *WebApplicationFirewallAction
 
 	// REQUIRED; List of match conditions.
-	MatchConditions []*MatchCondition `json:"matchConditions,omitempty"`
+	MatchConditions []*MatchCondition
 
 	// REQUIRED; Priority of the rule. Rules with a lower value will be evaluated before rules with a higher value.
-	Priority *int32 `json:"priority,omitempty"`
+	Priority *int32
 
 	// REQUIRED; The rule type.
-	RuleType *WebApplicationFirewallRuleType `json:"ruleType,omitempty"`
+	RuleType *WebApplicationFirewallRuleType
 
 	// The name of the resource that is unique within a policy. This name can be used to access the resource.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 }
 
 // WebApplicationFirewallPoliciesClientBeginDeleteOptions contains the optional parameters for the WebApplicationFirewallPoliciesClient.BeginDelete
@@ -12299,60 +12299,60 @@ type WebApplicationFirewallPoliciesClientListOptions struct {
 // WebApplicationFirewallPolicy - Defines web application firewall policy.
 type WebApplicationFirewallPolicy struct {
 	// Resource ID.
-	ID *string `json:"id,omitempty"`
+	ID *string
 
 	// Resource location.
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Properties of the web application firewall policy.
-	Properties *WebApplicationFirewallPolicyPropertiesFormat `json:"properties,omitempty"`
+	Properties *WebApplicationFirewallPolicyPropertiesFormat
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; A unique read-only string that changes whenever the resource is updated.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Resource name.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Resource type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // WebApplicationFirewallPolicyListResult - Result of the request to list WebApplicationFirewallPolicies. It contains a list
 // of WebApplicationFirewallPolicy objects and a URL link to get the next set of results.
 type WebApplicationFirewallPolicyListResult struct {
 	// READ-ONLY; URL to get the next set of WebApplicationFirewallPolicy objects if there are any.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 
 	// READ-ONLY; List of WebApplicationFirewallPolicies within a resource group.
-	Value []*WebApplicationFirewallPolicy `json:"value,omitempty" azure:"ro"`
+	Value []*WebApplicationFirewallPolicy
 }
 
 // WebApplicationFirewallPolicyPropertiesFormat - Defines web application firewall policy properties.
 type WebApplicationFirewallPolicyPropertiesFormat struct {
 	// REQUIRED; Describes the managedRules structure.
-	ManagedRules *ManagedRulesDefinition `json:"managedRules,omitempty"`
+	ManagedRules *ManagedRulesDefinition
 
 	// The custom rules inside the policy.
-	CustomRules []*WebApplicationFirewallCustomRule `json:"customRules,omitempty"`
+	CustomRules []*WebApplicationFirewallCustomRule
 
 	// The PolicySettings for policy.
-	PolicySettings *PolicySettings `json:"policySettings,omitempty"`
+	PolicySettings *PolicySettings
 
 	// READ-ONLY; A collection of references to application gateways.
-	ApplicationGateways []*ApplicationGateway `json:"applicationGateways,omitempty" azure:"ro"`
+	ApplicationGateways []*ApplicationGateway
 
 	// READ-ONLY; A collection of references to application gateway http listeners.
-	HTTPListeners []*SubResource `json:"httpListeners,omitempty" azure:"ro"`
+	HTTPListeners []*SubResource
 
 	// READ-ONLY; A collection of references to application gateway path rules.
-	PathBasedRules []*SubResource `json:"pathBasedRules,omitempty" azure:"ro"`
+	PathBasedRules []*SubResource
 
 	// READ-ONLY; The provisioning state of the web application firewall policy resource.
-	ProvisioningState *ProvisioningState `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *ProvisioningState
 
 	// READ-ONLY; Resource status of the policy.
-	ResourceState *WebApplicationFirewallPolicyResourceState `json:"resourceState,omitempty" azure:"ro"`
+	ResourceState *WebApplicationFirewallPolicyResourceState
 }

--- a/test/storage/2020-06-12/azblob/zz_models.go
+++ b/test/storage/2020-06-12/azblob/zz_models.go
@@ -1072,16 +1072,16 @@ type CpkScopeInfo struct {
 
 type DataLakeStorageError struct {
 	// The service error response object.
-	DataLakeStorageErrorDetails *DataLakeStorageErrorError `json:"error,omitempty"`
+	DataLakeStorageErrorDetails *DataLakeStorageErrorError
 }
 
 // DataLakeStorageErrorError - The service error response object.
 type DataLakeStorageErrorError struct {
 	// The service error code.
-	Code *string `json:"Code,omitempty"`
+	Code *string
 
 	// The service error message.
-	Message *string `json:"Message,omitempty"`
+	Message *string
 }
 
 // DelimitedTextConfiguration - delimited text configuration
@@ -1834,7 +1834,7 @@ type StaticWebsite struct {
 }
 
 type StorageError struct {
-	Message *string `json:"Message,omitempty"`
+	Message *string
 }
 
 // StorageServiceProperties - Storage Service Properties.

--- a/test/synapse/2019-06-01/azartifacts/zz_models.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_models.go
@@ -30,22 +30,22 @@ type ActivityClassification interface {
 // Activity - A pipeline activity.
 type Activity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type Activity.
@@ -54,10 +54,10 @@ func (a *Activity) GetActivity() *Activity { return a }
 // ActivityDependency - Activity dependency information.
 type ActivityDependency struct {
 	// REQUIRED; Activity name.
-	Activity *string `json:"activity,omitempty"`
+	Activity *string
 
 	// REQUIRED; Match-Condition for the dependency.
-	DependencyConditions []*DependencyCondition `json:"dependencyConditions,omitempty"`
+	DependencyConditions []*DependencyCondition
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -69,20 +69,20 @@ type ActivityPolicy struct {
 	AdditionalProperties map[string]any
 
 	// Maximum ordinary retry attempts. Default is 0. Type: integer (or Expression with resultType integer), minimum: 0.
-	Retry any `json:"retry,omitempty"`
+	Retry any
 
 	// Interval between each retry attempt (in seconds). The default is 30 sec.
-	RetryIntervalInSeconds *int32 `json:"retryIntervalInSeconds,omitempty"`
+	RetryIntervalInSeconds *int32
 
 	// When set to true, Input from activity is considered as secure and will not be logged to monitoring.
-	SecureInput *bool `json:"secureInput,omitempty"`
+	SecureInput *bool
 
 	// When set to true, Output from activity is considered as secure and will not be logged to monitoring.
-	SecureOutput *bool `json:"secureOutput,omitempty"`
+	SecureOutput *bool
 
 	// Specifies the timeout for the activity to run. The default timeout is 7 days. Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	Timeout any `json:"timeout,omitempty"`
+	Timeout any
 }
 
 // ActivityRun - Information about an activity run in a pipeline.
@@ -91,82 +91,82 @@ type ActivityRun struct {
 	AdditionalProperties map[string]any
 
 	// READ-ONLY; The name of the activity.
-	ActivityName *string `json:"activityName,omitempty" azure:"ro"`
+	ActivityName *string
 
 	// READ-ONLY; The end time of the activity run in 'ISO 8601' format.
-	ActivityRunEnd *time.Time `json:"activityRunEnd,omitempty" azure:"ro"`
+	ActivityRunEnd *time.Time
 
 	// READ-ONLY; The id of the activity run.
-	ActivityRunID *string `json:"activityRunId,omitempty" azure:"ro"`
+	ActivityRunID *string
 
 	// READ-ONLY; The start time of the activity run in 'ISO 8601' format.
-	ActivityRunStart *time.Time `json:"activityRunStart,omitempty" azure:"ro"`
+	ActivityRunStart *time.Time
 
 	// READ-ONLY; The type of the activity.
-	ActivityType *string `json:"activityType,omitempty" azure:"ro"`
+	ActivityType *string
 
 	// READ-ONLY; The duration of the activity run.
-	DurationInMs *int32 `json:"durationInMs,omitempty" azure:"ro"`
+	DurationInMs *int32
 
 	// READ-ONLY; The error if any from the activity run.
-	Error any `json:"error,omitempty" azure:"ro"`
+	Error any
 
 	// READ-ONLY; The input for the activity.
-	Input any `json:"input,omitempty" azure:"ro"`
+	Input any
 
 	// READ-ONLY; The name of the compute linked service.
-	LinkedServiceName *string `json:"linkedServiceName,omitempty" azure:"ro"`
+	LinkedServiceName *string
 
 	// READ-ONLY; The output for the activity.
-	Output any `json:"output,omitempty" azure:"ro"`
+	Output any
 
 	// READ-ONLY; The name of the pipeline.
-	PipelineName *string `json:"pipelineName,omitempty" azure:"ro"`
+	PipelineName *string
 
 	// READ-ONLY; The id of the pipeline run.
-	PipelineRunID *string `json:"pipelineRunId,omitempty" azure:"ro"`
+	PipelineRunID *string
 
 	// READ-ONLY; The status of the activity run.
-	Status *string `json:"status,omitempty" azure:"ro"`
+	Status *string
 }
 
 // ActivityRunsQueryResponse - A list activity runs.
 type ActivityRunsQueryResponse struct {
 	// REQUIRED; List of activity runs.
-	Value []*ActivityRun `json:"value,omitempty"`
+	Value []*ActivityRun
 
 	// The continuation token for getting the next page of results, if any remaining results exist, null otherwise.
-	ContinuationToken *string `json:"continuationToken,omitempty"`
+	ContinuationToken *string
 }
 
 // AddDataFlowToDebugSessionResponse - Response body structure for starting data flow debug session.
 type AddDataFlowToDebugSessionResponse struct {
 	// The ID of data flow debug job version.
-	JobVersion *string `json:"jobVersion,omitempty"`
+	JobVersion *string
 }
 
 // AmazonMWSLinkedService - Amazon Marketplace Web Service linked service.
 type AmazonMWSLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Amazon Marketplace Web Service linked service properties.
-	TypeProperties *AmazonMWSLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AmazonMWSLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AmazonMWSLinkedService.
@@ -184,71 +184,71 @@ func (a *AmazonMWSLinkedService) GetLinkedService() *LinkedService {
 // AmazonMWSLinkedServiceTypeProperties - Amazon Marketplace Web Service linked service properties.
 type AmazonMWSLinkedServiceTypeProperties struct {
 	// REQUIRED; The access key id used to access data.
-	AccessKeyID any `json:"accessKeyId,omitempty"`
+	AccessKeyID any
 
 	// REQUIRED; The endpoint of the Amazon MWS server, (i.e. mws.amazonservices.com)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// REQUIRED; The Amazon Marketplace ID you want to retrieve data from. To retrieve data from multiple Marketplace IDs, separate
 	// them with a comma (,). (i.e. A2EUQ1WTGCTBG2)
-	MarketplaceID any `json:"marketplaceID,omitempty"`
+	MarketplaceID any
 
 	// REQUIRED; The Amazon seller ID.
-	SellerID any `json:"sellerID,omitempty"`
+	SellerID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Amazon MWS authentication token.
-	MwsAuthToken SecretBaseClassification `json:"mwsAuthToken,omitempty"`
+	MwsAuthToken SecretBaseClassification
 
 	// The secret key used to access data.
-	SecretKey SecretBaseClassification `json:"secretKey,omitempty"`
+	SecretKey SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // AmazonMWSObjectDataset - Amazon Marketplace Web Service dataset.
 type AmazonMWSObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AmazonMWSObjectDataset.
@@ -269,25 +269,25 @@ func (a *AmazonMWSObjectDataset) GetDataset() *Dataset {
 // AmazonMWSSource - A copy activity Amazon Marketplace Web Service source.
 type AmazonMWSSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AmazonMWSSource.
@@ -316,25 +316,25 @@ func (a *AmazonMWSSource) GetTabularSource() *TabularSource {
 // AmazonRedshiftLinkedService - Linked service for Amazon Redshift.
 type AmazonRedshiftLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Amazon Redshift linked service properties.
-	TypeProperties *AmazonRedshiftLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AmazonRedshiftLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AmazonRedshiftLinkedService.
@@ -352,53 +352,53 @@ func (a *AmazonRedshiftLinkedService) GetLinkedService() *LinkedService {
 // AmazonRedshiftLinkedServiceTypeProperties - Amazon Redshift linked service properties.
 type AmazonRedshiftLinkedServiceTypeProperties struct {
 	// REQUIRED; The database name of the Amazon Redshift source. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// REQUIRED; The name of the Amazon Redshift server. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password of the Amazon Redshift source.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port number that the Amazon Redshift server uses to listen for client connections. The default value is 5439. Type:
 	// integer (or Expression with resultType integer).
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The username of the Amazon Redshift source. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // AmazonRedshiftSource - A copy activity source for Amazon Redshift Source.
 type AmazonRedshiftSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// The Amazon S3 settings needed for the interim Amazon S3 when copying from Amazon Redshift with unload. With this, data
 	// from Amazon Redshift source will be unloaded into S3 first and then copied into
 	// the targeted sink from the interim S3.
-	RedshiftUnloadSettings *RedshiftUnloadSettings `json:"redshiftUnloadSettings,omitempty"`
+	RedshiftUnloadSettings *RedshiftUnloadSettings
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AmazonRedshiftSource.
@@ -427,35 +427,35 @@ func (a *AmazonRedshiftSource) GetTabularSource() *TabularSource {
 // AmazonRedshiftTableDataset - The Amazon Redshift table dataset.
 type AmazonRedshiftTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Amazon Redshift table dataset properties.
-	TypeProperties *AmazonRedshiftTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AmazonRedshiftTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AmazonRedshiftTableDataset.
@@ -476,37 +476,37 @@ func (a *AmazonRedshiftTableDataset) GetDataset() *Dataset {
 // AmazonRedshiftTableDatasetTypeProperties - Amazon Redshift table dataset properties.
 type AmazonRedshiftTableDatasetTypeProperties struct {
 	// The Amazon Redshift schema name. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The Amazon Redshift table name. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AmazonS3LinkedService - Linked service for Amazon S3.
 type AmazonS3LinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Amazon S3 linked service properties.
-	TypeProperties *AmazonS3LinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AmazonS3LinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AmazonS3LinkedService.
@@ -525,40 +525,40 @@ func (a *AmazonS3LinkedService) GetLinkedService() *LinkedService {
 type AmazonS3LinkedServiceTypeProperties struct {
 	// The access key identifier of the Amazon S3 Identity and Access Management (IAM) user. Type: string (or Expression with
 	// resultType string).
-	AccessKeyID any `json:"accessKeyId,omitempty"`
+	AccessKeyID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The secret access key of the Amazon S3 Identity and Access Management (IAM) user.
-	SecretAccessKey SecretBaseClassification `json:"secretAccessKey,omitempty"`
+	SecretAccessKey SecretBaseClassification
 
 	// This value specifies the endpoint to access with the S3 Connector. This is an optional property; change it only if you
 	// want to try a different service endpoint or want to switch between https and
 	// http. Type: string (or Expression with resultType string).
-	ServiceURL any `json:"serviceUrl,omitempty"`
+	ServiceURL any
 }
 
 // AmazonS3Location - The location of amazon S3 dataset.
 type AmazonS3Location struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the bucketName of amazon S3. Type: string (or Expression with resultType string)
-	BucketName any `json:"bucketName,omitempty"`
+	BucketName any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 
 	// Specify the version of amazon S3. Type: string (or Expression with resultType string).
-	Version any `json:"version,omitempty"`
+	Version any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type AmazonS3Location.
@@ -574,35 +574,35 @@ func (a *AmazonS3Location) GetDatasetLocation() *DatasetLocation {
 // AmazonS3ReadSettings - Azure data lake store read settings.
 type AmazonS3ReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// The prefix filter for the S3 object name. Type: string (or Expression with resultType string).
-	Prefix any `json:"prefix,omitempty"`
+	Prefix any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// AmazonS3 wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// AmazonS3 wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type AmazonS3ReadSettings.
@@ -617,25 +617,25 @@ func (a *AmazonS3ReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // AppendVariableActivity - Append value for a Variable of type Array.
 type AppendVariableActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Append Variable activity properties.
-	TypeProperties *AppendVariableActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AppendVariableActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AppendVariableActivity.
@@ -665,71 +665,71 @@ func (a *AppendVariableActivity) GetControlActivity() *ControlActivity {
 // AppendVariableActivityTypeProperties - AppendVariable activity properties.
 type AppendVariableActivityTypeProperties struct {
 	// Value to be appended. Could be a static value or Expression
-	Value any `json:"value,omitempty"`
+	Value any
 
 	// Name of the variable whose value needs to be appended to.
-	VariableName *string `json:"variableName,omitempty"`
+	VariableName *string
 }
 
 // ArtifactRenameRequest - Request body structure for rename artifact.
 type ArtifactRenameRequest struct {
 	// New name of the artifact.
-	NewName *string `json:"newName,omitempty"`
+	NewName *string
 }
 
 // AutoPauseProperties - Auto-pausing properties of a Big Data pool powered by Apache Spark
 type AutoPauseProperties struct {
 	// Number of minutes of idle time before the Big Data pool is automatically paused.
-	DelayInMinutes *int32 `json:"delayInMinutes,omitempty"`
+	DelayInMinutes *int32
 
 	// Whether auto-pausing is enabled for the Big Data pool.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 }
 
 // AutoScaleProperties - Auto-scaling properties of a Big Data pool powered by Apache Spark
 type AutoScaleProperties struct {
 	// Whether automatic scaling is enabled for the Big Data pool.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 
 	// The maximum number of nodes the Big Data pool can support.
-	MaxNodeCount *int32 `json:"maxNodeCount,omitempty"`
+	MaxNodeCount *int32
 
 	// The minimum number of nodes the Big Data pool can support.
-	MinNodeCount *int32 `json:"minNodeCount,omitempty"`
+	MinNodeCount *int32
 }
 
 // AvroDataset - Avro dataset.
 type AvroDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Avro dataset properties.
-	TypeProperties *AvroDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AvroDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AvroDataset.
@@ -750,24 +750,24 @@ func (a *AvroDataset) GetDataset() *Dataset {
 // AvroDatasetTypeProperties - Avro dataset properties.
 type AvroDatasetTypeProperties struct {
 	// REQUIRED; The location of the avro storage.
-	Location             DatasetLocationClassification `json:"location,omitempty"`
-	AvroCompressionCodec *AvroCompressionCodec         `json:"avroCompressionCodec,omitempty"`
-	AvroCompressionLevel *int32                        `json:"avroCompressionLevel,omitempty"`
+	Location             DatasetLocationClassification
+	AvroCompressionCodec *AvroCompressionCodec
+	AvroCompressionLevel *int32
 }
 
 // AvroFormat - The data stored in Avro format.
 type AvroFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type AvroFormat.
@@ -783,31 +783,31 @@ func (a *AvroFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // AvroSink - A copy activity Avro sink.
 type AvroSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Avro format settings.
-	FormatSettings *AvroWriteSettings `json:"formatSettings,omitempty"`
+	FormatSettings *AvroWriteSettings
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Avro store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AvroSink.
@@ -826,22 +826,22 @@ func (a *AvroSink) GetCopySink() *CopySink {
 // AvroSource - A copy activity Avro source.
 type AvroSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Avro store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AvroSource.
@@ -858,16 +858,16 @@ func (a *AvroSource) GetCopySource() *CopySource {
 // AvroWriteSettings - Avro write settings.
 type AvroWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Top level record name in write result, which is required in AVRO spec.
-	RecordName *string `json:"recordName,omitempty"`
+	RecordName *string
 
 	// Record namespace in the write result.
-	RecordNamespace *string `json:"recordNamespace,omitempty"`
+	RecordNamespace *string
 }
 
 // GetFormatWriteSettings implements the FormatWriteSettingsClassification interface for type AvroWriteSettings.
@@ -881,25 +881,25 @@ func (a *AvroWriteSettings) GetFormatWriteSettings() *FormatWriteSettings {
 // AzureBatchLinkedService - Azure Batch linked service.
 type AzureBatchLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Batch linked service properties.
-	TypeProperties *AzureBatchLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureBatchLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureBatchLinkedService.
@@ -917,47 +917,47 @@ func (a *AzureBatchLinkedService) GetLinkedService() *LinkedService {
 // AzureBatchLinkedServiceTypeProperties - Azure Batch linked service properties.
 type AzureBatchLinkedServiceTypeProperties struct {
 	// REQUIRED; The Azure Batch account name. Type: string (or Expression with resultType string).
-	AccountName any `json:"accountName,omitempty"`
+	AccountName any
 
 	// REQUIRED; The Azure Batch URI. Type: string (or Expression with resultType string).
-	BatchURI any `json:"batchUri,omitempty"`
+	BatchURI any
 
 	// REQUIRED; The Azure Storage linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; The Azure Batch pool name. Type: string (or Expression with resultType string).
-	PoolName any `json:"poolName,omitempty"`
+	PoolName any
 
 	// The Azure Batch account access key.
-	AccessKey SecretBaseClassification `json:"accessKey,omitempty"`
+	AccessKey SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 }
 
 // AzureBlobFSLinkedService - Azure Data Lake Storage Gen2 linked service.
 type AzureBlobFSLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Lake Storage Gen2 linked service properties.
-	TypeProperties *AzureBlobFSLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureBlobFSLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureBlobFSLinkedService.
@@ -975,42 +975,42 @@ func (a *AzureBlobFSLinkedService) GetLinkedService() *LinkedService {
 // AzureBlobFSLinkedServiceTypeProperties - Azure Data Lake Storage Gen2 linked service properties.
 type AzureBlobFSLinkedServiceTypeProperties struct {
 	// REQUIRED; Endpoint for the Azure Data Lake Storage Gen2 service. Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// Account key for the Azure Data Lake Storage Gen2 service. Type: string (or Expression with resultType string).
-	AccountKey any `json:"accountKey,omitempty"`
+	AccountKey any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The ID of the application used to authenticate against the Azure Data Lake Storage Gen2 account. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The Key of the application used to authenticate against the Azure Data Lake Storage Gen2 account.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureBlobFSLocation - The location of azure blobFS dataset.
 type AzureBlobFSLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the fileSystem of azure blobFS. Type: string (or Expression with resultType string).
-	FileSystem any `json:"fileSystem,omitempty"`
+	FileSystem any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type AzureBlobFSLocation.
@@ -1026,32 +1026,32 @@ func (a *AzureBlobFSLocation) GetDatasetLocation() *DatasetLocation {
 // AzureBlobFSReadSettings - Azure blobFS read settings.
 type AzureBlobFSReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Azure blobFS wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Azure blobFS wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type AzureBlobFSReadSettings.
@@ -1066,28 +1066,28 @@ func (a *AzureBlobFSReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // AzureBlobFSSink - A copy activity Azure Data Lake Storage Gen2 sink.
 type AzureBlobFSSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureBlobFSSink.
@@ -1106,29 +1106,29 @@ func (a *AzureBlobFSSink) GetCopySink() *CopySink {
 // AzureBlobFSSource - A copy activity Azure BlobFS source.
 type AzureBlobFSSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Number of header lines to skip from each blob. Type: integer (or Expression with resultType integer).
-	SkipHeaderLineCount any `json:"skipHeaderLineCount,omitempty"`
+	SkipHeaderLineCount any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Treat empty as null. Type: boolean (or Expression with resultType boolean).
-	TreatEmptyAsNull any `json:"treatEmptyAsNull,omitempty"`
+	TreatEmptyAsNull any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureBlobFSSource.
@@ -1145,19 +1145,19 @@ func (a *AzureBlobFSSource) GetCopySource() *CopySource {
 // AzureBlobFSWriteSettings - Azure blobFS write settings.
 type AzureBlobFSWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).
-	BlockSizeInMB any `json:"blockSizeInMB,omitempty"`
+	BlockSizeInMB any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type AzureBlobFSWriteSettings.
@@ -1173,25 +1173,25 @@ func (a *AzureBlobFSWriteSettings) GetStoreWriteSettings() *StoreWriteSettings {
 // AzureBlobStorageLinkedService - The azure blob storage linked service.
 type AzureBlobStorageLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Blob Storage linked service properties.
-	TypeProperties *AzureBlobStorageLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureBlobStorageLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureBlobStorageLinkedService.
@@ -1209,52 +1209,52 @@ func (a *AzureBlobStorageLinkedService) GetLinkedService() *LinkedService {
 // AzureBlobStorageLinkedServiceTypeProperties - Azure Blob Storage linked service properties.
 type AzureBlobStorageLinkedServiceTypeProperties struct {
 	// The Azure key vault secret reference of accountKey in connection string.
-	AccountKey *AzureKeyVaultSecretReference `json:"accountKey,omitempty"`
+	AccountKey *AzureKeyVaultSecretReference
 
 	// The connection string. It is mutually exclusive with sasUri, serviceEndpoint property. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential *string `json:"encryptedCredential,omitempty"`
+	EncryptedCredential *string
 
 	// The Azure key vault secret reference of sasToken in sas uri.
-	SasToken *AzureKeyVaultSecretReference `json:"sasToken,omitempty"`
+	SasToken *AzureKeyVaultSecretReference
 
 	// SAS URI of the Azure Blob Storage resource. It is mutually exclusive with connectionString, serviceEndpoint property. Type:
 	// string, SecureString or AzureKeyVaultSecretReference.
-	SasURI any `json:"sasUri,omitempty"`
+	SasURI any
 
 	// Blob service endpoint of the Azure Blob Storage resource. It is mutually exclusive with connectionString, sasUri property.
-	ServiceEndpoint *string `json:"serviceEndpoint,omitempty"`
+	ServiceEndpoint *string
 
 	// The ID of the service principal used to authenticate against Azure SQL Data Warehouse. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against Azure SQL Data Warehouse.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureBlobStorageLocation - The location of azure blob dataset.
 type AzureBlobStorageLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the container of azure blob. Type: string (or Expression with resultType string).
-	Container any `json:"container,omitempty"`
+	Container any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type AzureBlobStorageLocation.
@@ -1270,35 +1270,35 @@ func (a *AzureBlobStorageLocation) GetDatasetLocation() *DatasetLocation {
 // AzureBlobStorageReadSettings - Azure blob read settings.
 type AzureBlobStorageReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// The prefix filter for the Azure Blob name. Type: string (or Expression with resultType string).
-	Prefix any `json:"prefix,omitempty"`
+	Prefix any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Azure blob wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Azure blob wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type AzureBlobStorageReadSettings.
@@ -1313,19 +1313,19 @@ func (a *AzureBlobStorageReadSettings) GetStoreReadSettings() *StoreReadSettings
 // AzureBlobStorageWriteSettings - Azure blob write settings.
 type AzureBlobStorageWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates the block size(MB) when writing data to blob. Type: integer (or Expression with resultType integer).
-	BlockSizeInMB any `json:"blockSizeInMB,omitempty"`
+	BlockSizeInMB any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type AzureBlobStorageWriteSettings.
@@ -1341,31 +1341,31 @@ func (a *AzureBlobStorageWriteSettings) GetStoreWriteSettings() *StoreWriteSetti
 // AzureDataExplorerCommandActivity - Azure Data Explorer command activity.
 type AzureDataExplorerCommandActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Explorer command activity properties.
-	TypeProperties *AzureDataExplorerCommandActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDataExplorerCommandActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AzureDataExplorerCommandActivity.
@@ -1398,40 +1398,40 @@ func (a *AzureDataExplorerCommandActivity) GetExecutionActivity() *ExecutionActi
 type AzureDataExplorerCommandActivityTypeProperties struct {
 	// REQUIRED; A control command, according to the Azure Data Explorer command syntax. Type: string (or Expression with resultType
 	// string).
-	Command any `json:"command,omitempty"`
+	Command any
 
 	// Control command timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9]))..)
-	CommandTimeout any `json:"commandTimeout,omitempty"`
+	CommandTimeout any
 }
 
 // AzureDataExplorerDatasetTypeProperties - Azure Data Explorer (Kusto) dataset properties.
 type AzureDataExplorerDatasetTypeProperties struct {
 	// The table name of the Azure Data Explorer database. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 }
 
 // AzureDataExplorerLinkedService - Azure Data Explorer (Kusto) linked service.
 type AzureDataExplorerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Explorer (Kusto) linked service properties.
-	TypeProperties *AzureDataExplorerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDataExplorerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureDataExplorerLinkedService.
@@ -1449,55 +1449,55 @@ func (a *AzureDataExplorerLinkedService) GetLinkedService() *LinkedService {
 // AzureDataExplorerLinkedServiceTypeProperties - Azure Data Explorer (Kusto) linked service properties.
 type AzureDataExplorerLinkedServiceTypeProperties struct {
 	// REQUIRED; Database name for connection. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// REQUIRED; The endpoint of Azure Data Explorer (the engine's endpoint). URL will be in the format https://..kusto.windows.net.
 	// Type: string (or Expression with resultType string)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// REQUIRED; The ID of the service principal used to authenticate against Azure Data Explorer. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// REQUIRED; The key of the service principal used to authenticate against Kusto.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// REQUIRED; The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType
 	// string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureDataExplorerSink - A copy activity Azure Data Explorer sink.
 type AzureDataExplorerSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// If set to true, any aggregation will be skipped. Default is false. Type: boolean.
-	FlushImmediately any `json:"flushImmediately,omitempty"`
+	FlushImmediately any
 
 	// An explicit column mapping description provided in a json format. Type: string.
-	IngestionMappingAsJSON any `json:"ingestionMappingAsJson,omitempty"`
+	IngestionMappingAsJSON any
 
 	// A name of a pre-created csv mapping that was defined on the target Kusto table. Type: string.
-	IngestionMappingName any `json:"ingestionMappingName,omitempty"`
+	IngestionMappingName any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureDataExplorerSink.
@@ -1516,29 +1516,29 @@ func (a *AzureDataExplorerSink) GetCopySink() *CopySink {
 // AzureDataExplorerSource - A copy activity Azure Data Explorer (Kusto) source.
 type AzureDataExplorerSource struct {
 	// REQUIRED; Database query. Should be a Kusto Query Language (KQL) query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The name of the Boolean option that controls whether truncation is applied to result-sets that go beyond a certain row-count
 	// limit.
-	NoTruncation any `json:"noTruncation,omitempty"`
+	NoTruncation any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9]))..
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureDataExplorerSource.
@@ -1555,35 +1555,35 @@ func (a *AzureDataExplorerSource) GetCopySource() *CopySource {
 // AzureDataExplorerTableDataset - The Azure Data Explorer (Kusto) dataset.
 type AzureDataExplorerTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Explorer (Kusto) dataset properties.
-	TypeProperties *AzureDataExplorerDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDataExplorerDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureDataExplorerTableDataset.
@@ -1604,25 +1604,25 @@ func (a *AzureDataExplorerTableDataset) GetDataset() *Dataset {
 // AzureDataLakeAnalyticsLinkedService - Azure Data Lake Analytics linked service.
 type AzureDataLakeAnalyticsLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Lake Analytics linked service properties.
-	TypeProperties *AzureDataLakeAnalyticsLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDataLakeAnalyticsLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureDataLakeAnalyticsLinkedService.
@@ -1640,57 +1640,57 @@ func (a *AzureDataLakeAnalyticsLinkedService) GetLinkedService() *LinkedService 
 // AzureDataLakeAnalyticsLinkedServiceTypeProperties - Azure Data Lake Analytics linked service properties.
 type AzureDataLakeAnalyticsLinkedServiceTypeProperties struct {
 	// REQUIRED; The Azure Data Lake Analytics account name. Type: string (or Expression with resultType string).
-	AccountName any `json:"accountName,omitempty"`
+	AccountName any
 
 	// REQUIRED; The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType
 	// string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// Azure Data Lake Analytics URI Type: string (or Expression with resultType string).
-	DataLakeAnalyticsURI any `json:"dataLakeAnalyticsUri,omitempty"`
+	DataLakeAnalyticsURI any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Data Lake Analytics account resource group name (if different from Data Factory account). Type: string (or Expression with
 	// resultType string).
-	ResourceGroupName any `json:"resourceGroupName,omitempty"`
+	ResourceGroupName any
 
 	// The ID of the application used to authenticate against the Azure Data Lake Analytics account. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The Key of the application used to authenticate against the Azure Data Lake Analytics account.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// Data Lake Analytics account subscription ID (if different from Data Factory account). Type: string (or Expression with
 	// resultType string).
-	SubscriptionID any `json:"subscriptionId,omitempty"`
+	SubscriptionID any
 }
 
 // AzureDataLakeStoreLinkedService - Azure Data Lake Store linked service.
 type AzureDataLakeStoreLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Data Lake Store linked service properties.
-	TypeProperties *AzureDataLakeStoreLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDataLakeStoreLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureDataLakeStoreLinkedService.
@@ -1708,47 +1708,47 @@ func (a *AzureDataLakeStoreLinkedService) GetLinkedService() *LinkedService {
 // AzureDataLakeStoreLinkedServiceTypeProperties - Azure Data Lake Store linked service properties.
 type AzureDataLakeStoreLinkedServiceTypeProperties struct {
 	// REQUIRED; Data Lake Store service URI. Type: string (or Expression with resultType string).
-	DataLakeStoreURI any `json:"dataLakeStoreUri,omitempty"`
+	DataLakeStoreURI any
 
 	// Data Lake Store account name. Type: string (or Expression with resultType string).
-	AccountName any `json:"accountName,omitempty"`
+	AccountName any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Data Lake Store account resource group name (if different from Data Factory account). Type: string (or Expression with
 	// resultType string).
-	ResourceGroupName any `json:"resourceGroupName,omitempty"`
+	ResourceGroupName any
 
 	// The ID of the application used to authenticate against the Azure Data Lake Store account. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The Key of the application used to authenticate against the Azure Data Lake Store account.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// Data Lake Store account subscription ID (if different from Data Factory account). Type: string (or Expression with resultType
 	// string).
-	SubscriptionID any `json:"subscriptionId,omitempty"`
+	SubscriptionID any
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureDataLakeStoreLocation - The location of azure data lake store dataset.
 type AzureDataLakeStoreLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type AzureDataLakeStoreLocation.
@@ -1764,32 +1764,32 @@ func (a *AzureDataLakeStoreLocation) GetDatasetLocation() *DatasetLocation {
 // AzureDataLakeStoreReadSettings - Azure data lake store read settings.
 type AzureDataLakeStoreReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// ADLS wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// ADLS wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type AzureDataLakeStoreReadSettings.
@@ -1804,31 +1804,31 @@ func (a *AzureDataLakeStoreReadSettings) GetStoreReadSettings() *StoreReadSettin
 // AzureDataLakeStoreSink - A copy activity Azure Data Lake Store sink.
 type AzureDataLakeStoreSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// Single File Parallel.
-	EnableAdlsSingleFileParallel any `json:"enableAdlsSingleFileParallel,omitempty"`
+	EnableAdlsSingleFileParallel any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureDataLakeStoreSink.
@@ -1847,23 +1847,23 @@ func (a *AzureDataLakeStoreSink) GetCopySink() *CopySink {
 // AzureDataLakeStoreSource - A copy activity Azure Data Lake source.
 type AzureDataLakeStoreSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureDataLakeStoreSource.
@@ -1880,16 +1880,16 @@ func (a *AzureDataLakeStoreSource) GetCopySource() *CopySource {
 // AzureDataLakeStoreWriteSettings - Azure data lake store write settings.
 type AzureDataLakeStoreWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type AzureDataLakeStoreWriteSettings.
@@ -1905,25 +1905,25 @@ func (a *AzureDataLakeStoreWriteSettings) GetStoreWriteSettings() *StoreWriteSet
 // AzureDatabricksLinkedService - Azure Databricks linked service.
 type AzureDatabricksLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Databricks linked service properties.
-	TypeProperties *AzureDatabricksLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureDatabricksLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureDatabricksLinkedService.
@@ -1942,101 +1942,101 @@ func (a *AzureDatabricksLinkedService) GetLinkedService() *LinkedService {
 type AzureDatabricksLinkedServiceTypeProperties struct {
 	// REQUIRED; Access token for databricks REST API. Refer to https://docs.azuredatabricks.net/api/latest/authentication.html.
 	// Type: string (or Expression with resultType string).
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// REQUIRED; .azuredatabricks.net, domain name of your Databricks deployment. Type: string (or Expression with resultType
 	// string).
-	Domain any `json:"domain,omitempty"`
+	Domain any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The id of an existing interactive cluster that will be used for all runs of this activity. Type: string (or Expression
 	// with resultType string).
-	ExistingClusterID any `json:"existingClusterId,omitempty"`
+	ExistingClusterID any
 
 	// The id of an existing instance pool that will be used for all runs of this activity. Type: string (or Expression with resultType
 	// string).
-	InstancePoolID any `json:"instancePoolId,omitempty"`
+	InstancePoolID any
 
 	// Additional tags for cluster resources. This property is ignored in instance pool configurations.
-	NewClusterCustomTags map[string]any `json:"newClusterCustomTags,omitempty"`
+	NewClusterCustomTags map[string]any
 
 	// The driver node type for the new job cluster. This property is ignored in instance pool configurations. Type: string (or
 	// Expression with resultType string).
-	NewClusterDriverNodeType any `json:"newClusterDriverNodeType,omitempty"`
+	NewClusterDriverNodeType any
 
 	// Enable the elastic disk on the new cluster. This property is now ignored, and takes the default elastic disk behavior in
 	// Databricks (elastic disks are always enabled). Type: boolean (or Expression
 	// with resultType boolean).
-	NewClusterEnableElasticDisk any `json:"newClusterEnableElasticDisk,omitempty"`
+	NewClusterEnableElasticDisk any
 
 	// User-defined initialization scripts for the new cluster. Type: array of strings (or Expression with resultType array of
 	// strings).
-	NewClusterInitScripts any `json:"newClusterInitScripts,omitempty"`
+	NewClusterInitScripts any
 
 	// The node type of the new job cluster. This property is required if newClusterVersion is specified and instancePoolId is
 	// not specified. If instancePoolId is specified, this property is ignored. Type:
 	// string (or Expression with resultType string).
-	NewClusterNodeType any `json:"newClusterNodeType,omitempty"`
+	NewClusterNodeType any
 
 	// If not using an existing interactive cluster, this specifies the number of worker nodes to use for the new job cluster
 	// or instance pool. For new job clusters, this a string-formatted Int32, like '1'
 	// means numOfWorker is 1 or '1:10' means auto-scale from 1 (min) to 10 (max). For instance pools, this is a string-formatted
 	// Int32, and can only specify a fixed number of worker nodes, such as '2'.
 	// Required if newClusterVersion is specified. Type: string (or Expression with resultType string).
-	NewClusterNumOfWorker any `json:"newClusterNumOfWorker,omitempty"`
+	NewClusterNumOfWorker any
 
 	// A set of optional, user-specified Spark configuration key-value pairs.
-	NewClusterSparkConf map[string]any `json:"newClusterSparkConf,omitempty"`
+	NewClusterSparkConf map[string]any
 
 	// A set of optional, user-specified Spark environment variables key-value pairs.
-	NewClusterSparkEnvVars map[string]any `json:"newClusterSparkEnvVars,omitempty"`
+	NewClusterSparkEnvVars map[string]any
 
 	// If not using an existing interactive cluster, this specifies the Spark version of a new job cluster or instance pool nodes
 	// created for each run of this activity. Required if instancePoolId is
 	// specified. Type: string (or Expression with resultType string).
-	NewClusterVersion any `json:"newClusterVersion,omitempty"`
+	NewClusterVersion any
 }
 
 // AzureEntityResource - The resource model definition for an Azure Resource Manager resource with an etag.
 type AzureEntityResource struct {
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // AzureFileStorageLinkedService - Azure File Storage linked service.
 type AzureFileStorageLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure File Storage linked service properties.
-	TypeProperties *AzureFileStorageLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureFileStorageLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureFileStorageLinkedService.
@@ -2054,32 +2054,32 @@ func (a *AzureFileStorageLinkedService) GetLinkedService() *LinkedService {
 // AzureFileStorageLinkedServiceTypeProperties - Azure File Storage linked service properties.
 type AzureFileStorageLinkedServiceTypeProperties struct {
 	// REQUIRED; Host name of the server. Type: string (or Expression with resultType string).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password to logon the server.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User ID to logon the server. Type: string (or Expression with resultType string).
-	UserID any `json:"userId,omitempty"`
+	UserID any
 }
 
 // AzureFileStorageLocation - The location of file server dataset.
 type AzureFileStorageLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type AzureFileStorageLocation.
@@ -2095,32 +2095,32 @@ func (a *AzureFileStorageLocation) GetDatasetLocation() *DatasetLocation {
 // AzureFileStorageReadSettings - Azure File Storage read settings.
 type AzureFileStorageReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Azure File Storage wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Azure File Storage wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type AzureFileStorageReadSettings.
@@ -2135,31 +2135,31 @@ func (a *AzureFileStorageReadSettings) GetStoreReadSettings() *StoreReadSettings
 // AzureFunctionActivity - Azure Function activity.
 type AzureFunctionActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Function activity properties.
-	TypeProperties *AzureFunctionActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureFunctionActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AzureFunctionActivity.
@@ -2192,43 +2192,43 @@ func (a *AzureFunctionActivity) GetExecutionActivity() *ExecutionActivity {
 type AzureFunctionActivityTypeProperties struct {
 	// REQUIRED; Name of the Function that the Azure Function Activity will call. Type: string (or Expression with resultType
 	// string)
-	FunctionName any `json:"functionName,omitempty"`
+	FunctionName any
 
 	// REQUIRED; Rest API method for target endpoint.
-	Method *AzureFunctionActivityMethod `json:"method,omitempty"`
+	Method *AzureFunctionActivityMethod
 
 	// Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type:
 	// string (or Expression with resultType string).
-	Body any `json:"body,omitempty"`
+	Body any
 
 	// Represents the headers that will be sent to the request. For example, to set the language and type on a request: "headers"
 	// : { "Accept-Language": "en-us", "Content-Type": "application/json" }. Type:
 	// string (or Expression with resultType string).
-	Headers any `json:"headers,omitempty"`
+	Headers any
 }
 
 // AzureFunctionLinkedService - Azure Function linked service.
 type AzureFunctionLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Function linked service properties.
-	TypeProperties *AzureFunctionLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureFunctionLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureFunctionLinkedService.
@@ -2246,38 +2246,38 @@ func (a *AzureFunctionLinkedService) GetLinkedService() *LinkedService {
 // AzureFunctionLinkedServiceTypeProperties - Azure Function linked service properties.
 type AzureFunctionLinkedServiceTypeProperties struct {
 	// REQUIRED; The endpoint of the Azure Function App. URL will be in the format https://.azurewebsites.net.
-	FunctionAppURL any `json:"functionAppUrl,omitempty"`
+	FunctionAppURL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Function or Host key for Azure Function App.
-	FunctionKey SecretBaseClassification `json:"functionKey,omitempty"`
+	FunctionKey SecretBaseClassification
 }
 
 // AzureKeyVaultLinkedService - Azure Key Vault linked service.
 type AzureKeyVaultLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Key Vault linked service properties.
-	TypeProperties *AzureKeyVaultLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureKeyVaultLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureKeyVaultLinkedService.
@@ -2296,23 +2296,23 @@ func (a *AzureKeyVaultLinkedService) GetLinkedService() *LinkedService {
 type AzureKeyVaultLinkedServiceTypeProperties struct {
 	// REQUIRED; The base URL of the Azure Key Vault. e.g. https://myakv.vault.azure.net Type: string (or Expression with resultType
 	// string).
-	BaseURL any `json:"baseUrl,omitempty"`
+	BaseURL any
 }
 
 // AzureKeyVaultSecretReference - Azure Key Vault secret reference.
 type AzureKeyVaultSecretReference struct {
 	// REQUIRED; The name of the secret in Azure Key Vault. Type: string (or Expression with resultType string).
-	SecretName any `json:"secretName,omitempty"`
+	SecretName any
 
 	// REQUIRED; The Azure Key Vault linked service reference.
-	Store *LinkedServiceReference `json:"store,omitempty"`
+	Store *LinkedServiceReference
 
 	// REQUIRED; Type of the secret.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// The version of the secret in Azure Key Vault. The default value is the latest version of the secret. Type: string (or Expression
 	// with resultType string).
-	SecretVersion any `json:"secretVersion,omitempty"`
+	SecretVersion any
 }
 
 // GetSecretBase implements the SecretBaseClassification interface for type AzureKeyVaultSecretReference.
@@ -2325,31 +2325,31 @@ func (a *AzureKeyVaultSecretReference) GetSecretBase() *SecretBase {
 // AzureMLBatchExecutionActivity - Azure ML Batch Execution activity.
 type AzureMLBatchExecutionActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure ML Batch Execution activity properties.
-	TypeProperties *AzureMLBatchExecutionActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMLBatchExecutionActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AzureMLBatchExecutionActivity.
@@ -2383,47 +2383,47 @@ type AzureMLBatchExecutionActivityTypeProperties struct {
 	// Key,Value pairs to be passed to the Azure ML Batch Execution Service endpoint. Keys must match the names of web service
 	// parameters defined in the published Azure ML web service. Values will be passed
 	// in the GlobalParameters property of the Azure ML batch execution request.
-	GlobalParameters map[string]any `json:"globalParameters,omitempty"`
+	GlobalParameters map[string]any
 
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Inputs to AzureMLWebServiceFile objects specifying
 	// the input Blob locations.. This information will be passed in the
 	// WebServiceInputs property of the Azure ML batch execution request.
-	WebServiceInputs map[string]*AzureMLWebServiceFile `json:"webServiceInputs,omitempty"`
+	WebServiceInputs map[string]*AzureMLWebServiceFile
 
 	// Key,Value pairs, mapping the names of Azure ML endpoint's Web Service Outputs to AzureMLWebServiceFile objects specifying
 	// the output Blob locations. This information will be passed in the
 	// WebServiceOutputs property of the Azure ML batch execution request.
-	WebServiceOutputs map[string]*AzureMLWebServiceFile `json:"webServiceOutputs,omitempty"`
+	WebServiceOutputs map[string]*AzureMLWebServiceFile
 }
 
 // AzureMLExecutePipelineActivity - Azure ML Execute Pipeline activity.
 type AzureMLExecutePipelineActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure ML Execute Pipeline activity properties.
-	TypeProperties *AzureMLExecutePipelineActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMLExecutePipelineActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AzureMLExecutePipelineActivity.
@@ -2455,52 +2455,52 @@ func (a *AzureMLExecutePipelineActivity) GetExecutionActivity() *ExecutionActivi
 // AzureMLExecutePipelineActivityTypeProperties - Azure ML Execute Pipeline activity properties.
 type AzureMLExecutePipelineActivityTypeProperties struct {
 	// REQUIRED; ID of the published Azure ML pipeline. Type: string (or Expression with resultType string).
-	MlPipelineID any `json:"mlPipelineId,omitempty"`
+	MlPipelineID any
 
 	// Whether to continue execution of other steps in the PipelineRun if a step fails. This information will be passed in the
 	// continueOnStepFailure property of the published pipeline execution request.
 	// Type: boolean (or Expression with resultType boolean).
-	ContinueOnStepFailure any `json:"continueOnStepFailure,omitempty"`
+	ContinueOnStepFailure any
 
 	// Run history experiment name of the pipeline run. This information will be passed in the ExperimentName property of the
 	// published pipeline execution request. Type: string (or Expression with resultType
 	// string).
-	ExperimentName any `json:"experimentName,omitempty"`
+	ExperimentName any
 
 	// The parent Azure ML Service pipeline run id. This information will be passed in the ParentRunId property of the published
 	// pipeline execution request. Type: string (or Expression with resultType
 	// string).
-	MlParentRunID any `json:"mlParentRunId,omitempty"`
+	MlParentRunID any
 
 	// Key,Value pairs to be passed to the published Azure ML pipeline endpoint. Keys must match the names of pipeline parameters
 	// defined in the published pipeline. Values will be passed in the
 	// ParameterAssignments property of the published pipeline execution request. Type: object with key value pairs (or Expression
 	// with resultType object).
-	MlPipelineParameters any `json:"mlPipelineParameters,omitempty"`
+	MlPipelineParameters any
 }
 
 // AzureMLLinkedService - Azure ML Studio Web Service linked service.
 type AzureMLLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure ML Studio Web Service linked service properties.
-	TypeProperties *AzureMLLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMLLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureMLLinkedService.
@@ -2518,53 +2518,53 @@ func (a *AzureMLLinkedService) GetLinkedService() *LinkedService {
 // AzureMLLinkedServiceTypeProperties - Azure ML Studio Web Service linked service properties.
 type AzureMLLinkedServiceTypeProperties struct {
 	// REQUIRED; The API key for accessing the Azure ML model endpoint.
-	APIKey SecretBaseClassification `json:"apiKey,omitempty"`
+	APIKey SecretBaseClassification
 
 	// REQUIRED; The Batch Execution REST URL for an Azure ML Studio Web Service endpoint. Type: string (or Expression with resultType
 	// string).
-	MlEndpoint any `json:"mlEndpoint,omitempty"`
+	MlEndpoint any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The ID of the service principal used to authenticate against the ARM-based updateResourceEndpoint of an Azure ML Studio
 	// web service. Type: string (or Expression with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against the ARM-based updateResourceEndpoint of an Azure ML Studio
 	// web service.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// The Update Resource REST URL for an Azure ML Studio Web Service endpoint. Type: string (or Expression with resultType string).
-	UpdateResourceEndpoint any `json:"updateResourceEndpoint,omitempty"`
+	UpdateResourceEndpoint any
 }
 
 // AzureMLServiceLinkedService - Azure ML Service linked service.
 type AzureMLServiceLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure ML Service linked service properties.
-	TypeProperties *AzureMLServiceLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMLServiceLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureMLServiceLinkedService.
@@ -2582,57 +2582,57 @@ func (a *AzureMLServiceLinkedService) GetLinkedService() *LinkedService {
 // AzureMLServiceLinkedServiceTypeProperties - Azure ML Service linked service properties.
 type AzureMLServiceLinkedServiceTypeProperties struct {
 	// REQUIRED; Azure ML Service workspace name. Type: string (or Expression with resultType string).
-	MlWorkspaceName any `json:"mlWorkspaceName,omitempty"`
+	MlWorkspaceName any
 
 	// REQUIRED; Azure ML Service workspace resource group name. Type: string (or Expression with resultType string).
-	ResourceGroupName any `json:"resourceGroupName,omitempty"`
+	ResourceGroupName any
 
 	// REQUIRED; Azure ML Service workspace subscription ID. Type: string (or Expression with resultType string).
-	SubscriptionID any `json:"subscriptionId,omitempty"`
+	SubscriptionID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The ID of the service principal used to authenticate against the endpoint of a published Azure ML Service pipeline. Type:
 	// string (or Expression with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against the endpoint of a published Azure ML Service pipeline.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureMLUpdateResourceActivity - Azure ML Update Resource management activity.
 type AzureMLUpdateResourceActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure ML Update Resource management activity properties.
-	TypeProperties *AzureMLUpdateResourceActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMLUpdateResourceActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type AzureMLUpdateResourceActivity.
@@ -2665,48 +2665,48 @@ func (a *AzureMLUpdateResourceActivity) GetExecutionActivity() *ExecutionActivit
 type AzureMLUpdateResourceActivityTypeProperties struct {
 	// REQUIRED; The relative file path in trainedModelLinkedService to represent the .ilearner file that will be uploaded by
 	// the update operation. Type: string (or Expression with resultType string).
-	TrainedModelFilePath any `json:"trainedModelFilePath,omitempty"`
+	TrainedModelFilePath any
 
 	// REQUIRED; Name of Azure Storage linked service holding the .ilearner file that will be uploaded by the update operation.
-	TrainedModelLinkedServiceName *LinkedServiceReference `json:"trainedModelLinkedServiceName,omitempty"`
+	TrainedModelLinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Name of the Trained Model module in the Web Service experiment to be updated. Type: string (or Expression with
 	// resultType string).
-	TrainedModelName any `json:"trainedModelName,omitempty"`
+	TrainedModelName any
 }
 
 // AzureMLWebServiceFile - Azure ML WebService Input/Output file
 type AzureMLWebServiceFile struct {
 	// REQUIRED; The relative file path, including container name, in the Azure Blob Storage specified by the LinkedService. Type:
 	// string (or Expression with resultType string).
-	FilePath any `json:"filePath,omitempty"`
+	FilePath any
 
 	// REQUIRED; Reference to an Azure Storage LinkedService, where Azure ML WebService Input/Output file located.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 }
 
 // AzureMariaDBLinkedService - Azure Database for MariaDB linked service.
 type AzureMariaDBLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Database for MariaDB linked service properties.
-	TypeProperties *AzureMariaDBLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMariaDBLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureMariaDBLinkedService.
@@ -2724,38 +2724,38 @@ func (a *AzureMariaDBLinkedService) GetLinkedService() *LinkedService {
 // AzureMariaDBLinkedServiceTypeProperties - Azure Database for MariaDB linked service properties.
 type AzureMariaDBLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // AzureMariaDBSource - A copy activity Azure MariaDB source.
 type AzureMariaDBSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureMariaDBSource.
@@ -2784,35 +2784,35 @@ func (a *AzureMariaDBSource) GetTabularSource() *TabularSource {
 // AzureMariaDBTableDataset - Azure Database for MariaDB dataset.
 type AzureMariaDBTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureMariaDBTableDataset.
@@ -2833,25 +2833,25 @@ func (a *AzureMariaDBTableDataset) GetDataset() *Dataset {
 // AzureMySQLLinkedService - Azure MySQL database linked service.
 type AzureMySQLLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure MySQL database linked service properties.
-	TypeProperties *AzureMySQLLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMySQLLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureMySQLLinkedService.
@@ -2869,41 +2869,41 @@ func (a *AzureMySQLLinkedService) GetLinkedService() *LinkedService {
 // AzureMySQLLinkedServiceTypeProperties - Azure MySQL database linked service properties.
 type AzureMySQLLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 }
 
 // AzureMySQLSink - A copy activity Azure MySql sink.
 type AzureMySQLSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to execute before starting the copy. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureMySQLSink.
@@ -2922,25 +2922,25 @@ func (a *AzureMySQLSink) GetCopySink() *CopySink {
 // AzureMySQLSource - A copy activity Azure MySQL source.
 type AzureMySQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureMySQLSource.
@@ -2969,35 +2969,35 @@ func (a *AzureMySQLSource) GetTabularSource() *TabularSource {
 // AzureMySQLTableDataset - The Azure MySQL database dataset.
 type AzureMySQLTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure MySQL database dataset properties.
-	TypeProperties *AzureMySQLTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureMySQLTableDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureMySQLTableDataset.
@@ -3018,34 +3018,34 @@ func (a *AzureMySQLTableDataset) GetDataset() *Dataset {
 // AzureMySQLTableDatasetTypeProperties - Azure MySQL database dataset properties.
 type AzureMySQLTableDatasetTypeProperties struct {
 	// The name of Azure MySQL database table. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// The Azure MySQL database table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzurePostgreSQLLinkedService - Azure PostgreSQL linked service.
 type AzurePostgreSQLLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure PostgreSQL linked service properties.
-	TypeProperties *AzurePostgreSQLLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzurePostgreSQLLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzurePostgreSQLLinkedService.
@@ -3063,41 +3063,41 @@ func (a *AzurePostgreSQLLinkedService) GetLinkedService() *LinkedService {
 // AzurePostgreSQLLinkedServiceTypeProperties - Azure PostgreSQL linked service properties.
 type AzurePostgreSQLLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 }
 
 // AzurePostgreSQLSink - A copy activity Azure PostgreSQL sink.
 type AzurePostgreSQLSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to execute before starting the copy. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzurePostgreSQLSink.
@@ -3116,25 +3116,25 @@ func (a *AzurePostgreSQLSink) GetCopySink() *CopySink {
 // AzurePostgreSQLSource - A copy activity Azure PostgreSQL source.
 type AzurePostgreSQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzurePostgreSQLSource.
@@ -3163,35 +3163,35 @@ func (a *AzurePostgreSQLSource) GetTabularSource() *TabularSource {
 // AzurePostgreSQLTableDataset - Azure PostgreSQL dataset.
 type AzurePostgreSQLTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *AzurePostgreSQLTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzurePostgreSQLTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AzurePostgreSQLTableDataset.
@@ -3212,38 +3212,38 @@ func (a *AzurePostgreSQLTableDataset) GetDataset() *Dataset {
 // AzurePostgreSQLTableDatasetTypeProperties - Azure PostgreSQL dataset properties.
 type AzurePostgreSQLTableDatasetTypeProperties struct {
 	// The schema name of the Azure PostgreSQL database. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Azure PostgreSQL database. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// The table name of the Azure PostgreSQL database which includes both schema and table. Type: string (or Expression with
 	// resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzureQueueSink - A copy activity Azure Queue sink.
 type AzureQueueSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureQueueSink.
@@ -3262,25 +3262,25 @@ func (a *AzureQueueSink) GetCopySink() *CopySink {
 // AzureSQLDWLinkedService - Azure SQL Data Warehouse linked service.
 type AzureSQLDWLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure SQL Data Warehouse linked service properties.
-	TypeProperties *AzureSQLDWLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLDWLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureSQLDWLinkedService.
@@ -3299,58 +3299,58 @@ func (a *AzureSQLDWLinkedService) GetLinkedService() *LinkedService {
 type AzureSQLDWLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference. Type: string, SecureString
 	// or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 
 	// The ID of the service principal used to authenticate against Azure SQL Data Warehouse. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against Azure SQL Data Warehouse.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureSQLDWTableDataset - The Azure SQL Data Warehouse dataset.
 type AzureSQLDWTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Azure SQL Data Warehouse dataset properties.
-	TypeProperties *AzureSQLDWTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLDWTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureSQLDWTableDataset.
@@ -3371,37 +3371,37 @@ func (a *AzureSQLDWTableDataset) GetDataset() *Dataset {
 // AzureSQLDWTableDatasetTypeProperties - Azure SQL Data Warehouse dataset properties.
 type AzureSQLDWTableDatasetTypeProperties struct {
 	// The schema name of the Azure SQL Data Warehouse. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Azure SQL Data Warehouse. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzureSQLDatabaseLinkedService - Microsoft Azure SQL Database linked service.
 type AzureSQLDatabaseLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure SQL Database linked service properties.
-	TypeProperties *AzureSQLDatabaseLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLDatabaseLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureSQLDatabaseLinkedService.
@@ -3419,48 +3419,48 @@ func (a *AzureSQLDatabaseLinkedService) GetLinkedService() *LinkedService {
 // AzureSQLDatabaseLinkedServiceTypeProperties - Azure SQL Database linked service properties.
 type AzureSQLDatabaseLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 
 	// The ID of the service principal used to authenticate against Azure SQL Database. Type: string (or Expression with resultType
 	// string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against Azure SQL Database.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureSQLMILinkedService - Azure SQL Managed Instance linked service.
 type AzureSQLMILinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure SQL Managed Instance linked service properties.
-	TypeProperties *AzureSQLMILinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLMILinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureSQLMILinkedService.
@@ -3478,58 +3478,58 @@ func (a *AzureSQLMILinkedService) GetLinkedService() *LinkedService {
 // AzureSQLMILinkedServiceTypeProperties - Azure SQL Managed Instance linked service properties.
 type AzureSQLMILinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 
 	// The ID of the service principal used to authenticate against Azure SQL Managed Instance. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key of the service principal used to authenticate against Azure SQL Managed Instance.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The name or ID of the tenant to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 }
 
 // AzureSQLMITableDataset - The Azure SQL Managed Instance dataset.
 type AzureSQLMITableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Azure SQL Managed Instance dataset properties.
-	TypeProperties *AzureSQLMITableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLMITableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureSQLMITableDataset.
@@ -3550,56 +3550,56 @@ func (a *AzureSQLMITableDataset) GetDataset() *Dataset {
 // AzureSQLMITableDatasetTypeProperties - Azure SQL Managed Instance dataset properties.
 type AzureSQLMITableDatasetTypeProperties struct {
 	// The schema name of the Azure SQL Managed Instance. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Azure SQL Managed Instance dataset. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzureSQLSink - A copy activity Azure SQL sink.
 type AzureSQLSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// SQL writer stored procedure name. Type: string (or Expression with resultType string).
-	SQLWriterStoredProcedureName any `json:"sqlWriterStoredProcedureName,omitempty"`
+	SQLWriterStoredProcedureName any
 
 	// SQL writer table type. Type: string (or Expression with resultType string).
-	SQLWriterTableType any `json:"sqlWriterTableType,omitempty"`
+	SQLWriterTableType any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
-	StoredProcedureTableTypeParameterName any `json:"storedProcedureTableTypeParameterName,omitempty"`
+	StoredProcedureTableTypeParameterName any
 
 	// The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression
 	// with resultType string).
-	TableOption any `json:"tableOption,omitempty"`
+	TableOption any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureSQLSink.
@@ -3618,35 +3618,35 @@ func (a *AzureSQLSink) GetCopySink() *CopySink {
 // AzureSQLSource - A copy activity Azure SQL source.
 type AzureSQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Which additional types to produce.
-	ProduceAdditionalTypes any `json:"produceAdditionalTypes,omitempty"`
+	ProduceAdditionalTypes any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// SQL reader query. Type: string (or Expression with resultType string).
-	SQLReaderQuery any `json:"sqlReaderQuery,omitempty"`
+	SQLReaderQuery any
 
 	// Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string
 	// (or Expression with resultType string).
-	SQLReaderStoredProcedureName any `json:"sqlReaderStoredProcedureName,omitempty"`
+	SQLReaderStoredProcedureName any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureSQLSource.
@@ -3675,35 +3675,35 @@ func (a *AzureSQLSource) GetTabularSource() *TabularSource {
 // AzureSQLTableDataset - The Azure SQL Server database dataset.
 type AzureSQLTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Azure SQL dataset properties.
-	TypeProperties *AzureSQLTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSQLTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureSQLTableDataset.
@@ -3724,47 +3724,47 @@ func (a *AzureSQLTableDataset) GetDataset() *Dataset {
 // AzureSQLTableDatasetTypeProperties - Azure SQL dataset properties.
 type AzureSQLTableDatasetTypeProperties struct {
 	// The schema name of the Azure SQL database. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Azure SQL database. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzureSearchIndexDataset - The Azure Search Index.
 type AzureSearchIndexDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this dataset type.
-	TypeProperties *AzureSearchIndexDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSearchIndexDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureSearchIndexDataset.
@@ -3785,34 +3785,34 @@ func (a *AzureSearchIndexDataset) GetDataset() *Dataset {
 // AzureSearchIndexDatasetTypeProperties - Properties specific to this dataset type.
 type AzureSearchIndexDatasetTypeProperties struct {
 	// REQUIRED; The name of the Azure Search Index. Type: string (or Expression with resultType string).
-	IndexName any `json:"indexName,omitempty"`
+	IndexName any
 }
 
 // AzureSearchIndexSink - A copy activity Azure Search Index sink.
 type AzureSearchIndexSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// Specify the write behavior when upserting documents into Azure Search Index.
-	WriteBehavior *AzureSearchIndexWriteBehaviorType `json:"writeBehavior,omitempty"`
+	WriteBehavior *AzureSearchIndexWriteBehaviorType
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureSearchIndexSink.
@@ -3831,25 +3831,25 @@ func (a *AzureSearchIndexSink) GetCopySink() *CopySink {
 // AzureSearchLinkedService - Linked service for Windows Azure Search Service.
 type AzureSearchLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Windows Azure Search Service linked service properties.
-	TypeProperties *AzureSearchLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureSearchLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureSearchLinkedService.
@@ -3867,38 +3867,38 @@ func (a *AzureSearchLinkedService) GetLinkedService() *LinkedService {
 // AzureSearchLinkedServiceTypeProperties - Windows Azure Search Service linked service properties.
 type AzureSearchLinkedServiceTypeProperties struct {
 	// REQUIRED; URL for Azure Search service. Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Admin Key for Azure Search service
-	Key SecretBaseClassification `json:"key,omitempty"`
+	Key SecretBaseClassification
 }
 
 // AzureStorageLinkedService - The storage account linked service.
 type AzureStorageLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Storage linked service properties.
-	TypeProperties *AzureStorageLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureStorageLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureStorageLinkedService.
@@ -3916,55 +3916,55 @@ func (a *AzureStorageLinkedService) GetLinkedService() *LinkedService {
 // AzureStorageLinkedServiceTypeProperties - Azure Storage linked service properties.
 type AzureStorageLinkedServiceTypeProperties struct {
 	// The Azure key vault secret reference of accountKey in connection string.
-	AccountKey *AzureKeyVaultSecretReference `json:"accountKey,omitempty"`
+	AccountKey *AzureKeyVaultSecretReference
 
 	// The connection string. It is mutually exclusive with sasUri property. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential *string `json:"encryptedCredential,omitempty"`
+	EncryptedCredential *string
 
 	// The Azure key vault secret reference of sasToken in sas uri.
-	SasToken *AzureKeyVaultSecretReference `json:"sasToken,omitempty"`
+	SasToken *AzureKeyVaultSecretReference
 
 	// SAS URI of the Azure Storage resource. It is mutually exclusive with connectionString property. Type: string, SecureString
 	// or AzureKeyVaultSecretReference.
-	SasURI any `json:"sasUri,omitempty"`
+	SasURI any
 }
 
 // AzureTableDataset - The Azure Table storage dataset.
 type AzureTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Table dataset properties.
-	TypeProperties *AzureTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureTableDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type AzureTableDataset.
@@ -3985,43 +3985,43 @@ func (a *AzureTableDataset) GetDataset() *Dataset {
 // AzureTableDatasetTypeProperties - Azure Table dataset properties.
 type AzureTableDatasetTypeProperties struct {
 	// REQUIRED; The table name of the Azure Table storage. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // AzureTableSink - A copy activity Azure Table sink.
 type AzureTableSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Azure Table default partition key value. Type: string (or Expression with resultType string).
-	AzureTableDefaultPartitionKeyValue any `json:"azureTableDefaultPartitionKeyValue,omitempty"`
+	AzureTableDefaultPartitionKeyValue any
 
 	// Azure Table insert type. Type: string (or Expression with resultType string).
-	AzureTableInsertType any `json:"azureTableInsertType,omitempty"`
+	AzureTableInsertType any
 
 	// Azure Table partition key name. Type: string (or Expression with resultType string).
-	AzureTablePartitionKeyName any `json:"azureTablePartitionKeyName,omitempty"`
+	AzureTablePartitionKeyName any
 
 	// Azure Table row key name. Type: string (or Expression with resultType string).
-	AzureTableRowKeyName any `json:"azureTableRowKeyName,omitempty"`
+	AzureTableRowKeyName any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type AzureTableSink.
@@ -4040,28 +4040,28 @@ func (a *AzureTableSink) GetCopySink() *CopySink {
 // AzureTableSource - A copy activity Azure Table source.
 type AzureTableSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Azure Table source ignore table not found. Type: boolean (or Expression with resultType boolean).
-	AzureTableSourceIgnoreTableNotFound any `json:"azureTableSourceIgnoreTableNotFound,omitempty"`
+	AzureTableSourceIgnoreTableNotFound any
 
 	// Azure Table source query. Type: string (or Expression with resultType string).
-	AzureTableSourceQuery any `json:"azureTableSourceQuery,omitempty"`
+	AzureTableSourceQuery any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type AzureTableSource.
@@ -4090,25 +4090,25 @@ func (a *AzureTableSource) GetTabularSource() *TabularSource {
 // AzureTableStorageLinkedService - The azure table storage linked service.
 type AzureTableStorageLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Azure Table Storage linked service properties.
-	TypeProperties *AzureStorageLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *AzureStorageLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type AzureTableStorageLinkedService.
@@ -4126,97 +4126,97 @@ func (a *AzureTableStorageLinkedService) GetLinkedService() *LinkedService {
 // BigDataPoolReference - Big data pool reference.
 type BigDataPoolReference struct {
 	// REQUIRED; Reference big data pool name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Big data pool reference type.
-	Type *BigDataPoolReferenceType `json:"type,omitempty"`
+	Type *BigDataPoolReferenceType
 }
 
 // BigDataPoolResourceInfo - A Big Data pool
 type BigDataPoolResourceInfo struct {
 	// REQUIRED; The geo-location where the resource lives
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Big Data pool properties
-	Properties *BigDataPoolResourceProperties `json:"properties,omitempty"`
+	Properties *BigDataPoolResourceProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // BigDataPoolResourceInfoListResult - Collection of Big Data pool information
 type BigDataPoolResourceInfoListResult struct {
 	// Link to the next page of results
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of Big Data pools
-	Value []*BigDataPoolResourceInfo `json:"value,omitempty"`
+	Value []*BigDataPoolResourceInfo
 }
 
 // BigDataPoolResourceProperties - Properties of a Big Data pool powered by Apache Spark
 type BigDataPoolResourceProperties struct {
 	// Auto-pausing properties
-	AutoPause *AutoPauseProperties `json:"autoPause,omitempty"`
+	AutoPause *AutoPauseProperties
 
 	// Auto-scaling properties
-	AutoScale *AutoScaleProperties `json:"autoScale,omitempty"`
+	AutoScale *AutoScaleProperties
 
 	// The cache size
-	CacheSize *int32 `json:"cacheSize,omitempty"`
+	CacheSize *int32
 
 	// The time when the Big Data pool was created.
-	CreationDate *time.Time `json:"creationDate,omitempty"`
+	CreationDate *time.Time
 
 	// List of custom libraries/packages associated with the spark pool.
-	CustomLibraries []*LibraryInfo `json:"customLibraries,omitempty"`
+	CustomLibraries []*LibraryInfo
 
 	// The default folder where Spark logs will be written.
-	DefaultSparkLogFolder *string `json:"defaultSparkLogFolder,omitempty"`
+	DefaultSparkLogFolder *string
 
 	// Dynamic Executor Allocation
-	DynamicExecutorAllocation *DynamicExecutorAllocation `json:"dynamicExecutorAllocation,omitempty"`
+	DynamicExecutorAllocation *DynamicExecutorAllocation
 
 	// Whether compute isolation is required or not.
-	IsComputeIsolationEnabled *bool `json:"isComputeIsolationEnabled,omitempty"`
+	IsComputeIsolationEnabled *bool
 
 	// Library version requirements
-	LibraryRequirements *LibraryRequirements `json:"libraryRequirements,omitempty"`
+	LibraryRequirements *LibraryRequirements
 
 	// The number of nodes in the Big Data pool.
-	NodeCount *int32 `json:"nodeCount,omitempty"`
+	NodeCount *int32
 
 	// The level of compute power that each node in the Big Data pool has.
-	NodeSize *NodeSize `json:"nodeSize,omitempty"`
+	NodeSize *NodeSize
 
 	// The kind of nodes that the Big Data pool provides.
-	NodeSizeFamily *NodeSizeFamily `json:"nodeSizeFamily,omitempty"`
+	NodeSizeFamily *NodeSizeFamily
 
 	// The state of the Big Data pool.
-	ProvisioningState *string `json:"provisioningState,omitempty"`
+	ProvisioningState *string
 
 	// Whether session level packages enabled.
-	SessionLevelPackagesEnabled *bool `json:"sessionLevelPackagesEnabled,omitempty"`
+	SessionLevelPackagesEnabled *bool
 
 	// Spark configuration file to specify additional properties
-	SparkConfigProperties *LibraryRequirements `json:"sparkConfigProperties,omitempty"`
+	SparkConfigProperties *LibraryRequirements
 
 	// The Spark events folder
-	SparkEventsFolder *string `json:"sparkEventsFolder,omitempty"`
+	SparkEventsFolder *string
 
 	// The Apache Spark version.
-	SparkVersion *string `json:"sparkVersion,omitempty"`
+	SparkVersion *string
 
 	// READ-ONLY; The time when the Big Data pool was updated successfully.
-	LastSucceededTimestamp *time.Time `json:"lastSucceededTimestamp,omitempty" azure:"ro"`
+	LastSucceededTimestamp *time.Time
 }
 
 // BigDataPoolsClientGetOptions contains the optional parameters for the BigDataPoolsClient.Get method.
@@ -4232,35 +4232,35 @@ type BigDataPoolsClientListOptions struct {
 // BinaryDataset - Binary dataset.
 type BinaryDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Binary dataset properties.
-	TypeProperties *BinaryDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *BinaryDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type BinaryDataset.
@@ -4281,37 +4281,37 @@ func (b *BinaryDataset) GetDataset() *Dataset {
 // BinaryDatasetTypeProperties - Binary dataset properties.
 type BinaryDatasetTypeProperties struct {
 	// REQUIRED; The location of the Binary storage.
-	Location DatasetLocationClassification `json:"location,omitempty"`
+	Location DatasetLocationClassification
 
 	// The data compression method used for the binary dataset.
-	Compression DatasetCompressionClassification `json:"compression,omitempty"`
+	Compression DatasetCompressionClassification
 }
 
 // BinarySink - A copy activity Binary sink.
 type BinarySink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Binary store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type BinarySink.
@@ -4330,22 +4330,22 @@ func (b *BinarySink) GetCopySink() *CopySink {
 // BinarySource - A copy activity Binary source.
 type BinarySource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Binary store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type BinarySource.
@@ -4362,25 +4362,25 @@ func (b *BinarySource) GetCopySource() *CopySource {
 // BlobEventsTrigger - Trigger that runs every time a Blob event occurs.
 type BlobEventsTrigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Blob Events Trigger properties.
-	TypeProperties *BlobEventsTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *BlobEventsTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Pipelines that need to be started.
-	Pipelines []*TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines []*TriggerPipelineReference
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type BlobEventsTrigger.
@@ -4409,59 +4409,59 @@ func (b *BlobEventsTrigger) GetTrigger() *Trigger {
 // BlobEventsTriggerTypeProperties - Blob Events Trigger properties.
 type BlobEventsTriggerTypeProperties struct {
 	// REQUIRED; The type of events that cause this trigger to fire.
-	Events []*BlobEventType `json:"events,omitempty"`
+	Events []*BlobEventType
 
 	// REQUIRED; The ARM resource ID of the Storage Account.
-	Scope *string `json:"scope,omitempty"`
+	Scope *string
 
 	// The blob path must begin with the pattern provided for trigger to fire. For example, '/records/blobs/december/' will only
 	// fire the trigger for blobs in the december folder under the records container.
 	// At least one of these must be provided: blobPathBeginsWith, blobPathEndsWith.
-	BlobPathBeginsWith *string `json:"blobPathBeginsWith,omitempty"`
+	BlobPathBeginsWith *string
 
 	// The blob path must end with the pattern provided for trigger to fire. For example, 'december/boxes.csv' will only fire
 	// the trigger for blobs named boxes in a december folder. At least one of these
 	// must be provided: blobPathBeginsWith, blobPathEndsWith.
-	BlobPathEndsWith *string `json:"blobPathEndsWith,omitempty"`
+	BlobPathEndsWith *string
 
 	// If set to true, blobs with zero bytes will be ignored.
-	IgnoreEmptyBlobs *bool `json:"ignoreEmptyBlobs,omitempty"`
+	IgnoreEmptyBlobs *bool
 }
 
 // BlobSink - A copy activity Azure Blob sink.
 type BlobSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Blob writer add header. Type: boolean (or Expression with resultType boolean).
-	BlobWriterAddHeader any `json:"blobWriterAddHeader,omitempty"`
+	BlobWriterAddHeader any
 
 	// Blob writer date time format. Type: string (or Expression with resultType string).
-	BlobWriterDateTimeFormat any `json:"blobWriterDateTimeFormat,omitempty"`
+	BlobWriterDateTimeFormat any
 
 	// Blob writer overwrite files. Type: boolean (or Expression with resultType boolean).
-	BlobWriterOverwriteFiles any `json:"blobWriterOverwriteFiles,omitempty"`
+	BlobWriterOverwriteFiles any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type BlobSink.
@@ -4480,29 +4480,29 @@ func (b *BlobSink) GetCopySink() *CopySink {
 // BlobSource - A copy activity Azure Blob source.
 type BlobSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Number of header lines to skip from each blob. Type: integer (or Expression with resultType integer).
-	SkipHeaderLineCount any `json:"skipHeaderLineCount,omitempty"`
+	SkipHeaderLineCount any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Treat empty as null. Type: boolean (or Expression with resultType boolean).
-	TreatEmptyAsNull any `json:"treatEmptyAsNull,omitempty"`
+	TreatEmptyAsNull any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type BlobSource.
@@ -4519,25 +4519,25 @@ func (b *BlobSource) GetCopySource() *CopySource {
 // BlobTrigger - Trigger that runs every time the selected Blob container changes.
 type BlobTrigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Blob Trigger properties.
-	TypeProperties *BlobTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *BlobTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Pipelines that need to be started.
-	Pipelines []*TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines []*TriggerPipelineReference
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type BlobTrigger.
@@ -4566,37 +4566,37 @@ func (b *BlobTrigger) GetTrigger() *Trigger {
 // BlobTriggerTypeProperties - Blob Trigger properties.
 type BlobTriggerTypeProperties struct {
 	// REQUIRED; The path of the container/folder that will trigger the pipeline.
-	FolderPath *string `json:"folderPath,omitempty"`
+	FolderPath *string
 
 	// REQUIRED; The Azure Storage linked service reference.
-	LinkedService *LinkedServiceReference `json:"linkedService,omitempty"`
+	LinkedService *LinkedServiceReference
 
 	// REQUIRED; The max number of parallel files to handle when it is triggered.
-	MaxConcurrency *int32 `json:"maxConcurrency,omitempty"`
+	MaxConcurrency *int32
 }
 
 // CassandraLinkedService - Linked service for Cassandra data source.
 type CassandraLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Cassandra linked service properties.
-	TypeProperties *CassandraLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CassandraLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CassandraLinkedService.
@@ -4614,29 +4614,29 @@ func (c *CassandraLinkedService) GetLinkedService() *LinkedService {
 // CassandraLinkedServiceTypeProperties - Cassandra linked service properties.
 type CassandraLinkedServiceTypeProperties struct {
 	// REQUIRED; Host name for connection. Type: string (or Expression with resultType string).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// AuthenticationType to be used for connection. Type: string (or Expression with resultType string).
-	AuthenticationType any `json:"authenticationType,omitempty"`
+	AuthenticationType any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The port for the connection. Type: integer (or Expression with resultType integer).
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Username for authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // CassandraSource - A copy activity source for a Cassandra database.
 type CassandraSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -4645,23 +4645,23 @@ type CassandraSource struct {
 	// client application. Cassandra checks the specified number of Cassandra servers
 	// for data to satisfy the read request. Must be one of cassandraSourceReadConsistencyLevels. The default value is 'ONE'.
 	// It is case-insensitive.
-	ConsistencyLevel *CassandraSourceReadConsistencyLevels `json:"consistencyLevel,omitempty"`
+	ConsistencyLevel *CassandraSourceReadConsistencyLevels
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Should be a SQL-92 query expression or Cassandra Query Language (CQL) command. Type: string (or Expression
 	// with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CassandraSource.
@@ -4690,35 +4690,35 @@ func (c *CassandraSource) GetTabularSource() *TabularSource {
 // CassandraTableDataset - The Cassandra database dataset.
 type CassandraTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Cassandra dataset properties.
-	TypeProperties *CassandraTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CassandraTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type CassandraTableDataset.
@@ -4739,10 +4739,10 @@ func (c *CassandraTableDataset) GetDataset() *Dataset {
 // CassandraTableDatasetTypeProperties - Cassandra dataset properties.
 type CassandraTableDatasetTypeProperties struct {
 	// The keyspace of the Cassandra database. Type: string (or Expression with resultType string).
-	Keyspace any `json:"keyspace,omitempty"`
+	Keyspace any
 
 	// The table name of the Cassandra database. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // ChainingTrigger - Trigger that allows the referenced pipeline to depend on other pipeline runs based on runDimension Name/Value
@@ -4751,25 +4751,25 @@ type CassandraTableDatasetTypeProperties struct {
 // match for all upstream pipeline runs.
 type ChainingTrigger struct {
 	// REQUIRED; Pipeline for which runs are created when all upstream pipelines complete successfully.
-	Pipeline *TriggerPipelineReference `json:"pipeline,omitempty"`
+	Pipeline *TriggerPipelineReference
 
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Chaining Trigger properties.
-	TypeProperties *ChainingTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ChainingTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetTrigger implements the TriggerClassification interface for type ChainingTrigger.
@@ -4786,44 +4786,44 @@ func (c *ChainingTrigger) GetTrigger() *Trigger {
 // ChainingTriggerTypeProperties - Chaining Trigger properties.
 type ChainingTriggerTypeProperties struct {
 	// REQUIRED; Upstream Pipelines.
-	DependsOn []*PipelineReference `json:"dependsOn,omitempty"`
+	DependsOn []*PipelineReference
 
 	// REQUIRED; Run Dimension property that needs to be emitted by upstream pipelines.
-	RunDimension *string `json:"runDimension,omitempty"`
+	RunDimension *string
 }
 
 // CommonDataServiceForAppsEntityDataset - The Common Data Service for Apps entity dataset.
 type CommonDataServiceForAppsEntityDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Common Data Service for Apps entity dataset properties.
-	TypeProperties *CommonDataServiceForAppsEntityDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CommonDataServiceForAppsEntityDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type CommonDataServiceForAppsEntityDataset.
@@ -4844,31 +4844,31 @@ func (c *CommonDataServiceForAppsEntityDataset) GetDataset() *Dataset {
 // CommonDataServiceForAppsEntityDatasetTypeProperties - Common Data Service for Apps entity dataset properties.
 type CommonDataServiceForAppsEntityDatasetTypeProperties struct {
 	// The logical name of the entity. Type: string (or Expression with resultType string).
-	EntityName any `json:"entityName,omitempty"`
+	EntityName any
 }
 
 // CommonDataServiceForAppsLinkedService - Common Data Service for Apps linked service.
 type CommonDataServiceForAppsLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Common Data Service for Apps linked service properties.
-	TypeProperties *CommonDataServiceForAppsLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CommonDataServiceForAppsLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CommonDataServiceForAppsLinkedService.
@@ -4888,90 +4888,90 @@ type CommonDataServiceForAppsLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication type to connect to Common Data Service for Apps server. 'Office365' for online scenario, 'Ifd'
 	// for on-premises with Ifd scenario. 'AADServicePrincipal' for Server-To-Server
 	// authentication in online scenario. Type: string (or Expression with resultType string).
-	AuthenticationType *DynamicsAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *DynamicsAuthenticationType
 
 	// REQUIRED; The deployment type of the Common Data Service for Apps instance. 'Online' for Common Data Service for Apps Online
 	// and 'OnPremisesWithIfd' for Common Data Service for Apps on-premises with Ifd. Type:
 	// string (or Expression with resultType string).
-	DeploymentType *DynamicsDeploymentType `json:"deploymentType,omitempty"`
+	DeploymentType *DynamicsDeploymentType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The host name of the on-premises Common Data Service for Apps server. The property is required for on-prem and not allowed
 	// for online. Type: string (or Expression with resultType string).
-	HostName any `json:"hostName,omitempty"`
+	HostName any
 
 	// The organization name of the Common Data Service for Apps instance. The property is required for on-prem and required for
 	// online when there are more than one Common Data Service for Apps instances
 	// associated with the user. Type: string (or Expression with resultType string).
-	OrganizationName any `json:"organizationName,omitempty"`
+	OrganizationName any
 
 	// Password to access the Common Data Service for Apps instance.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The port of on-premises Common Data Service for Apps server. The property is required for on-prem and not allowed for online.
 	// Default is 443. Type: integer (or Expression with resultType integer),
 	// minimum: 0.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The credential of the service principal object in Azure Active Directory. If servicePrincipalCredentialType is 'ServicePrincipalKey',
 	// servicePrincipalCredential can be SecureString or
 	// AzureKeyVaultSecretReference. If servicePrincipalCredentialType is 'ServicePrincipalCert', servicePrincipalCredential can
 	// only be AzureKeyVaultSecretReference.
-	ServicePrincipalCredential SecretBaseClassification `json:"servicePrincipalCredential,omitempty"`
+	ServicePrincipalCredential SecretBaseClassification
 
 	// The service principal credential type to use in Server-To-Server authentication. 'ServicePrincipalKey' for key/secret,
 	// 'ServicePrincipalCert' for certificate. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType `json:"servicePrincipalCredentialType,omitempty"`
+	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType
 
 	// The client ID of the application in Azure Active Directory used for Server-To-Server authentication. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The URL to the Microsoft Common Data Service for Apps server. The property is required for on-line and not allowed for
 	// on-prem. Type: string (or Expression with resultType string).
-	ServiceURI any `json:"serviceUri,omitempty"`
+	ServiceURI any
 
 	// User name to access the Common Data Service for Apps instance. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // CommonDataServiceForAppsSink - A copy activity Common Data Service for Apps sink.
 type CommonDataServiceForAppsSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; The write behavior for the operation.
-	WriteBehavior *DynamicsSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *DynamicsSinkWriteBehavior
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType
 	// string).
-	AlternateKeyName any `json:"alternateKeyName,omitempty"`
+	AlternateKeyName any
 
 	// The flag indicating whether to ignore null values from input dataset (except key fields) during write operation. Default
 	// is false. Type: boolean (or Expression with resultType boolean).
-	IgnoreNullValues any `json:"ignoreNullValues,omitempty"`
+	IgnoreNullValues any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type CommonDataServiceForAppsSink.
@@ -4990,23 +4990,23 @@ func (c *CommonDataServiceForAppsSink) GetCopySink() *CopySink {
 // CommonDataServiceForAppsSource - A copy activity Common Data Service for Apps source.
 type CommonDataServiceForAppsSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// FetchXML is a proprietary query language that is used in Microsoft Common Data Service for Apps (online & on-premises).
 	// Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CommonDataServiceForAppsSource.
@@ -5023,25 +5023,25 @@ func (c *CommonDataServiceForAppsSource) GetCopySource() *CopySource {
 // ConcurLinkedService - Concur Service linked service.
 type ConcurLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Concur Service linked service properties.
-	TypeProperties *ConcurLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ConcurLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ConcurLinkedService.
@@ -5059,61 +5059,61 @@ func (c *ConcurLinkedService) GetLinkedService() *LinkedService {
 // ConcurLinkedServiceTypeProperties - Concur Service linked service properties.
 type ConcurLinkedServiceTypeProperties struct {
 	// REQUIRED; Application client_id supplied by Concur App Management.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; The user name that you use to access Concur Service.
-	Username any `json:"username,omitempty"`
+	Username any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name that you provided in the username field.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // ConcurObjectDataset - Concur Service dataset.
 type ConcurObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ConcurObjectDataset.
@@ -5134,25 +5134,25 @@ func (c *ConcurObjectDataset) GetDataset() *Dataset {
 // ConcurSource - A copy activity Concur Service source.
 type ConcurSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ConcurSource.
@@ -5192,22 +5192,22 @@ type ControlActivityClassification interface {
 // ControlActivity - Base class for all control activities like IfCondition, ForEach , Until.
 type ControlActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ControlActivity.
@@ -5228,37 +5228,37 @@ func (c *ControlActivity) GetControlActivity() *ControlActivity { return c }
 // CopyActivity - Copy activity.
 type CopyActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Copy activity properties.
-	TypeProperties *CopyActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CopyActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// List of inputs for the activity.
-	Inputs []*DatasetReference `json:"inputs,omitempty"`
+	Inputs []*DatasetReference
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// List of outputs for the activity.
-	Outputs []*DatasetReference `json:"outputs,omitempty"`
+	Outputs []*DatasetReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type CopyActivity.
@@ -5290,40 +5290,40 @@ func (c *CopyActivity) GetExecutionActivity() *ExecutionActivity {
 // CopyActivityTypeProperties - Copy activity properties.
 type CopyActivityTypeProperties struct {
 	// REQUIRED; Copy activity sink.
-	Sink CopySinkClassification `json:"sink,omitempty"`
+	Sink CopySinkClassification
 
 	// REQUIRED; Copy activity source.
-	Source CopySourceClassification `json:"source,omitempty"`
+	Source CopySourceClassification
 
 	// Maximum number of data integration units that can be used to perform this data movement. Type: integer (or Expression with
 	// resultType integer), minimum: 0.
-	DataIntegrationUnits any `json:"dataIntegrationUnits,omitempty"`
+	DataIntegrationUnits any
 
 	// Whether to skip incompatible row. Default value is false. Type: boolean (or Expression with resultType boolean).
-	EnableSkipIncompatibleRow any `json:"enableSkipIncompatibleRow,omitempty"`
+	EnableSkipIncompatibleRow any
 
 	// Specifies whether to copy data via an interim staging. Default value is false. Type: boolean (or Expression with resultType
 	// boolean).
-	EnableStaging any `json:"enableStaging,omitempty"`
+	EnableStaging any
 
 	// Maximum number of concurrent sessions opened on the source or sink to avoid overloading the data store. Type: integer (or
 	// Expression with resultType integer), minimum: 0.
-	ParallelCopies any `json:"parallelCopies,omitempty"`
+	ParallelCopies any
 
 	// Preserve rules.
-	Preserve []any `json:"preserve,omitempty"`
+	Preserve []any
 
 	// Preserve Rules.
-	PreserveRules []any `json:"preserveRules,omitempty"`
+	PreserveRules []any
 
 	// Redirect incompatible row settings when EnableSkipIncompatibleRow is true.
-	RedirectIncompatibleRowSettings *RedirectIncompatibleRowSettings `json:"redirectIncompatibleRowSettings,omitempty"`
+	RedirectIncompatibleRowSettings *RedirectIncompatibleRowSettings
 
 	// Specifies interim staging settings when EnableStaging is true.
-	StagingSettings *StagingSettings `json:"stagingSettings,omitempty"`
+	StagingSettings *StagingSettings
 
 	// Copy activity translator. If not specified, tabular translator is used.
-	Translator any `json:"translator,omitempty"`
+	Translator any
 }
 
 // CopySinkClassification provides polymorphic access to related types.
@@ -5342,25 +5342,25 @@ type CopySinkClassification interface {
 // CopySink - A copy activity sink.
 type CopySink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type CopySink.
@@ -5390,19 +5390,19 @@ type CopySourceClassification interface {
 // CopySource - A copy activity source.
 type CopySource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CopySource.
@@ -5420,7 +5420,7 @@ type CopyTranslatorClassification interface {
 // CopyTranslator - A copy activity translator.
 type CopyTranslator struct {
 	// REQUIRED; Copy translator type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -5432,25 +5432,25 @@ func (c *CopyTranslator) GetCopyTranslator() *CopyTranslator { return c }
 // CosmosDbLinkedService - Microsoft Azure Cosmos Database (CosmosDB) linked service.
 type CosmosDbLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; CosmosDB linked service properties.
-	TypeProperties *CosmosDbLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CosmosDbLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CosmosDbLinkedService.
@@ -5468,54 +5468,54 @@ func (c *CosmosDbLinkedService) GetLinkedService() *LinkedService {
 // CosmosDbLinkedServiceTypeProperties - CosmosDB linked service properties.
 type CosmosDbLinkedServiceTypeProperties struct {
 	// The endpoint of the Azure CosmosDB account. Type: string (or Expression with resultType string)
-	AccountEndpoint any `json:"accountEndpoint,omitempty"`
+	AccountEndpoint any
 
 	// The account key of the Azure CosmosDB account. Type: SecureString or AzureKeyVaultSecretReference.
-	AccountKey SecretBaseClassification `json:"accountKey,omitempty"`
+	AccountKey SecretBaseClassification
 
 	// The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The name of the database. Type: string (or Expression with resultType string)
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 }
 
 // CosmosDbMongoDbAPICollectionDataset - The CosmosDB (MongoDB API) database dataset.
 type CosmosDbMongoDbAPICollectionDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; CosmosDB (MongoDB API) database dataset properties.
-	TypeProperties *CosmosDbMongoDbAPICollectionDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CosmosDbMongoDbAPICollectionDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type CosmosDbMongoDbAPICollectionDataset.
@@ -5536,31 +5536,31 @@ func (c *CosmosDbMongoDbAPICollectionDataset) GetDataset() *Dataset {
 // CosmosDbMongoDbAPICollectionDatasetTypeProperties - CosmosDB (MongoDB API) database dataset properties.
 type CosmosDbMongoDbAPICollectionDatasetTypeProperties struct {
 	// REQUIRED; The collection name of the CosmosDB (MongoDB API) database. Type: string (or Expression with resultType string).
-	Collection any `json:"collection,omitempty"`
+	Collection any
 }
 
 // CosmosDbMongoDbAPILinkedService - Linked service for CosmosDB (MongoDB API) data source.
 type CosmosDbMongoDbAPILinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; CosmosDB (MongoDB API) linked service properties.
-	TypeProperties *CosmosDbMongoDbAPILinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CosmosDbMongoDbAPILinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CosmosDbMongoDbAPILinkedService.
@@ -5579,40 +5579,40 @@ func (c *CosmosDbMongoDbAPILinkedService) GetLinkedService() *LinkedService {
 type CosmosDbMongoDbAPILinkedServiceTypeProperties struct {
 	// REQUIRED; The CosmosDB (MongoDB API) connection string. Type: string, SecureString or AzureKeyVaultSecretReference. Type:
 	// string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// REQUIRED; The name of the CosmosDB (MongoDB API) database that you want to access. Type: string (or Expression with resultType
 	// string).
-	Database any `json:"database,omitempty"`
+	Database any
 }
 
 // CosmosDbMongoDbAPISink - A copy activity sink for a CosmosDB (MongoDB API) database.
 type CosmosDbMongoDbAPISink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// Specifies whether the document with same key to be overwritten (upsert) rather than throw exception (insert). The default
 	// value is "insert". Type: string (or Expression with resultType string). Type:
 	// string (or Expression with resultType string).
-	WriteBehavior any `json:"writeBehavior,omitempty"`
+	WriteBehavior any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type CosmosDbMongoDbAPISink.
@@ -5631,7 +5631,7 @@ func (c *CosmosDbMongoDbAPISink) GetCopySink() *CopySink {
 // CosmosDbMongoDbAPISource - A copy activity source for a CosmosDB (MongoDB API) database.
 type CosmosDbMongoDbAPISource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -5639,26 +5639,26 @@ type CosmosDbMongoDbAPISource struct {
 	// Specifies the number of documents to return in each batch of the response from MongoDB instance. In most cases, modifying
 	// the batch size will not affect the user or the application. This property's
 	// main purpose is to avoid hit the limitation of response size. Type: integer (or Expression with resultType integer).
-	BatchSize any `json:"batchSize,omitempty"`
+	BatchSize any
 
 	// Cursor methods for Mongodb query.
-	CursorMethods *MongoDbCursorMethodsProperties `json:"cursorMethods,omitempty"`
+	CursorMethods *MongoDbCursorMethodsProperties
 
 	// Specifies selection filter using query operators. To return all documents in a collection, omit this parameter or pass
 	// an empty document ({}). Type: string (or Expression with resultType string).
-	Filter any `json:"filter,omitempty"`
+	Filter any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CosmosDbMongoDbAPISource.
@@ -5675,35 +5675,35 @@ func (c *CosmosDbMongoDbAPISource) GetCopySource() *CopySource {
 // CosmosDbSQLAPICollectionDataset - Microsoft Azure CosmosDB (SQL API) Collection dataset.
 type CosmosDbSQLAPICollectionDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; CosmosDB (SQL API) Collection dataset properties.
-	TypeProperties *CosmosDbSQLAPICollectionDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CosmosDbSQLAPICollectionDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type CosmosDbSQLAPICollectionDataset.
@@ -5724,35 +5724,35 @@ func (c *CosmosDbSQLAPICollectionDataset) GetDataset() *Dataset {
 // CosmosDbSQLAPICollectionDatasetTypeProperties - CosmosDB (SQL API) Collection dataset properties.
 type CosmosDbSQLAPICollectionDatasetTypeProperties struct {
 	// REQUIRED; CosmosDB (SQL API) collection name. Type: string (or Expression with resultType string).
-	CollectionName any `json:"collectionName,omitempty"`
+	CollectionName any
 }
 
 // CosmosDbSQLAPISink - A copy activity Azure CosmosDB (SQL API) Collection sink.
 type CosmosDbSQLAPISink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// Describes how to write data to Azure Cosmos DB. Type: string (or Expression with resultType string). Allowed values: insert
 	// and upsert.
-	WriteBehavior any `json:"writeBehavior,omitempty"`
+	WriteBehavior any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type CosmosDbSQLAPISink.
@@ -5771,28 +5771,28 @@ func (c *CosmosDbSQLAPISink) GetCopySink() *CopySink {
 // CosmosDbSQLAPISource - A copy activity Azure CosmosDB (SQL API) Collection source.
 type CosmosDbSQLAPISource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Page size of the result. Type: integer (or Expression with resultType integer).
-	PageSize any `json:"pageSize,omitempty"`
+	PageSize any
 
 	// Preferred regions. Type: array of strings (or Expression with resultType array of strings).
-	PreferredRegions any `json:"preferredRegions,omitempty"`
+	PreferredRegions any
 
 	// SQL API query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CosmosDbSQLAPISource.
@@ -5809,25 +5809,25 @@ func (c *CosmosDbSQLAPISource) GetCopySource() *CopySource {
 // CouchbaseLinkedService - Couchbase server linked service.
 type CouchbaseLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Couchbase server linked service properties.
-	TypeProperties *CouchbaseLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CouchbaseLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CouchbaseLinkedService.
@@ -5845,38 +5845,38 @@ func (c *CouchbaseLinkedService) GetLinkedService() *LinkedService {
 // CouchbaseLinkedServiceTypeProperties - Couchbase server linked service properties.
 type CouchbaseLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The Azure key vault secret reference of credString in connection string.
-	CredString *AzureKeyVaultSecretReference `json:"credString,omitempty"`
+	CredString *AzureKeyVaultSecretReference
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 }
 
 // CouchbaseSource - A copy activity Couchbase server source.
 type CouchbaseSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type CouchbaseSource.
@@ -5905,35 +5905,35 @@ func (c *CouchbaseSource) GetTabularSource() *TabularSource {
 // CouchbaseTableDataset - Couchbase server dataset.
 type CouchbaseTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type CouchbaseTableDataset.
@@ -5954,64 +5954,64 @@ func (c *CouchbaseTableDataset) GetDataset() *Dataset {
 // CreateDataFlowDebugSessionRequest - Request body structure for creating data flow debug session.
 type CreateDataFlowDebugSessionRequest struct {
 	// Timeout setting for Databricks cluster.
-	ClusterTimeout *int32 `json:"clusterTimeout,omitempty"`
+	ClusterTimeout *int32
 
 	// Data bricks linked service.
-	DataBricksLinkedService *LinkedServiceResource `json:"dataBricksLinkedService,omitempty"`
+	DataBricksLinkedService *LinkedServiceResource
 
 	// The name of the data flow.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// The ID of existing Databricks cluster.
-	ExistingClusterID *string `json:"existingClusterId,omitempty"`
+	ExistingClusterID *string
 
 	// The name of new Databricks cluster.
-	NewClusterName *string `json:"newClusterName,omitempty"`
+	NewClusterName *string
 
 	// The type of new Databricks cluster.
-	NewClusterNodeType *string `json:"newClusterNodeType,omitempty"`
+	NewClusterNodeType *string
 }
 
 // CreateDataFlowDebugSessionResponse - Response body structure for creating data flow debug session.
 type CreateDataFlowDebugSessionResponse struct {
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 }
 
 // CreateRunResponse - Response body with a run identifier.
 type CreateRunResponse struct {
 	// REQUIRED; Identifier of a run.
-	RunID *string `json:"runId,omitempty"`
+	RunID *string
 }
 
 // CustomActivity - Custom activity type.
 type CustomActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Custom activity properties.
-	TypeProperties *CustomActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *CustomActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type CustomActivity.
@@ -6043,56 +6043,56 @@ func (c *CustomActivity) GetExecutionActivity() *ExecutionActivity {
 // CustomActivityReferenceObject - Reference objects for custom activity
 type CustomActivityReferenceObject struct {
 	// Dataset references.
-	Datasets []*DatasetReference `json:"datasets,omitempty"`
+	Datasets []*DatasetReference
 
 	// Linked service references.
-	LinkedServices []*LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceReference
 }
 
 // CustomActivityTypeProperties - Custom activity properties.
 type CustomActivityTypeProperties struct {
 	// REQUIRED; Command for custom activity Type: string (or Expression with resultType string).
-	Command any `json:"command,omitempty"`
+	Command any
 
 	// User defined property bag. There is no restriction on the keys or values that can be used. The user specified custom activity
 	// has the full responsibility to consume and interpret the content defined.
-	ExtendedProperties map[string]any `json:"extendedProperties,omitempty"`
+	ExtendedProperties map[string]any
 
 	// Folder path for resource files Type: string (or Expression with resultType string).
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 
 	// Reference objects
-	ReferenceObjects *CustomActivityReferenceObject `json:"referenceObjects,omitempty"`
+	ReferenceObjects *CustomActivityReferenceObject
 
 	// Resource linked service reference.
-	ResourceLinkedService *LinkedServiceReference `json:"resourceLinkedService,omitempty"`
+	ResourceLinkedService *LinkedServiceReference
 
 	// The retention time for the files submitted for custom activity. Type: double (or Expression with resultType double).
-	RetentionTimeInDays any `json:"retentionTimeInDays,omitempty"`
+	RetentionTimeInDays any
 }
 
 // CustomDataSourceLinkedService - Custom linked service.
 type CustomDataSourceLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Custom linked service properties.
-	TypeProperties any `json:"typeProperties,omitempty"`
+	TypeProperties any
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type CustomDataSourceLinkedService.
@@ -6110,35 +6110,35 @@ func (c *CustomDataSourceLinkedService) GetLinkedService() *LinkedService {
 // CustomDataset - The custom dataset.
 type CustomDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Custom dataset properties.
-	TypeProperties any `json:"typeProperties,omitempty"`
+	TypeProperties any
 }
 
 // GetDataset implements the DatasetClassification interface for type CustomDataset.
@@ -6168,7 +6168,7 @@ type CustomSetupBaseClassification interface {
 // CustomSetupBase - The base definition of the custom setup.
 type CustomSetupBase struct {
 	// REQUIRED; The type of custom setup.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // GetCustomSetupBase implements the CustomSetupBaseClassification interface for type CustomSetupBase.
@@ -6177,19 +6177,19 @@ func (c *CustomSetupBase) GetCustomSetupBase() *CustomSetupBase { return c }
 // CustomerManagedKeyDetails - Details of the customer managed key associated with the workspace
 type CustomerManagedKeyDetails struct {
 	// The key object of the workspace
-	Key *WorkspaceKeyDetails `json:"key,omitempty"`
+	Key *WorkspaceKeyDetails
 
 	// READ-ONLY; The customer managed key status on the workspace
-	Status *string `json:"status,omitempty" azure:"ro"`
+	Status *string
 }
 
 // DWCopyCommandDefaultValue - Default value.
 type DWCopyCommandDefaultValue struct {
 	// Column name. Type: object (or Expression with resultType string).
-	ColumnName any `json:"columnName,omitempty"`
+	ColumnName any
 
 	// The default value of the column. Type: object (or Expression with resultType string).
-	DefaultValue any `json:"defaultValue,omitempty"`
+	DefaultValue any
 }
 
 // DWCopyCommandSettings - DW Copy Command settings.
@@ -6197,12 +6197,12 @@ type DWCopyCommandSettings struct {
 	// Additional options directly passed to SQL DW in Copy Command. Type: key value pairs (value should be string type) (or Expression
 	// with resultType object). Example: "additionalOptions": { "MAXERRORS":
 	// "1000", "DATEFORMAT": "'ymd'" }
-	AdditionalOptions map[string]*string `json:"additionalOptions,omitempty"`
+	AdditionalOptions map[string]*string
 
 	// Specifies the default values for each target column in SQL DW. The default values in the property overwrite the DEFAULT
 	// constraint set in the DB, and identity column cannot have a default value. Type:
 	// array of objects (or Expression with resultType array of objects).
-	DefaultValues []*DWCopyCommandDefaultValue `json:"defaultValues,omitempty"`
+	DefaultValues []*DWCopyCommandDefaultValue
 }
 
 // DataFlowClassification provides polymorphic access to related types.
@@ -6217,16 +6217,16 @@ type DataFlowClassification interface {
 // DataFlow - Azure Synapse nested object which contains a flow with data movements and transformations.
 type DataFlow struct {
 	// REQUIRED; Type of data flow.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// List of tags that can be used for describing the data flow.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The description of the data flow.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this data flow is in. If not specified, Data flow will appear at the root level.
-	Folder *DataFlowFolder `json:"folder,omitempty"`
+	Folder *DataFlowFolder
 }
 
 // GetDataFlow implements the DataFlowClassification interface for type DataFlow.
@@ -6270,25 +6270,25 @@ type DataFlowClientGetDataFlowsByWorkspaceOptions struct {
 // DataFlowDebugCommandRequest - Request body structure for data flow expression preview.
 type DataFlowDebugCommandRequest struct {
 	// REQUIRED; The command payload object.
-	CommandPayload any `json:"commandPayload,omitempty"`
+	CommandPayload any
 
 	// REQUIRED; The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// The command name.
-	CommandName *string `json:"commandName,omitempty"`
+	CommandName *string
 
 	// The data flow which contains the debug session.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 }
 
 // DataFlowDebugCommandResponse - Response body structure of data flow result for data preview, statistics or expression preview.
 type DataFlowDebugCommandResponse struct {
 	// The result data of data preview, statistics or expression preview.
-	Data *string `json:"data,omitempty"`
+	Data *string
 
 	// The run status of data preview, statistics or expression preview.
-	Status *string `json:"status,omitempty"`
+	Status *string
 }
 
 // DataFlowDebugPackage - Request body structure for starting data flow debug session.
@@ -6297,73 +6297,73 @@ type DataFlowDebugPackage struct {
 	AdditionalProperties map[string]any
 
 	// Data flow instance.
-	DataFlow *DataFlowDebugResource `json:"dataFlow,omitempty"`
+	DataFlow *DataFlowDebugResource
 
 	// List of datasets.
-	Datasets []*DatasetDebugResource `json:"datasets,omitempty"`
+	Datasets []*DatasetDebugResource
 
 	// Data flow debug settings.
-	DebugSettings *DataFlowDebugPackageDebugSettings `json:"debugSettings,omitempty"`
+	DebugSettings *DataFlowDebugPackageDebugSettings
 
 	// List of linked services.
-	LinkedServices []*LinkedServiceDebugResource `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceDebugResource
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// Staging info for debug session.
-	Staging *DataFlowStagingInfo `json:"staging,omitempty"`
+	Staging *DataFlowStagingInfo
 }
 
 // DataFlowDebugPackageDebugSettings - Data flow debug settings.
 type DataFlowDebugPackageDebugSettings struct {
 	// Parameters for dataset.
-	DatasetParameters any `json:"datasetParameters,omitempty"`
+	DatasetParameters any
 
 	// Data flow parameters.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 
 	// Source setting for data flow debug.
-	SourceSettings []*DataFlowSourceSetting `json:"sourceSettings,omitempty"`
+	SourceSettings []*DataFlowSourceSetting
 }
 
 // DataFlowDebugPreviewDataRequest - Request body structure for data flow preview data.
 type DataFlowDebugPreviewDataRequest struct {
 	// The data flow which contains the debug session.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// The row limit for preview request.
-	RowLimits *int32 `json:"rowLimits,omitempty"`
+	RowLimits *int32
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// The output stream name.
-	StreamName *string `json:"streamName,omitempty"`
+	StreamName *string
 }
 
 // DataFlowDebugQueryResponse - Response body structure of data flow query for data preview, statistics or expression preview.
 type DataFlowDebugQueryResponse struct {
 	// The run ID of data flow debug session.
-	RunID *string `json:"runId,omitempty"`
+	RunID *string
 }
 
 // DataFlowDebugResource - Data flow debug resource.
 type DataFlowDebugResource struct {
 	// REQUIRED; Data flow properties.
-	Properties DataFlowClassification `json:"properties,omitempty"`
+	Properties DataFlowClassification
 
 	// The resource name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // DataFlowDebugResultResponse - Response body structure of data flow result for data preview, statistics or expression preview.
 type DataFlowDebugResultResponse struct {
 	// The result data of data preview, statistics or expression preview.
-	Data *string `json:"data,omitempty"`
+	Data *string
 
 	// The run status of data preview, statistics or expression preview.
-	Status *string `json:"status,omitempty"`
+	Status *string
 }
 
 // DataFlowDebugSessionClientAddDataFlowOptions contains the optional parameters for the DataFlowDebugSessionClient.AddDataFlow
@@ -6404,118 +6404,118 @@ type DataFlowDebugSessionInfo struct {
 	AdditionalProperties map[string]any
 
 	// Compute type of the cluster.
-	ComputeType *string `json:"computeType,omitempty"`
+	ComputeType *string
 
 	// Core count of the cluster.
-	CoreCount *int32 `json:"coreCount,omitempty"`
+	CoreCount *int32
 
 	// The name of the data flow.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// Attached integration runtime name of data flow debug session.
-	IntegrationRuntimeName *string `json:"integrationRuntimeName,omitempty"`
+	IntegrationRuntimeName *string
 
 	// Last activity time of data flow debug session.
-	LastActivityTime *string `json:"lastActivityTime,omitempty"`
+	LastActivityTime *string
 
 	// Node count of the cluster. (deprecated property)
-	NodeCount *int32 `json:"nodeCount,omitempty"`
+	NodeCount *int32
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// Start time of data flow debug session.
-	StartTime *string `json:"startTime,omitempty"`
+	StartTime *string
 
 	// Compute type of the cluster.
-	TimeToLiveInMinutes *int32 `json:"timeToLiveInMinutes,omitempty"`
+	TimeToLiveInMinutes *int32
 }
 
 // DataFlowDebugStatisticsRequest - Request body structure for data flow statistics.
 type DataFlowDebugStatisticsRequest struct {
 	// List of column names.
-	Columns []*string `json:"columns,omitempty"`
+	Columns []*string
 
 	// The data flow which contains the debug session.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// The output stream name.
-	StreamName *string `json:"streamName,omitempty"`
+	StreamName *string
 }
 
 // DataFlowFolder - The folder that this data flow is in. If not specified, Data flow will appear at the root level.
 type DataFlowFolder struct {
 	// The name of the folder that this data flow is in.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // DataFlowListResponse - A list of data flow resources.
 type DataFlowListResponse struct {
 	// REQUIRED; List of data flows.
-	Value []*DataFlowResource `json:"value,omitempty"`
+	Value []*DataFlowResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DataFlowReference - Data flow reference type.
 type DataFlowReference struct {
 	// REQUIRED; Reference data flow name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Data flow reference type.
-	Type *DataFlowReferenceType `json:"type,omitempty"`
+	Type *DataFlowReferenceType
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Reference data flow parameters from dataset.
-	DatasetParameters any `json:"datasetParameters,omitempty"`
+	DatasetParameters any
 }
 
 // DataFlowResource - Data flow resource type.
 type DataFlowResource struct {
 	// REQUIRED; Data flow properties.
-	Properties DataFlowClassification `json:"properties,omitempty"`
+	Properties DataFlowClassification
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DataFlowSink - Transformation for data flow sink.
 type DataFlowSink struct {
 	// REQUIRED; Transformation name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// Transformation description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // DataFlowSource - Transformation for data flow source.
 type DataFlowSource struct {
 	// REQUIRED; Transformation name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// Transformation description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // DataFlowSourceSetting - Definition of data flow source setting for debug.
@@ -6524,49 +6524,49 @@ type DataFlowSourceSetting struct {
 	AdditionalProperties map[string]any
 
 	// Defines the row limit of data flow source in debug.
-	RowLimit *int32 `json:"rowLimit,omitempty"`
+	RowLimit *int32
 
 	// The data flow source name.
-	SourceName *string `json:"sourceName,omitempty"`
+	SourceName *string
 }
 
 // DataFlowStagingInfo - Staging info for execute data flow activity.
 type DataFlowStagingInfo struct {
 	// Folder path for staging blob.
-	FolderPath *string `json:"folderPath,omitempty"`
+	FolderPath *string
 
 	// Staging linked service reference.
-	LinkedService *LinkedServiceReference `json:"linkedService,omitempty"`
+	LinkedService *LinkedServiceReference
 }
 
 // DataLakeAnalyticsUSQLActivity - Data Lake Analytics U-SQL activity.
 type DataLakeAnalyticsUSQLActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Data Lake Analytics U-SQL activity properties.
-	TypeProperties *DataLakeAnalyticsUSQLActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DataLakeAnalyticsUSQLActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type DataLakeAnalyticsUSQLActivity.
@@ -6598,68 +6598,68 @@ func (d *DataLakeAnalyticsUSQLActivity) GetExecutionActivity() *ExecutionActivit
 // DataLakeAnalyticsUSQLActivityTypeProperties - DataLakeAnalyticsU-SQL activity properties.
 type DataLakeAnalyticsUSQLActivityTypeProperties struct {
 	// REQUIRED; Script linked service reference.
-	ScriptLinkedService *LinkedServiceReference `json:"scriptLinkedService,omitempty"`
+	ScriptLinkedService *LinkedServiceReference
 
 	// REQUIRED; Case-sensitive path to folder that contains the U-SQL script. Type: string (or Expression with resultType string).
-	ScriptPath any `json:"scriptPath,omitempty"`
+	ScriptPath any
 
 	// Compilation mode of U-SQL. Must be one of these values : Semantic, Full and SingleBox. Type: string (or Expression with
 	// resultType string).
-	CompilationMode any `json:"compilationMode,omitempty"`
+	CompilationMode any
 
 	// The maximum number of nodes simultaneously used to run the job. Default value is 1. Type: integer (or Expression with resultType
 	// integer), minimum: 1.
-	DegreeOfParallelism any `json:"degreeOfParallelism,omitempty"`
+	DegreeOfParallelism any
 
 	// Parameters for U-SQL job request.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 
 	// Determines which jobs out of all that are queued should be selected to run first. The lower the number, the higher the
 	// priority. Default value is 1000. Type: integer (or Expression with resultType
 	// integer), minimum: 1.
-	Priority any `json:"priority,omitempty"`
+	Priority any
 
 	// Runtime version of the U-SQL engine to use. Type: string (or Expression with resultType string).
-	RuntimeVersion any `json:"runtimeVersion,omitempty"`
+	RuntimeVersion any
 }
 
 // DataLakeStorageAccountDetails - Details of the data lake storage account associated with the workspace
 type DataLakeStorageAccountDetails struct {
 	// Account URL
-	AccountURL *string `json:"accountUrl,omitempty"`
+	AccountURL *string
 
 	// Filesystem name
-	Filesystem *string `json:"filesystem,omitempty"`
+	Filesystem *string
 }
 
 // DatabricksNotebookActivity - DatabricksNotebook activity.
 type DatabricksNotebookActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Databricks Notebook activity properties.
-	TypeProperties *DatabricksNotebookActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DatabricksNotebookActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type DatabricksNotebookActivity.
@@ -6692,44 +6692,44 @@ func (d *DatabricksNotebookActivity) GetExecutionActivity() *ExecutionActivity {
 type DatabricksNotebookActivityTypeProperties struct {
 	// REQUIRED; The absolute path of the notebook to be run in the Databricks Workspace. This path must begin with a slash. Type:
 	// string (or Expression with resultType string).
-	NotebookPath any `json:"notebookPath,omitempty"`
+	NotebookPath any
 
 	// Base parameters to be used for each run of this job.If the notebook takes a parameter that is not specified, the default
 	// value from the notebook will be used.
-	BaseParameters map[string]any `json:"baseParameters,omitempty"`
+	BaseParameters map[string]any
 
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries []map[string]any `json:"libraries,omitempty"`
+	Libraries []map[string]any
 }
 
 // DatabricksSparkJarActivity - DatabricksSparkJar activity.
 type DatabricksSparkJarActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Databricks SparkJar activity properties.
-	TypeProperties *DatabricksSparkJarActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DatabricksSparkJarActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type DatabricksSparkJarActivity.
@@ -6762,43 +6762,43 @@ func (d *DatabricksSparkJarActivity) GetExecutionActivity() *ExecutionActivity {
 type DatabricksSparkJarActivityTypeProperties struct {
 	// REQUIRED; The full name of the class containing the main method to be executed. This class must be contained in a JAR provided
 	// as a library. Type: string (or Expression with resultType string).
-	MainClassName any `json:"mainClassName,omitempty"`
+	MainClassName any
 
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries []map[string]any `json:"libraries,omitempty"`
+	Libraries []map[string]any
 
 	// Parameters that will be passed to the main method.
-	Parameters []any `json:"parameters,omitempty"`
+	Parameters []any
 }
 
 // DatabricksSparkPythonActivity - DatabricksSparkPython activity.
 type DatabricksSparkPythonActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Databricks SparkPython activity properties.
-	TypeProperties *DatabricksSparkPythonActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DatabricksSparkPythonActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type DatabricksSparkPythonActivity.
@@ -6831,13 +6831,13 @@ func (d *DatabricksSparkPythonActivity) GetExecutionActivity() *ExecutionActivit
 type DatabricksSparkPythonActivityTypeProperties struct {
 	// REQUIRED; The URI of the Python file to be executed. DBFS paths are supported. Type: string (or Expression with resultType
 	// string).
-	PythonFile any `json:"pythonFile,omitempty"`
+	PythonFile any
 
 	// A list of libraries to be installed on the cluster that will execute the job.
-	Libraries []map[string]any `json:"libraries,omitempty"`
+	Libraries []map[string]any
 
 	// Command line parameters that will be passed to the Python file.
-	Parameters []any `json:"parameters,omitempty"`
+	Parameters []any
 }
 
 // DatasetClassification provides polymorphic access to related types.
@@ -6868,32 +6868,32 @@ type DatasetClassification interface {
 // folders, and documents.
 type Dataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type Dataset.
@@ -6902,7 +6902,7 @@ func (d *Dataset) GetDataset() *Dataset { return d }
 // DatasetBZip2Compression - The BZip2 compression method used on a dataset.
 type DatasetBZip2Compression struct {
 	// REQUIRED; Type of dataset compression.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -6963,7 +6963,7 @@ type DatasetCompressionClassification interface {
 // DatasetCompression - The compression method used on a dataset.
 type DatasetCompression struct {
 	// REQUIRED; Type of dataset compression.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -6975,31 +6975,31 @@ func (d *DatasetCompression) GetDatasetCompression() *DatasetCompression { retur
 // DatasetDataElement - Columns that define the structure of the dataset.
 type DatasetDataElement struct {
 	// Name of the column. Type: string (or Expression with resultType string).
-	Name any `json:"name,omitempty"`
+	Name any
 
 	// Type of the column. Type: string (or Expression with resultType string).
-	Type any `json:"type,omitempty"`
+	Type any
 }
 
 // DatasetDebugResource - Dataset debug resource.
 type DatasetDebugResource struct {
 	// REQUIRED; Dataset properties.
-	Properties DatasetClassification `json:"properties,omitempty"`
+	Properties DatasetClassification
 
 	// The resource name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // DatasetDeflateCompression - The Deflate compression method used on a dataset.
 type DatasetDeflateCompression struct {
 	// REQUIRED; Type of dataset compression.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The Deflate compression level.
-	Level *DatasetCompressionLevel `json:"level,omitempty"`
+	Level *DatasetCompressionLevel
 }
 
 // GetDatasetCompression implements the DatasetCompressionClassification interface for type DatasetDeflateCompression.
@@ -7013,19 +7013,19 @@ func (d *DatasetDeflateCompression) GetDatasetCompression() *DatasetCompression 
 // DatasetFolder - The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
 type DatasetFolder struct {
 	// The name of the folder that this Dataset is in.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // DatasetGZipCompression - The GZip compression method used on a dataset.
 type DatasetGZipCompression struct {
 	// REQUIRED; Type of dataset compression.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The GZip compression level.
-	Level *DatasetCompressionLevel `json:"level,omitempty"`
+	Level *DatasetCompressionLevel
 }
 
 // GetDatasetCompression implements the DatasetCompressionClassification interface for type DatasetGZipCompression.
@@ -7039,10 +7039,10 @@ func (d *DatasetGZipCompression) GetDatasetCompression() *DatasetCompression {
 // DatasetListResponse - A list of dataset resources.
 type DatasetListResponse struct {
 	// REQUIRED; List of datasets.
-	Value []*DatasetResource `json:"value,omitempty"`
+	Value []*DatasetResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // DatasetLocationClassification provides polymorphic access to related types.
@@ -7059,16 +7059,16 @@ type DatasetLocationClassification interface {
 // DatasetLocation - Dataset location.
 type DatasetLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type DatasetLocation.
@@ -7077,31 +7077,31 @@ func (d *DatasetLocation) GetDatasetLocation() *DatasetLocation { return d }
 // DatasetReference - Dataset reference type.
 type DatasetReference struct {
 	// REQUIRED; Reference dataset name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Dataset reference type.
-	Type *DatasetReferenceType `json:"type,omitempty"`
+	Type *DatasetReferenceType
 
 	// Arguments for dataset.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 }
 
 // DatasetResource - Dataset resource type.
 type DatasetResource struct {
 	// REQUIRED; Dataset properties.
-	Properties DatasetClassification `json:"properties,omitempty"`
+	Properties DatasetClassification
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // DatasetSchemaDataElement - Columns that define the physical type schema of the dataset.
@@ -7110,10 +7110,10 @@ type DatasetSchemaDataElement struct {
 	AdditionalProperties map[string]any
 
 	// Name of the schema column. Type: string (or Expression with resultType string).
-	Name any `json:"name,omitempty"`
+	Name any
 
 	// Type of the schema column. Type: string (or Expression with resultType string).
-	Type any `json:"type,omitempty"`
+	Type any
 }
 
 // DatasetStorageFormatClassification provides polymorphic access to related types.
@@ -7128,16 +7128,16 @@ type DatasetStorageFormatClassification interface {
 // DatasetStorageFormat - The format definition of a storage.
 type DatasetStorageFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type DatasetStorageFormat.
@@ -7146,13 +7146,13 @@ func (d *DatasetStorageFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // DatasetZipDeflateCompression - The ZipDeflate compression method used on a dataset.
 type DatasetZipDeflateCompression struct {
 	// REQUIRED; Type of dataset compression.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The ZipDeflate compression level.
-	Level *DatasetCompressionLevel `json:"level,omitempty"`
+	Level *DatasetCompressionLevel
 }
 
 // GetDatasetCompression implements the DatasetCompressionClassification interface for type DatasetZipDeflateCompression.
@@ -7166,25 +7166,25 @@ func (d *DatasetZipDeflateCompression) GetDatasetCompression() *DatasetCompressi
 // Db2LinkedService - Linked service for DB2 data source.
 type Db2LinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; DB2 linked service properties.
-	TypeProperties *Db2LinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *Db2LinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type Db2LinkedService.
@@ -7202,53 +7202,53 @@ func (d *Db2LinkedService) GetLinkedService() *LinkedService {
 // Db2LinkedServiceTypeProperties - DB2 linked service properties.
 type Db2LinkedServiceTypeProperties struct {
 	// REQUIRED; Database name for connection. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// REQUIRED; Server name for connection. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// AuthenticationType to be used for connection.
-	AuthenticationType *Db2AuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *Db2AuthenticationType
 
 	// Certificate Common Name when TLS is enabled. Type: string (or Expression with resultType string).
-	CertificateCommonName any `json:"certificateCommonName,omitempty"`
+	CertificateCommonName any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Under where packages are created when querying database. Type: string (or Expression with resultType string).
-	PackageCollection any `json:"packageCollection,omitempty"`
+	PackageCollection any
 
 	// Password for authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Username for authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // Db2Source - A copy activity source for Db2 databases.
 type Db2Source struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type Db2Source.
@@ -7277,35 +7277,35 @@ func (d *Db2Source) GetTabularSource() *TabularSource {
 // Db2TableDataset - The Db2 table dataset.
 type Db2TableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Db2 table dataset properties.
-	TypeProperties *Db2TableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *Db2TableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type Db2TableDataset.
@@ -7326,43 +7326,43 @@ func (d *Db2TableDataset) GetDataset() *Dataset {
 // Db2TableDatasetTypeProperties - Db2 table dataset properties.
 type Db2TableDatasetTypeProperties struct {
 	// The Db2 schema name. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The Db2 table name. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // DeleteActivity - Delete activity.
 type DeleteActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Delete activity properties.
-	TypeProperties *DeleteActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DeleteActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type DeleteActivity.
@@ -7394,64 +7394,64 @@ func (d *DeleteActivity) GetExecutionActivity() *ExecutionActivity {
 // DeleteActivityTypeProperties - Delete activity properties.
 type DeleteActivityTypeProperties struct {
 	// REQUIRED; Delete activity dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// Whether to record detailed logs of delete-activity execution. Default value is false. Type: boolean (or Expression with
 	// resultType boolean).
-	EnableLogging any `json:"enableLogging,omitempty"`
+	EnableLogging any
 
 	// Log storage settings customer need to provide when enableLogging is true.
-	LogStorageSettings *LogStorageSettings `json:"logStorageSettings,omitempty"`
+	LogStorageSettings *LogStorageSettings
 
 	// The max concurrent connections to connect data source at the same time.
-	MaxConcurrentConnections *int32 `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections *int32
 
 	// If true, files or sub-folders under current folder path will be deleted recursively. Default is false. Type: boolean (or
 	// Expression with resultType boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 }
 
 // DeleteDataFlowDebugSessionRequest - Request body structure for deleting data flow debug session.
 type DeleteDataFlowDebugSessionRequest struct {
 	// The data flow which contains the debug session.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 }
 
 // DelimitedTextDataset - Delimited text dataset.
 type DelimitedTextDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Delimited text dataset properties.
-	TypeProperties *DelimitedTextDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DelimitedTextDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type DelimitedTextDataset.
@@ -7472,50 +7472,50 @@ func (d *DelimitedTextDataset) GetDataset() *Dataset {
 // DelimitedTextDatasetTypeProperties - DelimitedText dataset properties.
 type DelimitedTextDatasetTypeProperties struct {
 	// REQUIRED; The location of the delimited text storage.
-	Location DatasetLocationClassification `json:"location,omitempty"`
+	Location DatasetLocationClassification
 
 	// The column delimiter. Type: string (or Expression with resultType string).
-	ColumnDelimiter  any                            `json:"columnDelimiter,omitempty"`
-	CompressionCodec *DelimitedTextCompressionCodec `json:"compressionCodec,omitempty"`
+	ColumnDelimiter  any
+	CompressionCodec *DelimitedTextCompressionCodec
 
 	// The data compression method used for DelimitedText.
-	CompressionLevel *DatasetCompressionLevel `json:"compressionLevel,omitempty"`
+	CompressionLevel *DatasetCompressionLevel
 
 	// The code page name of the preferred encoding. If miss, the default value is UTF-8, unless BOM denotes another Unicode encoding.
 	// Refer to the name column of the table in the following link to set
 	// supported values: https://msdn.microsoft.com/library/system.text.encoding.aspx. Type: string (or Expression with resultType
 	// string).
-	EncodingName any `json:"encodingName,omitempty"`
+	EncodingName any
 
 	// The escape character. Type: string (or Expression with resultType string).
-	EscapeChar any `json:"escapeChar,omitempty"`
+	EscapeChar any
 
 	// When used as input, treat the first row of data as headers. When used as output,write the headers into the output as the
 	// first row of data. The default value is false. Type: boolean (or Expression
 	// with resultType boolean).
-	FirstRowAsHeader any `json:"firstRowAsHeader,omitempty"`
+	FirstRowAsHeader any
 
 	// The null value string. Type: string (or Expression with resultType string).
-	NullValue any `json:"nullValue,omitempty"`
+	NullValue any
 
 	// The quote character. Type: string (or Expression with resultType string).
-	QuoteChar any `json:"quoteChar,omitempty"`
+	QuoteChar any
 
 	// The row delimiter. Type: string (or Expression with resultType string).
-	RowDelimiter any `json:"rowDelimiter,omitempty"`
+	RowDelimiter any
 }
 
 // DelimitedTextReadSettings - Delimited text read settings.
 type DelimitedTextReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates the number of non-empty rows to skip when reading data from input files. Type: integer (or Expression with resultType
 	// integer).
-	SkipLineCount any `json:"skipLineCount,omitempty"`
+	SkipLineCount any
 }
 
 // GetFormatReadSettings implements the FormatReadSettingsClassification interface for type DelimitedTextReadSettings.
@@ -7529,31 +7529,31 @@ func (d *DelimitedTextReadSettings) GetFormatReadSettings() *FormatReadSettings 
 // DelimitedTextSink - A copy activity DelimitedText sink.
 type DelimitedTextSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// DelimitedText format settings.
-	FormatSettings *DelimitedTextWriteSettings `json:"formatSettings,omitempty"`
+	FormatSettings *DelimitedTextWriteSettings
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// DelimitedText store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type DelimitedTextSink.
@@ -7572,25 +7572,25 @@ func (d *DelimitedTextSink) GetCopySink() *CopySink {
 // DelimitedTextSource - A copy activity DelimitedText source.
 type DelimitedTextSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// DelimitedText format settings.
-	FormatSettings *DelimitedTextReadSettings `json:"formatSettings,omitempty"`
+	FormatSettings *DelimitedTextReadSettings
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// DelimitedText store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DelimitedTextSource.
@@ -7607,16 +7607,16 @@ func (d *DelimitedTextSource) GetCopySource() *CopySource {
 // DelimitedTextWriteSettings - Delimited text write settings.
 type DelimitedTextWriteSettings struct {
 	// REQUIRED; The file extension used to create the files. Type: string (or Expression with resultType string).
-	FileExtension any `json:"fileExtension,omitempty"`
+	FileExtension any
 
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether string values should always be enclosed with quotes. Type: boolean (or Expression with resultType boolean).
-	QuoteAllText any `json:"quoteAllText,omitempty"`
+	QuoteAllText any
 }
 
 // GetFormatWriteSettings implements the FormatWriteSettingsClassification interface for type DelimitedTextWriteSettings.
@@ -7639,7 +7639,7 @@ type DependencyReferenceClassification interface {
 // DependencyReference - Referenced dependency.
 type DependencyReference struct {
 	// REQUIRED; The type of dependency reference.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // GetDependencyReference implements the DependencyReferenceClassification interface for type DependencyReference.
@@ -7648,49 +7648,49 @@ func (d *DependencyReference) GetDependencyReference() *DependencyReference { re
 // DistcpSettings - Distcp settings.
 type DistcpSettings struct {
 	// REQUIRED; Specifies the Yarn ResourceManager endpoint. Type: string (or Expression with resultType string).
-	ResourceManagerEndpoint any `json:"resourceManagerEndpoint,omitempty"`
+	ResourceManagerEndpoint any
 
 	// REQUIRED; Specifies an existing folder path which will be used to store temp Distcp command script. The script file is
 	// generated by ADF and will be removed after Copy job finished. Type: string (or Expression
 	// with resultType string).
-	TempScriptPath any `json:"tempScriptPath,omitempty"`
+	TempScriptPath any
 
 	// Specifies the Distcp options. Type: string (or Expression with resultType string).
-	DistcpOptions any `json:"distcpOptions,omitempty"`
+	DistcpOptions any
 }
 
 // DocumentDbCollectionDataset - Microsoft Azure Document Database Collection dataset.
 type DocumentDbCollectionDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; DocumentDB Collection dataset properties.
-	TypeProperties *DocumentDbCollectionDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DocumentDbCollectionDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type DocumentDbCollectionDataset.
@@ -7711,38 +7711,38 @@ func (d *DocumentDbCollectionDataset) GetDataset() *Dataset {
 // DocumentDbCollectionDatasetTypeProperties - DocumentDB Collection dataset properties.
 type DocumentDbCollectionDatasetTypeProperties struct {
 	// REQUIRED; Document Database collection name. Type: string (or Expression with resultType string).
-	CollectionName any `json:"collectionName,omitempty"`
+	CollectionName any
 }
 
 // DocumentDbCollectionSink - A copy activity Document Database Collection sink.
 type DocumentDbCollectionSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Nested properties separator. Default is . (dot). Type: string (or Expression with resultType string).
-	NestingSeparator any `json:"nestingSeparator,omitempty"`
+	NestingSeparator any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// Describes how to write data to Azure Cosmos DB. Type: string (or Expression with resultType string). Allowed values: insert
 	// and upsert.
-	WriteBehavior any `json:"writeBehavior,omitempty"`
+	WriteBehavior any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type DocumentDbCollectionSink.
@@ -7761,28 +7761,28 @@ func (d *DocumentDbCollectionSink) GetCopySink() *CopySink {
 // DocumentDbCollectionSource - A copy activity Document Database Collection source.
 type DocumentDbCollectionSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Nested properties separator. Type: string (or Expression with resultType string).
-	NestingSeparator any `json:"nestingSeparator,omitempty"`
+	NestingSeparator any
 
 	// Documents query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DocumentDbCollectionSource.
@@ -7799,37 +7799,37 @@ func (d *DocumentDbCollectionSource) GetCopySource() *CopySource {
 // DrillDatasetTypeProperties - Drill Dataset Properties
 type DrillDatasetTypeProperties struct {
 	// The schema name of the Drill. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Drill. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // DrillLinkedService - Drill server linked service.
 type DrillLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Drill server linked service properties.
-	TypeProperties *DrillLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DrillLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type DrillLinkedService.
@@ -7847,38 +7847,38 @@ func (d *DrillLinkedService) GetLinkedService() *LinkedService {
 // DrillLinkedServiceTypeProperties - Drill server linked service properties.
 type DrillLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // DrillSource - A copy activity Drill server source.
 type DrillSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DrillSource.
@@ -7907,35 +7907,35 @@ func (d *DrillSource) GetTabularSource() *TabularSource {
 // DrillTableDataset - Drill server dataset.
 type DrillTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *DrillDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DrillDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type DrillTableDataset.
@@ -7956,31 +7956,31 @@ func (d *DrillTableDataset) GetDataset() *Dataset {
 // DynamicExecutorAllocation - Dynamic Executor Allocation Properties
 type DynamicExecutorAllocation struct {
 	// Indicates whether Dynamic Executor Allocation is enabled or not.
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool
 }
 
 // DynamicsAXLinkedService - Dynamics AX linked service.
 type DynamicsAXLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Dynamics AX linked service properties.
-	TypeProperties *DynamicsAXLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsAXLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type DynamicsAXLinkedService.
@@ -7998,61 +7998,61 @@ func (d *DynamicsAXLinkedService) GetLinkedService() *LinkedService {
 // DynamicsAXLinkedServiceTypeProperties - Dynamics AX linked service properties.
 type DynamicsAXLinkedServiceTypeProperties struct {
 	// REQUIRED; Specify the resource you are requesting authorization. Type: string (or Expression with resultType string).
-	AADResourceID any `json:"aadResourceId,omitempty"`
+	AADResourceID any
 
 	// REQUIRED; Specify the application's client ID. Type: string (or Expression with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// REQUIRED; Specify the application's key. Mark this field as a SecureString to store it securely in Data Factory, or reference
 	// a secret stored in Azure Key Vault. Type: string (or Expression with resultType
 	// string).
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// REQUIRED; Specify the tenant information (domain name or tenant ID) under which your application resides. Retrieve it by
 	// hovering the mouse in the top-right corner of the Azure portal. Type: string (or
 	// Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// REQUIRED; The Dynamics AX (or Dynamics 365 Finance and Operations) instance OData endpoint.
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 }
 
 // DynamicsAXResourceDataset - The path of the Dynamics AX OData entity.
 type DynamicsAXResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Dynamics AX OData resource dataset properties.
-	TypeProperties *DynamicsAXResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsAXResourceDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type DynamicsAXResourceDataset.
@@ -8073,31 +8073,31 @@ func (d *DynamicsAXResourceDataset) GetDataset() *Dataset {
 // DynamicsAXResourceDatasetTypeProperties - Dynamics AX OData resource dataset properties.
 type DynamicsAXResourceDatasetTypeProperties struct {
 	// REQUIRED; The path of the Dynamics AX OData entity. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // DynamicsAXSource - A copy activity Dynamics AX source.
 type DynamicsAXSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DynamicsAXSource.
@@ -8126,35 +8126,35 @@ func (d *DynamicsAXSource) GetTabularSource() *TabularSource {
 // DynamicsCrmEntityDataset - The Dynamics CRM entity dataset.
 type DynamicsCrmEntityDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Dynamics CRM entity dataset properties.
-	TypeProperties *DynamicsCrmEntityDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsCrmEntityDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type DynamicsCrmEntityDataset.
@@ -8175,31 +8175,31 @@ func (d *DynamicsCrmEntityDataset) GetDataset() *Dataset {
 // DynamicsCrmEntityDatasetTypeProperties - Dynamics CRM entity dataset properties.
 type DynamicsCrmEntityDatasetTypeProperties struct {
 	// The logical name of the entity. Type: string (or Expression with resultType string).
-	EntityName any `json:"entityName,omitempty"`
+	EntityName any
 }
 
 // DynamicsCrmLinkedService - Dynamics CRM linked service.
 type DynamicsCrmLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Dynamics CRM linked service properties.
-	TypeProperties *DynamicsCrmLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsCrmLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type DynamicsCrmLinkedService.
@@ -8219,88 +8219,88 @@ type DynamicsCrmLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication type to connect to Dynamics CRM server. 'Office365' for online scenario, 'Ifd' for on-premises
 	// with Ifd scenario, 'AADServicePrincipal' for Server-To-Server authentication in online
 	// scenario. Type: string (or Expression with resultType string).
-	AuthenticationType *DynamicsAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *DynamicsAuthenticationType
 
 	// REQUIRED; The deployment type of the Dynamics CRM instance. 'Online' for Dynamics CRM Online and 'OnPremisesWithIfd' for
 	// Dynamics CRM on-premises with Ifd. Type: string (or Expression with resultType string).
-	DeploymentType *DynamicsDeploymentType `json:"deploymentType,omitempty"`
+	DeploymentType *DynamicsDeploymentType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The host name of the on-premises Dynamics CRM server. The property is required for on-prem and not allowed for online.
 	// Type: string (or Expression with resultType string).
-	HostName any `json:"hostName,omitempty"`
+	HostName any
 
 	// The organization name of the Dynamics CRM instance. The property is required for on-prem and required for online when there
 	// are more than one Dynamics CRM instances associated with the user. Type:
 	// string (or Expression with resultType string).
-	OrganizationName any `json:"organizationName,omitempty"`
+	OrganizationName any
 
 	// Password to access the Dynamics CRM instance.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The port of on-premises Dynamics CRM server. The property is required for on-prem and not allowed for online. Default is
 	// 443. Type: integer (or Expression with resultType integer), minimum: 0.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The credential of the service principal object in Azure Active Directory. If servicePrincipalCredentialType is 'ServicePrincipalKey',
 	// servicePrincipalCredential can be SecureString or
 	// AzureKeyVaultSecretReference. If servicePrincipalCredentialType is 'ServicePrincipalCert', servicePrincipalCredential can
 	// only be AzureKeyVaultSecretReference.
-	ServicePrincipalCredential SecretBaseClassification `json:"servicePrincipalCredential,omitempty"`
+	ServicePrincipalCredential SecretBaseClassification
 
 	// The service principal credential type to use in Server-To-Server authentication. 'ServicePrincipalKey' for key/secret,
 	// 'ServicePrincipalCert' for certificate. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType `json:"servicePrincipalCredentialType,omitempty"`
+	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType
 
 	// The client ID of the application in Azure Active Directory used for Server-To-Server authentication. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The URL to the Microsoft Dynamics CRM server. The property is required for on-line and not allowed for on-prem. Type: string
 	// (or Expression with resultType string).
-	ServiceURI any `json:"serviceUri,omitempty"`
+	ServiceURI any
 
 	// User name to access the Dynamics CRM instance. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // DynamicsCrmSink - A copy activity Dynamics CRM sink.
 type DynamicsCrmSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; The write behavior for the operation.
-	WriteBehavior *DynamicsSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *DynamicsSinkWriteBehavior
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType
 	// string).
-	AlternateKeyName any `json:"alternateKeyName,omitempty"`
+	AlternateKeyName any
 
 	// The flag indicating whether to ignore null values from input dataset (except key fields) during write operation. Default
 	// is false. Type: boolean (or Expression with resultType boolean).
-	IgnoreNullValues any `json:"ignoreNullValues,omitempty"`
+	IgnoreNullValues any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type DynamicsCrmSink.
@@ -8319,23 +8319,23 @@ func (d *DynamicsCrmSink) GetCopySink() *CopySink {
 // DynamicsCrmSource - A copy activity Dynamics CRM source.
 type DynamicsCrmSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// FetchXML is a proprietary query language that is used in Microsoft Dynamics CRM (online & on-premises). Type: string (or
 	// Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DynamicsCrmSource.
@@ -8352,35 +8352,35 @@ func (d *DynamicsCrmSource) GetCopySource() *CopySource {
 // DynamicsEntityDataset - The Dynamics entity dataset.
 type DynamicsEntityDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Dynamics entity dataset properties.
-	TypeProperties *DynamicsEntityDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsEntityDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type DynamicsEntityDataset.
@@ -8401,31 +8401,31 @@ func (d *DynamicsEntityDataset) GetDataset() *Dataset {
 // DynamicsEntityDatasetTypeProperties - Dynamics entity dataset properties.
 type DynamicsEntityDatasetTypeProperties struct {
 	// The logical name of the entity. Type: string (or Expression with resultType string).
-	EntityName any `json:"entityName,omitempty"`
+	EntityName any
 }
 
 // DynamicsLinkedService - Dynamics linked service.
 type DynamicsLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Dynamics linked service properties.
-	TypeProperties *DynamicsLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *DynamicsLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type DynamicsLinkedService.
@@ -8445,88 +8445,88 @@ type DynamicsLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication type to connect to Dynamics server. 'Office365' for online scenario, 'Ifd' for on-premises
 	// with Ifd scenario, 'AADServicePrincipal' for Server-To-Server authentication in online
 	// scenario. Type: string (or Expression with resultType string).
-	AuthenticationType *DynamicsAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *DynamicsAuthenticationType
 
 	// REQUIRED; The deployment type of the Dynamics instance. 'Online' for Dynamics Online and 'OnPremisesWithIfd' for Dynamics
 	// on-premises with Ifd. Type: string (or Expression with resultType string).
-	DeploymentType *DynamicsDeploymentType `json:"deploymentType,omitempty"`
+	DeploymentType *DynamicsDeploymentType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The host name of the on-premises Dynamics server. The property is required for on-prem and not allowed for online. Type:
 	// string (or Expression with resultType string).
-	HostName *string `json:"hostName,omitempty"`
+	HostName *string
 
 	// The organization name of the Dynamics instance. The property is required for on-prem and required for online when there
 	// are more than one Dynamics instances associated with the user. Type: string (or
 	// Expression with resultType string).
-	OrganizationName *string `json:"organizationName,omitempty"`
+	OrganizationName *string
 
 	// Password to access the Dynamics instance.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The port of on-premises Dynamics server. The property is required for on-prem and not allowed for online. Default is 443.
 	// Type: integer (or Expression with resultType integer), minimum: 0.
-	Port *string `json:"port,omitempty"`
+	Port *string
 
 	// The credential of the service principal object in Azure Active Directory. If servicePrincipalCredentialType is 'ServicePrincipalKey',
 	// servicePrincipalCredential can be SecureString or
 	// AzureKeyVaultSecretReference. If servicePrincipalCredentialType is 'ServicePrincipalCert', servicePrincipalCredential can
 	// only be AzureKeyVaultSecretReference.
-	ServicePrincipalCredential SecretBaseClassification `json:"servicePrincipalCredential,omitempty"`
+	ServicePrincipalCredential SecretBaseClassification
 
 	// The service principal credential type to use in Server-To-Server authentication. 'ServicePrincipalKey' for key/secret,
 	// 'ServicePrincipalCert' for certificate. Type: string (or Expression with
 	// resultType string).
-	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType `json:"servicePrincipalCredentialType,omitempty"`
+	ServicePrincipalCredentialType *DynamicsServicePrincipalCredentialType
 
 	// The client ID of the application in Azure Active Directory used for Server-To-Server authentication. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The URL to the Microsoft Dynamics server. The property is required for on-line and not allowed for on-prem. Type: string
 	// (or Expression with resultType string).
-	ServiceURI *string `json:"serviceUri,omitempty"`
+	ServiceURI *string
 
 	// User name to access the Dynamics instance. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // DynamicsSink - A copy activity Dynamics sink.
 type DynamicsSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; The write behavior for the operation.
-	WriteBehavior *DynamicsSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *DynamicsSinkWriteBehavior
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The logical name of the alternate key which will be used when upserting records. Type: string (or Expression with resultType
 	// string).
-	AlternateKeyName any `json:"alternateKeyName,omitempty"`
+	AlternateKeyName any
 
 	// The flag indicating whether ignore null values from input dataset (except key fields) during write operation. Default is
 	// false. Type: boolean (or Expression with resultType boolean).
-	IgnoreNullValues any `json:"ignoreNullValues,omitempty"`
+	IgnoreNullValues any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type DynamicsSink.
@@ -8545,23 +8545,23 @@ func (d *DynamicsSink) GetCopySink() *CopySink {
 // DynamicsSource - A copy activity Dynamics source.
 type DynamicsSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// FetchXML is a proprietary query language that is used in Microsoft Dynamics (online & on-premises). Type: string (or Expression
 	// with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type DynamicsSource.
@@ -8578,25 +8578,25 @@ func (d *DynamicsSource) GetCopySource() *CopySource {
 // EloquaLinkedService - Eloqua server linked service.
 type EloquaLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Eloqua server linked service properties.
-	TypeProperties *EloquaLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *EloquaLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type EloquaLinkedService.
@@ -8614,61 +8614,61 @@ func (e *EloquaLinkedService) GetLinkedService() *LinkedService {
 // EloquaLinkedServiceTypeProperties - Eloqua server linked service properties.
 type EloquaLinkedServiceTypeProperties struct {
 	// REQUIRED; The endpoint of the Eloqua server. (i.e. eloqua.example.com)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// REQUIRED; The site name and user name of your Eloqua account in the form: sitename/username. (i.e. Eloqua/Alice)
-	Username any `json:"username,omitempty"`
+	Username any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // EloquaObjectDataset - Eloqua server dataset.
 type EloquaObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type EloquaObjectDataset.
@@ -8689,25 +8689,25 @@ func (e *EloquaObjectDataset) GetDataset() *Dataset {
 // EloquaSource - A copy activity Eloqua server source.
 type EloquaSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type EloquaSource.
@@ -8736,101 +8736,101 @@ func (e *EloquaSource) GetTabularSource() *TabularSource {
 // EncryptionDetails - Details of the encryption associated with the workspace
 type EncryptionDetails struct {
 	// Customer Managed Key Details
-	Cmk *CustomerManagedKeyDetails `json:"cmk,omitempty"`
+	Cmk *CustomerManagedKeyDetails
 
 	// READ-ONLY; Double Encryption enabled
-	DoubleEncryptionEnabled *bool `json:"doubleEncryptionEnabled,omitempty" azure:"ro"`
+	DoubleEncryptionEnabled *bool
 }
 
 // EntityReference - The entity reference.
 type EntityReference struct {
 	// The name of this referenced entity.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// The type of this referenced entity.
-	Type *IntegrationRuntimeEntityReferenceType `json:"type,omitempty"`
+	Type *IntegrationRuntimeEntityReferenceType
 }
 
 // ErrorAdditionalInfo - The resource management error additional info.
 type ErrorAdditionalInfo struct {
 	// READ-ONLY; The additional info.
-	Info any `json:"info,omitempty" azure:"ro"`
+	Info any
 
 	// READ-ONLY; The additional info type.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ErrorContract - Contains details when the response code indicates an error.
 type ErrorContract struct {
 	// The error details.
-	Error *ErrorResponse `json:"error,omitempty"`
+	Error *ErrorResponse
 }
 
 // ErrorResponse - Common error response for all Azure Resource Manager APIs to return error details for failed operations.
 // (This also follows the OData error response format.)
 type ErrorResponse struct {
 	// READ-ONLY; The error additional info.
-	AdditionalInfo []*ErrorAdditionalInfo `json:"additionalInfo,omitempty" azure:"ro"`
+	AdditionalInfo []*ErrorAdditionalInfo
 
 	// READ-ONLY; The error code.
-	Code *string `json:"code,omitempty" azure:"ro"`
+	Code *string
 
 	// READ-ONLY; The error details.
-	Details []*ErrorResponse `json:"details,omitempty" azure:"ro"`
+	Details []*ErrorResponse
 
 	// READ-ONLY; The error message.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 
 	// READ-ONLY; The error target.
-	Target *string `json:"target,omitempty" azure:"ro"`
+	Target *string
 }
 
 // EvaluateDataFlowExpressionRequest - Request body structure for data flow expression preview.
 type EvaluateDataFlowExpressionRequest struct {
 	// The data flow which contains the debug session.
-	DataFlowName *string `json:"dataFlowName,omitempty"`
+	DataFlowName *string
 
 	// The expression for preview.
-	Expression *string `json:"expression,omitempty"`
+	Expression *string
 
 	// The row limit for preview request.
-	RowLimits *int32 `json:"rowLimits,omitempty"`
+	RowLimits *int32
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// The output stream name.
-	StreamName *string `json:"streamName,omitempty"`
+	StreamName *string
 }
 
 // ExecuteDataFlowActivity - Execute data flow activity.
 type ExecuteDataFlowActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute data flow activity properties.
-	TypeProperties *ExecuteDataFlowActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ExecuteDataFlowActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ExecuteDataFlowActivity.
@@ -8862,49 +8862,49 @@ func (e *ExecuteDataFlowActivity) GetExecutionActivity() *ExecutionActivity {
 // ExecuteDataFlowActivityTypeProperties - Execute data flow activity properties.
 type ExecuteDataFlowActivityTypeProperties struct {
 	// REQUIRED; Data flow reference.
-	DataFlow *DataFlowReference `json:"dataFlow,omitempty"`
+	DataFlow *DataFlowReference
 
 	// Compute properties for data flow activity.
-	Compute *ExecuteDataFlowActivityTypePropertiesCompute `json:"compute,omitempty"`
+	Compute *ExecuteDataFlowActivityTypePropertiesCompute
 
 	// The integration runtime reference.
-	IntegrationRuntime *IntegrationRuntimeReference `json:"integrationRuntime,omitempty"`
+	IntegrationRuntime *IntegrationRuntimeReference
 
 	// Staging info for execute data flow activity.
-	Staging *DataFlowStagingInfo `json:"staging,omitempty"`
+	Staging *DataFlowStagingInfo
 }
 
 // ExecuteDataFlowActivityTypePropertiesCompute - Compute properties for data flow activity.
 type ExecuteDataFlowActivityTypePropertiesCompute struct {
 	// Compute type of the cluster which will execute data flow job.
-	ComputeType *DataFlowComputeType `json:"computeType,omitempty"`
+	ComputeType *DataFlowComputeType
 
 	// Core count of the cluster which will execute data flow job. Supported values are: 8, 16, 32, 48, 80, 144 and 272.
-	CoreCount *int32 `json:"coreCount,omitempty"`
+	CoreCount *int32
 }
 
 // ExecutePipelineActivity - Execute pipeline activity.
 type ExecutePipelineActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute pipeline activity properties.
-	TypeProperties *ExecutePipelineActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ExecutePipelineActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ExecutePipelineActivity.
@@ -8934,43 +8934,43 @@ func (e *ExecutePipelineActivity) GetControlActivity() *ControlActivity {
 // ExecutePipelineActivityTypeProperties - Execute pipeline activity properties.
 type ExecutePipelineActivityTypeProperties struct {
 	// REQUIRED; Pipeline reference.
-	Pipeline *PipelineReference `json:"pipeline,omitempty"`
+	Pipeline *PipelineReference
 
 	// Pipeline parameters.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 
 	// Defines whether activity execution will wait for the dependent pipeline execution to finish. Default is false.
-	WaitOnCompletion *bool `json:"waitOnCompletion,omitempty"`
+	WaitOnCompletion *bool
 }
 
 // ExecuteSSISPackageActivity - Execute SSIS package activity.
 type ExecuteSSISPackageActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute SSIS package activity properties.
-	TypeProperties *ExecuteSSISPackageActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ExecuteSSISPackageActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ExecuteSSISPackageActivity.
@@ -9002,41 +9002,41 @@ func (e *ExecuteSSISPackageActivity) GetExecutionActivity() *ExecutionActivity {
 // ExecuteSSISPackageActivityTypeProperties - Execute SSIS package activity properties.
 type ExecuteSSISPackageActivityTypeProperties struct {
 	// REQUIRED; The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// REQUIRED; SSIS package location.
-	PackageLocation *SSISPackageLocation `json:"packageLocation,omitempty"`
+	PackageLocation *SSISPackageLocation
 
 	// The environment path to execute the SSIS package. Type: string (or Expression with resultType string).
-	EnvironmentPath any `json:"environmentPath,omitempty"`
+	EnvironmentPath any
 
 	// The package execution credential.
-	ExecutionCredential *SSISExecutionCredential `json:"executionCredential,omitempty"`
+	ExecutionCredential *SSISExecutionCredential
 
 	// SSIS package execution log location.
-	LogLocation *SSISLogLocation `json:"logLocation,omitempty"`
+	LogLocation *SSISLogLocation
 
 	// The logging level of SSIS package execution. Type: string (or Expression with resultType string).
-	LoggingLevel any `json:"loggingLevel,omitempty"`
+	LoggingLevel any
 
 	// The package level connection managers to execute the SSIS package.
-	PackageConnectionManagers map[string]map[string]*SSISExecutionParameter `json:"packageConnectionManagers,omitempty"`
+	PackageConnectionManagers map[string]map[string]*SSISExecutionParameter
 
 	// The package level parameters to execute the SSIS package.
-	PackageParameters map[string]*SSISExecutionParameter `json:"packageParameters,omitempty"`
+	PackageParameters map[string]*SSISExecutionParameter
 
 	// The project level connection managers to execute the SSIS package.
-	ProjectConnectionManagers map[string]map[string]*SSISExecutionParameter `json:"projectConnectionManagers,omitempty"`
+	ProjectConnectionManagers map[string]map[string]*SSISExecutionParameter
 
 	// The project level parameters to execute the SSIS package.
-	ProjectParameters map[string]*SSISExecutionParameter `json:"projectParameters,omitempty"`
+	ProjectParameters map[string]*SSISExecutionParameter
 
 	// The property overrides to execute the SSIS package.
-	PropertyOverrides map[string]*SSISPropertyOverride `json:"propertyOverrides,omitempty"`
+	PropertyOverrides map[string]*SSISPropertyOverride
 
 	// Specifies the runtime to execute SSIS package. The value should be "x86" or "x64". Type: string (or Expression with resultType
 	// string).
-	Runtime any `json:"runtime,omitempty"`
+	Runtime any
 }
 
 // ExecutionActivityClassification provides polymorphic access to related types.
@@ -9057,28 +9057,28 @@ type ExecutionActivityClassification interface {
 // ExecutionActivity - Base class for all execution activities.
 type ExecutionActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ExecutionActivity.
@@ -9099,52 +9099,52 @@ func (e *ExecutionActivity) GetExecutionActivity() *ExecutionActivity { return e
 // ExposureControlRequest - The exposure control request.
 type ExposureControlRequest struct {
 	// The feature name.
-	FeatureName *string `json:"featureName,omitempty"`
+	FeatureName *string
 
 	// The feature type.
-	FeatureType *string `json:"featureType,omitempty"`
+	FeatureType *string
 }
 
 // ExposureControlResponse - The exposure control response.
 type ExposureControlResponse struct {
 	// READ-ONLY; The feature name.
-	FeatureName *string `json:"featureName,omitempty" azure:"ro"`
+	FeatureName *string
 
 	// READ-ONLY; The feature value.
-	Value *string `json:"value,omitempty" azure:"ro"`
+	Value *string
 }
 
 // Expression - Azure Synapse expression definition.
 type Expression struct {
 	// REQUIRED; Expression type.
-	Type *ExpressionType `json:"type,omitempty"`
+	Type *ExpressionType
 
 	// REQUIRED; Expression value.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // FileServerLinkedService - File system linked service.
 type FileServerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; File system linked service properties.
-	TypeProperties *FileServerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *FileServerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type FileServerLinkedService.
@@ -9162,32 +9162,32 @@ func (f *FileServerLinkedService) GetLinkedService() *LinkedService {
 // FileServerLinkedServiceTypeProperties - File system linked service properties.
 type FileServerLinkedServiceTypeProperties struct {
 	// REQUIRED; Host name of the server. Type: string (or Expression with resultType string).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password to logon the server.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User ID to logon the server. Type: string (or Expression with resultType string).
-	UserID any `json:"userId,omitempty"`
+	UserID any
 }
 
 // FileServerLocation - The location of file server dataset.
 type FileServerLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type FileServerLocation.
@@ -9203,32 +9203,32 @@ func (f *FileServerLocation) GetDatasetLocation() *DatasetLocation {
 // FileServerReadSettings - File server read settings.
 type FileServerReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// FileServer wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// FileServer wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type FileServerReadSettings.
@@ -9243,16 +9243,16 @@ func (f *FileServerReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // FileServerWriteSettings - File server write settings.
 type FileServerWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type FileServerWriteSettings.
@@ -9268,28 +9268,28 @@ func (f *FileServerWriteSettings) GetStoreWriteSettings() *StoreWriteSettings {
 // FileSystemSink - A copy activity file system sink.
 type FileSystemSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type FileSystemSink.
@@ -9308,23 +9308,23 @@ func (f *FileSystemSink) GetCopySink() *CopySink {
 // FileSystemSource - A copy activity file system source.
 type FileSystemSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type FileSystemSource.
@@ -9341,25 +9341,25 @@ func (f *FileSystemSource) GetCopySource() *CopySource {
 // FilterActivity - Filter and return results from input array based on the conditions.
 type FilterActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Filter activity properties.
-	TypeProperties *FilterActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *FilterActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type FilterActivity.
@@ -9389,34 +9389,34 @@ func (f *FilterActivity) GetControlActivity() *ControlActivity {
 // FilterActivityTypeProperties - Filter activity properties.
 type FilterActivityTypeProperties struct {
 	// REQUIRED; Condition to be used for filtering the input.
-	Condition *Expression `json:"condition,omitempty"`
+	Condition *Expression
 
 	// REQUIRED; Input array on which filter should be applied.
-	Items *Expression `json:"items,omitempty"`
+	Items *Expression
 }
 
 // ForEachActivity - This activity is used for iterating over a collection and execute given activities.
 type ForEachActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; ForEach activity properties.
-	TypeProperties *ForEachActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ForEachActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ForEachActivity.
@@ -9446,16 +9446,16 @@ func (f *ForEachActivity) GetControlActivity() *ControlActivity {
 // ForEachActivityTypeProperties - ForEach activity properties.
 type ForEachActivityTypeProperties struct {
 	// REQUIRED; List of activities to execute .
-	Activities []ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification
 
 	// REQUIRED; Collection to iterate.
-	Items *Expression `json:"items,omitempty"`
+	Items *Expression
 
 	// Batch count to be used for controlling the number of parallel execution (when isSequential is set to false).
-	BatchCount *int32 `json:"batchCount,omitempty"`
+	BatchCount *int32
 
 	// Should the loop be executed in sequence or in parallel (max 50)
-	IsSequential *bool `json:"isSequential,omitempty"`
+	IsSequential *bool
 }
 
 // FormatReadSettingsClassification provides polymorphic access to related types.
@@ -9470,7 +9470,7 @@ type FormatReadSettingsClassification interface {
 // FormatReadSettings - Format read settings.
 type FormatReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -9491,7 +9491,7 @@ type FormatWriteSettingsClassification interface {
 // FormatWriteSettings - Format write settings.
 type FormatWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -9503,26 +9503,26 @@ func (f *FormatWriteSettings) GetFormatWriteSettings() *FormatWriteSettings { re
 // FtpReadSettings - Ftp read settings.
 type FtpReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Specify whether to use binary transfer mode for FTP stores.
-	UseBinaryTransfer *bool `json:"useBinaryTransfer,omitempty"`
+	UseBinaryTransfer *bool
 
 	// Ftp wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Ftp wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type FtpReadSettings.
@@ -9537,25 +9537,25 @@ func (f *FtpReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // FtpServerLinkedService - A FTP server Linked Service.
 type FtpServerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *FtpServerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *FtpServerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type FtpServerLinkedService.
@@ -9573,47 +9573,47 @@ func (f *FtpServerLinkedService) GetLinkedService() *LinkedService {
 // FtpServerLinkedServiceTypeProperties - Properties specific to this linked service type.
 type FtpServerLinkedServiceTypeProperties struct {
 	// REQUIRED; Host name of the FTP server. Type: string (or Expression with resultType string).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The authentication type to be used to connect to the FTP server.
-	AuthenticationType *FtpAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *FtpAuthenticationType
 
 	// If true, connect to the FTP server over SSL/TLS channel. Default value is true. Type: boolean (or Expression with resultType
 	// boolean).
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// If true, validate the FTP server SSL certificate when connect over SSL/TLS channel. Default value is true. Type: boolean
 	// (or Expression with resultType boolean).
-	EnableServerCertificateValidation any `json:"enableServerCertificateValidation,omitempty"`
+	EnableServerCertificateValidation any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password to logon the FTP server.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port number that the FTP server uses to listen for client connections. Default value is 21. Type: integer (or Expression
 	// with resultType integer), minimum: 0.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Username to logon the FTP server. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // FtpServerLocation - The location of ftp server dataset.
 type FtpServerLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type FtpServerLocation.
@@ -9629,37 +9629,37 @@ func (f *FtpServerLocation) GetDatasetLocation() *DatasetLocation {
 // GenericDatasetTypeProperties - Properties specific to this dataset type.
 type GenericDatasetTypeProperties struct {
 	// The table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // GetMetadataActivity - Activity to get metadata of dataset
 type GetMetadataActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; GetMetadata activity properties.
-	TypeProperties *GetMetadataActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GetMetadataActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type GetMetadataActivity.
@@ -9691,55 +9691,55 @@ func (g *GetMetadataActivity) GetExecutionActivity() *ExecutionActivity {
 // GetMetadataActivityTypeProperties - GetMetadata activity properties.
 type GetMetadataActivityTypeProperties struct {
 	// REQUIRED; GetMetadata activity dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// Fields of metadata to get from dataset.
-	FieldList []any `json:"fieldList,omitempty"`
+	FieldList []any
 }
 
 // GetSsisObjectMetadataRequest - The request payload of get SSIS object metadata.
 type GetSsisObjectMetadataRequest struct {
 	// Metadata path.
-	MetadataPath *string `json:"metadataPath,omitempty"`
+	MetadataPath *string
 }
 
 type GitHubAccessTokenRequest struct {
 	// REQUIRED; The GitHub Access code.
-	GitHubAccessCode *string `json:"gitHubAccessCode,omitempty"`
+	GitHubAccessCode *string
 
 	// REQUIRED; The GitHub access token base URL.
-	GitHubAccessTokenBaseURL *string `json:"gitHubAccessTokenBaseUrl,omitempty"`
+	GitHubAccessTokenBaseURL *string
 
 	// REQUIRED; The GitHub Client Id.
-	GitHubClientID *string `json:"gitHubClientId,omitempty"`
+	GitHubClientID *string
 }
 
 type GitHubAccessTokenResponse struct {
-	GitHubAccessToken *string `json:"gitHubAccessToken,omitempty"`
+	GitHubAccessToken *string
 }
 
 // GoogleAdWordsLinkedService - Google AdWords service linked service.
 type GoogleAdWordsLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Google AdWords service linked service properties.
-	TypeProperties *GoogleAdWordsLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GoogleAdWordsLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type GoogleAdWordsLinkedService.
@@ -9758,77 +9758,77 @@ func (g *GoogleAdWordsLinkedService) GetLinkedService() *LinkedService {
 type GoogleAdWordsLinkedServiceTypeProperties struct {
 	// REQUIRED; The OAuth 2.0 authentication mechanism used for authentication. ServiceAuthentication can only be used on self-hosted
 	// IR.
-	AuthenticationType *GoogleAdWordsAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *GoogleAdWordsAuthenticationType
 
 	// REQUIRED; The Client customer ID of the AdWords account that you want to fetch report data for.
-	ClientCustomerID any `json:"clientCustomerID,omitempty"`
+	ClientCustomerID any
 
 	// REQUIRED; The developer token associated with the manager account that you use to grant access to the AdWords API.
-	DeveloperToken SecretBaseClassification `json:"developerToken,omitempty"`
+	DeveloperToken SecretBaseClassification
 
 	// The client id of the google application used to acquire the refresh token. Type: string (or Expression with resultType
 	// string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The client secret of the google application used to acquire the refresh token.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The service account email ID that is used for ServiceAuthentication and can only be used on self-hosted IR.
-	Email any `json:"email,omitempty"`
+	Email any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The full path to the .p12 key file that is used to authenticate the service account email address and can only be used
 	// on self-hosted IR.
-	KeyFilePath any `json:"keyFilePath,omitempty"`
+	KeyFilePath any
 
 	// The refresh token obtained from Google for authorizing access to AdWords for UserAuthentication.
-	RefreshToken SecretBaseClassification `json:"refreshToken,omitempty"`
+	RefreshToken SecretBaseClassification
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 }
 
 // GoogleAdWordsObjectDataset - Google AdWords service dataset.
 type GoogleAdWordsObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type GoogleAdWordsObjectDataset.
@@ -9849,25 +9849,25 @@ func (g *GoogleAdWordsObjectDataset) GetDataset() *Dataset {
 // GoogleAdWordsSource - A copy activity Google AdWords service source.
 type GoogleAdWordsSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type GoogleAdWordsSource.
@@ -9896,37 +9896,37 @@ func (g *GoogleAdWordsSource) GetTabularSource() *TabularSource {
 // GoogleBigQueryDatasetTypeProperties - Google BigQuery Dataset Properties
 type GoogleBigQueryDatasetTypeProperties struct {
 	// The database name of the Google BigQuery. Type: string (or Expression with resultType string).
-	Dataset any `json:"dataset,omitempty"`
+	Dataset any
 
 	// The table name of the Google BigQuery. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using database + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // GoogleBigQueryLinkedService - Google BigQuery service linked service.
 type GoogleBigQueryLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Google BigQuery service linked service properties.
-	TypeProperties *GoogleBigQueryLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GoogleBigQueryLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type GoogleBigQueryLinkedService.
@@ -9945,81 +9945,81 @@ func (g *GoogleBigQueryLinkedService) GetLinkedService() *LinkedService {
 type GoogleBigQueryLinkedServiceTypeProperties struct {
 	// REQUIRED; The OAuth 2.0 authentication mechanism used for authentication. ServiceAuthentication can only be used on self-hosted
 	// IR.
-	AuthenticationType *GoogleBigQueryAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *GoogleBigQueryAuthenticationType
 
 	// REQUIRED; The default BigQuery project to query against.
-	Project any `json:"project,omitempty"`
+	Project any
 
 	// A comma-separated list of public BigQuery projects to access.
-	AdditionalProjects any `json:"additionalProjects,omitempty"`
+	AdditionalProjects any
 
 	// The client id of the google application used to acquire the refresh token. Type: string (or Expression with resultType
 	// string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The client secret of the google application used to acquire the refresh token.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The service account email ID that is used for ServiceAuthentication and can only be used on self-hosted IR.
-	Email any `json:"email,omitempty"`
+	Email any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The full path to the .p12 key file that is used to authenticate the service account email address and can only be used
 	// on self-hosted IR.
-	KeyFilePath any `json:"keyFilePath,omitempty"`
+	KeyFilePath any
 
 	// The refresh token obtained from Google for authorizing access to BigQuery for UserAuthentication.
-	RefreshToken SecretBaseClassification `json:"refreshToken,omitempty"`
+	RefreshToken SecretBaseClassification
 
 	// Whether to request access to Google Drive. Allowing Google Drive access enables support for federated tables that combine
 	// BigQuery data with data from Google Drive. The default value is false.
-	RequestGoogleDriveScope any `json:"requestGoogleDriveScope,omitempty"`
+	RequestGoogleDriveScope any
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 }
 
 // GoogleBigQueryObjectDataset - Google BigQuery service dataset.
 type GoogleBigQueryObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GoogleBigQueryDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GoogleBigQueryDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type GoogleBigQueryObjectDataset.
@@ -10040,25 +10040,25 @@ func (g *GoogleBigQueryObjectDataset) GetDataset() *Dataset {
 // GoogleBigQuerySource - A copy activity Google BigQuery service source.
 type GoogleBigQuerySource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type GoogleBigQuerySource.
@@ -10087,25 +10087,25 @@ func (g *GoogleBigQuerySource) GetTabularSource() *TabularSource {
 // GoogleCloudStorageLinkedService - Linked service for Google Cloud Storage.
 type GoogleCloudStorageLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Google Cloud Storage linked service properties.
-	TypeProperties *GoogleCloudStorageLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GoogleCloudStorageLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type GoogleCloudStorageLinkedService.
@@ -10124,40 +10124,40 @@ func (g *GoogleCloudStorageLinkedService) GetLinkedService() *LinkedService {
 type GoogleCloudStorageLinkedServiceTypeProperties struct {
 	// The access key identifier of the Google Cloud Storage Identity and Access Management (IAM) user. Type: string (or Expression
 	// with resultType string).
-	AccessKeyID any `json:"accessKeyId,omitempty"`
+	AccessKeyID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The secret access key of the Google Cloud Storage Identity and Access Management (IAM) user.
-	SecretAccessKey SecretBaseClassification `json:"secretAccessKey,omitempty"`
+	SecretAccessKey SecretBaseClassification
 
 	// This value specifies the endpoint to access with the Google Cloud Storage Connector. This is an optional property; change
 	// it only if you want to try a different service endpoint or want to switch
 	// between https and http. Type: string (or Expression with resultType string).
-	ServiceURL any `json:"serviceUrl,omitempty"`
+	ServiceURL any
 }
 
 // GoogleCloudStorageLocation - The location of Google Cloud Storage dataset.
 type GoogleCloudStorageLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the bucketName of Google Cloud Storage. Type: string (or Expression with resultType string)
-	BucketName any `json:"bucketName,omitempty"`
+	BucketName any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 
 	// Specify the version of Google Cloud Storage. Type: string (or Expression with resultType string).
-	Version any `json:"version,omitempty"`
+	Version any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type GoogleCloudStorageLocation.
@@ -10173,35 +10173,35 @@ func (g *GoogleCloudStorageLocation) GetDatasetLocation() *DatasetLocation {
 // GoogleCloudStorageReadSettings - Google Cloud Storage read settings.
 type GoogleCloudStorageReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// The prefix filter for the Google Cloud Storage object name. Type: string (or Expression with resultType string).
-	Prefix any `json:"prefix,omitempty"`
+	Prefix any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Google Cloud Storage wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Google Cloud Storage wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type GoogleCloudStorageReadSettings.
@@ -10216,37 +10216,37 @@ func (g *GoogleCloudStorageReadSettings) GetStoreReadSettings() *StoreReadSettin
 // GreenplumDatasetTypeProperties - Greenplum Dataset Properties
 type GreenplumDatasetTypeProperties struct {
 	// The schema name of Greenplum. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of Greenplum. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // GreenplumLinkedService - Greenplum Database linked service.
 type GreenplumLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Greenplum Database linked service properties.
-	TypeProperties *GreenplumLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GreenplumLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type GreenplumLinkedService.
@@ -10264,38 +10264,38 @@ func (g *GreenplumLinkedService) GetLinkedService() *LinkedService {
 // GreenplumLinkedServiceTypeProperties - Greenplum Database linked service properties.
 type GreenplumLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // GreenplumSource - A copy activity Greenplum Database source.
 type GreenplumSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type GreenplumSource.
@@ -10324,35 +10324,35 @@ func (g *GreenplumSource) GetTabularSource() *TabularSource {
 // GreenplumTableDataset - Greenplum Database dataset.
 type GreenplumTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GreenplumDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GreenplumDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type GreenplumTableDataset.
@@ -10373,25 +10373,25 @@ func (g *GreenplumTableDataset) GetDataset() *Dataset {
 // HBaseLinkedService - HBase server linked service.
 type HBaseLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HBase server linked service properties.
-	TypeProperties *HBaseLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HBaseLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HBaseLinkedService.
@@ -10409,75 +10409,75 @@ func (h *HBaseLinkedService) GetLinkedService() *LinkedService {
 // HBaseLinkedServiceTypeProperties - HBase server linked service properties.
 type HBaseLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication mechanism to use to connect to the HBase server.
-	AuthenticationType *HBaseAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *HBaseAuthenticationType
 
 	// REQUIRED; The IP address or host name of the HBase server. (i.e. 192.168.222.160)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The partial URL corresponding to the HBase server. (i.e. /gateway/sandbox/hbase/version)
-	HTTPPath any `json:"httpPath,omitempty"`
+	HTTPPath any
 
 	// The password corresponding to the user name.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the HBase instance uses to listen for client connections. The default value is 9090.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// The user name used to connect to the HBase instance.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // HBaseObjectDataset - HBase server dataset.
 type HBaseObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type HBaseObjectDataset.
@@ -10498,25 +10498,25 @@ func (h *HBaseObjectDataset) GetDataset() *Dataset {
 // HBaseSource - A copy activity HBase server source.
 type HBaseSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type HBaseSource.
@@ -10545,31 +10545,31 @@ func (h *HBaseSource) GetTabularSource() *TabularSource {
 // HDInsightHiveActivity - HDInsight Hive activity type.
 type HDInsightHiveActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight Hive activity properties.
-	TypeProperties *HDInsightHiveActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightHiveActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type HDInsightHiveActivity.
@@ -10601,52 +10601,52 @@ func (h *HDInsightHiveActivity) GetExecutionActivity() *ExecutionActivity {
 // HDInsightHiveActivityTypeProperties - HDInsight Hive activity properties.
 type HDInsightHiveActivityTypeProperties struct {
 	// User specified arguments to HDInsightActivity.
-	Arguments []any `json:"arguments,omitempty"`
+	Arguments []any
 
 	// Allows user to specify defines for Hive job request.
-	Defines map[string]any `json:"defines,omitempty"`
+	Defines map[string]any
 
 	// Debug info option.
-	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
+	GetDebugInfo *HDInsightActivityDebugInfoOption
 
 	// Query timeout value (in minutes). Effective when the HDInsight cluster is with ESP (Enterprise Security Package)
-	QueryTimeout *int32 `json:"queryTimeout,omitempty"`
+	QueryTimeout *int32
 
 	// Script linked service reference.
-	ScriptLinkedService *LinkedServiceReference `json:"scriptLinkedService,omitempty"`
+	ScriptLinkedService *LinkedServiceReference
 
 	// Script path. Type: string (or Expression with resultType string).
-	ScriptPath any `json:"scriptPath,omitempty"`
+	ScriptPath any
 
 	// Storage linked service references.
-	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference
 
 	// User specified arguments under hivevar namespace.
-	Variables []any `json:"variables,omitempty"`
+	Variables []any
 }
 
 // HDInsightLinkedService - HDInsight linked service.
 type HDInsightLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight linked service properties.
-	TypeProperties *HDInsightLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HDInsightLinkedService.
@@ -10664,60 +10664,60 @@ func (h *HDInsightLinkedService) GetLinkedService() *LinkedService {
 // HDInsightLinkedServiceTypeProperties - HDInsight linked service properties.
 type HDInsightLinkedServiceTypeProperties struct {
 	// REQUIRED; HDInsight cluster URI. Type: string (or Expression with resultType string).
-	ClusterURI any `json:"clusterUri,omitempty"`
+	ClusterURI any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specify the FileSystem if the main storage for the HDInsight is ADLS Gen2. Type: string (or Expression with resultType
 	// string).
-	FileSystem any `json:"fileSystem,omitempty"`
+	FileSystem any
 
 	// A reference to the Azure SQL linked service that points to the HCatalog database.
-	HcatalogLinkedServiceName *LinkedServiceReference `json:"hcatalogLinkedServiceName,omitempty"`
+	HcatalogLinkedServiceName *LinkedServiceReference
 
 	// Specify if the HDInsight is created with ESP (Enterprise Security Package). Type: Boolean.
-	IsEspEnabled any `json:"isEspEnabled,omitempty"`
+	IsEspEnabled any
 
 	// The Azure Storage linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// HDInsight cluster password.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// HDInsight cluster user name. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // HDInsightMapReduceActivity - HDInsight MapReduce activity type.
 type HDInsightMapReduceActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight MapReduce activity properties.
-	TypeProperties *HDInsightMapReduceActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightMapReduceActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type HDInsightMapReduceActivity.
@@ -10749,52 +10749,52 @@ func (h *HDInsightMapReduceActivity) GetExecutionActivity() *ExecutionActivity {
 // HDInsightMapReduceActivityTypeProperties - HDInsight MapReduce activity properties.
 type HDInsightMapReduceActivityTypeProperties struct {
 	// REQUIRED; Class name. Type: string (or Expression with resultType string).
-	ClassName any `json:"className,omitempty"`
+	ClassName any
 
 	// REQUIRED; Jar path. Type: string (or Expression with resultType string).
-	JarFilePath any `json:"jarFilePath,omitempty"`
+	JarFilePath any
 
 	// User specified arguments to HDInsightActivity.
-	Arguments []any `json:"arguments,omitempty"`
+	Arguments []any
 
 	// Allows user to specify defines for the MapReduce job request.
-	Defines map[string]any `json:"defines,omitempty"`
+	Defines map[string]any
 
 	// Debug info option.
-	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
+	GetDebugInfo *HDInsightActivityDebugInfoOption
 
 	// Jar libs.
-	JarLibs []any `json:"jarLibs,omitempty"`
+	JarLibs []any
 
 	// Jar linked service reference.
-	JarLinkedService *LinkedServiceReference `json:"jarLinkedService,omitempty"`
+	JarLinkedService *LinkedServiceReference
 
 	// Storage linked service references.
-	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference
 }
 
 // HDInsightOnDemandLinkedService - HDInsight ondemand linked service.
 type HDInsightOnDemandLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight ondemand linked service properties.
-	TypeProperties *HDInsightOnDemandLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightOnDemandLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HDInsightOnDemandLinkedService.
@@ -10812,142 +10812,142 @@ func (h *HDInsightOnDemandLinkedService) GetLinkedService() *LinkedService {
 // HDInsightOnDemandLinkedServiceTypeProperties - HDInsight ondemand linked service properties.
 type HDInsightOnDemandLinkedServiceTypeProperties struct {
 	// REQUIRED; The resource group where the cluster belongs. Type: string (or Expression with resultType string).
-	ClusterResourceGroup any `json:"clusterResourceGroup,omitempty"`
+	ClusterResourceGroup any
 
 	// REQUIRED; Number of worker/data nodes in the cluster. Suggestion value: 4. Type: string (or Expression with resultType
 	// string).
-	ClusterSize any `json:"clusterSize,omitempty"`
+	ClusterSize any
 
 	// REQUIRED; The customer’s subscription to host the cluster. Type: string (or Expression with resultType string).
-	HostSubscriptionID any `json:"hostSubscriptionId,omitempty"`
+	HostSubscriptionID any
 
 	// REQUIRED; Azure Storage linked service to be used by the on-demand cluster for storing and processing data.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; The Tenant id/name to which the service principal belongs. Type: string (or Expression with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// REQUIRED; The allowed idle time for the on-demand HDInsight cluster. Specifies how long the on-demand HDInsight cluster
 	// stays alive after completion of an activity run if there are no other active jobs in the
 	// cluster. The minimum value is 5 mins. Type: string (or Expression with resultType string).
-	TimeToLive any `json:"timeToLive,omitempty"`
+	TimeToLive any
 
 	// REQUIRED; Version of the HDInsight cluster. Type: string (or Expression with resultType string).
-	Version any `json:"version,omitempty"`
+	Version any
 
 	// Specifies additional storage accounts for the HDInsight linked service so that the Data Factory service can register them
 	// on your behalf.
-	AdditionalLinkedServiceNames []*LinkedServiceReference `json:"additionalLinkedServiceNames,omitempty"`
+	AdditionalLinkedServiceNames []*LinkedServiceReference
 
 	// The prefix of cluster name, postfix will be distinct with timestamp. Type: string (or Expression with resultType string).
-	ClusterNamePrefix any `json:"clusterNamePrefix,omitempty"`
+	ClusterNamePrefix any
 
 	// The password to access the cluster.
-	ClusterPassword SecretBaseClassification `json:"clusterPassword,omitempty"`
+	ClusterPassword SecretBaseClassification
 
 	// The password to SSH remotely connect cluster’s node (for Linux).
-	ClusterSSHPassword SecretBaseClassification `json:"clusterSshPassword,omitempty"`
+	ClusterSSHPassword SecretBaseClassification
 
 	// The username to SSH remotely connect to cluster’s node (for Linux). Type: string (or Expression with resultType string).
-	ClusterSSHUserName any `json:"clusterSshUserName,omitempty"`
+	ClusterSSHUserName any
 
 	// The cluster type. Type: string (or Expression with resultType string).
-	ClusterType any `json:"clusterType,omitempty"`
+	ClusterType any
 
 	// The username to access the cluster. Type: string (or Expression with resultType string).
-	ClusterUserName any `json:"clusterUserName,omitempty"`
+	ClusterUserName any
 
 	// Specifies the core configuration parameters (as in core-site.xml) for the HDInsight cluster to be created.
-	CoreConfiguration any `json:"coreConfiguration,omitempty"`
+	CoreConfiguration any
 
 	// Specifies the size of the data node for the HDInsight cluster.
-	DataNodeSize any `json:"dataNodeSize,omitempty"`
+	DataNodeSize any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies the HBase configuration parameters (hbase-site.xml) for the HDInsight cluster.
-	HBaseConfiguration any `json:"hBaseConfiguration,omitempty"`
+	HBaseConfiguration any
 
 	// The name of Azure SQL linked service that point to the HCatalog database. The on-demand HDInsight cluster is created by
 	// using the Azure SQL database as the metastore.
-	HcatalogLinkedServiceName *LinkedServiceReference `json:"hcatalogLinkedServiceName,omitempty"`
+	HcatalogLinkedServiceName *LinkedServiceReference
 
 	// Specifies the HDFS configuration parameters (hdfs-site.xml) for the HDInsight cluster.
-	HdfsConfiguration any `json:"hdfsConfiguration,omitempty"`
+	HdfsConfiguration any
 
 	// Specifies the size of the head node for the HDInsight cluster.
-	HeadNodeSize any `json:"headNodeSize,omitempty"`
+	HeadNodeSize any
 
 	// Specifies the hive configuration parameters (hive-site.xml) for the HDInsight cluster.
-	HiveConfiguration any `json:"hiveConfiguration,omitempty"`
+	HiveConfiguration any
 
 	// Specifies the MapReduce configuration parameters (mapred-site.xml) for the HDInsight cluster.
-	MapReduceConfiguration any `json:"mapReduceConfiguration,omitempty"`
+	MapReduceConfiguration any
 
 	// Specifies the Oozie configuration parameters (oozie-site.xml) for the HDInsight cluster.
-	OozieConfiguration any `json:"oozieConfiguration,omitempty"`
+	OozieConfiguration any
 
 	// Custom script actions to run on HDI ondemand cluster once it's up. Please refer to
 	// https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-hadoop-customize-cluster-linux?toc=%2Fen-us%2Fazure%2Fhdinsight%2Fr-server%2FTOC.json&bc=%2Fen-us%2Fazure%2Fbread%2Ftoc.json#understanding-script-actions.
-	ScriptActions []*ScriptAction `json:"scriptActions,omitempty"`
+	ScriptActions []*ScriptAction
 
 	// The service principal id for the hostSubscriptionId. Type: string (or Expression with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The key for the service principal id.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The version of spark if the cluster type is 'spark'. Type: string (or Expression with resultType string).
-	SparkVersion any `json:"sparkVersion,omitempty"`
+	SparkVersion any
 
 	// Specifies the Storm configuration parameters (storm-site.xml) for the HDInsight cluster.
-	StormConfiguration any `json:"stormConfiguration,omitempty"`
+	StormConfiguration any
 
 	// The ARM resource ID for the subnet in the vNet. If virtualNetworkId was specified, then this property is required. Type:
 	// string (or Expression with resultType string).
-	SubnetName any `json:"subnetName,omitempty"`
+	SubnetName any
 
 	// The ARM resource ID for the vNet to which the cluster should be joined after creation. Type: string (or Expression with
 	// resultType string).
-	VirtualNetworkID any `json:"virtualNetworkId,omitempty"`
+	VirtualNetworkID any
 
 	// Specifies the Yarn configuration parameters (yarn-site.xml) for the HDInsight cluster.
-	YarnConfiguration any `json:"yarnConfiguration,omitempty"`
+	YarnConfiguration any
 
 	// Specifies the size of the Zoo Keeper node for the HDInsight cluster.
-	ZookeeperNodeSize any `json:"zookeeperNodeSize,omitempty"`
+	ZookeeperNodeSize any
 }
 
 // HDInsightPigActivity - HDInsight Pig activity type.
 type HDInsightPigActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight Pig activity properties.
-	TypeProperties *HDInsightPigActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightPigActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type HDInsightPigActivity.
@@ -10979,52 +10979,52 @@ func (h *HDInsightPigActivity) GetExecutionActivity() *ExecutionActivity {
 // HDInsightPigActivityTypeProperties - HDInsight Pig activity properties.
 type HDInsightPigActivityTypeProperties struct {
 	// User specified arguments to HDInsightActivity. Type: array (or Expression with resultType array).
-	Arguments any `json:"arguments,omitempty"`
+	Arguments any
 
 	// Allows user to specify defines for Pig job request.
-	Defines map[string]any `json:"defines,omitempty"`
+	Defines map[string]any
 
 	// Debug info option.
-	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
+	GetDebugInfo *HDInsightActivityDebugInfoOption
 
 	// Script linked service reference.
-	ScriptLinkedService *LinkedServiceReference `json:"scriptLinkedService,omitempty"`
+	ScriptLinkedService *LinkedServiceReference
 
 	// Script path. Type: string (or Expression with resultType string).
-	ScriptPath any `json:"scriptPath,omitempty"`
+	ScriptPath any
 
 	// Storage linked service references.
-	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference
 }
 
 // HDInsightSparkActivity - HDInsight Spark activity.
 type HDInsightSparkActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight spark activity properties.
-	TypeProperties *HDInsightSparkActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightSparkActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type HDInsightSparkActivity.
@@ -11057,59 +11057,59 @@ func (h *HDInsightSparkActivity) GetExecutionActivity() *ExecutionActivity {
 type HDInsightSparkActivityTypeProperties struct {
 	// REQUIRED; The relative path to the root folder of the code/package to be executed. Type: string (or Expression with resultType
 	// string).
-	EntryFilePath any `json:"entryFilePath,omitempty"`
+	EntryFilePath any
 
 	// REQUIRED; The root path in 'sparkJobLinkedService' for all the job’s files. Type: string (or Expression with resultType
 	// string).
-	RootPath any `json:"rootPath,omitempty"`
+	RootPath any
 
 	// The user-specified arguments to HDInsightSparkActivity.
-	Arguments []any `json:"arguments,omitempty"`
+	Arguments []any
 
 	// The application's Java/Spark main class.
-	ClassName *string `json:"className,omitempty"`
+	ClassName *string
 
 	// Debug info option.
-	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
+	GetDebugInfo *HDInsightActivityDebugInfoOption
 
 	// The user to impersonate that will execute the job. Type: string (or Expression with resultType string).
-	ProxyUser any `json:"proxyUser,omitempty"`
+	ProxyUser any
 
 	// Spark configuration property.
-	SparkConfig map[string]any `json:"sparkConfig,omitempty"`
+	SparkConfig map[string]any
 
 	// The storage linked service for uploading the entry file and dependencies, and for receiving logs.
-	SparkJobLinkedService *LinkedServiceReference `json:"sparkJobLinkedService,omitempty"`
+	SparkJobLinkedService *LinkedServiceReference
 }
 
 // HDInsightStreamingActivity - HDInsight streaming activity type.
 type HDInsightStreamingActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDInsight streaming activity properties.
-	TypeProperties *HDInsightStreamingActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HDInsightStreamingActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type HDInsightStreamingActivity.
@@ -11141,64 +11141,64 @@ func (h *HDInsightStreamingActivity) GetExecutionActivity() *ExecutionActivity {
 // HDInsightStreamingActivityTypeProperties - HDInsight streaming activity properties.
 type HDInsightStreamingActivityTypeProperties struct {
 	// REQUIRED; Paths to streaming job files. Can be directories.
-	FilePaths []any `json:"filePaths,omitempty"`
+	FilePaths []any
 
 	// REQUIRED; Input blob path. Type: string (or Expression with resultType string).
-	Input any `json:"input,omitempty"`
+	Input any
 
 	// REQUIRED; Mapper executable name. Type: string (or Expression with resultType string).
-	Mapper any `json:"mapper,omitempty"`
+	Mapper any
 
 	// REQUIRED; Output blob path. Type: string (or Expression with resultType string).
-	Output any `json:"output,omitempty"`
+	Output any
 
 	// REQUIRED; Reducer executable name. Type: string (or Expression with resultType string).
-	Reducer any `json:"reducer,omitempty"`
+	Reducer any
 
 	// User specified arguments to HDInsightActivity.
-	Arguments []any `json:"arguments,omitempty"`
+	Arguments []any
 
 	// Combiner executable name. Type: string (or Expression with resultType string).
-	Combiner any `json:"combiner,omitempty"`
+	Combiner any
 
 	// Command line environment values.
-	CommandEnvironment []any `json:"commandEnvironment,omitempty"`
+	CommandEnvironment []any
 
 	// Allows user to specify defines for streaming job request.
-	Defines map[string]any `json:"defines,omitempty"`
+	Defines map[string]any
 
 	// Linked service reference where the files are located.
-	FileLinkedService *LinkedServiceReference `json:"fileLinkedService,omitempty"`
+	FileLinkedService *LinkedServiceReference
 
 	// Debug info option.
-	GetDebugInfo *HDInsightActivityDebugInfoOption `json:"getDebugInfo,omitempty"`
+	GetDebugInfo *HDInsightActivityDebugInfoOption
 
 	// Storage linked service references.
-	StorageLinkedServices []*LinkedServiceReference `json:"storageLinkedServices,omitempty"`
+	StorageLinkedServices []*LinkedServiceReference
 }
 
 // HTTPLinkedService - Linked service for an HTTP source.
 type HTTPLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *HTTPLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HTTPLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HTTPLinkedService.
@@ -11217,58 +11217,58 @@ func (h *HTTPLinkedService) GetLinkedService() *LinkedService {
 type HTTPLinkedServiceTypeProperties struct {
 	// REQUIRED; The base URL of the HTTP endpoint, e.g. http://www.microsoft.com. Type: string (or Expression with resultType
 	// string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// The authentication type to be used to connect to the HTTP server.
-	AuthenticationType *HTTPAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *HTTPAuthenticationType
 
 	// Thumbprint of certificate for ClientCertificate authentication. Only valid for on-premises copy. For on-premises copy with
 	// ClientCertificate authentication, either CertThumbprint or
 	// EmbeddedCertData/Password should be specified. Type: string (or Expression with resultType string).
-	CertThumbprint any `json:"certThumbprint,omitempty"`
+	CertThumbprint any
 
 	// Base64 encoded certificate data for ClientCertificate authentication. For on-premises copy with ClientCertificate authentication,
 	// either CertThumbprint or EmbeddedCertData/Password should be
 	// specified. Type: string (or Expression with resultType string).
-	EmbeddedCertData any `json:"embeddedCertData,omitempty"`
+	EmbeddedCertData any
 
 	// If true, validate the HTTPS server SSL certificate. Default value is true. Type: boolean (or Expression with resultType
 	// boolean).
-	EnableServerCertificateValidation any `json:"enableServerCertificateValidation,omitempty"`
+	EnableServerCertificateValidation any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for Basic, Digest, Windows, or ClientCertificate with EmbeddedCertData authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User name for Basic, Digest, or Windows authentication. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // HTTPReadSettings - Sftp read settings.
 type HTTPReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string).
-	AdditionalHeaders any `json:"additionalHeaders,omitempty"`
+	AdditionalHeaders any
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The HTTP request body to the RESTful API if requestMethod is POST. Type: string (or Expression with resultType string).
-	RequestBody any `json:"requestBody,omitempty"`
+	RequestBody any
 
 	// The HTTP method used to call the RESTful API. The default is GET. Type: string (or Expression with resultType string).
-	RequestMethod any `json:"requestMethod,omitempty"`
+	RequestMethod any
 
 	// Specifies the timeout for a HTTP client to get HTTP response from HTTP server.
-	RequestTimeout any `json:"requestTimeout,omitempty"`
+	RequestTimeout any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type HTTPReadSettings.
@@ -11283,19 +11283,19 @@ func (h *HTTPReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // HTTPServerLocation - The location of http server.
 type HTTPServerLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 
 	// Specify the relativeUrl of http server. Type: string (or Expression with resultType string)
-	RelativeURL any `json:"relativeUrl,omitempty"`
+	RelativeURL any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type HTTPServerLocation.
@@ -11311,7 +11311,7 @@ func (h *HTTPServerLocation) GetDatasetLocation() *DatasetLocation {
 // HTTPSource - A copy activity source for an HTTP file.
 type HTTPSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -11319,16 +11319,16 @@ type HTTPSource struct {
 	// Specifies the timeout for a HTTP client to get HTTP response from HTTP server. The default value is equivalent to System.Net.HttpWebRequest.Timeout.
 	// Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	HTTPRequestTimeout any `json:"httpRequestTimeout,omitempty"`
+	HTTPRequestTimeout any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type HTTPSource.
@@ -11345,25 +11345,25 @@ func (h *HTTPSource) GetCopySource() *CopySource {
 // HdfsLinkedService - Hadoop Distributed File System (HDFS) linked service.
 type HdfsLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; HDFS linked service properties.
-	TypeProperties *HdfsLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HdfsLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HdfsLinkedService.
@@ -11382,36 +11382,36 @@ func (h *HdfsLinkedService) GetLinkedService() *LinkedService {
 type HdfsLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of the HDFS service endpoint, e.g. http://myhostname:50070/webhdfs/v1 . Type: string (or Expression with
 	// resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// Type of authentication used to connect to the HDFS. Possible values are: Anonymous and Windows. Type: string (or Expression
 	// with resultType string).
-	AuthenticationType any `json:"authenticationType,omitempty"`
+	AuthenticationType any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for Windows authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User name for Windows authentication. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // HdfsLocation - The location of HDFS.
 type HdfsLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type HdfsLocation.
@@ -11427,35 +11427,35 @@ func (h *HdfsLocation) GetDatasetLocation() *DatasetLocation {
 // HdfsReadSettings - HDFS read settings.
 type HdfsReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specifies Distcp-related settings.
-	DistcpSettings *DistcpSettings `json:"distcpSettings,omitempty"`
+	DistcpSettings *DistcpSettings
 
 	// Indicates whether to enable partition discovery.
-	EnablePartitionDiscovery *bool `json:"enablePartitionDiscovery,omitempty"`
+	EnablePartitionDiscovery *bool
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// HDFS wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// HDFS wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type HdfsReadSettings.
@@ -11470,26 +11470,26 @@ func (h *HdfsReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // HdfsSource - A copy activity HDFS source.
 type HdfsSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specifies Distcp-related settings.
-	DistcpSettings *DistcpSettings `json:"distcpSettings,omitempty"`
+	DistcpSettings *DistcpSettings
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type HdfsSource.
@@ -11506,37 +11506,37 @@ func (h *HdfsSource) GetCopySource() *CopySource {
 // HiveDatasetTypeProperties - Hive Properties
 type HiveDatasetTypeProperties struct {
 	// The schema name of the Hive. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Hive. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // HiveLinkedService - Hive Server linked service.
 type HiveLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Hive Server linked service properties.
-	TypeProperties *HiveLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HiveLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HiveLinkedService.
@@ -11554,95 +11554,95 @@ func (h *HiveLinkedService) GetLinkedService() *LinkedService {
 // HiveLinkedServiceTypeProperties - Hive Server linked service properties.
 type HiveLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication method used to access the Hive server.
-	AuthenticationType *HiveAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *HiveAuthenticationType
 
 	// REQUIRED; IP address or host name of the Hive server, separated by ';' for multiple hosts (only when serviceDiscoveryMode
 	// is enable).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The partial URL corresponding to the Hive server.
-	HTTPPath any `json:"httpPath,omitempty"`
+	HTTPPath any
 
 	// The password corresponding to the user name that you provided in the Username field
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the Hive server uses to listen for client connections.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The type of Hive server.
-	ServerType *HiveServerType `json:"serverType,omitempty"`
+	ServerType *HiveServerType
 
 	// true to indicate using the ZooKeeper service, false not.
-	ServiceDiscoveryMode any `json:"serviceDiscoveryMode,omitempty"`
+	ServiceDiscoveryMode any
 
 	// The transport protocol to use in the Thrift layer.
-	ThriftTransportProtocol *HiveThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+	ThriftTransportProtocol *HiveThriftTransportProtocol
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether the driver uses native HiveQL queries,or converts them into an equivalent form in HiveQL.
-	UseNativeQuery any `json:"useNativeQuery,omitempty"`
+	UseNativeQuery any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 
 	// The user name that you use to access Hive Server.
-	Username any `json:"username,omitempty"`
+	Username any
 
 	// The namespace on ZooKeeper under which Hive Server 2 nodes are added.
-	ZooKeeperNameSpace any `json:"zooKeeperNameSpace,omitempty"`
+	ZooKeeperNameSpace any
 }
 
 // HiveObjectDataset - Hive Server dataset.
 type HiveObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *HiveDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HiveDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type HiveObjectDataset.
@@ -11663,25 +11663,25 @@ func (h *HiveObjectDataset) GetDataset() *Dataset {
 // HiveSource - A copy activity Hive Server source.
 type HiveSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type HiveSource.
@@ -11710,25 +11710,25 @@ func (h *HiveSource) GetTabularSource() *TabularSource {
 // HubspotLinkedService - Hubspot Service linked service.
 type HubspotLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Hubspot Service linked service properties.
-	TypeProperties *HubspotLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *HubspotLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type HubspotLinkedService.
@@ -11746,64 +11746,64 @@ func (h *HubspotLinkedService) GetLinkedService() *LinkedService {
 // HubspotLinkedServiceTypeProperties - Hubspot Service linked service properties.
 type HubspotLinkedServiceTypeProperties struct {
 	// REQUIRED; The client ID associated with your Hubspot application.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The access token obtained when initially authenticating your OAuth integration.
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// The client secret associated with your Hubspot application.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The refresh token obtained when initially authenticating your OAuth integration.
-	RefreshToken SecretBaseClassification `json:"refreshToken,omitempty"`
+	RefreshToken SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // HubspotObjectDataset - Hubspot Service dataset.
 type HubspotObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type HubspotObjectDataset.
@@ -11824,25 +11824,25 @@ func (h *HubspotObjectDataset) GetDataset() *Dataset {
 // HubspotSource - A copy activity Hubspot Service source.
 type HubspotSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type HubspotSource.
@@ -11872,25 +11872,25 @@ func (h *HubspotSource) GetTabularSource() *TabularSource {
 // property or the ifFalseActivities property depending on the result of the expression.
 type IfConditionActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; IfCondition activity properties.
-	TypeProperties *IfConditionActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *IfConditionActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type IfConditionActivity.
@@ -11921,51 +11921,51 @@ func (i *IfConditionActivity) GetControlActivity() *ControlActivity {
 type IfConditionActivityTypeProperties struct {
 	// REQUIRED; An expression that would evaluate to Boolean. This is used to determine the block of activities (ifTrueActivities
 	// or ifFalseActivities) that will be executed.
-	Expression *Expression `json:"expression,omitempty"`
+	Expression *Expression
 
 	// List of activities to execute if expression is evaluated to false. This is an optional property and if not provided, the
 	// activity will exit without any action.
-	IfFalseActivities []ActivityClassification `json:"ifFalseActivities,omitempty"`
+	IfFalseActivities []ActivityClassification
 
 	// List of activities to execute if expression is evaluated to true. This is an optional property and if not provided, the
 	// activity will exit without any action.
-	IfTrueActivities []ActivityClassification `json:"ifTrueActivities,omitempty"`
+	IfTrueActivities []ActivityClassification
 }
 
 // ImpalaDatasetTypeProperties - Impala Dataset Properties
 type ImpalaDatasetTypeProperties struct {
 	// The schema name of the Impala. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Impala. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // ImpalaLinkedService - Impala server linked service.
 type ImpalaLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Impala server linked service properties.
-	TypeProperties *ImpalaLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ImpalaLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ImpalaLinkedService.
@@ -11983,76 +11983,76 @@ func (i *ImpalaLinkedService) GetLinkedService() *LinkedService {
 // ImpalaLinkedServiceTypeProperties - Impala server linked service properties.
 type ImpalaLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication type to use.
-	AuthenticationType *ImpalaAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *ImpalaAuthenticationType
 
 	// REQUIRED; The IP address or host name of the Impala server. (i.e. 192.168.222.160)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name when using UsernameAndPassword.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the Impala server uses to listen for client connections. The default value is 21050.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 
 	// The user name used to access the Impala server. The default value is anonymous when using SASLUsername.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // ImpalaObjectDataset - Impala server dataset.
 type ImpalaObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *ImpalaDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ImpalaDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ImpalaObjectDataset.
@@ -12073,25 +12073,25 @@ func (i *ImpalaObjectDataset) GetDataset() *Dataset {
 // ImpalaSource - A copy activity Impala server source.
 type ImpalaSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ImpalaSource.
@@ -12120,25 +12120,25 @@ func (i *ImpalaSource) GetTabularSource() *TabularSource {
 // InformixLinkedService - Informix linked service.
 type InformixLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Informix linked service properties.
-	TypeProperties *InformixLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *InformixLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type InformixLinkedService.
@@ -12157,51 +12157,51 @@ func (i *InformixLinkedService) GetLinkedService() *LinkedService {
 type InformixLinkedServiceTypeProperties struct {
 	// REQUIRED; The non-access credential portion of the connection string as well as an optional encrypted credential. Type:
 	// string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// Type of authentication used to connect to the Informix as ODBC data store. Possible values are: Anonymous and Basic. Type:
 	// string (or Expression with resultType string).
-	AuthenticationType any `json:"authenticationType,omitempty"`
+	AuthenticationType any
 
 	// The access credential portion of the connection string specified in driver-specific property-value format.
-	Credential SecretBaseClassification `json:"credential,omitempty"`
+	Credential SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User name for Basic authentication. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // InformixSink - A copy activity Informix sink.
 type InformixSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to execute before starting the copy. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type InformixSink.
@@ -12220,25 +12220,25 @@ func (i *InformixSink) GetCopySink() *CopySink {
 // InformixSource - A copy activity source for Informix.
 type InformixSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type InformixSource.
@@ -12267,35 +12267,35 @@ func (i *InformixSource) GetTabularSource() *TabularSource {
 // InformixTableDataset - The Informix table dataset.
 type InformixTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Informix table dataset properties.
-	TypeProperties *InformixTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *InformixTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type InformixTableDataset.
@@ -12316,7 +12316,7 @@ func (i *InformixTableDataset) GetDataset() *Dataset {
 // InformixTableDatasetTypeProperties - Informix table dataset properties.
 type InformixTableDatasetTypeProperties struct {
 	// The Informix table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // IntegrationRuntimeClassification provides polymorphic access to related types.
@@ -12331,13 +12331,13 @@ type IntegrationRuntimeClassification interface {
 // IntegrationRuntime - Azure Synapse nested object which serves as a compute resource for activities.
 type IntegrationRuntime struct {
 	// REQUIRED; Type of integration runtime.
-	Type *IntegrationRuntimeType `json:"type,omitempty"`
+	Type *IntegrationRuntimeType
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Integration runtime description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // GetIntegrationRuntime implements the IntegrationRuntimeClassification interface for type IntegrationRuntime.
@@ -12349,31 +12349,31 @@ type IntegrationRuntimeComputeProperties struct {
 	AdditionalProperties map[string]any
 
 	// Data flow properties for managed integration runtime.
-	DataFlowProperties *IntegrationRuntimeDataFlowProperties `json:"dataFlowProperties,omitempty"`
+	DataFlowProperties *IntegrationRuntimeDataFlowProperties
 
 	// The location for managed integration runtime. The supported regions could be found on https://docs.microsoft.com/en-us/azure/data-factory/data-factory-data-movement-activities
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Maximum parallel executions count per node for managed integration runtime.
-	MaxParallelExecutionsPerNode *int32 `json:"maxParallelExecutionsPerNode,omitempty"`
+	MaxParallelExecutionsPerNode *int32
 
 	// The node size requirement to managed integration runtime.
-	NodeSize *string `json:"nodeSize,omitempty"`
+	NodeSize *string
 
 	// The required number of nodes for managed integration runtime.
-	NumberOfNodes *int32 `json:"numberOfNodes,omitempty"`
+	NumberOfNodes *int32
 
 	// VNet properties for managed integration runtime.
-	VNetProperties *IntegrationRuntimeVNetProperties `json:"vNetProperties,omitempty"`
+	VNetProperties *IntegrationRuntimeVNetProperties
 }
 
 // IntegrationRuntimeCustomSetupScriptProperties - Custom setup script properties for a managed dedicated integration runtime.
 type IntegrationRuntimeCustomSetupScriptProperties struct {
 	// The URI of the Azure blob container that contains the custom setup script.
-	BlobContainerURI *string `json:"blobContainerUri,omitempty"`
+	BlobContainerURI *string
 
 	// The SAS token of the Azure blob container.
-	SasToken *SecureString `json:"sasToken,omitempty"`
+	SasToken *SecureString
 }
 
 // IntegrationRuntimeDataFlowProperties - Data flow properties for managed integration runtime.
@@ -12382,64 +12382,64 @@ type IntegrationRuntimeDataFlowProperties struct {
 	AdditionalProperties map[string]any
 
 	// Compute type of the cluster which will execute data flow job.
-	ComputeType *DataFlowComputeType `json:"computeType,omitempty"`
+	ComputeType *DataFlowComputeType
 
 	// Core count of the cluster which will execute data flow job. Supported values are: 8, 16, 32, 48, 80, 144 and 272.
-	CoreCount *int32 `json:"coreCount,omitempty"`
+	CoreCount *int32
 
 	// Time to live (in minutes) setting of the cluster which will execute data flow job.
-	TimeToLive *int32 `json:"timeToLive,omitempty"`
+	TimeToLive *int32
 }
 
 // IntegrationRuntimeDataProxyProperties - Data proxy properties for a managed dedicated integration runtime.
 type IntegrationRuntimeDataProxyProperties struct {
 	// The self-hosted integration runtime reference.
-	ConnectVia *EntityReference `json:"connectVia,omitempty"`
+	ConnectVia *EntityReference
 
 	// The path to contain the staged data in the Blob storage.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// The staging linked service reference.
-	StagingLinkedService *EntityReference `json:"stagingLinkedService,omitempty"`
+	StagingLinkedService *EntityReference
 }
 
 // IntegrationRuntimeListResponse - A list of integration runtime resources.
 type IntegrationRuntimeListResponse struct {
 	// REQUIRED; List of integration runtimes.
-	Value []*IntegrationRuntimeResource `json:"value,omitempty"`
+	Value []*IntegrationRuntimeResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // IntegrationRuntimeReference - Integration runtime reference type.
 type IntegrationRuntimeReference struct {
 	// REQUIRED; Reference integration runtime name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Type of integration runtime.
-	Type *IntegrationRuntimeReferenceType `json:"type,omitempty"`
+	Type *IntegrationRuntimeReferenceType
 
 	// Arguments for integration runtime.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 }
 
 // IntegrationRuntimeResource - Integration runtime resource type.
 type IntegrationRuntimeResource struct {
 	// REQUIRED; Integration runtime properties.
-	Properties IntegrationRuntimeClassification `json:"properties,omitempty"`
+	Properties IntegrationRuntimeClassification
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // IntegrationRuntimeSsisCatalogInfo - Catalog information for managed dedicated integration runtime.
@@ -12448,16 +12448,16 @@ type IntegrationRuntimeSsisCatalogInfo struct {
 	AdditionalProperties map[string]any
 
 	// The password of the administrator user account of the catalog database.
-	CatalogAdminPassword *SecureString `json:"catalogAdminPassword,omitempty"`
+	CatalogAdminPassword *SecureString
 
 	// The administrator user name of catalog database.
-	CatalogAdminUserName *string `json:"catalogAdminUserName,omitempty"`
+	CatalogAdminUserName *string
 
 	// The pricing tier for the catalog database. The valid values could be found in https://azure.microsoft.com/en-us/pricing/details/sql-database/
-	CatalogPricingTier *IntegrationRuntimeSsisCatalogPricingTier `json:"catalogPricingTier,omitempty"`
+	CatalogPricingTier *IntegrationRuntimeSsisCatalogPricingTier
 
 	// The catalog database server URL.
-	CatalogServerEndpoint *string `json:"catalogServerEndpoint,omitempty"`
+	CatalogServerEndpoint *string
 }
 
 // IntegrationRuntimeSsisProperties - SSIS properties for managed integration runtime.
@@ -12466,22 +12466,22 @@ type IntegrationRuntimeSsisProperties struct {
 	AdditionalProperties map[string]any
 
 	// Catalog information for managed dedicated integration runtime.
-	CatalogInfo *IntegrationRuntimeSsisCatalogInfo `json:"catalogInfo,omitempty"`
+	CatalogInfo *IntegrationRuntimeSsisCatalogInfo
 
 	// Custom setup script properties for a managed dedicated integration runtime.
-	CustomSetupScriptProperties *IntegrationRuntimeCustomSetupScriptProperties `json:"customSetupScriptProperties,omitempty"`
+	CustomSetupScriptProperties *IntegrationRuntimeCustomSetupScriptProperties
 
 	// Data proxy properties for a managed dedicated integration runtime.
-	DataProxyProperties *IntegrationRuntimeDataProxyProperties `json:"dataProxyProperties,omitempty"`
+	DataProxyProperties *IntegrationRuntimeDataProxyProperties
 
 	// The edition for the SSIS Integration Runtime
-	Edition *IntegrationRuntimeEdition `json:"edition,omitempty"`
+	Edition *IntegrationRuntimeEdition
 
 	// Custom setup without script properties for a SSIS integration runtime.
-	ExpressCustomSetupProperties []CustomSetupBaseClassification `json:"expressCustomSetupProperties,omitempty"`
+	ExpressCustomSetupProperties []CustomSetupBaseClassification
 
 	// License type for bringing your own license scenario.
-	LicenseType *IntegrationRuntimeLicenseType `json:"licenseType,omitempty"`
+	LicenseType *IntegrationRuntimeLicenseType
 }
 
 // IntegrationRuntimeVNetProperties - VNet properties for managed integration runtime.
@@ -12490,13 +12490,13 @@ type IntegrationRuntimeVNetProperties struct {
 	AdditionalProperties map[string]any
 
 	// Resource IDs of the public IP addresses that this integration runtime will use.
-	PublicIPs []*string `json:"publicIPs,omitempty"`
+	PublicIPs []*string
 
 	// The name of the subnet this integration runtime will join.
-	Subnet *string `json:"subnet,omitempty"`
+	Subnet *string
 
 	// The ID of the VNet that this integration runtime will join.
-	VNetID *string `json:"vNetId,omitempty"`
+	VNetID *string
 }
 
 // IntegrationRuntimesClientGetOptions contains the optional parameters for the IntegrationRuntimesClient.Get method.
@@ -12512,35 +12512,35 @@ type IntegrationRuntimesClientListOptions struct {
 // JSONDataset - Json dataset.
 type JSONDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Json dataset properties.
-	TypeProperties *JSONDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *JSONDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type JSONDataset.
@@ -12561,55 +12561,55 @@ func (j *JSONDataset) GetDataset() *Dataset {
 // JSONDatasetTypeProperties - Json dataset properties.
 type JSONDatasetTypeProperties struct {
 	// REQUIRED; The location of the json data storage.
-	Location DatasetLocationClassification `json:"location,omitempty"`
+	Location DatasetLocationClassification
 
 	// The data compression method used for the json dataset.
-	Compression DatasetCompressionClassification `json:"compression,omitempty"`
+	Compression DatasetCompressionClassification
 
 	// The code page name of the preferred encoding. If not specified, the default value is UTF-8, unless BOM denotes another
 	// Unicode encoding. Refer to the name column of the table in the following link to
 	// set supported values: https://msdn.microsoft.com/library/system.text.encoding.aspx. Type: string (or Expression with resultType
 	// string).
-	EncodingName any `json:"encodingName,omitempty"`
+	EncodingName any
 }
 
 // JSONFormat - The data stored in JSON format.
 type JSONFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// The code page name of the preferred encoding. If not provided, the default value is 'utf-8', unless the byte order mark
 	// (BOM) denotes another Unicode encoding. The full list of supported values can be
 	// found in the 'Name' column of the table of encodings in the following reference: https://go.microsoft.com/fwlink/?linkid=861078.
 	// Type: string (or Expression with resultType string).
-	EncodingName any `json:"encodingName,omitempty"`
+	EncodingName any
 
 	// File pattern of JSON. To be more specific, the way of separating a collection of JSON objects. The default value is 'setOfObjects'.
 	// It is case-sensitive.
-	FilePattern *JSONFormatFilePattern `json:"filePattern,omitempty"`
+	FilePattern *JSONFormatFilePattern
 
 	// The JSONPath of the JSON array element to be flattened. Example: "$.ArrayPath". Type: string (or Expression with resultType
 	// string).
-	JSONNodeReference any `json:"jsonNodeReference,omitempty"`
+	JSONNodeReference any
 
 	// The JSONPath definition for each column mapping with a customized column name to extract data from JSON file. For fields
 	// under root object, start with "$"; for fields inside the array chosen by
 	// jsonNodeReference property, start from the array element. Example: {"Column1": "$.Column1Path", "Column2": "Column2PathInArray"}.
 	// Type: object (or Expression with resultType object).
-	JSONPathDefinition any `json:"jsonPathDefinition,omitempty"`
+	JSONPathDefinition any
 
 	// The character used to separate nesting levels. Default value is '.' (dot). Type: string (or Expression with resultType
 	// string).
-	NestingSeparator any `json:"nestingSeparator,omitempty"`
+	NestingSeparator any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type JSONFormat.
@@ -12625,31 +12625,31 @@ func (j *JSONFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // JSONSink - A copy activity Json sink.
 type JSONSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Json format settings.
-	FormatSettings *JSONWriteSettings `json:"formatSettings,omitempty"`
+	FormatSettings *JSONWriteSettings
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Json store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type JSONSink.
@@ -12668,22 +12668,22 @@ func (j *JSONSink) GetCopySink() *CopySink {
 // JSONSource - A copy activity Json source.
 type JSONSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Json store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type JSONSource.
@@ -12700,14 +12700,14 @@ func (j *JSONSource) GetCopySource() *CopySource {
 // JSONWriteSettings - Json write settings.
 type JSONWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// File pattern of JSON. This setting controls the way a collection of JSON objects will be treated. The default value is
 	// 'setOfObjects'. It is case-sensitive.
-	FilePattern *JSONWriteFilePattern `json:"filePattern,omitempty"`
+	FilePattern *JSONWriteFilePattern
 }
 
 // GetFormatWriteSettings implements the FormatWriteSettingsClassification interface for type JSONWriteSettings.
@@ -12721,25 +12721,25 @@ func (j *JSONWriteSettings) GetFormatWriteSettings() *FormatWriteSettings {
 // JiraLinkedService - Jira Service linked service.
 type JiraLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Jira Service linked service properties.
-	TypeProperties *JiraLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *JiraLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type JiraLinkedService.
@@ -12757,65 +12757,65 @@ func (j *JiraLinkedService) GetLinkedService() *LinkedService {
 // JiraLinkedServiceTypeProperties - Jira Service linked service properties.
 type JiraLinkedServiceTypeProperties struct {
 	// REQUIRED; The IP address or host name of the Jira service. (e.g. jira.example.com)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// REQUIRED; The user name that you use to access Jira Service.
-	Username any `json:"username,omitempty"`
+	Username any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name that you provided in the username field.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the Jira server uses to listen for client connections. The default value is 443 if connecting through
 	// HTTPS, or 8080 if connecting through HTTP.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // JiraObjectDataset - Jira Service dataset.
 type JiraObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type JiraObjectDataset.
@@ -12836,25 +12836,25 @@ func (j *JiraObjectDataset) GetDataset() *Dataset {
 // JiraSource - A copy activity Jira Service source.
 type JiraSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type JiraSource.
@@ -12924,127 +12924,127 @@ type LibraryClientListOptions struct {
 // LibraryInfo - Library/package information of a Big Data pool powered by Apache Spark
 type LibraryInfo struct {
 	// Storage blob container name.
-	ContainerName *string `json:"containerName,omitempty"`
+	ContainerName *string
 
 	// Name of the library.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Storage blob path of library.
-	Path *string `json:"path,omitempty"`
+	Path *string
 
 	// Type of the library.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// READ-ONLY; Creator Id of the library/package.
-	CreatorID *string `json:"creatorId,omitempty" azure:"ro"`
+	CreatorID *string
 
 	// READ-ONLY; Provisioning status of the library/package.
-	ProvisioningStatus *string `json:"provisioningStatus,omitempty" azure:"ro"`
+	ProvisioningStatus *string
 
 	// READ-ONLY; The last update time of the library.
-	UploadedTimestamp *time.Time `json:"uploadedTimestamp,omitempty" azure:"ro"`
+	UploadedTimestamp *time.Time
 }
 
 // LibraryListResponse - A list of Library resources.
 type LibraryListResponse struct {
 	// REQUIRED; List of Library.
-	Value []*LibraryResource `json:"value,omitempty"`
+	Value []*LibraryResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // LibraryRequirements - Library requirements for a Big Data pool powered by Apache Spark
 type LibraryRequirements struct {
 	// The library requirements.
-	Content *string `json:"content,omitempty"`
+	Content *string
 
 	// The filename of the library requirements file.
-	Filename *string `json:"filename,omitempty"`
+	Filename *string
 
 	// READ-ONLY; The last update time of the library requirements file.
-	Time *time.Time `json:"time,omitempty" azure:"ro"`
+	Time *time.Time
 }
 
 // LibraryResource - Library response details
 type LibraryResource struct {
 	// REQUIRED; Library/package properties.
-	Properties *LibraryResourceProperties `json:"properties,omitempty"`
+	Properties *LibraryResourceProperties
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LibraryResourceInfo - Library resource info
 type LibraryResourceInfo struct {
 	// READ-ONLY; artifact Id of the library/package.
-	ArtifactID *string `json:"artifactId,omitempty" azure:"ro"`
+	ArtifactID *string
 
 	// READ-ONLY; The last updated time of the library/package.
-	Changed *string `json:"changed,omitempty" azure:"ro"`
+	Changed *string
 
 	// READ-ONLY; The creation time of the library/package.
-	Created *string `json:"created,omitempty" azure:"ro"`
+	Created *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; Name of the library/package.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Operation Id of the operation performed on library/package.
-	OperationID *string `json:"operationId,omitempty" azure:"ro"`
+	OperationID *string
 
 	// READ-ONLY; record Id of the library/package.
-	RecordID *int32 `json:"recordId,omitempty" azure:"ro"`
+	RecordID *int32
 
 	// READ-ONLY; Provisioning status of the library/package.
-	State *string `json:"state,omitempty" azure:"ro"`
+	State *string
 
 	// READ-ONLY; The type of the resource. E.g. LibraryArtifact
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LibraryResourceProperties - Library/package properties
 type LibraryResourceProperties struct {
 	// READ-ONLY; Container name of the library/package.
-	ContainerName *string `json:"containerName,omitempty" azure:"ro"`
+	ContainerName *string
 
 	// READ-ONLY; Creator Id of the library/package.
-	CreatorID *string `json:"creatorId,omitempty" azure:"ro"`
+	CreatorID *string
 
 	// READ-ONLY; Name of the library/package.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; Location of library/package in storage account.
-	Path *string `json:"path,omitempty" azure:"ro"`
+	Path *string
 
 	// READ-ONLY; Provisioning status of the library/package.
-	ProvisioningStatus *string `json:"provisioningStatus,omitempty" azure:"ro"`
+	ProvisioningStatus *string
 
 	// READ-ONLY; Type of the library/package.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 
 	// READ-ONLY; The last update time of the library/package.
-	UploadedTimestamp *string `json:"uploadedTimestamp,omitempty" azure:"ro"`
+	UploadedTimestamp *string
 }
 
 // LinkedIntegrationRuntimeKeyAuthorization - The key authorization type integration runtime.
 type LinkedIntegrationRuntimeKeyAuthorization struct {
 	// REQUIRED; The authorization type for integration runtime sharing.
-	AuthorizationType *string `json:"authorizationType,omitempty"`
+	AuthorizationType *string
 
 	// REQUIRED; The key used for authorization.
-	Key *SecureString `json:"key,omitempty"`
+	Key *SecureString
 }
 
 // GetLinkedIntegrationRuntimeType implements the LinkedIntegrationRuntimeTypeClassification interface for type LinkedIntegrationRuntimeKeyAuthorization.
@@ -13057,10 +13057,10 @@ func (l *LinkedIntegrationRuntimeKeyAuthorization) GetLinkedIntegrationRuntimeTy
 // LinkedIntegrationRuntimeRbacAuthorization - The role based access control (RBAC) authorization type integration runtime.
 type LinkedIntegrationRuntimeRbacAuthorization struct {
 	// REQUIRED; The authorization type for integration runtime sharing.
-	AuthorizationType *string `json:"authorizationType,omitempty"`
+	AuthorizationType *string
 
 	// REQUIRED; The resource identifier of the integration runtime to be shared.
-	ResourceID *string `json:"resourceId,omitempty"`
+	ResourceID *string
 }
 
 // GetLinkedIntegrationRuntimeType implements the LinkedIntegrationRuntimeTypeClassification interface for type LinkedIntegrationRuntimeRbacAuthorization.
@@ -13082,7 +13082,7 @@ type LinkedIntegrationRuntimeTypeClassification interface {
 // LinkedIntegrationRuntimeType - The base definition of a linked integration runtime.
 type LinkedIntegrationRuntimeType struct {
 	// REQUIRED; The authorization type for integration runtime sharing.
-	AuthorizationType *string `json:"authorizationType,omitempty"`
+	AuthorizationType *string
 }
 
 // GetLinkedIntegrationRuntimeType implements the LinkedIntegrationRuntimeTypeClassification interface for type LinkedIntegrationRuntimeType.
@@ -13121,22 +13121,22 @@ type LinkedServiceClassification interface {
 // with related store or compute resource.
 type LinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type LinkedService.
@@ -13183,91 +13183,91 @@ type LinkedServiceClientGetLinkedServicesByWorkspaceOptions struct {
 // LinkedServiceDebugResource - Linked service debug resource.
 type LinkedServiceDebugResource struct {
 	// REQUIRED; Properties of linked service.
-	Properties LinkedServiceClassification `json:"properties,omitempty"`
+	Properties LinkedServiceClassification
 
 	// The resource name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // LinkedServiceListResponse - A list of linked service resources.
 type LinkedServiceListResponse struct {
 	// REQUIRED; List of linked services.
-	Value []*LinkedServiceResource `json:"value,omitempty"`
+	Value []*LinkedServiceResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // LinkedServiceReference - Linked service reference type.
 type LinkedServiceReference struct {
 	// REQUIRED; Reference LinkedService name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Linked service reference type.
-	Type *Type `json:"type,omitempty"`
+	Type *Type
 
 	// Arguments for LinkedService.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 }
 
 // LinkedServiceResource - Linked service resource type.
 type LinkedServiceResource struct {
 	// REQUIRED; Properties of linked service.
-	Properties LinkedServiceClassification `json:"properties,omitempty"`
+	Properties LinkedServiceClassification
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // LogStorageSettings - Log storage settings.
 type LogStorageSettings struct {
 	// REQUIRED; Log storage linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The path to storage for storing detailed logs of activity execution. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // LookupActivity - Lookup activity.
 type LookupActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Lookup activity properties.
-	TypeProperties *LookupActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *LookupActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type LookupActivity.
@@ -13299,37 +13299,37 @@ func (l *LookupActivity) GetExecutionActivity() *ExecutionActivity {
 // LookupActivityTypeProperties - Lookup activity properties.
 type LookupActivityTypeProperties struct {
 	// REQUIRED; Lookup activity dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// REQUIRED; Dataset-specific source properties, same as copy activity source.
-	Source CopySourceClassification `json:"source,omitempty"`
+	Source CopySourceClassification
 
 	// Whether to return first row or all rows. Default value is true. Type: boolean (or Expression with resultType boolean).
-	FirstRowOnly any `json:"firstRowOnly,omitempty"`
+	FirstRowOnly any
 }
 
 // MagentoLinkedService - Magento server linked service.
 type MagentoLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Magento server linked service properties.
-	TypeProperties *MagentoLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MagentoLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MagentoLinkedService.
@@ -13347,58 +13347,58 @@ func (m *MagentoLinkedService) GetLinkedService() *LinkedService {
 // MagentoLinkedServiceTypeProperties - Magento server linked service properties.
 type MagentoLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of the Magento instance. (i.e. 192.168.222.110/magento3)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The access token from Magento.
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // MagentoObjectDataset - Magento server dataset.
 type MagentoObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type MagentoObjectDataset.
@@ -13419,25 +13419,25 @@ func (m *MagentoObjectDataset) GetDataset() *Dataset {
 // MagentoSource - A copy activity Magento server source.
 type MagentoSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MagentoSource.
@@ -13466,31 +13466,31 @@ func (m *MagentoSource) GetTabularSource() *TabularSource {
 // ManagedIdentity - The workspace managed identity
 type ManagedIdentity struct {
 	// The type of managed identity for the workspace
-	Type *ResourceIdentityType `json:"type,omitempty"`
+	Type *ResourceIdentityType
 
 	// READ-ONLY; The principal ID of the workspace managed identity
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The tenant ID of the workspace managed identity
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 // ManagedIntegrationRuntime - Managed integration runtime, including managed elastic and managed dedicated integration runtimes.
 type ManagedIntegrationRuntime struct {
 	// REQUIRED; Type of integration runtime.
-	Type *IntegrationRuntimeType `json:"type,omitempty"`
+	Type *IntegrationRuntimeType
 
 	// REQUIRED; Managed integration runtime properties.
-	TypeProperties *ManagedIntegrationRuntimeTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ManagedIntegrationRuntimeTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Integration runtime description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// READ-ONLY; Integration runtime state, only valid for managed dedicated integration runtime.
-	State *IntegrationRuntimeState `json:"state,omitempty" azure:"ro"`
+	State *IntegrationRuntimeState
 }
 
 // GetIntegrationRuntime implements the IntegrationRuntimeClassification interface for type ManagedIntegrationRuntime.
@@ -13505,40 +13505,40 @@ func (m *ManagedIntegrationRuntime) GetIntegrationRuntime() *IntegrationRuntime 
 // ManagedIntegrationRuntimeTypeProperties - Managed integration runtime type properties.
 type ManagedIntegrationRuntimeTypeProperties struct {
 	// The compute resource for managed integration runtime.
-	ComputeProperties *IntegrationRuntimeComputeProperties `json:"computeProperties,omitempty"`
+	ComputeProperties *IntegrationRuntimeComputeProperties
 
 	// SSIS properties for managed integration runtime.
-	SsisProperties *IntegrationRuntimeSsisProperties `json:"ssisProperties,omitempty"`
+	SsisProperties *IntegrationRuntimeSsisProperties
 }
 
 // ManagedVirtualNetworkSettings - Managed Virtual Network Settings
 type ManagedVirtualNetworkSettings struct {
 	// Allowed Aad Tenant Ids For Linking
-	AllowedAADTenantIDsForLinking []*string `json:"allowedAadTenantIdsForLinking,omitempty"`
+	AllowedAADTenantIDsForLinking []*string
 
 	// Linked Access Check On Target Resource
-	LinkedAccessCheckOnTargetResource *bool `json:"linkedAccessCheckOnTargetResource,omitempty"`
+	LinkedAccessCheckOnTargetResource *bool
 
 	// Prevent Data Exfiltration
-	PreventDataExfiltration *bool `json:"preventDataExfiltration,omitempty"`
+	PreventDataExfiltration *bool
 }
 
 // MappingDataFlow - Mapping data flow.
 type MappingDataFlow struct {
 	// REQUIRED; Type of data flow.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// List of tags that can be used for describing the data flow.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The description of the data flow.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this data flow is in. If not specified, Data flow will appear at the root level.
-	Folder *DataFlowFolder `json:"folder,omitempty"`
+	Folder *DataFlowFolder
 
 	// Mapping data flow type properties.
-	TypeProperties *MappingDataFlowTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MappingDataFlowTypeProperties
 }
 
 // GetDataFlow implements the DataFlowClassification interface for type MappingDataFlow.
@@ -13554,40 +13554,40 @@ func (m *MappingDataFlow) GetDataFlow() *DataFlow {
 // MappingDataFlowTypeProperties - Mapping data flow type properties.
 type MappingDataFlowTypeProperties struct {
 	// DataFlow script.
-	Script *string `json:"script,omitempty"`
+	Script *string
 
 	// List of sinks in data flow.
-	Sinks []*DataFlowSink `json:"sinks,omitempty"`
+	Sinks []*DataFlowSink
 
 	// List of sources in data flow.
-	Sources []*DataFlowSource `json:"sources,omitempty"`
+	Sources []*DataFlowSource
 
 	// List of transformations in data flow.
-	Transformations []*Transformation `json:"transformations,omitempty"`
+	Transformations []*Transformation
 }
 
 // MariaDBLinkedService - MariaDB server linked service.
 type MariaDBLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MariaDB server linked service properties.
-	TypeProperties *MariaDBLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MariaDBLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MariaDBLinkedService.
@@ -13605,38 +13605,38 @@ func (m *MariaDBLinkedService) GetLinkedService() *LinkedService {
 // MariaDBLinkedServiceTypeProperties - MariaDB server linked service properties.
 type MariaDBLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // MariaDBSource - A copy activity MariaDB server source.
 type MariaDBSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MariaDBSource.
@@ -13665,35 +13665,35 @@ func (m *MariaDBSource) GetTabularSource() *TabularSource {
 // MariaDBTableDataset - MariaDB server dataset.
 type MariaDBTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type MariaDBTableDataset.
@@ -13714,25 +13714,25 @@ func (m *MariaDBTableDataset) GetDataset() *Dataset {
 // MarketoLinkedService - Marketo server linked service.
 type MarketoLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Marketo server linked service properties.
-	TypeProperties *MarketoLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MarketoLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MarketoLinkedService.
@@ -13750,61 +13750,61 @@ func (m *MarketoLinkedService) GetLinkedService() *LinkedService {
 // MarketoLinkedServiceTypeProperties - Marketo server linked service properties.
 type MarketoLinkedServiceTypeProperties struct {
 	// REQUIRED; The client Id of your Marketo service.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; The endpoint of the Marketo server. (i.e. 123-ABC-321.mktorest.com)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// The client secret of your Marketo service.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // MarketoObjectDataset - Marketo server dataset.
 type MarketoObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type MarketoObjectDataset.
@@ -13825,25 +13825,25 @@ func (m *MarketoObjectDataset) GetDataset() *Dataset {
 // MarketoSource - A copy activity Marketo server source.
 type MarketoSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MarketoSource.
@@ -13872,25 +13872,25 @@ func (m *MarketoSource) GetTabularSource() *TabularSource {
 // MicrosoftAccessLinkedService - Microsoft Access linked service.
 type MicrosoftAccessLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Microsoft Access linked service properties.
-	TypeProperties *MicrosoftAccessLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MicrosoftAccessLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MicrosoftAccessLinkedService.
@@ -13909,51 +13909,51 @@ func (m *MicrosoftAccessLinkedService) GetLinkedService() *LinkedService {
 type MicrosoftAccessLinkedServiceTypeProperties struct {
 	// REQUIRED; The non-access credential portion of the connection string as well as an optional encrypted credential. Type:
 	// string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// Type of authentication used to connect to the Microsoft Access as ODBC data store. Possible values are: Anonymous and Basic.
 	// Type: string (or Expression with resultType string).
-	AuthenticationType any `json:"authenticationType,omitempty"`
+	AuthenticationType any
 
 	// The access credential portion of the connection string specified in driver-specific property-value format.
-	Credential SecretBaseClassification `json:"credential,omitempty"`
+	Credential SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User name for Basic authentication. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // MicrosoftAccessSink - A copy activity Microsoft Access sink.
 type MicrosoftAccessSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to execute before starting the copy. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type MicrosoftAccessSink.
@@ -13972,22 +13972,22 @@ func (m *MicrosoftAccessSink) GetCopySink() *CopySink {
 // MicrosoftAccessSource - A copy activity source for Microsoft Access.
 type MicrosoftAccessSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MicrosoftAccessSource.
@@ -14004,35 +14004,35 @@ func (m *MicrosoftAccessSource) GetCopySource() *CopySource {
 // MicrosoftAccessTableDataset - The Microsoft Access table dataset.
 type MicrosoftAccessTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Microsoft Access table dataset properties.
-	TypeProperties *MicrosoftAccessTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MicrosoftAccessTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type MicrosoftAccessTableDataset.
@@ -14053,41 +14053,41 @@ func (m *MicrosoftAccessTableDataset) GetDataset() *Dataset {
 // MicrosoftAccessTableDatasetTypeProperties - Microsoft Access table dataset properties.
 type MicrosoftAccessTableDatasetTypeProperties struct {
 	// The Microsoft Access table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // MongoDbCollectionDataset - The MongoDB database dataset.
 type MongoDbCollectionDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MongoDB database dataset properties.
-	TypeProperties *MongoDbCollectionDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MongoDbCollectionDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type MongoDbCollectionDataset.
@@ -14108,7 +14108,7 @@ func (m *MongoDbCollectionDataset) GetDataset() *Dataset {
 // MongoDbCollectionDatasetTypeProperties - MongoDB database dataset properties.
 type MongoDbCollectionDatasetTypeProperties struct {
 	// REQUIRED; The table name of the MongoDB database. Type: string (or Expression with resultType string).
-	CollectionName any `json:"collectionName,omitempty"`
+	CollectionName any
 }
 
 // MongoDbCursorMethodsProperties - Cursor methods for Mongodb query
@@ -14118,44 +14118,44 @@ type MongoDbCursorMethodsProperties struct {
 
 	// Specifies the maximum number of documents the server returns. limit() is analogous to the LIMIT statement in a SQL database.
 	// Type: integer (or Expression with resultType integer).
-	Limit any `json:"limit,omitempty"`
+	Limit any
 
 	// Specifies the fields to return in the documents that match the query filter. To return all fields in the matching documents,
 	// omit this parameter. Type: string (or Expression with resultType string).
-	Project any `json:"project,omitempty"`
+	Project any
 
 	// Specifies the how many documents skipped and where MongoDB begins returning results. This approach may be useful in implementing
 	// paginated results. Type: integer (or Expression with resultType
 	// integer).
-	Skip any `json:"skip,omitempty"`
+	Skip any
 
 	// Specifies the order in which the query returns matching documents. Type: string (or Expression with resultType string).
 	// Type: string (or Expression with resultType string).
-	Sort any `json:"sort,omitempty"`
+	Sort any
 }
 
 // MongoDbLinkedService - Linked service for MongoDb data source.
 type MongoDbLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MongoDB linked service properties.
-	TypeProperties *MongoDbLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MongoDbLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MongoDbLinkedService.
@@ -14173,59 +14173,59 @@ func (m *MongoDbLinkedService) GetLinkedService() *LinkedService {
 // MongoDbLinkedServiceTypeProperties - MongoDB linked service properties.
 type MongoDbLinkedServiceTypeProperties struct {
 	// REQUIRED; The name of the MongoDB database that you want to access. Type: string (or Expression with resultType string).
-	DatabaseName any `json:"databaseName,omitempty"`
+	DatabaseName any
 
 	// REQUIRED; The IP address or server name of the MongoDB server. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false. Type: boolean (or Expression
 	// with resultType boolean).
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Database to verify the username and password. Type: string (or Expression with resultType string).
-	AuthSource any `json:"authSource,omitempty"`
+	AuthSource any
 
 	// The authentication type to be used to connect to the MongoDB database.
-	AuthenticationType *MongoDbAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *MongoDbAuthenticationType
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false. Type: boolean (or
 	// Expression with resultType boolean).
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port number that the MongoDB server uses to listen for client connections. The default value is 27017. Type: integer
 	// (or Expression with resultType integer), minimum: 0.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Username for authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // MongoDbSource - A copy activity source for a MongoDB database.
 type MongoDbSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Should be a SQL-92 query expression. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MongoDbSource.
@@ -14242,35 +14242,35 @@ func (m *MongoDbSource) GetCopySource() *CopySource {
 // MongoDbV2CollectionDataset - The MongoDB database dataset.
 type MongoDbV2CollectionDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MongoDB database dataset properties.
-	TypeProperties *MongoDbV2CollectionDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MongoDbV2CollectionDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type MongoDbV2CollectionDataset.
@@ -14291,31 +14291,31 @@ func (m *MongoDbV2CollectionDataset) GetDataset() *Dataset {
 // MongoDbV2CollectionDatasetTypeProperties - MongoDB database dataset properties.
 type MongoDbV2CollectionDatasetTypeProperties struct {
 	// REQUIRED; The collection name of the MongoDB database. Type: string (or Expression with resultType string).
-	Collection any `json:"collection,omitempty"`
+	Collection any
 }
 
 // MongoDbV2LinkedService - Linked service for MongoDB data source.
 type MongoDbV2LinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MongoDB linked service properties.
-	TypeProperties *MongoDbV2LinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MongoDbV2LinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MongoDbV2LinkedService.
@@ -14334,16 +14334,16 @@ func (m *MongoDbV2LinkedService) GetLinkedService() *LinkedService {
 type MongoDbV2LinkedServiceTypeProperties struct {
 	// REQUIRED; The MongoDB connection string. Type: string, SecureString or AzureKeyVaultSecretReference. Type: string, SecureString
 	// or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// REQUIRED; The name of the MongoDB database that you want to access. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 }
 
 // MongoDbV2Source - A copy activity source for a MongoDB database.
 type MongoDbV2Source struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -14351,26 +14351,26 @@ type MongoDbV2Source struct {
 	// Specifies the number of documents to return in each batch of the response from MongoDB instance. In most cases, modifying
 	// the batch size will not affect the user or the application. This property's
 	// main purpose is to avoid hit the limitation of response size. Type: integer (or Expression with resultType integer).
-	BatchSize any `json:"batchSize,omitempty"`
+	BatchSize any
 
 	// Cursor methods for Mongodb query
-	CursorMethods *MongoDbCursorMethodsProperties `json:"cursorMethods,omitempty"`
+	CursorMethods *MongoDbCursorMethodsProperties
 
 	// Specifies selection filter using query operators. To return all documents in a collection, omit this parameter or pass
 	// an empty document ({}). Type: string (or Expression with resultType string).
-	Filter any `json:"filter,omitempty"`
+	Filter any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MongoDbV2Source.
@@ -14397,22 +14397,22 @@ type MultiplePipelineTriggerClassification interface {
 // MultiplePipelineTrigger - Base class for all triggers that support one to many model for trigger to pipeline.
 type MultiplePipelineTrigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Pipelines that need to be started.
-	Pipelines []*TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines []*TriggerPipelineReference
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type MultiplePipelineTrigger.
@@ -14432,25 +14432,25 @@ func (m *MultiplePipelineTrigger) GetTrigger() *Trigger {
 // MySQLLinkedService - Linked service for MySQL data source.
 type MySQLLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; MySQL linked service properties.
-	TypeProperties *MySQLLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MySQLLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type MySQLLinkedService.
@@ -14468,38 +14468,38 @@ func (m *MySQLLinkedService) GetLinkedService() *LinkedService {
 // MySQLLinkedServiceTypeProperties - MySQL linked service properties.
 type MySQLLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 }
 
 // MySQLSource - A copy activity source for MySQL databases.
 type MySQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type MySQLSource.
@@ -14528,35 +14528,35 @@ func (m *MySQLSource) GetTabularSource() *TabularSource {
 // MySQLTableDataset - The MySQL table dataset.
 type MySQLTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// MySQL table dataset properties.
-	TypeProperties *MySQLTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *MySQLTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type MySQLTableDataset.
@@ -14577,31 +14577,31 @@ func (m *MySQLTableDataset) GetDataset() *Dataset {
 // MySQLTableDatasetTypeProperties - MySql table dataset properties.
 type MySQLTableDatasetTypeProperties struct {
 	// The MySQL table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // NetezzaLinkedService - Netezza linked service.
 type NetezzaLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Netezza linked service properties.
-	TypeProperties *NetezzaLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *NetezzaLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type NetezzaLinkedService.
@@ -14619,59 +14619,59 @@ func (n *NetezzaLinkedService) GetLinkedService() *LinkedService {
 // NetezzaLinkedServiceTypeProperties - Netezza linked service properties.
 type NetezzaLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // NetezzaPartitionSettings - The settings that will be leveraged for Netezza source partitioning.
 type NetezzaPartitionSettings struct {
 	// The name of the column in integer type that will be used for proceeding range partitioning. Type: string (or Expression
 	// with resultType string).
-	PartitionColumnName any `json:"partitionColumnName,omitempty"`
+	PartitionColumnName any
 
 	// The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionLowerBound any `json:"partitionLowerBound,omitempty"`
+	PartitionLowerBound any
 
 	// The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionUpperBound any `json:"partitionUpperBound,omitempty"`
+	PartitionUpperBound any
 }
 
 // NetezzaSource - A copy activity Netezza source.
 type NetezzaSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The partition mechanism that will be used for Netezza read in parallel.
-	PartitionOption *NetezzaPartitionOption `json:"partitionOption,omitempty"`
+	PartitionOption *NetezzaPartitionOption
 
 	// The settings that will be leveraged for Netezza source partitioning.
-	PartitionSettings *NetezzaPartitionSettings `json:"partitionSettings,omitempty"`
+	PartitionSettings *NetezzaPartitionSettings
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type NetezzaSource.
@@ -14700,35 +14700,35 @@ func (n *NetezzaSource) GetTabularSource() *TabularSource {
 // NetezzaTableDataset - Netezza dataset.
 type NetezzaTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *NetezzaTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *NetezzaTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type NetezzaTableDataset.
@@ -14749,82 +14749,82 @@ func (n *NetezzaTableDataset) GetDataset() *Dataset {
 // NetezzaTableDatasetTypeProperties - Netezza dataset properties.
 type NetezzaTableDatasetTypeProperties struct {
 	// The schema name of the Netezza. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Netezza. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // Notebook.
 type Notebook struct {
 	// REQUIRED; Array of cells of the current notebook.
-	Cells []*NotebookCell `json:"cells,omitempty"`
+	Cells []*NotebookCell
 
 	// REQUIRED; Notebook root-level metadata.
-	Metadata *NotebookMetadata `json:"metadata,omitempty"`
+	Metadata *NotebookMetadata
 
 	// REQUIRED; Notebook format (major number). Incremented between backwards incompatible changes to the notebook format.
-	Nbformat *int32 `json:"nbformat,omitempty"`
+	Nbformat *int32
 
 	// REQUIRED; Notebook format (minor number). Incremented for backward compatible changes to the notebook format.
-	NbformatMinor *int32 `json:"nbformat_minor,omitempty"`
+	NbformatMinor *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Big data pool reference.
-	BigDataPool *BigDataPoolReference `json:"bigDataPool,omitempty"`
+	BigDataPool *BigDataPoolReference
 
 	// The description of the notebook.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Session properties.
-	SessionProperties *NotebookSessionProperties `json:"sessionProperties,omitempty"`
+	SessionProperties *NotebookSessionProperties
 }
 
 // NotebookCell - Notebook cell.
 type NotebookCell struct {
 	// REQUIRED; String identifying the type of cell.
-	CellType *string `json:"cell_type,omitempty"`
+	CellType *string
 
 	// REQUIRED; Cell-level metadata.
-	Metadata any `json:"metadata,omitempty"`
+	Metadata any
 
 	// REQUIRED; Contents of the cell, represented as an array of lines.
-	Source []*string `json:"source,omitempty"`
+	Source []*string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Attachments associated with the cell.
-	Attachments any `json:"attachments,omitempty"`
+	Attachments any
 
 	// Cell-level output items.
-	Outputs []*NotebookCellOutputItem `json:"outputs,omitempty"`
+	Outputs []*NotebookCellOutputItem
 }
 
 // NotebookCellOutputItem - An item of the notebook cell execution output.
 type NotebookCellOutputItem struct {
 	// REQUIRED; Execution, display, or stream outputs.
-	OutputType *CellOutputType `json:"output_type,omitempty"`
+	OutputType *CellOutputType
 
 	// Output data. Use MIME type as key, and content as value.
-	Data any `json:"data,omitempty"`
+	Data any
 
 	// Execution sequence number.
-	ExecutionCount *int32 `json:"execution_count,omitempty"`
+	ExecutionCount *int32
 
 	// Metadata for the output item.
-	Metadata any `json:"metadata,omitempty"`
+	Metadata any
 
 	// For output_type=stream, determines the name of stream (stdout / stderr).
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// For output_type=stream, the stream's text output, represented as a string or an array of strings.
-	Text any `json:"text,omitempty"`
+	Text any
 }
 
 // NotebookClientBeginCreateOrUpdateNotebookOptions contains the optional parameters for the NotebookClient.BeginCreateOrUpdateNotebook
@@ -14871,10 +14871,10 @@ type NotebookClientGetNotebooksByWorkspaceOptions struct {
 // NotebookKernelSpec - Kernel information.
 type NotebookKernelSpec struct {
 	// REQUIRED; Name to display in UI.
-	DisplayName *string `json:"display_name,omitempty"`
+	DisplayName *string
 
 	// REQUIRED; Name of the kernel specification.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -14883,22 +14883,22 @@ type NotebookKernelSpec struct {
 // NotebookLanguageInfo - Language info.
 type NotebookLanguageInfo struct {
 	// REQUIRED; The programming language which this kernel runs.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The codemirror mode to use for code in this language.
-	CodemirrorMode *string `json:"codemirror_mode,omitempty"`
+	CodemirrorMode *string
 }
 
 // NotebookListResponse - A list of Notebook resources.
 type NotebookListResponse struct {
 	// REQUIRED; List of Notebooks.
-	Value []*NotebookResource `json:"value,omitempty"`
+	Value []*NotebookResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // NotebookMetadata - Notebook root-level metadata.
@@ -14907,70 +14907,70 @@ type NotebookMetadata struct {
 	AdditionalProperties map[string]any
 
 	// Kernel information.
-	Kernelspec *NotebookKernelSpec `json:"kernelspec,omitempty"`
+	Kernelspec *NotebookKernelSpec
 
 	// Language info.
-	LanguageInfo *NotebookLanguageInfo `json:"language_info,omitempty"`
+	LanguageInfo *NotebookLanguageInfo
 }
 
 // NotebookResource - Notebook resource type.
 type NotebookResource struct {
 	// REQUIRED; The name of the resource
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Properties of Notebook.
-	Properties *Notebook `json:"properties,omitempty"`
+	Properties *Notebook
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // NotebookSessionProperties - Session properties.
 type NotebookSessionProperties struct {
 	// REQUIRED; Number of cores to use for the driver.
-	DriverCores *int32 `json:"driverCores,omitempty"`
+	DriverCores *int32
 
 	// REQUIRED; Amount of memory to use for the driver process.
-	DriverMemory *string `json:"driverMemory,omitempty"`
+	DriverMemory *string
 
 	// REQUIRED; Number of cores to use for each executor.
-	ExecutorCores *int32 `json:"executorCores,omitempty"`
+	ExecutorCores *int32
 
 	// REQUIRED; Amount of memory to use per executor process.
-	ExecutorMemory *string `json:"executorMemory,omitempty"`
+	ExecutorMemory *string
 
 	// REQUIRED; Number of executors to launch for this session.
-	NumExecutors *int32 `json:"numExecutors,omitempty"`
+	NumExecutors *int32
 }
 
 // ODataLinkedService - Open Data Protocol (OData) linked service.
 type ODataLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; OData linked service properties.
-	TypeProperties *ODataLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ODataLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ODataLinkedService.
@@ -14988,80 +14988,80 @@ func (o *ODataLinkedService) GetLinkedService() *LinkedService {
 // ODataLinkedServiceTypeProperties - OData linked service properties.
 type ODataLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of the OData service endpoint. Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// Specify the resource you are requesting authorization to use Directory. Type: string (or Expression with resultType string).
-	AADResourceID any `json:"aadResourceId,omitempty"`
+	AADResourceID any
 
 	// Specify the credential type (key or cert) is used for service principal.
-	AADServicePrincipalCredentialType *ODataAADServicePrincipalCredentialType `json:"aadServicePrincipalCredentialType,omitempty"`
+	AADServicePrincipalCredentialType *ODataAADServicePrincipalCredentialType
 
 	// Type of authentication used to connect to the OData service.
-	AuthenticationType *ODataAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *ODataAuthenticationType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password of the OData service.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Specify the base64 encoded certificate of your application registered in Azure Active Directory. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalEmbeddedCert SecretBaseClassification `json:"servicePrincipalEmbeddedCert,omitempty"`
+	ServicePrincipalEmbeddedCert SecretBaseClassification
 
 	// Specify the password of your certificate if your certificate has a password and you are using AadServicePrincipal authentication.
 	// Type: string (or Expression with resultType string).
-	ServicePrincipalEmbeddedCertPassword SecretBaseClassification `json:"servicePrincipalEmbeddedCertPassword,omitempty"`
+	ServicePrincipalEmbeddedCertPassword SecretBaseClassification
 
 	// Specify the application id of your application registered in Azure Active Directory. Type: string (or Expression with resultType
 	// string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// Specify the secret of your application registered in Azure Active Directory. Type: string (or Expression with resultType
 	// string).
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// Specify the tenant information (domain name or tenant ID) under which your application resides. Type: string (or Expression
 	// with resultType string).
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// User name of the OData service. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // ODataResourceDataset - The Open Data Protocol (OData) resource dataset.
 type ODataResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// OData dataset properties.
-	TypeProperties *ODataResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ODataResourceDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ODataResourceDataset.
@@ -15082,28 +15082,28 @@ func (o *ODataResourceDataset) GetDataset() *Dataset {
 // ODataResourceDatasetTypeProperties - OData dataset properties.
 type ODataResourceDatasetTypeProperties struct {
 	// The OData resource path. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // ODataSource - A copy activity source for OData source.
 type ODataSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// OData query. For example, "$top=1". Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ODataSource.
@@ -15120,25 +15120,25 @@ func (o *ODataSource) GetCopySource() *CopySource {
 // OdbcLinkedService - Open Database Connectivity (ODBC) linked service.
 type OdbcLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; ODBC linked service properties.
-	TypeProperties *OdbcLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OdbcLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type OdbcLinkedService.
@@ -15157,51 +15157,51 @@ func (o *OdbcLinkedService) GetLinkedService() *LinkedService {
 type OdbcLinkedServiceTypeProperties struct {
 	// REQUIRED; The non-access credential portion of the connection string as well as an optional encrypted credential. Type:
 	// string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// Type of authentication used to connect to the ODBC data store. Possible values are: Anonymous and Basic. Type: string (or
 	// Expression with resultType string).
-	AuthenticationType any `json:"authenticationType,omitempty"`
+	AuthenticationType any
 
 	// The access credential portion of the connection string specified in driver-specific property-value format.
-	Credential SecretBaseClassification `json:"credential,omitempty"`
+	Credential SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// User name for Basic authentication. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // OdbcSink - A copy activity ODBC sink.
 type OdbcSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to execute before starting the copy. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type OdbcSink.
@@ -15220,25 +15220,25 @@ func (o *OdbcSink) GetCopySink() *CopySink {
 // OdbcSource - A copy activity source for ODBC databases.
 type OdbcSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type OdbcSource.
@@ -15267,35 +15267,35 @@ func (o *OdbcSource) GetTabularSource() *TabularSource {
 // OdbcTableDataset - The ODBC table dataset.
 type OdbcTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// ODBC table dataset properties.
-	TypeProperties *OdbcTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OdbcTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type OdbcTableDataset.
@@ -15316,41 +15316,41 @@ func (o *OdbcTableDataset) GetDataset() *Dataset {
 // OdbcTableDatasetTypeProperties - ODBC table dataset properties.
 type OdbcTableDatasetTypeProperties struct {
 	// The ODBC table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // Office365Dataset - The Office365 account.
 type Office365Dataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Office365 dataset properties.
-	TypeProperties *Office365DatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *Office365DatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type Office365Dataset.
@@ -15371,35 +15371,35 @@ func (o *Office365Dataset) GetDataset() *Dataset {
 // Office365DatasetTypeProperties - Office365 dataset properties.
 type Office365DatasetTypeProperties struct {
 	// REQUIRED; Name of the dataset to extract from Office 365. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 
 	// A predicate expression that can be used to filter the specific rows to extract from Office 365. Type: string (or Expression
 	// with resultType string).
-	Predicate any `json:"predicate,omitempty"`
+	Predicate any
 }
 
 // Office365LinkedService - Office365 linked service.
 type Office365LinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Office365 linked service properties.
-	TypeProperties *Office365LinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *Office365LinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type Office365LinkedService.
@@ -15417,58 +15417,58 @@ func (o *Office365LinkedService) GetLinkedService() *LinkedService {
 // Office365LinkedServiceTypeProperties - Office365 linked service properties.
 type Office365LinkedServiceTypeProperties struct {
 	// REQUIRED; Azure tenant ID to which the Office 365 account belongs. Type: string (or Expression with resultType string).
-	Office365TenantID any `json:"office365TenantId,omitempty"`
+	Office365TenantID any
 
 	// REQUIRED; Specify the application's client ID. Type: string (or Expression with resultType string).
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// REQUIRED; Specify the application's key.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// REQUIRED; Specify the tenant information under which your Azure AD web application resides. Type: string (or Expression
 	// with resultType string).
-	ServicePrincipalTenantID any `json:"servicePrincipalTenantId,omitempty"`
+	ServicePrincipalTenantID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 }
 
 // Office365Source - A copy activity source for an Office 365 service.
 type Office365Source struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The groups containing all the users. Type: array of strings (or Expression with resultType array of strings).
-	AllowedGroups any `json:"allowedGroups,omitempty"`
+	AllowedGroups any
 
 	// The Column to apply the and . Type: string (or Expression with resultType string).
-	DateFilterColumn any `json:"dateFilterColumn,omitempty"`
+	DateFilterColumn any
 
 	// End time of the requested range for this dataset. Type: string (or Expression with resultType string).
-	EndTime any `json:"endTime,omitempty"`
+	EndTime any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The columns to be read out from the Office 365 table. Type: array of objects (or Expression with resultType array of objects).
 	// Example: [ { "name": "Id" }, { "name": "CreatedDateTime" } ]
-	OutputColumns any `json:"outputColumns,omitempty"`
+	OutputColumns any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Start time of the requested range for this dataset. Type: string (or Expression with resultType string).
-	StartTime any `json:"startTime,omitempty"`
+	StartTime any
 
 	// The user scope uri. Type: string (or Expression with resultType string).
-	UserScopeFilterURI any `json:"userScopeFilterUri,omitempty"`
+	UserScopeFilterURI any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type Office365Source.
@@ -15485,34 +15485,34 @@ func (o *Office365Source) GetCopySource() *CopySource {
 // OperationResult - Operation status for the operation
 type OperationResult struct {
 	// Error data
-	Error *CloudErrorBodyAutoGenerated `json:"error,omitempty"`
+	Error *CloudErrorBodyAutoGenerated
 
 	// READ-ONLY; Operation status
-	Status *string `json:"status,omitempty" azure:"ro"`
+	Status *string
 }
 
 // OracleLinkedService - Oracle database.
 type OracleLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Oracle database linked service properties.
-	TypeProperties *OracleLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OracleLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type OracleLinkedService.
@@ -15530,56 +15530,56 @@ func (o *OracleLinkedService) GetLinkedService() *LinkedService {
 // OracleLinkedServiceTypeProperties - Oracle database linked service properties.
 type OracleLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 }
 
 // OraclePartitionSettings - The settings that will be leveraged for Oracle source partitioning.
 type OraclePartitionSettings struct {
 	// The name of the column in integer type that will be used for proceeding range partitioning. Type: string (or Expression
 	// with resultType string).
-	PartitionColumnName any `json:"partitionColumnName,omitempty"`
+	PartitionColumnName any
 
 	// The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionLowerBound any `json:"partitionLowerBound,omitempty"`
+	PartitionLowerBound any
 
 	// Names of the physical partitions of Oracle table.
-	PartitionNames any `json:"partitionNames,omitempty"`
+	PartitionNames any
 
 	// The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionUpperBound any `json:"partitionUpperBound,omitempty"`
+	PartitionUpperBound any
 }
 
 // OracleServiceCloudLinkedService - Oracle Service Cloud linked service.
 type OracleServiceCloudLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Oracle Service Cloud linked service properties.
-	TypeProperties *OracleServiceCloudLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OracleServiceCloudLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type OracleServiceCloudLinkedService.
@@ -15597,64 +15597,64 @@ func (o *OracleServiceCloudLinkedService) GetLinkedService() *LinkedService {
 // OracleServiceCloudLinkedServiceTypeProperties - Oracle Service Cloud linked service properties.
 type OracleServiceCloudLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of the Oracle Service Cloud instance.
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// REQUIRED; The password corresponding to the user name that you provided in the username key.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// REQUIRED; The user name that you use to access Oracle Service Cloud server.
-	Username any `json:"username,omitempty"`
+	Username any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true. Type: boolean (or Expression
 	// with resultType boolean).
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true. Type: boolean (or Expression with
 	// resultType boolean).
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true. Type: boolean
 	// (or Expression with resultType boolean).
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // OracleServiceCloudObjectDataset - Oracle Service Cloud dataset.
 type OracleServiceCloudObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type OracleServiceCloudObjectDataset.
@@ -15675,25 +15675,25 @@ func (o *OracleServiceCloudObjectDataset) GetDataset() *Dataset {
 // OracleServiceCloudSource - A copy activity Oracle Service Cloud source.
 type OracleServiceCloudSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type OracleServiceCloudSource.
@@ -15722,28 +15722,28 @@ func (o *OracleServiceCloudSource) GetTabularSource() *TabularSource {
 // OracleSink - A copy activity Oracle sink.
 type OracleSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type OracleSink.
@@ -15762,31 +15762,31 @@ func (o *OracleSink) GetCopySink() *CopySink {
 // OracleSource - A copy activity Oracle source.
 type OracleSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Oracle reader query. Type: string (or Expression with resultType string).
-	OracleReaderQuery any `json:"oracleReaderQuery,omitempty"`
+	OracleReaderQuery any
 
 	// The partition mechanism that will be used for Oracle read in parallel.
-	PartitionOption *OraclePartitionOption `json:"partitionOption,omitempty"`
+	PartitionOption *OraclePartitionOption
 
 	// The settings that will be leveraged for Oracle source partitioning.
-	PartitionSettings *OraclePartitionSettings `json:"partitionSettings,omitempty"`
+	PartitionSettings *OraclePartitionSettings
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type OracleSource.
@@ -15803,35 +15803,35 @@ func (o *OracleSource) GetCopySource() *CopySource {
 // OracleTableDataset - The on-premises Oracle database dataset.
 type OracleTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// On-premises Oracle dataset properties.
-	TypeProperties *OracleTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OracleTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type OracleTableDataset.
@@ -15852,47 +15852,47 @@ func (o *OracleTableDataset) GetDataset() *Dataset {
 // OracleTableDatasetTypeProperties - On-premises Oracle dataset properties.
 type OracleTableDatasetTypeProperties struct {
 	// The schema name of the on-premises Oracle database. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the on-premises Oracle database. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // OrcDataset - ORC dataset.
 type OrcDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// ORC dataset properties.
-	TypeProperties *OrcDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *OrcDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type OrcDataset.
@@ -15913,23 +15913,23 @@ func (o *OrcDataset) GetDataset() *Dataset {
 // OrcDatasetTypeProperties - ORC dataset properties.
 type OrcDatasetTypeProperties struct {
 	// REQUIRED; The location of the ORC data storage.
-	Location            DatasetLocationClassification `json:"location,omitempty"`
-	OrcCompressionCodec *OrcCompressionCodec          `json:"orcCompressionCodec,omitempty"`
+	Location            DatasetLocationClassification
+	OrcCompressionCodec *OrcCompressionCodec
 }
 
 // OrcFormat - The data stored in Optimized Row Columnar (ORC) format.
 type OrcFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type OrcFormat.
@@ -15945,28 +15945,28 @@ func (o *OrcFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // OrcSink - A copy activity ORC sink.
 type OrcSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// ORC store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type OrcSink.
@@ -15985,22 +15985,22 @@ func (o *OrcSink) GetCopySink() *CopySink {
 // OrcSource - A copy activity ORC source.
 type OrcSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// ORC store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type OrcSource.
@@ -16017,44 +16017,44 @@ func (o *OrcSource) GetCopySource() *CopySource {
 // ParameterSpecification - Definition of a single parameter for an entity.
 type ParameterSpecification struct {
 	// REQUIRED; Parameter type.
-	Type *ParameterType `json:"type,omitempty"`
+	Type *ParameterType
 
 	// Default value of parameter.
-	DefaultValue any `json:"defaultValue,omitempty"`
+	DefaultValue any
 }
 
 // ParquetDataset - Parquet dataset.
 type ParquetDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Parquet dataset properties.
-	TypeProperties *ParquetDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ParquetDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ParquetDataset.
@@ -16075,23 +16075,23 @@ func (p *ParquetDataset) GetDataset() *Dataset {
 // ParquetDatasetTypeProperties - Parquet dataset properties.
 type ParquetDatasetTypeProperties struct {
 	// REQUIRED; The location of the parquet storage.
-	Location         DatasetLocationClassification `json:"location,omitempty"`
-	CompressionCodec *ParquetCompressionCodec      `json:"compressionCodec,omitempty"`
+	Location         DatasetLocationClassification
+	CompressionCodec *ParquetCompressionCodec
 }
 
 // ParquetFormat - The data stored in Parquet format.
 type ParquetFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type ParquetFormat.
@@ -16107,28 +16107,28 @@ func (p *ParquetFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // ParquetSink - A copy activity Parquet sink.
 type ParquetSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Parquet store settings.
-	StoreSettings StoreWriteSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreWriteSettingsClassification
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type ParquetSink.
@@ -16147,22 +16147,22 @@ func (p *ParquetSink) GetCopySink() *CopySink {
 // ParquetSource - A copy activity Parquet source.
 type ParquetSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Parquet store settings.
-	StoreSettings StoreReadSettingsClassification `json:"storeSettings,omitempty"`
+	StoreSettings StoreReadSettingsClassification
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ParquetSource.
@@ -16179,25 +16179,25 @@ func (p *ParquetSource) GetCopySource() *CopySource {
 // PaypalLinkedService - Paypal Service linked service.
 type PaypalLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Paypal Service linked service properties.
-	TypeProperties *PaypalLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PaypalLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type PaypalLinkedService.
@@ -16215,61 +16215,61 @@ func (p *PaypalLinkedService) GetLinkedService() *LinkedService {
 // PaypalLinkedServiceTypeProperties - Paypal Service linked service properties.
 type PaypalLinkedServiceTypeProperties struct {
 	// REQUIRED; The client ID associated with your PayPal application.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; The URL of the PayPal instance. (i.e. api.sandbox.paypal.com)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The client secret associated with your PayPal application.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // PaypalObjectDataset - Paypal Service dataset.
 type PaypalObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type PaypalObjectDataset.
@@ -16290,25 +16290,25 @@ func (p *PaypalObjectDataset) GetDataset() *Dataset {
 // PaypalSource - A copy activity Paypal Service source.
 type PaypalSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type PaypalSource.
@@ -16337,37 +16337,37 @@ func (p *PaypalSource) GetTabularSource() *TabularSource {
 // PhoenixDatasetTypeProperties - Phoenix Dataset Properties
 type PhoenixDatasetTypeProperties struct {
 	// The schema name of the Phoenix. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Phoenix. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // PhoenixLinkedService - Phoenix server linked service.
 type PhoenixLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Phoenix server linked service properties.
-	TypeProperties *PhoenixLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PhoenixLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type PhoenixLinkedService.
@@ -16385,80 +16385,80 @@ func (p *PhoenixLinkedService) GetLinkedService() *LinkedService {
 // PhoenixLinkedServiceTypeProperties - Phoenix server linked service properties.
 type PhoenixLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication mechanism used to connect to the Phoenix server.
-	AuthenticationType *PhoenixAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *PhoenixAuthenticationType
 
 	// REQUIRED; The IP address or host name of the Phoenix server. (i.e. 192.168.222.160)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The partial URL corresponding to the Phoenix server. (i.e. /gateway/sandbox/phoenix/version). The default value is hbasephoenix
 	// if using WindowsAzureHDInsightService.
-	HTTPPath any `json:"httpPath,omitempty"`
+	HTTPPath any
 
 	// The password corresponding to the user name.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the Phoenix server uses to listen for client connections. The default value is 8765.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 
 	// The user name used to connect to the Phoenix server.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // PhoenixObjectDataset - Phoenix server dataset.
 type PhoenixObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *PhoenixDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PhoenixDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type PhoenixObjectDataset.
@@ -16479,25 +16479,25 @@ func (p *PhoenixObjectDataset) GetDataset() *Dataset {
 // PhoenixSource - A copy activity Phoenix server source.
 type PhoenixSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type PhoenixSource.
@@ -16526,28 +16526,28 @@ func (p *PhoenixSource) GetTabularSource() *TabularSource {
 // Pipeline - A workspace pipeline.
 type Pipeline struct {
 	// List of activities in pipeline.
-	Activities []ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification
 
 	// List of tags that can be used for describing the Pipeline.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The max number of concurrent runs for the pipeline.
-	Concurrency *int32 `json:"concurrency,omitempty"`
+	Concurrency *int32
 
 	// The description of the pipeline.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Pipeline is in. If not specified, Pipeline will appear at the root level.
-	Folder *PipelineFolder `json:"folder,omitempty"`
+	Folder *PipelineFolder
 
 	// List of parameters for pipeline.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Dimensions emitted by Pipeline.
-	RunDimensions map[string]any `json:"runDimensions,omitempty"`
+	RunDimensions map[string]any
 
 	// List of variables for pipeline.
-	Variables map[string]*VariableSpecification `json:"variables,omitempty"`
+	Variables map[string]*VariableSpecification
 }
 
 // PipelineClientBeginCreateOrUpdatePipelineOptions contains the optional parameters for the PipelineClient.BeginCreateOrUpdatePipeline
@@ -16601,49 +16601,49 @@ type PipelineClientGetPipelinesByWorkspaceOptions struct {
 // PipelineFolder - The folder that this Pipeline is in. If not specified, Pipeline will appear at the root level.
 type PipelineFolder struct {
 	// The name of the folder that this Pipeline is in.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // PipelineListResponse - A list of pipeline resources.
 type PipelineListResponse struct {
 	// REQUIRED; List of pipelines.
-	Value []*PipelineResource `json:"value,omitempty"`
+	Value []*PipelineResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // PipelineReference - Pipeline reference type.
 type PipelineReference struct {
 	// REQUIRED; Reference pipeline name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Pipeline reference type.
-	Type *PipelineReferenceType `json:"type,omitempty"`
+	Type *PipelineReferenceType
 
 	// Reference name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // PipelineResource - Pipeline resource type.
 type PipelineResource struct {
 	// REQUIRED; Properties of the pipeline.
-	Properties *Pipeline `json:"properties,omitempty"`
+	Properties *Pipeline
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PipelineRun - Information about a pipeline run.
@@ -16652,40 +16652,40 @@ type PipelineRun struct {
 	AdditionalProperties map[string]any
 
 	// READ-ONLY; The duration of a pipeline run.
-	DurationInMs *int32 `json:"durationInMs,omitempty" azure:"ro"`
+	DurationInMs *int32
 
 	// READ-ONLY; Entity that started the pipeline run.
-	InvokedBy *PipelineRunInvokedBy `json:"invokedBy,omitempty" azure:"ro"`
+	InvokedBy *PipelineRunInvokedBy
 
 	// READ-ONLY; Indicates if the recovered pipeline run is the latest in its group.
-	IsLatest *bool `json:"isLatest,omitempty" azure:"ro"`
+	IsLatest *bool
 
 	// READ-ONLY; The last updated timestamp for the pipeline run event in ISO8601 format.
-	LastUpdated *time.Time `json:"lastUpdated,omitempty" azure:"ro"`
+	LastUpdated *time.Time
 
 	// READ-ONLY; The message from a pipeline run.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 
 	// READ-ONLY; The full or partial list of parameter name, value pair used in the pipeline run.
-	Parameters map[string]*string `json:"parameters,omitempty" azure:"ro"`
+	Parameters map[string]*string
 
 	// READ-ONLY; The pipeline name.
-	PipelineName *string `json:"pipelineName,omitempty" azure:"ro"`
+	PipelineName *string
 
 	// READ-ONLY; The end time of a pipeline run in ISO8601 format.
-	RunEnd *time.Time `json:"runEnd,omitempty" azure:"ro"`
+	RunEnd *time.Time
 
 	// READ-ONLY; Identifier that correlates all the recovery runs of a pipeline run.
-	RunGroupID *string `json:"runGroupId,omitempty" azure:"ro"`
+	RunGroupID *string
 
 	// READ-ONLY; Identifier of a run.
-	RunID *string `json:"runId,omitempty" azure:"ro"`
+	RunID *string
 
 	// READ-ONLY; The start time of a pipeline run in ISO8601 format.
-	RunStart *time.Time `json:"runStart,omitempty" azure:"ro"`
+	RunStart *time.Time
 
 	// READ-ONLY; The status of a pipeline run.
-	Status *string `json:"status,omitempty" azure:"ro"`
+	Status *string
 }
 
 // PipelineRunClientCancelPipelineRunOptions contains the optional parameters for the PipelineRunClient.CancelPipelineRun
@@ -16715,22 +16715,22 @@ type PipelineRunClientQueryPipelineRunsByWorkspaceOptions struct {
 // PipelineRunInvokedBy - Provides entity name and id that started the pipeline run.
 type PipelineRunInvokedBy struct {
 	// READ-ONLY; The ID of the entity that started the run.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The type of the entity that started the run.
-	InvokedByType *string `json:"invokedByType,omitempty" azure:"ro"`
+	InvokedByType *string
 
 	// READ-ONLY; Name of the entity that started the pipeline run.
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 }
 
 // PipelineRunsQueryResponse - A list pipeline runs.
 type PipelineRunsQueryResponse struct {
 	// REQUIRED; List of pipeline runs.
-	Value []*PipelineRun `json:"value,omitempty"`
+	Value []*PipelineRun
 
 	// The continuation token for getting the next page of results, if any remaining results exist, null otherwise.
-	ContinuationToken *string `json:"continuationToken,omitempty"`
+	ContinuationToken *string
 }
 
 // PolybaseSettings - PolyBase settings.
@@ -16740,42 +16740,42 @@ type PolybaseSettings struct {
 
 	// Determines the number of rows to attempt to retrieve before the PolyBase recalculates the percentage of rejected rows.
 	// Type: integer (or Expression with resultType integer), minimum: 0.
-	RejectSampleValue any `json:"rejectSampleValue,omitempty"`
+	RejectSampleValue any
 
 	// Reject type.
-	RejectType *PolybaseSettingsRejectType `json:"rejectType,omitempty"`
+	RejectType *PolybaseSettingsRejectType
 
 	// Specifies the value or the percentage of rows that can be rejected before the query fails. Type: number (or Expression
 	// with resultType number), minimum: 0.
-	RejectValue any `json:"rejectValue,omitempty"`
+	RejectValue any
 
 	// Specifies how to handle missing values in delimited text files when PolyBase retrieves data from the text file. Type: boolean
 	// (or Expression with resultType boolean).
-	UseTypeDefault any `json:"useTypeDefault,omitempty"`
+	UseTypeDefault any
 }
 
 // PostgreSQLLinkedService - Linked service for PostgreSQL data source.
 type PostgreSQLLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; PostgreSQL linked service properties.
-	TypeProperties *PostgreSQLLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PostgreSQLLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type PostgreSQLLinkedService.
@@ -16793,38 +16793,38 @@ func (p *PostgreSQLLinkedService) GetLinkedService() *LinkedService {
 // PostgreSQLLinkedServiceTypeProperties - PostgreSQL linked service properties.
 type PostgreSQLLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Password *AzureKeyVaultSecretReference `json:"password,omitempty"`
+	Password *AzureKeyVaultSecretReference
 }
 
 // PostgreSQLSource - A copy activity source for PostgreSQL databases.
 type PostgreSQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type PostgreSQLSource.
@@ -16853,35 +16853,35 @@ func (p *PostgreSQLSource) GetTabularSource() *TabularSource {
 // PostgreSQLTableDataset - The PostgreSQL table dataset.
 type PostgreSQLTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// PostgreSQL table dataset properties.
-	TypeProperties *PostgreSQLTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PostgreSQLTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type PostgreSQLTableDataset.
@@ -16902,49 +16902,49 @@ func (p *PostgreSQLTableDataset) GetDataset() *Dataset {
 // PostgreSQLTableDatasetTypeProperties - PostgreSQL table dataset properties.
 type PostgreSQLTableDatasetTypeProperties struct {
 	// The PostgreSQL schema name. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The PostgreSQL table name. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // PrestoDatasetTypeProperties - Presto Dataset Properties
 type PrestoDatasetTypeProperties struct {
 	// The schema name of the Presto. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Presto. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // PrestoLinkedService - Presto server linked service.
 type PrestoLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Presto server linked service properties.
-	TypeProperties *PrestoLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PrestoLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type PrestoLinkedService.
@@ -16962,86 +16962,86 @@ func (p *PrestoLinkedService) GetLinkedService() *LinkedService {
 // PrestoLinkedServiceTypeProperties - Presto server linked service properties.
 type PrestoLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication mechanism used to connect to the Presto server.
-	AuthenticationType *PrestoAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *PrestoAuthenticationType
 
 	// REQUIRED; The catalog context for all request against the server.
-	Catalog any `json:"catalog,omitempty"`
+	Catalog any
 
 	// REQUIRED; The IP address or host name of the Presto server. (i.e. 192.168.222.160)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// REQUIRED; The version of the Presto server. (i.e. 0.148-t)
-	ServerVersion any `json:"serverVersion,omitempty"`
+	ServerVersion any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port that the Presto server uses to listen for client connections. The default value is 8080.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// The local time zone used by the connection. Valid values for this option are specified in the IANA Time Zone Database.
 	// The default value is the system time zone.
-	TimeZoneID any `json:"timeZoneID,omitempty"`
+	TimeZoneID any
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 
 	// The user name used to connect to the Presto server.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // PrestoObjectDataset - Presto server dataset.
 type PrestoObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *PrestoDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *PrestoDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type PrestoObjectDataset.
@@ -17062,25 +17062,25 @@ func (p *PrestoObjectDataset) GetDataset() *Dataset {
 // PrestoSource - A copy activity Presto server source.
 type PrestoSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type PrestoSource.
@@ -17109,98 +17109,98 @@ func (p *PrestoSource) GetTabularSource() *TabularSource {
 // PrivateEndpoint - Private endpoint details
 type PrivateEndpoint struct {
 	// READ-ONLY; Resource id of the private endpoint.
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 }
 
 // PrivateEndpointConnection - A private endpoint connection
 type PrivateEndpointConnection struct {
 	// Private endpoint connection properties.
-	Properties *PrivateEndpointConnectionProperties `json:"properties,omitempty"`
+	Properties *PrivateEndpointConnectionProperties
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PrivateEndpointConnectionProperties - Properties of a private endpoint connection.
 type PrivateEndpointConnectionProperties struct {
 	// The private endpoint which the connection belongs to.
-	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty"`
+	PrivateEndpoint *PrivateEndpoint
 
 	// Connection state of the private endpoint connection.
-	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState `json:"privateLinkServiceConnectionState,omitempty"`
+	PrivateLinkServiceConnectionState *PrivateLinkServiceConnectionState
 
 	// READ-ONLY; Provisioning state of the private endpoint connection.
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 }
 
 // PrivateLinkServiceConnectionState - Connection state details of the private endpoint
 type PrivateLinkServiceConnectionState struct {
 	// The private link service connection description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The private link service connection status.
-	Status *string `json:"status,omitempty"`
+	Status *string
 
 	// READ-ONLY; The actions required for private link service connection.
-	ActionsRequired *string `json:"actionsRequired,omitempty" azure:"ro"`
+	ActionsRequired *string
 }
 
 // ProxyResource - The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a
 // location
 type ProxyResource struct {
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // PurviewConfiguration - Purview Configuration
 type PurviewConfiguration struct {
 	// Purview Resource ID
-	PurviewResourceID *string `json:"purviewResourceId,omitempty"`
+	PurviewResourceID *string
 }
 
 // QueryDataFlowDebugSessionsResponse - A list of active debug sessions.
 type QueryDataFlowDebugSessionsResponse struct {
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// Array with all active debug sessions.
-	Value []*DataFlowDebugSessionInfo `json:"value,omitempty"`
+	Value []*DataFlowDebugSessionInfo
 }
 
 // QuickBooksLinkedService - QuickBooks server linked service.
 type QuickBooksLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; QuickBooks server linked service properties.
-	TypeProperties *QuickBooksLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *QuickBooksLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type QuickBooksLinkedService.
@@ -17218,63 +17218,63 @@ func (q *QuickBooksLinkedService) GetLinkedService() *LinkedService {
 // QuickBooksLinkedServiceTypeProperties - QuickBooks server linked service properties.
 type QuickBooksLinkedServiceTypeProperties struct {
 	// REQUIRED; The access token for OAuth 1.0 authentication.
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// REQUIRED; The access token secret for OAuth 1.0 authentication.
-	AccessTokenSecret SecretBaseClassification `json:"accessTokenSecret,omitempty"`
+	AccessTokenSecret SecretBaseClassification
 
 	// REQUIRED; The company ID of the QuickBooks company to authorize.
-	CompanyID any `json:"companyId,omitempty"`
+	CompanyID any
 
 	// REQUIRED; The consumer key for OAuth 1.0 authentication.
-	ConsumerKey any `json:"consumerKey,omitempty"`
+	ConsumerKey any
 
 	// REQUIRED; The consumer secret for OAuth 1.0 authentication.
-	ConsumerSecret SecretBaseClassification `json:"consumerSecret,omitempty"`
+	ConsumerSecret SecretBaseClassification
 
 	// REQUIRED; The endpoint of the QuickBooks server. (i.e. quickbooks.api.intuit.com)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 }
 
 // QuickBooksObjectDataset - QuickBooks server dataset.
 type QuickBooksObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type QuickBooksObjectDataset.
@@ -17295,25 +17295,25 @@ func (q *QuickBooksObjectDataset) GetDataset() *Dataset {
 // QuickBooksSource - A copy activity QuickBooks server source.
 type QuickBooksSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type QuickBooksSource.
@@ -17345,19 +17345,19 @@ type RecurrenceSchedule struct {
 	AdditionalProperties map[string]any
 
 	// The hours.
-	Hours []*int32 `json:"hours,omitempty"`
+	Hours []*int32
 
 	// The minutes.
-	Minutes []*int32 `json:"minutes,omitempty"`
+	Minutes []*int32
 
 	// The month days.
-	MonthDays []*int32 `json:"monthDays,omitempty"`
+	MonthDays []*int32
 
 	// The monthly occurrences.
-	MonthlyOccurrences []*RecurrenceScheduleOccurrence `json:"monthlyOccurrences,omitempty"`
+	MonthlyOccurrences []*RecurrenceScheduleOccurrence
 
 	// The days of the week.
-	WeekDays []*DayOfWeek `json:"weekDays,omitempty"`
+	WeekDays []*DayOfWeek
 }
 
 // RecurrenceScheduleOccurrence - The recurrence schedule occurrence.
@@ -17366,10 +17366,10 @@ type RecurrenceScheduleOccurrence struct {
 	AdditionalProperties map[string]any
 
 	// The day of the week.
-	Day *DayOfWeek `json:"day,omitempty"`
+	Day *DayOfWeek
 
 	// The occurrence.
-	Occurrence *int32 `json:"occurrence,omitempty"`
+	Occurrence *int32
 }
 
 // RedirectIncompatibleRowSettings - Redirect incompatible row settings
@@ -17377,13 +17377,13 @@ type RedirectIncompatibleRowSettings struct {
 	// REQUIRED; Name of the Azure Storage, Storage SAS, or Azure Data Lake Store linked service used for redirecting incompatible
 	// row. Must be specified if redirectIncompatibleRowSettings is specified. Type: string
 	// (or Expression with resultType string).
-	LinkedServiceName any `json:"linkedServiceName,omitempty"`
+	LinkedServiceName any
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The path for storing the redirect incompatible row data. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // RedshiftUnloadSettings - The Amazon S3 settings needed for the interim Amazon S3 when copying from Amazon Redshift with
@@ -17393,32 +17393,32 @@ type RedshiftUnloadSettings struct {
 	// REQUIRED; The bucket of the interim Amazon S3 which will be used to store the unloaded data from Amazon Redshift source.
 	// The bucket must be in the same region as the Amazon Redshift source. Type: string (or
 	// Expression with resultType string).
-	BucketName any `json:"bucketName,omitempty"`
+	BucketName any
 
 	// REQUIRED; The name of the Amazon S3 linked service which will be used for the unload operation when copying from the Amazon
 	// Redshift source.
-	S3LinkedServiceName *LinkedServiceReference `json:"s3LinkedServiceName,omitempty"`
+	S3LinkedServiceName *LinkedServiceReference
 }
 
 // RelationalSource - A copy activity source for various relational databases.
 type RelationalSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type RelationalSource.
@@ -17435,35 +17435,35 @@ func (r *RelationalSource) GetCopySource() *CopySource {
 // RelationalTableDataset - The relational table dataset.
 type RelationalTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Relational table dataset properties.
-	TypeProperties *RelationalTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *RelationalTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type RelationalTableDataset.
@@ -17484,56 +17484,56 @@ func (r *RelationalTableDataset) GetDataset() *Dataset {
 // RelationalTableDatasetTypeProperties - Relational table dataset properties.
 type RelationalTableDatasetTypeProperties struct {
 	// The relational table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // RerunTriggerListResponse - A list of rerun triggers.
 type RerunTriggerListResponse struct {
 	// REQUIRED; List of rerun triggers.
-	Value []*RerunTriggerResource `json:"value,omitempty"`
+	Value []*RerunTriggerResource
 
 	// READ-ONLY; The continuation token for getting the next page of results, if any remaining results exist, null otherwise.
-	NextLink *string `json:"nextLink,omitempty" azure:"ro"`
+	NextLink *string
 }
 
 // RerunTriggerResource - RerunTrigger resource type.
 type RerunTriggerResource struct {
 	// REQUIRED; Properties of the rerun trigger.
-	Properties *RerunTumblingWindowTrigger `json:"properties,omitempty"`
+	Properties *RerunTumblingWindowTrigger
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // RerunTumblingWindowTrigger - Trigger that schedules pipeline reruns for all fixed time interval windows from a requested
 // start time to requested end time.
 type RerunTumblingWindowTrigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Rerun Trigger properties.
-	TypeProperties *RerunTumblingWindowTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *RerunTumblingWindowTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetTrigger implements the TriggerClassification interface for type RerunTumblingWindowTrigger.
@@ -17550,64 +17550,64 @@ func (r *RerunTumblingWindowTrigger) GetTrigger() *Trigger {
 // RerunTumblingWindowTriggerActionParameters - Rerun tumbling window trigger Parameters.
 type RerunTumblingWindowTriggerActionParameters struct {
 	// REQUIRED; The end time for the time period for which restatement is initiated. Only UTC time is currently supported.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// REQUIRED; The max number of parallel time windows (ready for execution) for which a rerun is triggered.
-	MaxConcurrency *int32 `json:"maxConcurrency,omitempty"`
+	MaxConcurrency *int32
 
 	// REQUIRED; The start time for the time period for which restatement is initiated. Only UTC time is currently supported.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 }
 
 // RerunTumblingWindowTriggerTypeProperties - Rerun Trigger properties.
 type RerunTumblingWindowTriggerTypeProperties struct {
 	// REQUIRED; The max number of parallel time windows (ready for execution) for which a rerun is triggered.
-	MaxConcurrency *int32 `json:"maxConcurrency,omitempty"`
+	MaxConcurrency *int32
 
 	// REQUIRED; The end time for the time period for which restatement is initiated. Only UTC time is currently supported.
-	RequestedEndTime *time.Time `json:"requestedEndTime,omitempty"`
+	RequestedEndTime *time.Time
 
 	// REQUIRED; The start time for the time period for which restatement is initiated. Only UTC time is currently supported.
-	RequestedStartTime *time.Time `json:"requestedStartTime,omitempty"`
+	RequestedStartTime *time.Time
 
 	// The parent trigger reference.
-	ParentTrigger any `json:"parentTrigger,omitempty"`
+	ParentTrigger any
 }
 
 // Resource - Common fields that are returned in the response for all Azure Resource Manager resources
 type Resource struct {
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // ResponsysLinkedService - Responsys linked service.
 type ResponsysLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Responsys linked service properties.
-	TypeProperties *ResponsysLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ResponsysLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ResponsysLinkedService.
@@ -17625,64 +17625,64 @@ func (r *ResponsysLinkedService) GetLinkedService() *LinkedService {
 // ResponsysLinkedServiceTypeProperties - Responsys linked service properties.
 type ResponsysLinkedServiceTypeProperties struct {
 	// REQUIRED; The client ID associated with the Responsys application. Type: string (or Expression with resultType string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; The endpoint of the Responsys server.
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// The client secret associated with the Responsys application. Type: string (or Expression with resultType string).
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true. Type: boolean (or Expression
 	// with resultType boolean).
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true. Type: boolean (or Expression with
 	// resultType boolean).
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true. Type: boolean
 	// (or Expression with resultType boolean).
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // ResponsysObjectDataset - Responsys dataset.
 type ResponsysObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ResponsysObjectDataset.
@@ -17703,25 +17703,25 @@ func (r *ResponsysObjectDataset) GetDataset() *Dataset {
 // ResponsysSource - A copy activity Responsys source.
 type ResponsysSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ResponsysSource.
@@ -17750,35 +17750,35 @@ func (r *ResponsysSource) GetTabularSource() *TabularSource {
 // RestResourceDataset - A Rest service dataset.
 type RestResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *RestResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *RestResourceDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type RestResourceDataset.
@@ -17799,43 +17799,43 @@ func (r *RestResourceDataset) GetDataset() *Dataset {
 // RestResourceDatasetTypeProperties - Properties specific to this dataset type.
 type RestResourceDatasetTypeProperties struct {
 	// The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string).
-	AdditionalHeaders any `json:"additionalHeaders,omitempty"`
+	AdditionalHeaders any
 
 	// The pagination rules to compose next page requests. Type: string (or Expression with resultType string).
-	PaginationRules any `json:"paginationRules,omitempty"`
+	PaginationRules any
 
 	// The relative URL to the resource that the RESTful API provides. Type: string (or Expression with resultType string).
-	RelativeURL any `json:"relativeUrl,omitempty"`
+	RelativeURL any
 
 	// The HTTP request body to the RESTful API if requestMethod is POST. Type: string (or Expression with resultType string).
-	RequestBody any `json:"requestBody,omitempty"`
+	RequestBody any
 
 	// The HTTP method used to call the RESTful API. The default is GET. Type: string (or Expression with resultType string).
-	RequestMethod any `json:"requestMethod,omitempty"`
+	RequestMethod any
 }
 
 // RestServiceLinkedService - Rest Service linked service.
 type RestServiceLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Rest Service linked service properties.
-	TypeProperties *RestServiceLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *RestServiceLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type RestServiceLinkedService.
@@ -17853,46 +17853,46 @@ func (r *RestServiceLinkedService) GetLinkedService() *LinkedService {
 // RestServiceLinkedServiceTypeProperties - Rest Service linked service properties.
 type RestServiceLinkedServiceTypeProperties struct {
 	// REQUIRED; Type of authentication used to connect to the REST service.
-	AuthenticationType *RestServiceAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *RestServiceAuthenticationType
 
 	// REQUIRED; The base URL of the REST service.
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// The resource you are requesting authorization to use.
-	AADResourceID any `json:"aadResourceId,omitempty"`
+	AADResourceID any
 
 	// Whether to validate server side SSL certificate when connecting to the endpoint.The default value is true. Type: boolean
 	// (or Expression with resultType boolean).
-	EnableServerCertificateValidation any `json:"enableServerCertificateValidation,omitempty"`
+	EnableServerCertificateValidation any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password used in Basic authentication type.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The application's client ID used in AadServicePrincipal authentication type.
-	ServicePrincipalID any `json:"servicePrincipalId,omitempty"`
+	ServicePrincipalID any
 
 	// The application's key used in AadServicePrincipal authentication type.
-	ServicePrincipalKey SecretBaseClassification `json:"servicePrincipalKey,omitempty"`
+	ServicePrincipalKey SecretBaseClassification
 
 	// The tenant information (domain name or tenant ID) used in AadServicePrincipal authentication type under which your application
 	// resides.
-	Tenant any `json:"tenant,omitempty"`
+	Tenant any
 
 	// The user name used in Basic authentication type.
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // RestSource - A copy activity Rest service source.
 type RestSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// The additional HTTP headers in the request to the RESTful API. Type: string (or Expression with resultType string).
-	AdditionalHeaders any `json:"additionalHeaders,omitempty"`
+	AdditionalHeaders any
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -17900,28 +17900,28 @@ type RestSource struct {
 	// The timeout (TimeSpan) to get an HTTP response. It is the timeout to get a response, not the timeout to read response data.
 	// Default value: 00:01:40. Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	HTTPRequestTimeout any `json:"httpRequestTimeout,omitempty"`
+	HTTPRequestTimeout any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The pagination rules to compose next page requests. Type: string (or Expression with resultType string).
-	PaginationRules any `json:"paginationRules,omitempty"`
+	PaginationRules any
 
 	// The HTTP request body to the RESTful API if requestMethod is POST. Type: string (or Expression with resultType string).
-	RequestBody any `json:"requestBody,omitempty"`
+	RequestBody any
 
 	// The time to await before sending next page request.
-	RequestInterval any `json:"requestInterval,omitempty"`
+	RequestInterval any
 
 	// The HTTP method used to call the RESTful API. The default is GET. Type: string (or Expression with resultType string).
-	RequestMethod any `json:"requestMethod,omitempty"`
+	RequestMethod any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type RestSource.
@@ -17938,28 +17938,28 @@ func (r *RestSource) GetCopySource() *CopySource {
 // RetryPolicy - Execution policy for an activity.
 type RetryPolicy struct {
 	// Maximum ordinary retry attempts. Default is 0. Type: integer (or Expression with resultType integer), minimum: 0.
-	Count any `json:"count,omitempty"`
+	Count any
 
 	// Interval between retries in seconds. Default is 30.
-	IntervalInSeconds *int32 `json:"intervalInSeconds,omitempty"`
+	IntervalInSeconds *int32
 }
 
 // RunFilterParameters - Query parameters for listing runs.
 type RunFilterParameters struct {
 	// REQUIRED; The time at or after which the run event was updated in 'ISO 8601' format.
-	LastUpdatedAfter *time.Time `json:"lastUpdatedAfter,omitempty"`
+	LastUpdatedAfter *time.Time
 
 	// REQUIRED; The time at or before which the run event was updated in 'ISO 8601' format.
-	LastUpdatedBefore *time.Time `json:"lastUpdatedBefore,omitempty"`
+	LastUpdatedBefore *time.Time
 
 	// The continuation token for getting the next page of results. Null for first page.
-	ContinuationToken *string `json:"continuationToken,omitempty"`
+	ContinuationToken *string
 
 	// List of filters.
-	Filters []*RunQueryFilter `json:"filters,omitempty"`
+	Filters []*RunQueryFilter
 
 	// List of OrderBy option.
-	OrderBy []*RunQueryOrderBy `json:"orderBy,omitempty"`
+	OrderBy []*RunQueryOrderBy
 }
 
 // RunQueryFilter - Query filter option for listing runs.
@@ -17967,46 +17967,46 @@ type RunQueryFilter struct {
 	// REQUIRED; Parameter name to be used for filter. The allowed operands to query pipeline runs are PipelineName, RunStart,
 	// RunEnd and Status; to query activity runs are ActivityName, ActivityRunStart,
 	// ActivityRunEnd, ActivityType and Status, and to query trigger runs are TriggerName, TriggerRunTimestamp and Status.
-	Operand *RunQueryFilterOperand `json:"operand,omitempty"`
+	Operand *RunQueryFilterOperand
 
 	// REQUIRED; Operator to be used for filter.
-	Operator *RunQueryFilterOperator `json:"operator,omitempty"`
+	Operator *RunQueryFilterOperator
 
 	// REQUIRED; List of filter values.
-	Values []*string `json:"values,omitempty"`
+	Values []*string
 }
 
 // RunQueryOrderBy - An object to provide order by options for listing runs.
 type RunQueryOrderBy struct {
 	// REQUIRED; Sorting order of the parameter.
-	Order *RunQueryOrder `json:"order,omitempty"`
+	Order *RunQueryOrder
 
 	// REQUIRED; Parameter name to be used for order by. The allowed parameters to order by for pipeline runs are PipelineName,
 	// RunStart, RunEnd and Status; for activity runs are ActivityName, ActivityRunStart,
 	// ActivityRunEnd and Status; for trigger runs are TriggerName, TriggerRunTimestamp and Status.
-	OrderBy *RunQueryOrderByField `json:"orderBy,omitempty"`
+	OrderBy *RunQueryOrderByField
 }
 
 // SKU - SQL pool SKU
 type SKU struct {
 	// If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the
 	// resource this may be omitted.
-	Capacity *int32 `json:"capacity,omitempty"`
+	Capacity *int32
 
 	// The SKU name
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The service tier
-	Tier *string `json:"tier,omitempty"`
+	Tier *string
 }
 
 // SQLConnection - The connection used to execute the SQL script.
 type SQLConnection struct {
 	// REQUIRED; The identifier of the connection.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The type of the connection.
-	Type *SQLConnectionType `json:"type,omitempty"`
+	Type *SQLConnectionType
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -18015,45 +18015,45 @@ type SQLConnection struct {
 // SQLDWSink - A copy activity SQL Data Warehouse sink.
 type SQLDWSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Indicates to use Copy Command to copy data into SQL Data Warehouse. Type: boolean (or Expression with resultType boolean).
-	AllowCopyCommand any `json:"allowCopyCommand,omitempty"`
+	AllowCopyCommand any
 
 	// Indicates to use PolyBase to copy data into SQL Data Warehouse when applicable. Type: boolean (or Expression with resultType
 	// boolean).
-	AllowPolyBase any `json:"allowPolyBase,omitempty"`
+	AllowPolyBase any
 
 	// Specifies Copy Command related settings when allowCopyCommand is true.
-	CopyCommandSettings *DWCopyCommandSettings `json:"copyCommandSettings,omitempty"`
+	CopyCommandSettings *DWCopyCommandSettings
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Specifies PolyBase-related settings when allowPolyBase is true.
-	PolyBaseSettings *PolybaseSettings `json:"polyBaseSettings,omitempty"`
+	PolyBaseSettings *PolybaseSettings
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression
 	// with resultType string).
-	TableOption any `json:"tableOption,omitempty"`
+	TableOption any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SQLDWSink.
@@ -18072,33 +18072,33 @@ func (s *SQLDWSink) GetCopySink() *CopySink {
 // SQLDWSource - A copy activity SQL Data Warehouse source.
 type SQLDWSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// SQL Data Warehouse reader query. Type: string (or Expression with resultType string).
-	SQLReaderQuery any `json:"sqlReaderQuery,omitempty"`
+	SQLReaderQuery any
 
 	// Name of the stored procedure for a SQL Data Warehouse source. This cannot be used at the same time as SqlReaderQuery. Type:
 	// string (or Expression with resultType string).
-	SQLReaderStoredProcedureName any `json:"sqlReaderStoredProcedureName,omitempty"`
+	SQLReaderStoredProcedureName any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}". Type: object
 	// (or Expression with resultType object), itemType: StoredProcedureParameter.
-	StoredProcedureParameters any `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SQLDWSource.
@@ -18127,44 +18127,44 @@ func (s *SQLDWSource) GetTabularSource() *TabularSource {
 // SQLMISink - A copy activity Azure SQL Managed Instance sink.
 type SQLMISink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// SQL writer stored procedure name. Type: string (or Expression with resultType string).
-	SQLWriterStoredProcedureName any `json:"sqlWriterStoredProcedureName,omitempty"`
+	SQLWriterStoredProcedureName any
 
 	// SQL writer table type. Type: string (or Expression with resultType string).
-	SQLWriterTableType any `json:"sqlWriterTableType,omitempty"`
+	SQLWriterTableType any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
-	StoredProcedureTableTypeParameterName any `json:"storedProcedureTableTypeParameterName,omitempty"`
+	StoredProcedureTableTypeParameterName any
 
 	// The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression
 	// with resultType string).
-	TableOption any `json:"tableOption,omitempty"`
+	TableOption any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SQLMISink.
@@ -18183,35 +18183,35 @@ func (s *SQLMISink) GetCopySink() *CopySink {
 // SQLMISource - A copy activity Azure SQL Managed Instance source.
 type SQLMISource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Which additional types to produce.
-	ProduceAdditionalTypes any `json:"produceAdditionalTypes,omitempty"`
+	ProduceAdditionalTypes any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// SQL reader query. Type: string (or Expression with resultType string).
-	SQLReaderQuery any `json:"sqlReaderQuery,omitempty"`
+	SQLReaderQuery any
 
 	// Name of the stored procedure for a Azure SQL Managed Instance source. This cannot be used at the same time as SqlReaderQuery.
 	// Type: string (or Expression with resultType string).
-	SQLReaderStoredProcedureName any `json:"sqlReaderStoredProcedureName,omitempty"`
+	SQLReaderStoredProcedureName any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SQLMISource.
@@ -18240,100 +18240,100 @@ func (s *SQLMISource) GetTabularSource() *TabularSource {
 // SQLPool - A SQL Analytics pool
 type SQLPool struct {
 	// REQUIRED; The geo-location where the resource lives
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// SQL pool properties
-	Properties *SQLPoolResourceProperties `json:"properties,omitempty"`
+	Properties *SQLPoolResourceProperties
 
 	// SQL pool SKU
-	SKU *SKU `json:"sku,omitempty"`
+	SKU *SKU
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SQLPoolInfoListResult - List of SQL pools
 type SQLPoolInfoListResult struct {
 	// Link to the next page of results
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 
 	// List of SQL pools
-	Value []*SQLPool `json:"value,omitempty"`
+	Value []*SQLPool
 }
 
 // SQLPoolReference - SQL pool reference type.
 type SQLPoolReference struct {
 	// REQUIRED; Reference SQL pool name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; SQL pool reference type.
-	Type *SQLPoolReferenceType `json:"type,omitempty"`
+	Type *SQLPoolReferenceType
 }
 
 // SQLPoolResourceProperties - Properties of a SQL Analytics pool
 type SQLPoolResourceProperties struct {
 	// Collation mode
-	Collation *string `json:"collation,omitempty"`
+	Collation *string
 
 	// What is this?
-	CreateMode *string `json:"createMode,omitempty"`
+	CreateMode *string
 
 	// Date the SQL pool was created
-	CreationDate *time.Time `json:"creationDate,omitempty"`
+	CreationDate *time.Time
 
 	// Maximum size in bytes
-	MaxSizeBytes *int64 `json:"maxSizeBytes,omitempty"`
+	MaxSizeBytes *int64
 
 	// Resource state
-	ProvisioningState *string `json:"provisioningState,omitempty"`
+	ProvisioningState *string
 
 	// Backup database to restore from
-	RecoverableDatabaseID *string `json:"recoverableDatabaseId,omitempty"`
+	RecoverableDatabaseID *string
 
 	// Snapshot time to restore
-	RestorePointInTime *string `json:"restorePointInTime,omitempty"`
+	RestorePointInTime *string
 
 	// Source database to create from
-	SourceDatabaseID *string `json:"sourceDatabaseId,omitempty"`
+	SourceDatabaseID *string
 
 	// Resource status
-	Status *string `json:"status,omitempty"`
+	Status *string
 }
 
 // SQLPoolStoredProcedureActivity - Execute SQL pool stored procedure activity.
 type SQLPoolStoredProcedureActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; SQL pool stored procedure reference.
-	SQLPool *SQLPoolReference `json:"sqlPool,omitempty"`
+	SQLPool *SQLPoolReference
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute SQL pool stored procedure activity properties.
-	TypeProperties *SQLPoolStoredProcedureActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SQLPoolStoredProcedureActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SQLPoolStoredProcedureActivity.
@@ -18351,10 +18351,10 @@ func (s *SQLPoolStoredProcedureActivity) GetActivity() *Activity {
 // SQLPoolStoredProcedureActivityTypeProperties - SQL stored procedure activity properties.
 type SQLPoolStoredProcedureActivityTypeProperties struct {
 	// REQUIRED; Stored procedure name. Type: string (or Expression with resultType string).
-	StoredProcedureName any `json:"storedProcedureName,omitempty"`
+	StoredProcedureName any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // SQLPoolsClientGetOptions contains the optional parameters for the SQLPoolsClient.Get method.
@@ -18370,16 +18370,16 @@ type SQLPoolsClientListOptions struct {
 // SQLScript - SQL script.
 type SQLScript struct {
 	// REQUIRED; The content of the SQL script.
-	Content *SQLScriptContent `json:"content,omitempty"`
+	Content *SQLScriptContent
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The description of the SQL script.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The type of the SQL script.
-	Type *SQLScriptType `json:"type,omitempty"`
+	Type *SQLScriptType
 }
 
 // SQLScriptClientBeginCreateOrUpdateSQLScriptOptions contains the optional parameters for the SQLScriptClient.BeginCreateOrUpdateSQLScript
@@ -18422,16 +18422,16 @@ type SQLScriptClientGetSQLScriptsByWorkspaceOptions struct {
 // SQLScriptContent - The content of the SQL script.
 type SQLScriptContent struct {
 	// REQUIRED; The connection used to execute the SQL script.
-	CurrentConnection *SQLConnection `json:"currentConnection,omitempty"`
+	CurrentConnection *SQLConnection
 
 	// REQUIRED; SQL query to execute.
-	Query *string `json:"query,omitempty"`
+	Query *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The metadata of the SQL script.
-	Metadata *SQLScriptMetadata `json:"metadata,omitempty"`
+	Metadata *SQLScriptMetadata
 }
 
 // SQLScriptMetadata - The metadata of the SQL script.
@@ -18440,58 +18440,58 @@ type SQLScriptMetadata struct {
 	AdditionalProperties map[string]any
 
 	// The language of the SQL script.
-	Language *string `json:"language,omitempty"`
+	Language *string
 }
 
 // SQLScriptResource - Sql Script resource type.
 type SQLScriptResource struct {
 	// REQUIRED; The name of the resource
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Properties of sql script.
-	Properties *SQLScript `json:"properties,omitempty"`
+	Properties *SQLScript
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource Id for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The type of the resource. Ex- Microsoft.Compute/virtualMachines or Microsoft.Storage/storageAccounts.
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SQLScriptsListResponse - A list of sql scripts resources.
 type SQLScriptsListResponse struct {
 	// REQUIRED; List of sql scripts.
-	Value []*SQLScriptResource `json:"value,omitempty"`
+	Value []*SQLScriptResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // SQLServerLinkedService - SQL Server linked service.
 type SQLServerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SQL Server linked service properties.
-	TypeProperties *SQLServerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SQLServerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SQLServerLinkedService.
@@ -18509,60 +18509,60 @@ func (s *SQLServerLinkedService) GetLinkedService() *LinkedService {
 // SQLServerLinkedServiceTypeProperties - SQL Server linked service properties.
 type SQLServerLinkedServiceTypeProperties struct {
 	// REQUIRED; The connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The on-premises Windows authentication password.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The on-premises Windows authentication user name. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SQLServerSink - A copy activity SQL server sink.
 type SQLServerSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// SQL writer stored procedure name. Type: string (or Expression with resultType string).
-	SQLWriterStoredProcedureName any `json:"sqlWriterStoredProcedureName,omitempty"`
+	SQLWriterStoredProcedureName any
 
 	// SQL writer table type. Type: string (or Expression with resultType string).
-	SQLWriterTableType any `json:"sqlWriterTableType,omitempty"`
+	SQLWriterTableType any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
-	StoredProcedureTableTypeParameterName any `json:"storedProcedureTableTypeParameterName,omitempty"`
+	StoredProcedureTableTypeParameterName any
 
 	// The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression
 	// with resultType string).
-	TableOption any `json:"tableOption,omitempty"`
+	TableOption any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SQLServerSink.
@@ -18581,35 +18581,35 @@ func (s *SQLServerSink) GetCopySink() *CopySink {
 // SQLServerSource - A copy activity SQL server source.
 type SQLServerSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Which additional types to produce.
-	ProduceAdditionalTypes any `json:"produceAdditionalTypes,omitempty"`
+	ProduceAdditionalTypes any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// SQL reader query. Type: string (or Expression with resultType string).
-	SQLReaderQuery any `json:"sqlReaderQuery,omitempty"`
+	SQLReaderQuery any
 
 	// Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string
 	// (or Expression with resultType string).
-	SQLReaderStoredProcedureName any `json:"sqlReaderStoredProcedureName,omitempty"`
+	SQLReaderStoredProcedureName any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SQLServerSource.
@@ -18638,31 +18638,31 @@ func (s *SQLServerSource) GetTabularSource() *TabularSource {
 // SQLServerStoredProcedureActivity - SQL stored procedure activity type.
 type SQLServerStoredProcedureActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SQL stored procedure activity properties.
-	TypeProperties *SQLServerStoredProcedureActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SQLServerStoredProcedureActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SQLServerStoredProcedureActivity.
@@ -18694,44 +18694,44 @@ func (s *SQLServerStoredProcedureActivity) GetExecutionActivity() *ExecutionActi
 // SQLServerStoredProcedureActivityTypeProperties - SQL stored procedure activity properties.
 type SQLServerStoredProcedureActivityTypeProperties struct {
 	// REQUIRED; Stored procedure name. Type: string (or Expression with resultType string).
-	StoredProcedureName any `json:"storedProcedureName,omitempty"`
+	StoredProcedureName any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // SQLServerTableDataset - The on-premises SQL Server dataset.
 type SQLServerTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// On-premises SQL Server dataset properties.
-	TypeProperties *SQLServerTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SQLServerTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SQLServerTableDataset.
@@ -18752,56 +18752,56 @@ func (s *SQLServerTableDataset) GetDataset() *Dataset {
 // SQLServerTableDatasetTypeProperties - On-premises SQL Server dataset properties.
 type SQLServerTableDatasetTypeProperties struct {
 	// The schema name of the SQL Server dataset. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the SQL Server dataset. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // SQLSink - A copy activity SQL sink.
 type SQLSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SQL pre-copy script. Type: string (or Expression with resultType string).
-	PreCopyScript any `json:"preCopyScript,omitempty"`
+	PreCopyScript any
 
 	// SQL writer stored procedure name. Type: string (or Expression with resultType string).
-	SQLWriterStoredProcedureName any `json:"sqlWriterStoredProcedureName,omitempty"`
+	SQLWriterStoredProcedureName any
 
 	// SQL writer table type. Type: string (or Expression with resultType string).
-	SQLWriterTableType any `json:"sqlWriterTableType,omitempty"`
+	SQLWriterTableType any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// SQL stored procedure parameters.
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 
 	// The stored procedure parameter name of the table type. Type: string (or Expression with resultType string).
-	StoredProcedureTableTypeParameterName any `json:"storedProcedureTableTypeParameterName,omitempty"`
+	StoredProcedureTableTypeParameterName any
 
 	// The option to handle sink table, such as autoCreate. For now only 'autoCreate' value is supported. Type: string (or Expression
 	// with resultType string).
-	TableOption any `json:"tableOption,omitempty"`
+	TableOption any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SQLSink.
@@ -18820,32 +18820,32 @@ func (s *SQLSink) GetCopySink() *CopySink {
 // SQLSource - A copy activity SQL source.
 type SQLSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// SQL reader query. Type: string (or Expression with resultType string).
-	SQLReaderQuery any `json:"sqlReaderQuery,omitempty"`
+	SQLReaderQuery any
 
 	// Name of the stored procedure for a SQL Database source. This cannot be used at the same time as SqlReaderQuery. Type: string
 	// (or Expression with resultType string).
-	SQLReaderStoredProcedureName any `json:"sqlReaderStoredProcedureName,omitempty"`
+	SQLReaderStoredProcedureName any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 
 	// Value and type setting for stored procedure parameters. Example: "{Parameter1: {value: "1", type: "int"}}".
-	StoredProcedureParameters map[string]*StoredProcedureParameter `json:"storedProcedureParameters,omitempty"`
+	StoredProcedureParameters map[string]*StoredProcedureParameter
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SQLSource.
@@ -18874,137 +18874,137 @@ func (s *SQLSource) GetTabularSource() *TabularSource {
 // SSISAccessCredential - SSIS access credential.
 type SSISAccessCredential struct {
 	// REQUIRED; Domain for windows authentication.
-	Domain any `json:"domain,omitempty"`
+	Domain any
 
 	// REQUIRED; Password for windows authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// REQUIRED; UseName for windows authentication.
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SSISChildPackage - SSIS embedded child package.
 type SSISChildPackage struct {
 	// REQUIRED; Content for embedded child package. Type: string (or Expression with resultType string).
-	PackageContent any `json:"packageContent,omitempty"`
+	PackageContent any
 
 	// REQUIRED; Path for embedded child package. Type: string (or Expression with resultType string).
-	PackagePath any `json:"packagePath,omitempty"`
+	PackagePath any
 
 	// Last modified date for embedded child package.
-	PackageLastModifiedDate *string `json:"packageLastModifiedDate,omitempty"`
+	PackageLastModifiedDate *string
 
 	// Name for embedded child package.
-	PackageName *string `json:"packageName,omitempty"`
+	PackageName *string
 }
 
 // SSISExecutionCredential - SSIS package execution credential.
 type SSISExecutionCredential struct {
 	// REQUIRED; Domain for windows authentication.
-	Domain any `json:"domain,omitempty"`
+	Domain any
 
 	// REQUIRED; Password for windows authentication.
-	Password *SecureString `json:"password,omitempty"`
+	Password *SecureString
 
 	// REQUIRED; UseName for windows authentication.
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SSISExecutionParameter - SSIS execution parameter.
 type SSISExecutionParameter struct {
 	// REQUIRED; SSIS package execution parameter value. Type: string (or Expression with resultType string).
-	Value any `json:"value,omitempty"`
+	Value any
 }
 
 // SSISLogLocation - SSIS package execution log location
 type SSISLogLocation struct {
 	// REQUIRED; The SSIS package execution log path. Type: string (or Expression with resultType string).
-	LogPath any `json:"logPath,omitempty"`
+	LogPath any
 
 	// REQUIRED; The type of SSIS log location.
-	Type *SsisLogLocationType `json:"type,omitempty"`
+	Type *SsisLogLocationType
 
 	// REQUIRED; SSIS package execution log location properties.
-	TypeProperties *SSISLogLocationTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SSISLogLocationTypeProperties
 }
 
 // SSISLogLocationTypeProperties - SSIS package execution log location properties.
 type SSISLogLocationTypeProperties struct {
 	// The package execution log access credential.
-	AccessCredential *SSISAccessCredential `json:"accessCredential,omitempty"`
+	AccessCredential *SSISAccessCredential
 
 	// Specifies the interval to refresh log. The default interval is 5 minutes. Type: string (or Expression with resultType string),
 	// pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	LogRefreshInterval any `json:"logRefreshInterval,omitempty"`
+	LogRefreshInterval any
 }
 
 // SSISPackageLocation - SSIS package location.
 type SSISPackageLocation struct {
 	// The SSIS package path. Type: string (or Expression with resultType string).
-	PackagePath any `json:"packagePath,omitempty"`
+	PackagePath any
 
 	// The type of SSIS package location.
-	Type *SsisPackageLocationType `json:"type,omitempty"`
+	Type *SsisPackageLocationType
 
 	// SSIS package location properties.
-	TypeProperties *SSISPackageLocationTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SSISPackageLocationTypeProperties
 }
 
 // SSISPackageLocationTypeProperties - SSIS package location properties.
 type SSISPackageLocationTypeProperties struct {
 	// The package access credential.
-	AccessCredential *SSISAccessCredential `json:"accessCredential,omitempty"`
+	AccessCredential *SSISAccessCredential
 
 	// The embedded child package list.
-	ChildPackages []*SSISChildPackage `json:"childPackages,omitempty"`
+	ChildPackages []*SSISChildPackage
 
 	// The configuration file of the package execution. Type: string (or Expression with resultType string).
-	ConfigurationPath any `json:"configurationPath,omitempty"`
+	ConfigurationPath any
 
 	// The embedded package content. Type: string (or Expression with resultType string).
-	PackageContent any `json:"packageContent,omitempty"`
+	PackageContent any
 
 	// The embedded package last modified date.
-	PackageLastModifiedDate *string `json:"packageLastModifiedDate,omitempty"`
+	PackageLastModifiedDate *string
 
 	// The package name.
-	PackageName *string `json:"packageName,omitempty"`
+	PackageName *string
 
 	// Password of the package.
-	PackagePassword SecretBaseClassification `json:"packagePassword,omitempty"`
+	PackagePassword SecretBaseClassification
 }
 
 // SSISPropertyOverride - SSIS property override.
 type SSISPropertyOverride struct {
 	// REQUIRED; SSIS package property override value. Type: string (or Expression with resultType string).
-	Value any `json:"value,omitempty"`
+	Value any
 
 	// Whether SSIS package property override value is sensitive data. Value will be encrypted in SSISDB if it is true
-	IsSensitive *bool `json:"isSensitive,omitempty"`
+	IsSensitive *bool
 }
 
 // SalesforceLinkedService - Linked service for Salesforce.
 type SalesforceLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Salesforce linked service properties.
-	TypeProperties *SalesforceLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SalesforceLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SalesforceLinkedService.
@@ -19023,45 +19023,45 @@ func (s *SalesforceLinkedService) GetLinkedService() *LinkedService {
 type SalesforceLinkedServiceTypeProperties struct {
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The URL of Salesforce instance. Default is 'https://login.salesforce.com'. To copy data from sandbox, specify 'https://test.salesforce.com'.
 	// To copy data from custom domain, specify, for example,
 	// 'https://[domain].my.salesforce.com'. Type: string (or Expression with resultType string).
-	EnvironmentURL any `json:"environmentUrl,omitempty"`
+	EnvironmentURL any
 
 	// The password for Basic authentication of the Salesforce instance.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The security token is required to remotely access Salesforce instance.
-	SecurityToken SecretBaseClassification `json:"securityToken,omitempty"`
+	SecurityToken SecretBaseClassification
 
 	// The username for Basic authentication of the Salesforce instance. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // SalesforceMarketingCloudLinkedService - Salesforce Marketing Cloud linked service.
 type SalesforceMarketingCloudLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Salesforce Marketing Cloud linked service properties.
-	TypeProperties *SalesforceMarketingCloudLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SalesforceMarketingCloudLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SalesforceMarketingCloudLinkedService.
@@ -19080,62 +19080,62 @@ func (s *SalesforceMarketingCloudLinkedService) GetLinkedService() *LinkedServic
 type SalesforceMarketingCloudLinkedServiceTypeProperties struct {
 	// REQUIRED; The client ID associated with the Salesforce Marketing Cloud application. Type: string (or Expression with resultType
 	// string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The client secret associated with the Salesforce Marketing Cloud application. Type: string (or Expression with resultType
 	// string).
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true. Type: boolean (or Expression
 	// with resultType boolean).
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true. Type: boolean (or Expression with
 	// resultType boolean).
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true. Type: boolean
 	// (or Expression with resultType boolean).
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // SalesforceMarketingCloudObjectDataset - Salesforce Marketing Cloud dataset.
 type SalesforceMarketingCloudObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SalesforceMarketingCloudObjectDataset.
@@ -19156,25 +19156,25 @@ func (s *SalesforceMarketingCloudObjectDataset) GetDataset() *Dataset {
 // SalesforceMarketingCloudSource - A copy activity Salesforce Marketing Cloud source.
 type SalesforceMarketingCloudSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SalesforceMarketingCloudSource.
@@ -19203,35 +19203,35 @@ func (s *SalesforceMarketingCloudSource) GetTabularSource() *TabularSource {
 // SalesforceObjectDataset - The Salesforce object dataset.
 type SalesforceObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Salesforce object dataset properties.
-	TypeProperties *SalesforceObjectDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SalesforceObjectDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SalesforceObjectDataset.
@@ -19252,31 +19252,31 @@ func (s *SalesforceObjectDataset) GetDataset() *Dataset {
 // SalesforceObjectDatasetTypeProperties - Salesforce object dataset properties.
 type SalesforceObjectDatasetTypeProperties struct {
 	// The Salesforce object API name. Type: string (or Expression with resultType string).
-	ObjectAPIName any `json:"objectApiName,omitempty"`
+	ObjectAPIName any
 }
 
 // SalesforceServiceCloudLinkedService - Linked service for Salesforce Service Cloud.
 type SalesforceServiceCloudLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Salesforce Service Cloud linked service properties.
-	TypeProperties *SalesforceServiceCloudLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SalesforceServiceCloudLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SalesforceServiceCloudLinkedService.
@@ -19295,58 +19295,58 @@ func (s *SalesforceServiceCloudLinkedService) GetLinkedService() *LinkedService 
 type SalesforceServiceCloudLinkedServiceTypeProperties struct {
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The URL of Salesforce Service Cloud instance. Default is 'https://login.salesforce.com'. To copy data from sandbox, specify
 	// 'https://test.salesforce.com'. To copy data from custom domain, specify, for
 	// example, 'https://[domain].my.salesforce.com'. Type: string (or Expression with resultType string).
-	EnvironmentURL any `json:"environmentUrl,omitempty"`
+	EnvironmentURL any
 
 	// Extended properties appended to the connection string. Type: string (or Expression with resultType string).
-	ExtendedProperties any `json:"extendedProperties,omitempty"`
+	ExtendedProperties any
 
 	// The password for Basic authentication of the Salesforce instance.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The security token is required to remotely access Salesforce instance.
-	SecurityToken SecretBaseClassification `json:"securityToken,omitempty"`
+	SecurityToken SecretBaseClassification
 
 	// The username for Basic authentication of the Salesforce instance. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // SalesforceServiceCloudObjectDataset - The Salesforce Service Cloud object dataset.
 type SalesforceServiceCloudObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Salesforce Service Cloud object dataset properties.
-	TypeProperties *SalesforceServiceCloudObjectDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SalesforceServiceCloudObjectDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SalesforceServiceCloudObjectDataset.
@@ -19367,20 +19367,20 @@ func (s *SalesforceServiceCloudObjectDataset) GetDataset() *Dataset {
 // SalesforceServiceCloudObjectDatasetTypeProperties - Salesforce Service Cloud object dataset properties.
 type SalesforceServiceCloudObjectDatasetTypeProperties struct {
 	// The Salesforce Service Cloud object API name. Type: string (or Expression with resultType string).
-	ObjectAPIName any `json:"objectApiName,omitempty"`
+	ObjectAPIName any
 }
 
 // SalesforceServiceCloudSink - A copy activity Salesforce Service Cloud sink.
 type SalesforceServiceCloudSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The name of the external ID field for upsert operation. Default value is 'Id' column. Type: string (or Expression with
 	// resultType string).
-	ExternalIDFieldName any `json:"externalIdFieldName,omitempty"`
+	ExternalIDFieldName any
 
 	// The flag indicating whether or not to ignore null values from input dataset (except key fields) during write operation.
 	// Default value is false. If set it to true, it means ADF will leave the data in
@@ -19388,25 +19388,25 @@ type SalesforceServiceCloudSink struct {
 	// operation, versus ADF will update the data in the destination object to NULL when
 	// doing upsert/update operation and insert NULL value when doing insert operation. Type: boolean (or Expression with resultType
 	// boolean).
-	IgnoreNullValues any `json:"ignoreNullValues,omitempty"`
+	IgnoreNullValues any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// The write behavior for the operation. Default is Insert.
-	WriteBehavior *SalesforceSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *SalesforceSinkWriteBehavior
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SalesforceServiceCloudSink.
@@ -19425,25 +19425,25 @@ func (s *SalesforceServiceCloudSink) GetCopySink() *CopySink {
 // SalesforceServiceCloudSource - A copy activity Salesforce Service Cloud source.
 type SalesforceServiceCloudSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// The read behavior for the operation. Default is Query.
-	ReadBehavior *SalesforceSourceReadBehavior `json:"readBehavior,omitempty"`
+	ReadBehavior *SalesforceSourceReadBehavior
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SalesforceServiceCloudSource.
@@ -19460,14 +19460,14 @@ func (s *SalesforceServiceCloudSource) GetCopySource() *CopySource {
 // SalesforceSink - A copy activity Salesforce sink.
 type SalesforceSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The name of the external ID field for upsert operation. Default value is 'Id' column. Type: string (or Expression with
 	// resultType string).
-	ExternalIDFieldName any `json:"externalIdFieldName,omitempty"`
+	ExternalIDFieldName any
 
 	// The flag indicating whether or not to ignore null values from input dataset (except key fields) during write operation.
 	// Default value is false. If set it to true, it means ADF will leave the data in
@@ -19475,25 +19475,25 @@ type SalesforceSink struct {
 	// operation, versus ADF will update the data in the destination object to NULL when
 	// doing upsert/update operation and insert NULL value when doing insert operation. Type: boolean (or Expression with resultType
 	// boolean).
-	IgnoreNullValues any `json:"ignoreNullValues,omitempty"`
+	IgnoreNullValues any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// The write behavior for the operation. Default is Insert.
-	WriteBehavior *SalesforceSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *SalesforceSinkWriteBehavior
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SalesforceSink.
@@ -19512,28 +19512,28 @@ func (s *SalesforceSink) GetCopySink() *CopySink {
 // SalesforceSource - A copy activity Salesforce source.
 type SalesforceSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// The read behavior for the operation. Default is Query.
-	ReadBehavior *SalesforceSourceReadBehavior `json:"readBehavior,omitempty"`
+	ReadBehavior *SalesforceSourceReadBehavior
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SalesforceSource.
@@ -19562,25 +19562,25 @@ func (s *SalesforceSource) GetTabularSource() *TabularSource {
 // SapBWLinkedService - SAP Business Warehouse Linked Service.
 type SapBWLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *SapBWLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapBWLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapBWLinkedService.
@@ -19599,55 +19599,55 @@ func (s *SapBWLinkedService) GetLinkedService() *LinkedService {
 type SapBWLinkedServiceTypeProperties struct {
 	// REQUIRED; Client ID of the client on the BW system. (Usually a three-digit decimal number represented as a string) Type:
 	// string (or Expression with resultType string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; Host name of the SAP BW instance. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// REQUIRED; System number of the BW system. (Usually a two-digit decimal number represented as a string.) Type: string (or
 	// Expression with resultType string).
-	SystemNumber any `json:"systemNumber,omitempty"`
+	SystemNumber any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password to access the SAP BW server.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Username to access the SAP BW server. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SapBwCubeDataset - The SAP BW cube dataset.
 type SapBwCubeDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type SapBwCubeDataset.
@@ -19668,25 +19668,25 @@ func (s *SapBwCubeDataset) GetDataset() *Dataset {
 // SapBwSource - A copy activity source for SapBW server via MDX.
 type SapBwSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// MDX query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapBwSource.
@@ -19715,25 +19715,25 @@ func (s *SapBwSource) GetTabularSource() *TabularSource {
 // SapCloudForCustomerLinkedService - Linked service for SAP Cloud for Customer.
 type SapCloudForCustomerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SAP Cloud for Customer linked service properties.
-	TypeProperties *SapCloudForCustomerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapCloudForCustomerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapCloudForCustomerLinkedService.
@@ -19752,52 +19752,52 @@ func (s *SapCloudForCustomerLinkedService) GetLinkedService() *LinkedService {
 type SapCloudForCustomerLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of SAP Cloud for Customer OData API. For example, '[https://[tenantname].crm.ondemand.com/sap/c4c/odata/v1]'.
 	// Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Either encryptedCredential or username/password must be provided. Type:
 	// string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The username for Basic authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // SapCloudForCustomerResourceDataset - The path of the SAP Cloud for Customer OData entity.
 type SapCloudForCustomerResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SAP Cloud For Customer OData resource dataset properties.
-	TypeProperties *SapCloudForCustomerResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapCloudForCustomerResourceDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type SapCloudForCustomerResourceDataset.
@@ -19818,34 +19818,34 @@ func (s *SapCloudForCustomerResourceDataset) GetDataset() *Dataset {
 // SapCloudForCustomerResourceDatasetTypeProperties - Sap Cloud For Customer OData resource dataset properties.
 type SapCloudForCustomerResourceDatasetTypeProperties struct {
 	// REQUIRED; The path of the SAP Cloud for Customer OData entity. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // SapCloudForCustomerSink - A copy activity SAP Cloud for Customer sink.
 type SapCloudForCustomerSink struct {
 	// REQUIRED; Copy sink type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the sink data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Sink retry count. Type: integer (or Expression with resultType integer).
-	SinkRetryCount any `json:"sinkRetryCount,omitempty"`
+	SinkRetryCount any
 
 	// Sink retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SinkRetryWait any `json:"sinkRetryWait,omitempty"`
+	SinkRetryWait any
 
 	// Write batch size. Type: integer (or Expression with resultType integer), minimum: 0.
-	WriteBatchSize any `json:"writeBatchSize,omitempty"`
+	WriteBatchSize any
 
 	// Write batch timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	WriteBatchTimeout any `json:"writeBatchTimeout,omitempty"`
+	WriteBatchTimeout any
 
 	// The write behavior for the operation. Default is 'Insert'.
-	WriteBehavior *SapCloudForCustomerSinkWriteBehavior `json:"writeBehavior,omitempty"`
+	WriteBehavior *SapCloudForCustomerSinkWriteBehavior
 }
 
 // GetCopySink implements the CopySinkClassification interface for type SapCloudForCustomerSink.
@@ -19864,25 +19864,25 @@ func (s *SapCloudForCustomerSink) GetCopySink() *CopySink {
 // SapCloudForCustomerSource - A copy activity source for SAP Cloud for Customer source.
 type SapCloudForCustomerSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SAP Cloud for Customer OData query. For example, "$top=1". Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapCloudForCustomerSource.
@@ -19911,25 +19911,25 @@ func (s *SapCloudForCustomerSource) GetTabularSource() *TabularSource {
 // SapEccLinkedService - Linked service for SAP ERP Central Component(SAP ECC).
 type SapEccLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SAP ECC linked service properties.
-	TypeProperties *SapEccLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapEccLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapEccLinkedService.
@@ -19948,52 +19948,52 @@ func (s *SapEccLinkedService) GetLinkedService() *LinkedService {
 type SapEccLinkedServiceTypeProperties struct {
 	// REQUIRED; The URL of SAP ECC OData API. For example, '[https://hostname:port/sap/opu/odata/sap/servicename/]'. Type: string
 	// (or Expression with resultType string).
-	URL *string `json:"url,omitempty"`
+	URL *string
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Either encryptedCredential or username/password must be provided. Type:
 	// string (or Expression with resultType string).
-	EncryptedCredential *string `json:"encryptedCredential,omitempty"`
+	EncryptedCredential *string
 
 	// The password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The username for Basic authentication. Type: string (or Expression with resultType string).
-	Username *string `json:"username,omitempty"`
+	Username *string
 }
 
 // SapEccResourceDataset - The path of the SAP ECC OData entity.
 type SapEccResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SAP ECC OData resource dataset properties.
-	TypeProperties *SapEccResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapEccResourceDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type SapEccResourceDataset.
@@ -20014,31 +20014,31 @@ func (s *SapEccResourceDataset) GetDataset() *Dataset {
 // SapEccResourceDatasetTypeProperties - Sap ECC OData resource dataset properties.
 type SapEccResourceDatasetTypeProperties struct {
 	// REQUIRED; The path of the SAP ECC OData entity. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // SapEccSource - A copy activity source for SAP ECC source.
 type SapEccSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// SAP ECC OData query. For example, "$top=1". Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapEccSource.
@@ -20067,25 +20067,25 @@ func (s *SapEccSource) GetTabularSource() *TabularSource {
 // SapHanaLinkedService - SAP HANA Linked Service.
 type SapHanaLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *SapHanaLinkedServiceProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapHanaLinkedServiceProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapHanaLinkedService.
@@ -20103,63 +20103,63 @@ func (s *SapHanaLinkedService) GetLinkedService() *LinkedService {
 // SapHanaLinkedServiceProperties - Properties specific to this linked service type.
 type SapHanaLinkedServiceProperties struct {
 	// REQUIRED; Host name of the SAP HANA server. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// The authentication type to be used to connect to the SAP HANA server.
-	AuthenticationType *SapHanaAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *SapHanaAuthenticationType
 
 	// SAP HANA ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password to access the SAP HANA server.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Username to access the SAP HANA server. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SapHanaPartitionSettings - The settings that will be leveraged for SAP HANA source partitioning.
 type SapHanaPartitionSettings struct {
 	// The name of the column that will be used for proceeding range partitioning. Type: string (or Expression with resultType
 	// string).
-	PartitionColumnName any `json:"partitionColumnName,omitempty"`
+	PartitionColumnName any
 }
 
 // SapHanaSource - A copy activity source for SAP HANA source.
 type SapHanaSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The packet size of data read from SAP HANA. Type: integer(or Expression with resultType integer).
-	PacketSize any `json:"packetSize,omitempty"`
+	PacketSize any
 
 	// The partition mechanism that will be used for SAP HANA read in parallel.
-	PartitionOption *SapHanaPartitionOption `json:"partitionOption,omitempty"`
+	PartitionOption *SapHanaPartitionOption
 
 	// The settings that will be leveraged for SAP HANA source partitioning.
-	PartitionSettings *SapHanaPartitionSettings `json:"partitionSettings,omitempty"`
+	PartitionSettings *SapHanaPartitionSettings
 
 	// SAP HANA Sql query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapHanaSource.
@@ -20188,35 +20188,35 @@ func (s *SapHanaSource) GetTabularSource() *TabularSource {
 // SapHanaTableDataset - SAP HANA Table properties.
 type SapHanaTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// SAP HANA Table properties.
-	TypeProperties *SapHanaTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapHanaTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SapHanaTableDataset.
@@ -20237,34 +20237,34 @@ func (s *SapHanaTableDataset) GetDataset() *Dataset {
 // SapHanaTableDatasetTypeProperties - SAP HANA Table properties.
 type SapHanaTableDatasetTypeProperties struct {
 	// The schema name of SAP HANA. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of SAP HANA. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 }
 
 // SapOpenHubLinkedService - SAP Business Warehouse Open Hub Destination Linked Service.
 type SapOpenHubLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to SAP Business Warehouse Open Hub Destination linked service type.
-	TypeProperties *SapOpenHubLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapOpenHubLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapOpenHubLinkedService.
@@ -20284,36 +20284,36 @@ func (s *SapOpenHubLinkedService) GetLinkedService() *LinkedService {
 type SapOpenHubLinkedServiceTypeProperties struct {
 	// REQUIRED; Client ID of the client on the BW system where the open hub destination is located. (Usually a three-digit decimal
 	// number represented as a string) Type: string (or Expression with resultType string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; Host name of the SAP BW instance where the open hub destination is located. Type: string (or Expression with
 	// resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// REQUIRED; System number of the BW system where the open hub destination is located. (Usually a two-digit decimal number
 	// represented as a string.) Type: string (or Expression with resultType string).
-	SystemNumber any `json:"systemNumber,omitempty"`
+	SystemNumber any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Language of the BW system where the open hub destination is located. The default value is EN. Type: string (or Expression
 	// with resultType string).
-	Language any `json:"language,omitempty"`
+	Language any
 
 	// Password to access the SAP BW server where the open hub destination is located.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Username to access the SAP BW server where the open hub destination is located. Type: string (or Expression with resultType
 	// string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SapOpenHubSource - A copy activity source for SAP Business Warehouse Open Hub Destination source.
 type SapOpenHubSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
@@ -20321,23 +20321,23 @@ type SapOpenHubSource struct {
 	// The ID of request for delta loading. Once it is set, only data with requestId larger than the value of this property will
 	// be retrieved. The default value is 0. Type: integer (or Expression with
 	// resultType integer ).
-	BaseRequestID any `json:"baseRequestId,omitempty"`
+	BaseRequestID any
 
 	// Whether to exclude the records of the last request. The default value is true. Type: boolean (or Expression with resultType
 	// boolean).
-	ExcludeLastRequest any `json:"excludeLastRequest,omitempty"`
+	ExcludeLastRequest any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapOpenHubSource.
@@ -20366,35 +20366,35 @@ func (s *SapOpenHubSource) GetTabularSource() *TabularSource {
 // SapOpenHubTableDataset - Sap Business Warehouse Open Hub Destination Table properties.
 type SapOpenHubTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Sap Business Warehouse Open Hub Destination Table properties.
-	TypeProperties *SapOpenHubTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapOpenHubTableDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type SapOpenHubTableDataset.
@@ -20416,40 +20416,40 @@ func (s *SapOpenHubTableDataset) GetDataset() *Dataset {
 type SapOpenHubTableDatasetTypeProperties struct {
 	// REQUIRED; The name of the Open Hub Destination with destination type as Database Table. Type: string (or Expression with
 	// resultType string).
-	OpenHubDestinationName any `json:"openHubDestinationName,omitempty"`
+	OpenHubDestinationName any
 
 	// The ID of request for delta loading. Once it is set, only data with requestId larger than the value of this property will
 	// be retrieved. The default value is 0. Type: integer (or Expression with
 	// resultType integer ).
-	BaseRequestID any `json:"baseRequestId,omitempty"`
+	BaseRequestID any
 
 	// Whether to exclude the records of the last request. The default value is true. Type: boolean (or Expression with resultType
 	// boolean).
-	ExcludeLastRequest any `json:"excludeLastRequest,omitempty"`
+	ExcludeLastRequest any
 }
 
 // SapTableLinkedService - SAP Table Linked Service.
 type SapTableLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *SapTableLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapTableLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SapTableLinkedService.
@@ -20468,110 +20468,110 @@ func (s *SapTableLinkedService) GetLinkedService() *LinkedService {
 type SapTableLinkedServiceTypeProperties struct {
 	// Client ID of the client on the SAP system where the table is located. (Usually a three-digit decimal number represented
 	// as a string) Type: string (or Expression with resultType string).
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Language of the SAP system where the table is located. The default value is EN. Type: string (or Expression with resultType
 	// string).
-	Language any `json:"language,omitempty"`
+	Language any
 
 	// The Logon Group for the SAP System. Type: string (or Expression with resultType string).
-	LogonGroup any `json:"logonGroup,omitempty"`
+	LogonGroup any
 
 	// The hostname of the SAP Message Server. Type: string (or Expression with resultType string).
-	MessageServer any `json:"messageServer,omitempty"`
+	MessageServer any
 
 	// The service name or port number of the Message Server. Type: string (or Expression with resultType string).
-	MessageServerService any `json:"messageServerService,omitempty"`
+	MessageServerService any
 
 	// Password to access the SAP server where the table is located.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Host name of the SAP instance where the table is located. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// External security product's library to access the SAP server where the table is located. Type: string (or Expression with
 	// resultType string).
-	SncLibraryPath any `json:"sncLibraryPath,omitempty"`
+	SncLibraryPath any
 
 	// SNC activation indicator to access the SAP server where the table is located. Must be either 0 (off) or 1 (on). Type: string
 	// (or Expression with resultType string).
-	SncMode any `json:"sncMode,omitempty"`
+	SncMode any
 
 	// Initiator's SNC name to access the SAP server where the table is located. Type: string (or Expression with resultType string).
-	SncMyName any `json:"sncMyName,omitempty"`
+	SncMyName any
 
 	// Communication partner's SNC name to access the SAP server where the table is located. Type: string (or Expression with
 	// resultType string).
-	SncPartnerName any `json:"sncPartnerName,omitempty"`
+	SncPartnerName any
 
 	// SNC Quality of Protection. Allowed value include: 1, 2, 3, 8, 9. Type: string (or Expression with resultType string).
-	SncQop any `json:"sncQop,omitempty"`
+	SncQop any
 
 	// SystemID of the SAP system where the table is located. Type: string (or Expression with resultType string).
-	SystemID any `json:"systemId,omitempty"`
+	SystemID any
 
 	// System number of the SAP system where the table is located. (Usually a two-digit decimal number represented as a string.)
 	// Type: string (or Expression with resultType string).
-	SystemNumber any `json:"systemNumber,omitempty"`
+	SystemNumber any
 
 	// Username to access the SAP server where the table is located. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SapTablePartitionSettings - The settings that will be leveraged for SAP table source partitioning.
 type SapTablePartitionSettings struct {
 	// The maximum value of partitions the table will be split into. Type: integer (or Expression with resultType string).
-	MaxPartitionsNumber any `json:"maxPartitionsNumber,omitempty"`
+	MaxPartitionsNumber any
 
 	// The name of the column that will be used for proceeding range partitioning. Type: string (or Expression with resultType
 	// string).
-	PartitionColumnName any `json:"partitionColumnName,omitempty"`
+	PartitionColumnName any
 
 	// The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionLowerBound any `json:"partitionLowerBound,omitempty"`
+	PartitionLowerBound any
 
 	// The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionUpperBound any `json:"partitionUpperBound,omitempty"`
+	PartitionUpperBound any
 }
 
 // SapTableResourceDataset - SAP Table Resource properties.
 type SapTableResourceDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; SAP Table Resource properties.
-	TypeProperties *SapTableResourceDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SapTableResourceDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type SapTableResourceDataset.
@@ -20592,56 +20592,56 @@ func (s *SapTableResourceDataset) GetDataset() *Dataset {
 // SapTableResourceDatasetTypeProperties - SAP Table Resource properties.
 type SapTableResourceDatasetTypeProperties struct {
 	// REQUIRED; The name of the SAP Table. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // SapTableSource - A copy activity source for SAP Table source.
 type SapTableSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specifies the maximum number of rows that will be retrieved at a time when retrieving data from SAP Table. Type: integer
 	// (or Expression with resultType integer).
-	BatchSize any `json:"batchSize,omitempty"`
+	BatchSize any
 
 	// Specifies the custom RFC function module that will be used to read data from SAP Table. Type: string (or Expression with
 	// resultType string).
-	CustomRFCReadTableFunctionModule any `json:"customRfcReadTableFunctionModule,omitempty"`
+	CustomRFCReadTableFunctionModule any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The partition mechanism that will be used for SAP table read in parallel.
-	PartitionOption *SapTablePartitionOption `json:"partitionOption,omitempty"`
+	PartitionOption *SapTablePartitionOption
 
 	// The settings that will be leveraged for SAP table source partitioning.
-	PartitionSettings *SapTablePartitionSettings `json:"partitionSettings,omitempty"`
+	PartitionSettings *SapTablePartitionSettings
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// The fields of the SAP table that will be retrieved. For example, column0, column1. Type: string (or Expression with resultType
 	// string).
-	RFCTableFields any `json:"rfcTableFields,omitempty"`
+	RFCTableFields any
 
 	// The options for the filtering of the SAP Table. For example, COLUMN0 EQ SOME VALUE. Type: string (or Expression with resultType
 	// string).
-	RFCTableOptions any `json:"rfcTableOptions,omitempty"`
+	RFCTableOptions any
 
 	// The number of rows to be retrieved. Type: integer(or Expression with resultType integer).
-	RowCount any `json:"rowCount,omitempty"`
+	RowCount any
 
 	// The number of rows that will be skipped. Type: integer (or Expression with resultType integer).
-	RowSkips any `json:"rowSkips,omitempty"`
+	RowSkips any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SapTableSource.
@@ -20670,25 +20670,25 @@ func (s *SapTableSource) GetTabularSource() *TabularSource {
 // ScheduleTrigger - Trigger that creates pipeline runs periodically, on schedule.
 type ScheduleTrigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Schedule Trigger properties.
-	TypeProperties *ScheduleTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ScheduleTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Pipelines that need to be started.
-	Pipelines []*TriggerPipelineReference `json:"pipelines,omitempty"`
+	Pipelines []*TriggerPipelineReference
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetMultiplePipelineTrigger implements the MultiplePipelineTriggerClassification interface for type ScheduleTrigger.
@@ -20720,43 +20720,43 @@ type ScheduleTriggerRecurrence struct {
 	AdditionalProperties map[string]any
 
 	// The end time.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// The frequency.
-	Frequency *RecurrenceFrequency `json:"frequency,omitempty"`
+	Frequency *RecurrenceFrequency
 
 	// The interval.
-	Interval *int32 `json:"interval,omitempty"`
+	Interval *int32
 
 	// The recurrence schedule.
-	Schedule *RecurrenceSchedule `json:"schedule,omitempty"`
+	Schedule *RecurrenceSchedule
 
 	// The start time.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// The time zone.
-	TimeZone *string `json:"timeZone,omitempty"`
+	TimeZone *string
 }
 
 // ScheduleTriggerTypeProperties - Schedule Trigger properties.
 type ScheduleTriggerTypeProperties struct {
 	// REQUIRED; Recurrence schedule configuration.
-	Recurrence *ScheduleTriggerRecurrence `json:"recurrence,omitempty"`
+	Recurrence *ScheduleTriggerRecurrence
 }
 
 // ScriptAction - Custom script action to run on HDI ondemand cluster once it's up.
 type ScriptAction struct {
 	// REQUIRED; The user provided name of the script action.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; The node types on which the script action should be executed.
-	Roles *HdiNodeTypes `json:"roles,omitempty"`
+	Roles *HdiNodeTypes
 
 	// REQUIRED; The URI for the script action.
-	URI *string `json:"uri,omitempty"`
+	URI *string
 
 	// The parameters for the script action.
-	Parameters *string `json:"parameters,omitempty"`
+	Parameters *string
 }
 
 // SecretBaseClassification provides polymorphic access to related types.
@@ -20771,7 +20771,7 @@ type SecretBaseClassification interface {
 // SecretBase - The base definition of a secret type.
 type SecretBase struct {
 	// REQUIRED; Type of the secret.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // GetSecretBase implements the SecretBaseClassification interface for type SecretBase.
@@ -20781,10 +20781,10 @@ func (s *SecretBase) GetSecretBase() *SecretBase { return s }
 // List API calls.
 type SecureString struct {
 	// REQUIRED; Type of the secret.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Value of secure string.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // GetSecretBase implements the SecretBaseClassification interface for type SecureString.
@@ -20797,13 +20797,13 @@ func (s *SecureString) GetSecretBase() *SecretBase {
 // SelfDependencyTumblingWindowTriggerReference - Self referenced tumbling window trigger dependency.
 type SelfDependencyTumblingWindowTriggerReference struct {
 	// REQUIRED; Timespan applied to the start time of a tumbling window when evaluating dependency.
-	Offset *string `json:"offset,omitempty"`
+	Offset *string
 
 	// REQUIRED; The type of dependency reference.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// The size of the window when evaluating the dependency. If undefined the frequency of the tumbling window will be used.
-	Size *string `json:"size,omitempty"`
+	Size *string
 }
 
 // GetDependencyReference implements the DependencyReferenceClassification interface for type SelfDependencyTumblingWindowTriggerReference.
@@ -20816,17 +20816,17 @@ func (s *SelfDependencyTumblingWindowTriggerReference) GetDependencyReference() 
 // SelfHostedIntegrationRuntime - Self-hosted integration runtime.
 type SelfHostedIntegrationRuntime struct {
 	// REQUIRED; Type of integration runtime.
-	Type *IntegrationRuntimeType `json:"type,omitempty"`
+	Type *IntegrationRuntimeType
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Integration runtime description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// When this property is not null, means this is a linked integration runtime. The property is used to access original integration
 	// runtime.
-	TypeProperties *SelfHostedIntegrationRuntimeTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SelfHostedIntegrationRuntimeTypeProperties
 }
 
 // GetIntegrationRuntime implements the IntegrationRuntimeClassification interface for type SelfHostedIntegrationRuntime.
@@ -20841,31 +20841,31 @@ func (s *SelfHostedIntegrationRuntime) GetIntegrationRuntime() *IntegrationRunti
 // SelfHostedIntegrationRuntimeTypeProperties - The self-hosted integration runtime properties.
 type SelfHostedIntegrationRuntimeTypeProperties struct {
 	// Linked integration runtime type from data factory
-	LinkedInfo LinkedIntegrationRuntimeTypeClassification `json:"linkedInfo,omitempty"`
+	LinkedInfo LinkedIntegrationRuntimeTypeClassification
 }
 
 // ServiceNowLinkedService - ServiceNow server linked service.
 type ServiceNowLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; ServiceNow server linked service properties.
-	TypeProperties *ServiceNowLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ServiceNowLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ServiceNowLinkedService.
@@ -20883,70 +20883,70 @@ func (s *ServiceNowLinkedService) GetLinkedService() *LinkedService {
 // ServiceNowLinkedServiceTypeProperties - ServiceNow server linked service properties.
 type ServiceNowLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication type to use.
-	AuthenticationType *ServiceNowAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *ServiceNowAuthenticationType
 
 	// REQUIRED; The endpoint of the ServiceNow server. (i.e. .service-now.com)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// The client id for OAuth2 authentication.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// The client secret for OAuth2 authentication.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The password corresponding to the user name for Basic and OAuth2 authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 
 	// The user name used to connect to the ServiceNow server for Basic and OAuth2 authentication.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // ServiceNowObjectDataset - ServiceNow server dataset.
 type ServiceNowObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ServiceNowObjectDataset.
@@ -20967,25 +20967,25 @@ func (s *ServiceNowObjectDataset) GetDataset() *Dataset {
 // ServiceNowSource - A copy activity ServiceNow server source.
 type ServiceNowSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ServiceNowSource.
@@ -21014,25 +21014,25 @@ func (s *ServiceNowSource) GetTabularSource() *TabularSource {
 // SetVariableActivity - Set value for a Variable.
 type SetVariableActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Set Variable activity properties.
-	TypeProperties *SetVariableActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SetVariableActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SetVariableActivity.
@@ -21062,25 +21062,25 @@ func (s *SetVariableActivity) GetControlActivity() *ControlActivity {
 // SetVariableActivityTypeProperties - SetVariable activity properties.
 type SetVariableActivityTypeProperties struct {
 	// Value to be set. Could be a static value or Expression
-	Value any `json:"value,omitempty"`
+	Value any
 
 	// Name of the variable whose value needs to be set.
-	VariableName *string `json:"variableName,omitempty"`
+	VariableName *string
 }
 
 // SftpLocation - The location of SFTP dataset.
 type SftpLocation struct {
 	// REQUIRED; Type of dataset storage location.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specify the file name of dataset. Type: string (or Expression with resultType string).
-	FileName any `json:"fileName,omitempty"`
+	FileName any
 
 	// Specify the folder path of dataset. Type: string (or Expression with resultType string)
-	FolderPath any `json:"folderPath,omitempty"`
+	FolderPath any
 }
 
 // GetDatasetLocation implements the DatasetLocationClassification interface for type SftpLocation.
@@ -21096,29 +21096,29 @@ func (s *SftpLocation) GetDatasetLocation() *DatasetLocation {
 // SftpReadSettings - Sftp read settings.
 type SftpReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The end of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeEnd any `json:"modifiedDatetimeEnd,omitempty"`
+	ModifiedDatetimeEnd any
 
 	// The start of file's modified datetime. Type: string (or Expression with resultType string).
-	ModifiedDatetimeStart any `json:"modifiedDatetimeStart,omitempty"`
+	ModifiedDatetimeStart any
 
 	// If true, files under the folder path will be read recursively. Default is true. Type: boolean (or Expression with resultType
 	// boolean).
-	Recursive any `json:"recursive,omitempty"`
+	Recursive any
 
 	// Sftp wildcardFileName. Type: string (or Expression with resultType string).
-	WildcardFileName any `json:"wildcardFileName,omitempty"`
+	WildcardFileName any
 
 	// Sftp wildcardFolderPath. Type: string (or Expression with resultType string).
-	WildcardFolderPath any `json:"wildcardFolderPath,omitempty"`
+	WildcardFolderPath any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type SftpReadSettings.
@@ -21133,25 +21133,25 @@ func (s *SftpReadSettings) GetStoreReadSettings() *StoreReadSettings {
 // SftpServerLinkedService - A linked service for an SSH File Transfer Protocol (SFTP) server.
 type SftpServerLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Properties specific to this linked service type.
-	TypeProperties *SftpServerLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SftpServerLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SftpServerLinkedService.
@@ -21169,63 +21169,63 @@ func (s *SftpServerLinkedService) GetLinkedService() *LinkedService {
 // SftpServerLinkedServiceTypeProperties - Properties specific to this linked service type.
 type SftpServerLinkedServiceTypeProperties struct {
 	// REQUIRED; The SFTP server host name. Type: string (or Expression with resultType string).
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The authentication type to be used to connect to the FTP server.
-	AuthenticationType *SftpAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *SftpAuthenticationType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The host key finger-print of the SFTP server. When SkipHostKeyValidation is false, HostKeyFingerprint should be specified.
 	// Type: string (or Expression with resultType string).
-	HostKeyFingerprint any `json:"hostKeyFingerprint,omitempty"`
+	HostKeyFingerprint any
 
 	// The password to decrypt the SSH private key if the SSH private key is encrypted.
-	PassPhrase SecretBaseClassification `json:"passPhrase,omitempty"`
+	PassPhrase SecretBaseClassification
 
 	// Password to logon the SFTP server for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The TCP port number that the SFTP server uses to listen for client connections. Default value is 22. Type: integer (or
 	// Expression with resultType integer), minimum: 0.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Base64 encoded SSH private key content for SshPublicKey authentication. For on-premises copy with SshPublicKey authentication,
 	// either PrivateKeyPath or PrivateKeyContent should be specified. SSH
 	// private key should be OpenSSH format.
-	PrivateKeyContent SecretBaseClassification `json:"privateKeyContent,omitempty"`
+	PrivateKeyContent SecretBaseClassification
 
 	// The SSH private key file path for SshPublicKey authentication. Only valid for on-premises copy. For on-premises copy with
 	// SshPublicKey authentication, either PrivateKeyPath or PrivateKeyContent should
 	// be specified. SSH private key should be OpenSSH format. Type: string (or Expression with resultType string).
-	PrivateKeyPath any `json:"privateKeyPath,omitempty"`
+	PrivateKeyPath any
 
 	// If true, skip the SSH host key validation. Default value is false. Type: boolean (or Expression with resultType boolean).
-	SkipHostKeyValidation any `json:"skipHostKeyValidation,omitempty"`
+	SkipHostKeyValidation any
 
 	// The username used to log on to the SFTP server. Type: string (or Expression with resultType string).
-	UserName any `json:"userName,omitempty"`
+	UserName any
 }
 
 // SftpWriteSettings - Sftp write settings.
 type SftpWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Specifies the timeout for writing each chunk to SFTP server. Default value: 01:00:00 (one hour). Type: string (or Expression
 	// with resultType string).
-	OperationTimeout any `json:"operationTimeout,omitempty"`
+	OperationTimeout any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type SftpWriteSettings.
@@ -21241,25 +21241,25 @@ func (s *SftpWriteSettings) GetStoreWriteSettings() *StoreWriteSettings {
 // ShopifyLinkedService - Shopify Service linked service.
 type ShopifyLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Shopify Service linked service properties.
-	TypeProperties *ShopifyLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ShopifyLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ShopifyLinkedService.
@@ -21277,58 +21277,58 @@ func (s *ShopifyLinkedService) GetLinkedService() *LinkedService {
 // ShopifyLinkedServiceTypeProperties - Shopify Service linked service properties.
 type ShopifyLinkedServiceTypeProperties struct {
 	// REQUIRED; The endpoint of the Shopify server. (i.e. mystore.myshopify.com)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The API access token that can be used to access Shopify’s data. The token won't expire if it is offline mode.
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // ShopifyObjectDataset - Shopify Service dataset.
 type ShopifyObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ShopifyObjectDataset.
@@ -21349,25 +21349,25 @@ func (s *ShopifyObjectDataset) GetDataset() *Dataset {
 // ShopifySource - A copy activity Shopify Service source.
 type ShopifySource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ShopifySource.
@@ -21395,116 +21395,116 @@ func (s *ShopifySource) GetTabularSource() *TabularSource {
 
 type SparkBatchJob struct {
 	// REQUIRED; The session Id.
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// The application id of this session
-	AppID *string `json:"appId,omitempty"`
+	AppID *string
 
 	// The detailed application info.
-	AppInfo map[string]*string `json:"appInfo,omitempty"`
+	AppInfo map[string]*string
 
 	// The artifact identifier.
-	ArtifactID *string `json:"artifactId,omitempty"`
+	ArtifactID *string
 
 	// The error information.
-	Errors []*SparkServiceError `json:"errorInfo,omitempty"`
+	Errors []*SparkServiceError
 
 	// The job type.
-	JobType  *SparkJobType       `json:"jobType,omitempty"`
-	LivyInfo *SparkBatchJobState `json:"livyInfo,omitempty"`
+	JobType  *SparkJobType
+	LivyInfo *SparkBatchJobState
 
 	// The log lines.
-	LogLines []*string `json:"log,omitempty"`
+	LogLines []*string
 
 	// The batch name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The plugin information.
-	Plugin *SparkServicePlugin `json:"pluginInfo,omitempty"`
+	Plugin *SparkServicePlugin
 
 	// The Spark batch job result.
-	Result *SparkBatchJobResultType `json:"result,omitempty"`
+	Result *SparkBatchJobResultType
 
 	// The scheduler information.
-	Scheduler *SparkScheduler `json:"schedulerInfo,omitempty"`
+	Scheduler *SparkScheduler
 
 	// The Spark pool name.
-	SparkPoolName *string `json:"sparkPoolName,omitempty"`
+	SparkPoolName *string
 
 	// The batch state
-	State *string `json:"state,omitempty"`
+	State *string
 
 	// The submitter identifier.
-	SubmitterID *string `json:"submitterId,omitempty"`
+	SubmitterID *string
 
 	// The submitter name.
-	SubmitterName *string `json:"submitterName,omitempty"`
+	SubmitterName *string
 
 	// The tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The workspace name.
-	WorkspaceName *string `json:"workspaceName,omitempty"`
+	WorkspaceName *string
 }
 
 type SparkBatchJobState struct {
 	// the Spark job state.
-	CurrentState *string `json:"currentState,omitempty"`
+	CurrentState *string
 
 	// time that at which "dead" livy state was first seen.
-	DeadAt             *time.Time    `json:"deadAt,omitempty"`
-	JobCreationRequest *SparkRequest `json:"jobCreationRequest,omitempty"`
+	DeadAt             *time.Time
+	JobCreationRequest *SparkRequest
 
 	// the time that at which "not_started" livy state was first seen.
-	NotStartedAt *time.Time `json:"notStartedAt,omitempty"`
+	NotStartedAt *time.Time
 
 	// the time that at which "recovering" livy state was first seen.
-	RecoveringAt *time.Time `json:"recoveringAt,omitempty"`
+	RecoveringAt *time.Time
 
 	// the time that at which "running" livy state was first seen.
-	RunningAt *time.Time `json:"runningAt,omitempty"`
+	RunningAt *time.Time
 
 	// the time that at which "starting" livy state was first seen.
-	StartingAt *time.Time `json:"startingAt,omitempty"`
+	StartingAt *time.Time
 
 	// the time that at which "success" livy state was first seen.
-	SuccessAt *time.Time `json:"successAt,omitempty"`
+	SuccessAt *time.Time
 
 	// the time that at which "killed" livy state was first seen.
-	TerminatedAt *time.Time `json:"killedAt,omitempty"`
+	TerminatedAt *time.Time
 }
 
 // SparkDatasetTypeProperties - Spark Properties
 type SparkDatasetTypeProperties struct {
 	// The schema name of the Spark. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Spark. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // SparkJobDefinition - Spark job definition.
 type SparkJobDefinition struct {
 	// REQUIRED; The properties of the Spark job.
-	JobProperties *SparkJobProperties `json:"jobProperties,omitempty"`
+	JobProperties *SparkJobProperties
 
 	// REQUIRED; Big data pool reference.
-	TargetBigDataPool *BigDataPoolReference `json:"targetBigDataPool,omitempty"`
+	TargetBigDataPool *BigDataPoolReference
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The description of the Spark job definition.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The language of the Spark application.
-	Language *string `json:"language,omitempty"`
+	Language *string
 
 	// The required Spark version of the application.
-	RequiredSparkVersion *string `json:"requiredSparkVersion,omitempty"`
+	RequiredSparkVersion *string
 }
 
 // SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions contains the optional parameters for the SparkJobDefinitionClient.BeginCreateOrUpdateSparkJobDefinition
@@ -21562,97 +21562,97 @@ type SparkJobDefinitionClientGetSparkJobDefinitionsByWorkspaceOptions struct {
 // SparkJobDefinitionResource - Spark job definition resource type.
 type SparkJobDefinitionResource struct {
 	// REQUIRED; Properties of spark job definition.
-	Properties *SparkJobDefinition `json:"properties,omitempty"`
+	Properties *SparkJobDefinition
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SparkJobDefinitionsListResponse - A list of spark job definitions resources.
 type SparkJobDefinitionsListResponse struct {
 	// REQUIRED; List of spark job definitions.
-	Value []*SparkJobDefinitionResource `json:"value,omitempty"`
+	Value []*SparkJobDefinitionResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // SparkJobProperties - The properties of the Spark job.
 type SparkJobProperties struct {
 	// REQUIRED; Number of cores to use for the driver.
-	DriverCores *int32 `json:"driverCores,omitempty"`
+	DriverCores *int32
 
 	// REQUIRED; Amount of memory to use for the driver process.
-	DriverMemory *string `json:"driverMemory,omitempty"`
+	DriverMemory *string
 
 	// REQUIRED; Number of cores to use for each executor.
-	ExecutorCores *int32 `json:"executorCores,omitempty"`
+	ExecutorCores *int32
 
 	// REQUIRED; Amount of memory to use per executor process.
-	ExecutorMemory *string `json:"executorMemory,omitempty"`
+	ExecutorMemory *string
 
 	// REQUIRED; File containing the application to execute.
-	File *string `json:"file,omitempty"`
+	File *string
 
 	// REQUIRED; Number of executors to launch for this job.
-	NumExecutors *int32 `json:"numExecutors,omitempty"`
+	NumExecutors *int32
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Archives to be used in this job.
-	Archives []*string `json:"archives,omitempty"`
+	Archives []*string
 
 	// Command line arguments for the application.
-	Args []*string `json:"args,omitempty"`
+	Args []*string
 
 	// Main class for Java/Scala application.
-	ClassName *string `json:"className,omitempty"`
+	ClassName *string
 
 	// Spark configuration properties.
-	Conf any `json:"conf,omitempty"`
+	Conf any
 
 	// files to be used in this job.
-	Files []*string `json:"files,omitempty"`
+	Files []*string
 
 	// Jars to be used in this job.
-	Jars []*string `json:"jars,omitempty"`
+	Jars []*string
 
 	// The name of the job.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // SparkLinkedService - Spark Server linked service.
 type SparkLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Spark Server linked service properties.
-	TypeProperties *SparkLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SparkLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SparkLinkedService.
@@ -21670,85 +21670,85 @@ func (s *SparkLinkedService) GetLinkedService() *LinkedService {
 // SparkLinkedServiceTypeProperties - Spark Server linked service properties.
 type SparkLinkedServiceTypeProperties struct {
 	// REQUIRED; The authentication method used to access the Spark server.
-	AuthenticationType *SparkAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *SparkAuthenticationType
 
 	// REQUIRED; IP address or host name of the Spark server
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// REQUIRED; The TCP port that the Spark server uses to listen for client connections.
-	Port any `json:"port,omitempty"`
+	Port any
 
 	// Specifies whether to require a CA-issued SSL certificate name to match the host name of the server when connecting over
 	// SSL. The default value is false.
-	AllowHostNameCNMismatch any `json:"allowHostNameCNMismatch,omitempty"`
+	AllowHostNameCNMismatch any
 
 	// Specifies whether to allow self-signed certificates from the server. The default value is false.
-	AllowSelfSignedServerCert any `json:"allowSelfSignedServerCert,omitempty"`
+	AllowSelfSignedServerCert any
 
 	// Specifies whether the connections to the server are encrypted using SSL. The default value is false.
-	EnableSSL any `json:"enableSsl,omitempty"`
+	EnableSSL any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The partial URL corresponding to the Spark server.
-	HTTPPath any `json:"httpPath,omitempty"`
+	HTTPPath any
 
 	// The password corresponding to the user name that you provided in the Username field
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// The type of Spark server.
-	ServerType *SparkServerType `json:"serverType,omitempty"`
+	ServerType *SparkServerType
 
 	// The transport protocol to use in the Thrift layer.
-	ThriftTransportProtocol *SparkThriftTransportProtocol `json:"thriftTransportProtocol,omitempty"`
+	ThriftTransportProtocol *SparkThriftTransportProtocol
 
 	// The full path of the .pem file containing trusted CA certificates for verifying the server when connecting over SSL. This
 	// property can only be set when using SSL on self-hosted IR. The default value
 	// is the cacerts.pem file installed with the IR.
-	TrustedCertPath any `json:"trustedCertPath,omitempty"`
+	TrustedCertPath any
 
 	// Specifies whether to use a CA certificate from the system trust store or from a specified PEM file. The default value is
 	// false.
-	UseSystemTrustStore any `json:"useSystemTrustStore,omitempty"`
+	UseSystemTrustStore any
 
 	// The user name that you use to access Spark Server.
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // SparkObjectDataset - Spark Server dataset.
 type SparkObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *SparkDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SparkDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SparkObjectDataset.
@@ -21767,69 +21767,69 @@ func (s *SparkObjectDataset) GetDataset() *Dataset {
 }
 
 type SparkRequest struct {
-	Archives  []*string `json:"archives,omitempty"`
-	Arguments []*string `json:"args,omitempty"`
-	ClassName *string   `json:"className,omitempty"`
+	Archives  []*string
+	Arguments []*string
+	ClassName *string
 
 	// Dictionary of
-	Configuration  map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          []*string          `json:"files,omitempty"`
-	Jars           []*string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string
+	DriverCores    *int32
+	DriverMemory   *string
+	ExecutorCores  *int32
+	ExecutorCount  *int32
+	ExecutorMemory *string
+	File           *string
+	Files          []*string
+	Jars           []*string
+	Name           *string
+	PythonFiles    []*string
 }
 
 type SparkScheduler struct {
-	CancellationRequestedAt *time.Time             `json:"cancellationRequestedAt,omitempty"`
-	CurrentState            *SchedulerCurrentState `json:"currentState,omitempty"`
-	EndedAt                 *time.Time             `json:"endedAt,omitempty"`
-	ScheduledAt             *time.Time             `json:"scheduledAt,omitempty"`
-	SubmittedAt             *time.Time             `json:"submittedAt,omitempty"`
+	CancellationRequestedAt *time.Time
+	CurrentState            *SchedulerCurrentState
+	EndedAt                 *time.Time
+	ScheduledAt             *time.Time
+	SubmittedAt             *time.Time
 }
 
 type SparkServiceError struct {
-	ErrorCode *string           `json:"errorCode,omitempty"`
-	Message   *string           `json:"message,omitempty"`
-	Source    *SparkErrorSource `json:"source,omitempty"`
+	ErrorCode *string
+	Message   *string
+	Source    *SparkErrorSource
 }
 
 type SparkServicePlugin struct {
-	CleanupStartedAt             *time.Time          `json:"cleanupStartedAt,omitempty"`
-	CurrentState                 *PluginCurrentState `json:"currentState,omitempty"`
-	MonitoringStartedAt          *time.Time          `json:"monitoringStartedAt,omitempty"`
-	PreparationStartedAt         *time.Time          `json:"preparationStartedAt,omitempty"`
-	ResourceAcquisitionStartedAt *time.Time          `json:"resourceAcquisitionStartedAt,omitempty"`
-	SubmissionStartedAt          *time.Time          `json:"submissionStartedAt,omitempty"`
+	CleanupStartedAt             *time.Time
+	CurrentState                 *PluginCurrentState
+	MonitoringStartedAt          *time.Time
+	PreparationStartedAt         *time.Time
+	ResourceAcquisitionStartedAt *time.Time
+	SubmissionStartedAt          *time.Time
 }
 
 // SparkSource - A copy activity Spark Server source.
 type SparkSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SparkSource.
@@ -21858,25 +21858,25 @@ func (s *SparkSource) GetTabularSource() *TabularSource {
 // SquareLinkedService - Square Service linked service.
 type SquareLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Square Service linked service properties.
-	TypeProperties *SquareLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SquareLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SquareLinkedService.
@@ -21894,64 +21894,64 @@ func (s *SquareLinkedService) GetLinkedService() *LinkedService {
 // SquareLinkedServiceTypeProperties - Square Service linked service properties.
 type SquareLinkedServiceTypeProperties struct {
 	// REQUIRED; The client ID associated with your Square application.
-	ClientID any `json:"clientId,omitempty"`
+	ClientID any
 
 	// REQUIRED; The URL of the Square instance. (i.e. mystore.mysquare.com)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// REQUIRED; The redirect URL assigned in the Square application dashboard. (i.e. http://localhost:2500)
-	RedirectURI any `json:"redirectUri,omitempty"`
+	RedirectURI any
 
 	// The client secret associated with your Square application.
-	ClientSecret SecretBaseClassification `json:"clientSecret,omitempty"`
+	ClientSecret SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // SquareObjectDataset - Square Service dataset.
 type SquareObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SquareObjectDataset.
@@ -21972,25 +21972,25 @@ func (s *SquareObjectDataset) GetDataset() *Dataset {
 // SquareSource - A copy activity Square Service source.
 type SquareSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SquareSource.
@@ -22019,62 +22019,62 @@ func (s *SquareSource) GetTabularSource() *TabularSource {
 // SsisObjectMetadataStatusResponse - The status of the operation.
 type SsisObjectMetadataStatusResponse struct {
 	// The operation error message.
-	Error *string `json:"error,omitempty"`
+	Error *string
 
 	// The operation name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The operation properties.
-	Properties *string `json:"properties,omitempty"`
+	Properties *string
 
 	// The status of the operation.
-	Status *string `json:"status,omitempty"`
+	Status *string
 }
 
 // StagingSettings - Staging settings.
 type StagingSettings struct {
 	// REQUIRED; Staging linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Specifies whether to use compression when copying data via an interim staging. Default value is false. Type: boolean (or
 	// Expression with resultType boolean).
-	EnableCompression any `json:"enableCompression,omitempty"`
+	EnableCompression any
 
 	// The path to storage for storing the interim data. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // StartDataFlowDebugSessionRequest - Request body structure for starting data flow debug session.
 type StartDataFlowDebugSessionRequest struct {
 	// Data flow instance.
-	DataFlow *DataFlowResource `json:"dataFlow,omitempty"`
+	DataFlow *DataFlowResource
 
 	// List of datasets.
-	Datasets []*DatasetResource `json:"datasets,omitempty"`
+	Datasets []*DatasetResource
 
 	// Data flow debug settings.
-	DebugSettings any `json:"debugSettings,omitempty"`
+	DebugSettings any
 
 	// The type of new Databricks cluster.
-	IncrementalDebug *bool `json:"incrementalDebug,omitempty"`
+	IncrementalDebug *bool
 
 	// List of linked services.
-	LinkedServices []*LinkedServiceResource `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceResource
 
 	// The ID of data flow debug session.
-	SessionID *string `json:"sessionId,omitempty"`
+	SessionID *string
 
 	// Staging info for debug session.
-	Staging any `json:"staging,omitempty"`
+	Staging any
 }
 
 // StartDataFlowDebugSessionResponse - Response body structure for starting data flow debug session.
 type StartDataFlowDebugSessionResponse struct {
 	// The ID of data flow debug job version.
-	JobVersion *string `json:"jobVersion,omitempty"`
+	JobVersion *string
 }
 
 // StoreReadSettingsClassification provides polymorphic access to related types.
@@ -22091,13 +22091,13 @@ type StoreReadSettingsClassification interface {
 // StoreReadSettings - Connector read setting.
 type StoreReadSettings struct {
 	// REQUIRED; The read setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreReadSettings implements the StoreReadSettingsClassification interface for type StoreReadSettings.
@@ -22116,16 +22116,16 @@ type StoreWriteSettingsClassification interface {
 // StoreWriteSettings - Connector write settings.
 type StoreWriteSettings struct {
 	// REQUIRED; The write setting type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The type of copy behavior for copy sink.
-	CopyBehavior any `json:"copyBehavior,omitempty"`
+	CopyBehavior any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 }
 
 // GetStoreWriteSettings implements the StoreWriteSettingsClassification interface for type StoreWriteSettings.
@@ -22134,56 +22134,56 @@ func (s *StoreWriteSettings) GetStoreWriteSettings() *StoreWriteSettings { retur
 // StoredProcedureParameter - SQL stored procedure parameter.
 type StoredProcedureParameter struct {
 	// Stored procedure parameter type.
-	Type *StoredProcedureParameterType `json:"type,omitempty"`
+	Type *StoredProcedureParameterType
 
 	// Stored procedure parameter value. Type: string (or Expression with resultType string).
-	Value any `json:"value,omitempty"`
+	Value any
 }
 
 // SubResource - Azure Synapse nested resource, which belongs to a workspace.
 type SubResource struct {
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // SubResourceDebugResource - Azure Synapse nested debug resource.
 type SubResourceDebugResource struct {
 	// The resource name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // SwitchActivity - This activity evaluates an expression and executes activities under the cases property that correspond
 // to the expression evaluation expected in the equals property.
 type SwitchActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Switch activity properties.
-	TypeProperties *SwitchActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SwitchActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SwitchActivity.
@@ -22214,48 +22214,48 @@ func (s *SwitchActivity) GetControlActivity() *ControlActivity {
 type SwitchActivityTypeProperties struct {
 	// REQUIRED; An expression that would evaluate to a string or integer. This is used to determine the block of activities in
 	// cases that will be executed.
-	On *Expression `json:"on,omitempty"`
+	On *Expression
 
 	// List of cases that correspond to expected values of the 'on' property. This is an optional property and if not provided,
 	// the activity will execute activities provided in defaultActivities.
-	Cases []*SwitchCase `json:"cases,omitempty"`
+	Cases []*SwitchCase
 
 	// List of activities to execute if no case condition is satisfied. This is an optional property and if not provided, the
 	// activity will exit without any action.
-	DefaultActivities []ActivityClassification `json:"defaultActivities,omitempty"`
+	DefaultActivities []ActivityClassification
 }
 
 // SwitchCase - Switch cases with have a value and corresponding activities.
 type SwitchCase struct {
 	// List of activities to execute for satisfied case condition.
-	Activities []ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification
 
 	// Expected value that satisfies the expression result of the 'on' property.
-	Value *string `json:"value,omitempty"`
+	Value *string
 }
 
 // SybaseLinkedService - Linked service for Sybase data source.
 type SybaseLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Sybase linked service properties.
-	TypeProperties *SybaseLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SybaseLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type SybaseLinkedService.
@@ -22273,50 +22273,50 @@ func (s *SybaseLinkedService) GetLinkedService() *LinkedService {
 // SybaseLinkedServiceTypeProperties - Sybase linked service properties.
 type SybaseLinkedServiceTypeProperties struct {
 	// REQUIRED; Database name for connection. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// REQUIRED; Server name for connection. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// AuthenticationType to be used for connection.
-	AuthenticationType *SybaseAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *SybaseAuthenticationType
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Schema name for connection. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Username for authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // SybaseSource - A copy activity source for Sybase databases.
 type SybaseSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Database query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type SybaseSource.
@@ -22345,35 +22345,35 @@ func (s *SybaseSource) GetTabularSource() *TabularSource {
 // SybaseTableDataset - The Sybase table dataset.
 type SybaseTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Sybase table dataset properties.
-	TypeProperties *SybaseTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SybaseTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type SybaseTableDataset.
@@ -22394,37 +22394,37 @@ func (s *SybaseTableDataset) GetDataset() *Dataset {
 // SybaseTableDatasetTypeProperties - Sybase table dataset properties.
 type SybaseTableDatasetTypeProperties struct {
 	// The Sybase table name. Type: string (or Expression with resultType string).
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // SynapseNotebookActivity - Execute Synapse notebook activity.
 type SynapseNotebookActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute Synapse notebook activity properties.
-	TypeProperties *SynapseNotebookActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SynapseNotebookActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SynapseNotebookActivity.
@@ -22456,55 +22456,55 @@ func (s *SynapseNotebookActivity) GetExecutionActivity() *ExecutionActivity {
 // SynapseNotebookActivityTypeProperties - Execute Synapse notebook activity properties.
 type SynapseNotebookActivityTypeProperties struct {
 	// REQUIRED; Synapse notebook reference.
-	Notebook *SynapseNotebookReference `json:"notebook,omitempty"`
+	Notebook *SynapseNotebookReference
 
 	// Notebook parameters.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 }
 
 // SynapseNotebookReference - Synapse notebook reference type.
 type SynapseNotebookReference struct {
 	// REQUIRED; Reference notebook name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Synapse notebook reference type.
-	Type *NotebookReferenceType `json:"type,omitempty"`
+	Type *NotebookReferenceType
 }
 
 // SynapseSparkJobActivityTypeProperties - Execute spark job activity properties.
 type SynapseSparkJobActivityTypeProperties struct {
 	// REQUIRED; Synapse spark job reference.
-	SparkJob *SynapseSparkJobReference `json:"sparkJob,omitempty"`
+	SparkJob *SynapseSparkJobReference
 }
 
 // SynapseSparkJobDefinitionActivity - Execute spark job activity.
 type SynapseSparkJobDefinitionActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Execute spark job activity properties.
-	TypeProperties *SynapseSparkJobActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *SynapseSparkJobActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type SynapseSparkJobDefinitionActivity.
@@ -22536,10 +22536,10 @@ func (s *SynapseSparkJobDefinitionActivity) GetExecutionActivity() *ExecutionAct
 // SynapseSparkJobReference - Synapse spark job reference type.
 type SynapseSparkJobReference struct {
 	// REQUIRED; Reference spark job name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Synapse spark job reference type.
-	Type *SparkJobReferenceType `json:"type,omitempty"`
+	Type *SparkJobReferenceType
 }
 
 // TabularSourceClassification provides polymorphic access to related types.
@@ -22562,22 +22562,22 @@ type TabularSourceClassification interface {
 // TabularSource - Copy activity sources of tabular type.
 type TabularSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type TabularSource.
@@ -22597,33 +22597,33 @@ func (t *TabularSource) GetTabularSource() *TabularSource { return t }
 // TabularTranslator - A copy activity tabular translator.
 type TabularTranslator struct {
 	// REQUIRED; Copy translator type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The JSON Path of the Nested Array that is going to do cross-apply. Type: object (or Expression with resultType object).
-	CollectionReference any `json:"collectionReference,omitempty"`
+	CollectionReference any
 
 	// Column mappings. Example: "UserId: MyUserId, Group: MyGroup, Name: MyName" Type: string (or Expression with resultType
 	// string). This property will be retired. Please use mappings property.
-	ColumnMappings any `json:"columnMappings,omitempty"`
+	ColumnMappings any
 
 	// Whether to map complex (array and object) values to simple strings in json format. Type: boolean (or Expression with resultType
 	// boolean).
-	MapComplexValuesToString any `json:"mapComplexValuesToString,omitempty"`
+	MapComplexValuesToString any
 
 	// Column mappings with logical types. Tabular->tabular example:
 	// [{"source":{"name":"CustomerName","type":"String"},"sink":{"name":"ClientName","type":"String"}},{"source":{"name":"CustomerAddress","type":"String"},"sink":{"name":"ClientAddress","type":"String"}}].
 	// Hierarchical->tabular example:
 	// [{"source":{"path":"$.CustomerName","type":"String"},"sink":{"name":"ClientName","type":"String"}},{"source":{"path":"$.CustomerAddress","type":"String"},"sink":{"name":"ClientAddress","type":"String"}}].
 	// Type: object (or Expression with resultType object).
-	Mappings any `json:"mappings,omitempty"`
+	Mappings any
 
 	// The schema mapping to map between tabular data and hierarchical data. Example: {"Column1": "$.Column1", "Column2": "$.Column2.Property1",
 	// "Column3": "$.Column2.Property2"}. Type: object (or Expression
 	// with resultType object). This property will be retired. Please use mappings property.
-	SchemaMapping any `json:"schemaMapping,omitempty"`
+	SchemaMapping any
 }
 
 // GetCopyTranslator implements the CopyTranslatorClassification interface for type TabularTranslator.
@@ -22637,25 +22637,25 @@ func (t *TabularTranslator) GetCopyTranslator() *CopyTranslator {
 // TeradataLinkedService - Linked service for Teradata data source.
 type TeradataLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Teradata linked service properties.
-	TypeProperties *TeradataLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *TeradataLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type TeradataLinkedService.
@@ -22673,68 +22673,68 @@ func (t *TeradataLinkedService) GetLinkedService() *LinkedService {
 // TeradataLinkedServiceTypeProperties - Teradata linked service properties.
 type TeradataLinkedServiceTypeProperties struct {
 	// AuthenticationType to be used for connection.
-	AuthenticationType *TeradataAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *TeradataAuthenticationType
 
 	// Teradata ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Password for authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Server name for connection. Type: string (or Expression with resultType string).
-	Server any `json:"server,omitempty"`
+	Server any
 
 	// Username for authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // TeradataPartitionSettings - The settings that will be leveraged for teradata source partitioning.
 type TeradataPartitionSettings struct {
 	// The name of the column that will be used for proceeding range or hash partitioning. Type: string (or Expression with resultType
 	// string).
-	PartitionColumnName any `json:"partitionColumnName,omitempty"`
+	PartitionColumnName any
 
 	// The minimum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionLowerBound any `json:"partitionLowerBound,omitempty"`
+	PartitionLowerBound any
 
 	// The maximum value of column specified in partitionColumnName that will be used for proceeding range partitioning. Type:
 	// string (or Expression with resultType string).
-	PartitionUpperBound any `json:"partitionUpperBound,omitempty"`
+	PartitionUpperBound any
 }
 
 // TeradataSource - A copy activity Teradata source.
 type TeradataSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// The partition mechanism that will be used for teradata read in parallel.
-	PartitionOption *TeradataPartitionOption `json:"partitionOption,omitempty"`
+	PartitionOption *TeradataPartitionOption
 
 	// The settings that will be leveraged for teradata source partitioning.
-	PartitionSettings *TeradataPartitionSettings `json:"partitionSettings,omitempty"`
+	PartitionSettings *TeradataPartitionSettings
 
 	// Teradata query. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type TeradataSource.
@@ -22763,35 +22763,35 @@ func (t *TeradataSource) GetTabularSource() *TabularSource {
 // TeradataTableDataset - The Teradata database dataset.
 type TeradataTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Teradata dataset properties.
-	TypeProperties *TeradataTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *TeradataTableDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type TeradataTableDataset.
@@ -22812,59 +22812,59 @@ func (t *TeradataTableDataset) GetDataset() *Dataset {
 // TeradataTableDatasetTypeProperties - Teradata dataset properties.
 type TeradataTableDatasetTypeProperties struct {
 	// The database name of Teradata. Type: string (or Expression with resultType string).
-	Database any `json:"database,omitempty"`
+	Database any
 
 	// The table name of Teradata. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 }
 
 // TextFormat - The data stored in text format.
 type TextFormat struct {
 	// REQUIRED; Type of dataset storage format.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The column delimiter. Type: string (or Expression with resultType string).
-	ColumnDelimiter any `json:"columnDelimiter,omitempty"`
+	ColumnDelimiter any
 
 	// Deserializer. Type: string (or Expression with resultType string).
-	Deserializer any `json:"deserializer,omitempty"`
+	Deserializer any
 
 	// The code page name of the preferred encoding. If miss, the default value is ΓÇ£utf-8ΓÇ¥, unless BOM denotes another Unicode
 	// encoding. Refer to the ΓÇ£NameΓÇ¥ column of the table in the following link
 	// to set supported values: https://msdn.microsoft.com/library/system.text.encoding.aspx. Type: string (or Expression with
 	// resultType string).
-	EncodingName any `json:"encodingName,omitempty"`
+	EncodingName any
 
 	// The escape character. Type: string (or Expression with resultType string).
-	EscapeChar any `json:"escapeChar,omitempty"`
+	EscapeChar any
 
 	// When used as input, treat the first row of data as headers. When used as output,write the headers into the output as the
 	// first row of data. The default value is false. Type: boolean (or Expression
 	// with resultType boolean).
-	FirstRowAsHeader any `json:"firstRowAsHeader,omitempty"`
+	FirstRowAsHeader any
 
 	// The null value string. Type: string (or Expression with resultType string).
-	NullValue any `json:"nullValue,omitempty"`
+	NullValue any
 
 	// The quote character. Type: string (or Expression with resultType string).
-	QuoteChar any `json:"quoteChar,omitempty"`
+	QuoteChar any
 
 	// The row delimiter. Type: string (or Expression with resultType string).
-	RowDelimiter any `json:"rowDelimiter,omitempty"`
+	RowDelimiter any
 
 	// Serializer. Type: string (or Expression with resultType string).
-	Serializer any `json:"serializer,omitempty"`
+	Serializer any
 
 	// The number of lines/rows to be skipped when parsing text files. The default value is 0. Type: integer (or Expression with
 	// resultType integer).
-	SkipLineCount any `json:"skipLineCount,omitempty"`
+	SkipLineCount any
 
 	// Treat empty column values in the text file as null. The default value is true. Type: boolean (or Expression with resultType
 	// boolean).
-	TreatEmptyAsNull any `json:"treatEmptyAsNull,omitempty"`
+	TreatEmptyAsNull any
 }
 
 // GetDatasetStorageFormat implements the DatasetStorageFormatClassification interface for type TextFormat.
@@ -22881,28 +22881,28 @@ func (t *TextFormat) GetDatasetStorageFormat() *DatasetStorageFormat {
 // and a 'location'
 type TrackedResource struct {
 	// REQUIRED; The geo-location where the resource lives
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // Transformation - A data flow transformation.
 type Transformation struct {
 	// REQUIRED; Transformation name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// Transformation description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 }
 
 // TriggerClassification provides polymorphic access to related types.
@@ -22918,19 +22918,19 @@ type TriggerClassification interface {
 // Trigger - Azure Synapse nested object which contains information about creating pipeline run
 type Trigger struct {
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetTrigger implements the TriggerClassification interface for type Trigger.
@@ -23000,10 +23000,10 @@ type TriggerClientGetTriggersByWorkspaceOptions struct {
 // TriggerDependencyProvisioningStatus - Defines the response of a provision trigger dependency operation.
 type TriggerDependencyProvisioningStatus struct {
 	// REQUIRED; Provisioning status.
-	ProvisioningStatus *string `json:"provisioningStatus,omitempty"`
+	ProvisioningStatus *string
 
 	// REQUIRED; Trigger name.
-	TriggerName *string `json:"triggerName,omitempty"`
+	TriggerName *string
 }
 
 // TriggerDependencyReferenceClassification provides polymorphic access to related types.
@@ -23019,10 +23019,10 @@ type TriggerDependencyReferenceClassification interface {
 // TriggerDependencyReference - Trigger referenced dependency.
 type TriggerDependencyReference struct {
 	// REQUIRED; Referenced trigger.
-	ReferenceTrigger *TriggerReference `json:"referenceTrigger,omitempty"`
+	ReferenceTrigger *TriggerReference
 
 	// REQUIRED; The type of dependency reference.
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // GetDependencyReference implements the DependencyReferenceClassification interface for type TriggerDependencyReference.
@@ -23040,46 +23040,46 @@ func (t *TriggerDependencyReference) GetTriggerDependencyReference() *TriggerDep
 // TriggerListResponse - A list of trigger resources.
 type TriggerListResponse struct {
 	// REQUIRED; List of triggers.
-	Value []*TriggerResource `json:"value,omitempty"`
+	Value []*TriggerResource
 
 	// The link to the next page of results, if any remaining results exist.
-	NextLink *string `json:"nextLink,omitempty"`
+	NextLink *string
 }
 
 // TriggerPipelineReference - Pipeline that needs to be triggered with the given parameters.
 type TriggerPipelineReference struct {
 	// Pipeline parameters.
-	Parameters map[string]any `json:"parameters,omitempty"`
+	Parameters map[string]any
 
 	// Pipeline reference.
-	PipelineReference *PipelineReference `json:"pipelineReference,omitempty"`
+	PipelineReference *PipelineReference
 }
 
 // TriggerReference - Trigger reference type.
 type TriggerReference struct {
 	// REQUIRED; Reference trigger name.
-	ReferenceName *string `json:"referenceName,omitempty"`
+	ReferenceName *string
 
 	// REQUIRED; Trigger reference type.
-	Type *TriggerReferenceType `json:"type,omitempty"`
+	Type *TriggerReferenceType
 }
 
 // TriggerResource - Trigger resource type.
 type TriggerResource struct {
 	// REQUIRED; Properties of the trigger.
-	Properties TriggerClassification `json:"properties,omitempty"`
+	Properties TriggerClassification
 
 	// READ-ONLY; Resource Etag.
-	Etag *string `json:"etag,omitempty" azure:"ro"`
+	Etag *string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // TriggerRun - Trigger runs.
@@ -23088,28 +23088,28 @@ type TriggerRun struct {
 	AdditionalProperties map[string]any
 
 	// READ-ONLY; Trigger error message.
-	Message *string `json:"message,omitempty" azure:"ro"`
+	Message *string
 
 	// READ-ONLY; List of property name and value related to trigger run. Name, value pair depends on type of trigger.
-	Properties map[string]*string `json:"properties,omitempty" azure:"ro"`
+	Properties map[string]*string
 
 	// READ-ONLY; Trigger run status.
-	Status *TriggerRunStatus `json:"status,omitempty" azure:"ro"`
+	Status *TriggerRunStatus
 
 	// READ-ONLY; Trigger name.
-	TriggerName *string `json:"triggerName,omitempty" azure:"ro"`
+	TriggerName *string
 
 	// READ-ONLY; Trigger run id.
-	TriggerRunID *string `json:"triggerRunId,omitempty" azure:"ro"`
+	TriggerRunID *string
 
 	// READ-ONLY; Trigger run start time.
-	TriggerRunTimestamp *time.Time `json:"triggerRunTimestamp,omitempty" azure:"ro"`
+	TriggerRunTimestamp *time.Time
 
 	// READ-ONLY; Trigger type.
-	TriggerType *string `json:"triggerType,omitempty" azure:"ro"`
+	TriggerType *string
 
 	// READ-ONLY; List of pipeline name and run Id triggered by the trigger run.
-	TriggeredPipelines map[string]*string `json:"triggeredPipelines,omitempty" azure:"ro"`
+	TriggeredPipelines map[string]*string
 }
 
 // TriggerRunClientCancelTriggerInstanceOptions contains the optional parameters for the TriggerRunClient.CancelTriggerInstance
@@ -23133,44 +23133,44 @@ type TriggerRunClientRerunTriggerInstanceOptions struct {
 // TriggerRunsQueryResponse - A list of trigger runs.
 type TriggerRunsQueryResponse struct {
 	// REQUIRED; List of trigger runs.
-	Value []*TriggerRun `json:"value,omitempty"`
+	Value []*TriggerRun
 
 	// The continuation token for getting the next page of results, if any remaining results exist, null otherwise.
-	ContinuationToken *string `json:"continuationToken,omitempty"`
+	ContinuationToken *string
 }
 
 // TriggerSubscriptionOperationStatus - Defines the response of a trigger subscription operation.
 type TriggerSubscriptionOperationStatus struct {
 	// READ-ONLY; Event Subscription Status.
-	Status *EventSubscriptionStatus `json:"status,omitempty" azure:"ro"`
+	Status *EventSubscriptionStatus
 
 	// READ-ONLY; Trigger name.
-	TriggerName *string `json:"triggerName,omitempty" azure:"ro"`
+	TriggerName *string
 }
 
 // TumblingWindowTrigger - Trigger that schedules pipeline runs for all fixed time interval windows from a start time without
 // gaps and also supports backfill scenarios (when start time is in the past).
 type TumblingWindowTrigger struct {
 	// REQUIRED; Pipeline for which runs are created when an event is fired for trigger window that is ready.
-	Pipeline *TriggerPipelineReference `json:"pipeline,omitempty"`
+	Pipeline *TriggerPipelineReference
 
 	// REQUIRED; Trigger type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Tumbling Window Trigger properties.
-	TypeProperties *TumblingWindowTriggerTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *TumblingWindowTriggerTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the trigger.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Trigger description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// READ-ONLY; Indicates if trigger is running or not. Updated when Start/Stop APIs are called on the Trigger.
-	RuntimeState *TriggerRuntimeState `json:"runtimeState,omitempty" azure:"ro"`
+	RuntimeState *TriggerRuntimeState
 }
 
 // GetTrigger implements the TriggerClassification interface for type TumblingWindowTrigger.
@@ -23187,16 +23187,16 @@ func (t *TumblingWindowTrigger) GetTrigger() *Trigger {
 // TumblingWindowTriggerDependencyReference - Referenced tumbling window trigger dependency.
 type TumblingWindowTriggerDependencyReference struct {
 	// REQUIRED; Referenced trigger.
-	ReferenceTrigger *TriggerReference `json:"referenceTrigger,omitempty"`
+	ReferenceTrigger *TriggerReference
 
 	// REQUIRED; The type of dependency reference.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Timespan applied to the start time of a tumbling window when evaluating dependency.
-	Offset *string `json:"offset,omitempty"`
+	Offset *string
 
 	// The size of the window when evaluating the dependency. If undefined the frequency of the tumbling window will be used.
-	Size *string `json:"size,omitempty"`
+	Size *string
 }
 
 // GetDependencyReference implements the DependencyReferenceClassification interface for type TumblingWindowTriggerDependencyReference.
@@ -23217,57 +23217,57 @@ func (t *TumblingWindowTriggerDependencyReference) GetTriggerDependencyReference
 // TumblingWindowTriggerTypeProperties - Tumbling Window Trigger properties.
 type TumblingWindowTriggerTypeProperties struct {
 	// REQUIRED; The frequency of the time windows.
-	Frequency *TumblingWindowFrequency `json:"frequency,omitempty"`
+	Frequency *TumblingWindowFrequency
 
 	// REQUIRED; The interval of the time windows. The minimum interval allowed is 15 Minutes.
-	Interval *int32 `json:"interval,omitempty"`
+	Interval *int32
 
 	// REQUIRED; The max number of parallel time windows (ready for execution) for which a new run is triggered.
-	MaxConcurrency *int32 `json:"maxConcurrency,omitempty"`
+	MaxConcurrency *int32
 
 	// REQUIRED; The start time for the time period for the trigger during which events are fired for windows that are ready.
 	// Only UTC time is currently supported.
-	StartTime *time.Time `json:"startTime,omitempty"`
+	StartTime *time.Time
 
 	// Specifies how long the trigger waits past due time before triggering new run. It doesn't alter window start and end time.
 	// The default is 0. Type: string (or Expression with resultType string),
 	// pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	Delay any `json:"delay,omitempty"`
+	Delay any
 
 	// Triggers that this trigger depends on. Only tumbling window triggers are supported.
-	DependsOn []DependencyReferenceClassification `json:"dependsOn,omitempty"`
+	DependsOn []DependencyReferenceClassification
 
 	// The end time for the time period for the trigger during which events are fired for windows that are ready. Only UTC time
 	// is currently supported.
-	EndTime *time.Time `json:"endTime,omitempty"`
+	EndTime *time.Time
 
 	// Retry policy that will be applied for failed pipeline runs.
-	RetryPolicy *RetryPolicy `json:"retryPolicy,omitempty"`
+	RetryPolicy *RetryPolicy
 }
 
 // UntilActivity - This activity executes inner activities until the specified boolean expression results to true or timeout
 // is reached, whichever is earlier.
 type UntilActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Until activity properties.
-	TypeProperties *UntilActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *UntilActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type UntilActivity.
@@ -23297,49 +23297,49 @@ func (u *UntilActivity) GetControlActivity() *ControlActivity {
 // UntilActivityTypeProperties - Until activity properties.
 type UntilActivityTypeProperties struct {
 	// REQUIRED; List of activities to execute.
-	Activities []ActivityClassification `json:"activities,omitempty"`
+	Activities []ActivityClassification
 
 	// REQUIRED; An expression that would evaluate to Boolean. The loop will continue until this expression evaluates to true
-	Expression *Expression `json:"expression,omitempty"`
+	Expression *Expression
 
 	// Specifies the timeout for the activity to run. If there is no value specified, it takes the value of TimeSpan.FromDays(7)
 	// which is 1 week as default. Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])). Type: string (or Expression with resultType string),
 	// pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	Timeout any `json:"timeout,omitempty"`
+	Timeout any
 }
 
 // UserProperty - User property.
 type UserProperty struct {
 	// REQUIRED; User property name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; User property value. Type: string (or Expression with resultType string).
-	Value any `json:"value,omitempty"`
+	Value any
 }
 
 // ValidationActivity - This activity verifies that an external resource exists.
 type ValidationActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Validation activity properties.
-	TypeProperties *ValidationActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ValidationActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type ValidationActivity.
@@ -23369,69 +23369,69 @@ func (v *ValidationActivity) GetControlActivity() *ControlActivity {
 // ValidationActivityTypeProperties - Validation activity properties.
 type ValidationActivityTypeProperties struct {
 	// REQUIRED; Validation activity dataset reference.
-	Dataset *DatasetReference `json:"dataset,omitempty"`
+	Dataset *DatasetReference
 
 	// Can be used if dataset points to a folder. If set to true, the folder must have at least one file. If set to false, the
 	// folder must be empty. Type: boolean (or Expression with resultType boolean).
-	ChildItems any `json:"childItems,omitempty"`
+	ChildItems any
 
 	// Can be used if dataset points to a file. The file must be greater than or equal in size to the value specified. Type: integer
 	// (or Expression with resultType integer).
-	MinimumSize any `json:"minimumSize,omitempty"`
+	MinimumSize any
 
 	// A delay in seconds between validation attempts. If no value is specified, 10 seconds will be used as the default. Type:
 	// integer (or Expression with resultType integer).
-	Sleep any `json:"sleep,omitempty"`
+	Sleep any
 
 	// Specifies the timeout for the activity to run. If there is no value specified, it takes the value of TimeSpan.FromDays(7)
 	// which is 1 week as default. Type: string (or Expression with resultType
 	// string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	Timeout any `json:"timeout,omitempty"`
+	Timeout any
 }
 
 // VariableSpecification - Definition of a single variable for a Pipeline.
 type VariableSpecification struct {
 	// REQUIRED; Variable type.
-	Type *VariableType `json:"type,omitempty"`
+	Type *VariableType
 
 	// Default value of variable.
-	DefaultValue any `json:"defaultValue,omitempty"`
+	DefaultValue any
 }
 
 // VerticaDatasetTypeProperties - Vertica Properties
 type VerticaDatasetTypeProperties struct {
 	// The schema name of the Vertica. Type: string (or Expression with resultType string).
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// The table name of the Vertica. Type: string (or Expression with resultType string).
-	Table any `json:"table,omitempty"`
+	Table any
 
 	// This property will be retired. Please consider using schema + table properties instead.
-	TableName any `json:"tableName,omitempty"`
+	TableName any
 }
 
 // VerticaLinkedService - Vertica linked service.
 type VerticaLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Vertica linked service properties.
-	TypeProperties *VerticaLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *VerticaLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type VerticaLinkedService.
@@ -23449,38 +23449,38 @@ func (v *VerticaLinkedService) GetLinkedService() *LinkedService {
 // VerticaLinkedServiceTypeProperties - Vertica linked service properties.
 type VerticaLinkedServiceTypeProperties struct {
 	// An ODBC connection string. Type: string, SecureString or AzureKeyVaultSecretReference.
-	ConnectionString any `json:"connectionString,omitempty"`
+	ConnectionString any
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The Azure key vault secret reference of password in connection string.
-	Pwd *AzureKeyVaultSecretReference `json:"pwd,omitempty"`
+	Pwd *AzureKeyVaultSecretReference
 }
 
 // VerticaSource - A copy activity Vertica source.
 type VerticaSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type VerticaSource.
@@ -23509,35 +23509,35 @@ func (v *VerticaSource) GetTabularSource() *TabularSource {
 // VerticaTableDataset - Vertica dataset.
 type VerticaTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *VerticaDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *VerticaDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type VerticaTableDataset.
@@ -23558,31 +23558,31 @@ func (v *VerticaTableDataset) GetDataset() *Dataset {
 // VirtualNetworkProfile - Virtual Network Profile
 type VirtualNetworkProfile struct {
 	// Subnet ID used for computes in workspace
-	ComputeSubnetID *string `json:"computeSubnetId,omitempty"`
+	ComputeSubnetID *string
 }
 
 // WaitActivity - This activity suspends pipeline execution for the specified interval.
 type WaitActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Wait activity properties.
-	TypeProperties *WaitActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *WaitActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type WaitActivity.
@@ -23612,37 +23612,37 @@ func (w *WaitActivity) GetControlActivity() *ControlActivity {
 // WaitActivityTypeProperties - Wait activity properties.
 type WaitActivityTypeProperties struct {
 	// REQUIRED; Duration in seconds.
-	WaitTimeInSeconds *int32 `json:"waitTimeInSeconds,omitempty"`
+	WaitTimeInSeconds *int32
 }
 
 // WebActivity - Web activity.
 type WebActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Web activity properties.
-	TypeProperties *WebActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *WebActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// Activity policy.
-	Policy *ActivityPolicy `json:"policy,omitempty"`
+	Policy *ActivityPolicy
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type WebActivity.
@@ -23674,59 +23674,59 @@ func (w *WebActivity) GetExecutionActivity() *ExecutionActivity {
 // WebActivityAuthentication - Web activity authentication properties.
 type WebActivityAuthentication struct {
 	// REQUIRED; Web activity authentication (Basic/ClientCertificate/MSI)
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// Password for the PFX file or basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// Base64-encoded contents of a PFX file.
-	Pfx SecretBaseClassification `json:"pfx,omitempty"`
+	Pfx SecretBaseClassification
 
 	// Resource for which Azure Auth token will be requested when using MSI Authentication.
-	Resource *string `json:"resource,omitempty"`
+	Resource *string
 
 	// Web activity authentication user name for basic authentication.
-	Username *string `json:"username,omitempty"`
+	Username *string
 }
 
 // WebActivityTypeProperties - Web activity type properties.
 type WebActivityTypeProperties struct {
 	// REQUIRED; Rest API method for target endpoint.
-	Method *WebActivityMethod `json:"method,omitempty"`
+	Method *WebActivityMethod
 
 	// REQUIRED; Web activity target endpoint and path. Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// Authentication method used for calling the endpoint.
-	Authentication *WebActivityAuthentication `json:"authentication,omitempty"`
+	Authentication *WebActivityAuthentication
 
 	// Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type:
 	// string (or Expression with resultType string).
-	Body any `json:"body,omitempty"`
+	Body any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// List of datasets passed to web endpoint.
-	Datasets []*DatasetReference `json:"datasets,omitempty"`
+	Datasets []*DatasetReference
 
 	// Represents the headers that will be sent to the request. For example, to set the language and type on a request: "headers"
 	// : { "Accept-Language": "en-us", "Content-Type": "application/json" }. Type:
 	// string (or Expression with resultType string).
-	Headers any `json:"headers,omitempty"`
+	Headers any
 
 	// List of linked services passed to web endpoint.
-	LinkedServices []*LinkedServiceReference `json:"linkedServices,omitempty"`
+	LinkedServices []*LinkedServiceReference
 }
 
 // WebAnonymousAuthentication - A WebLinkedService that uses anonymous authentication to communicate with an HTTP endpoint.
 type WebAnonymousAuthentication struct {
 	// REQUIRED; Type of authentication used to connect to the web table source.
-	AuthenticationType *WebAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *WebAuthenticationType
 
 	// REQUIRED; The URL of the web service endpoint, e.g. http://www.microsoft.com . Type: string (or Expression with resultType
 	// string).
-	URL any `json:"url,omitempty"`
+	URL any
 }
 
 // GetWebLinkedServiceTypeProperties implements the WebLinkedServiceTypePropertiesClassification interface for type WebAnonymousAuthentication.
@@ -23740,17 +23740,17 @@ func (w *WebAnonymousAuthentication) GetWebLinkedServiceTypeProperties() *WebLin
 // WebBasicAuthentication - A WebLinkedService that uses basic authentication to communicate with an HTTP endpoint.
 type WebBasicAuthentication struct {
 	// REQUIRED; Type of authentication used to connect to the web table source.
-	AuthenticationType *WebAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *WebAuthenticationType
 
 	// REQUIRED; The password for Basic authentication.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// REQUIRED; The URL of the web service endpoint, e.g. http://www.microsoft.com . Type: string (or Expression with resultType
 	// string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// REQUIRED; User name for Basic authentication. Type: string (or Expression with resultType string).
-	Username any `json:"username,omitempty"`
+	Username any
 }
 
 // GetWebLinkedServiceTypeProperties implements the WebLinkedServiceTypePropertiesClassification interface for type WebBasicAuthentication.
@@ -23766,17 +23766,17 @@ func (w *WebBasicAuthentication) GetWebLinkedServiceTypeProperties() *WebLinkedS
 // the client.
 type WebClientCertificateAuthentication struct {
 	// REQUIRED; Type of authentication used to connect to the web table source.
-	AuthenticationType *WebAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *WebAuthenticationType
 
 	// REQUIRED; Password for the PFX file.
-	Password SecretBaseClassification `json:"password,omitempty"`
+	Password SecretBaseClassification
 
 	// REQUIRED; Base64-encoded contents of a PFX file.
-	Pfx SecretBaseClassification `json:"pfx,omitempty"`
+	Pfx SecretBaseClassification
 
 	// REQUIRED; The URL of the web service endpoint, e.g. http://www.microsoft.com . Type: string (or Expression with resultType
 	// string).
-	URL any `json:"url,omitempty"`
+	URL any
 }
 
 // GetWebLinkedServiceTypeProperties implements the WebLinkedServiceTypePropertiesClassification interface for type WebClientCertificateAuthentication.
@@ -23790,25 +23790,25 @@ func (w *WebClientCertificateAuthentication) GetWebLinkedServiceTypeProperties()
 // WebHookActivity - WebHook activity.
 type WebHookActivity struct {
 	// REQUIRED; Activity name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// REQUIRED; Type of activity.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; WebHook activity properties.
-	TypeProperties *WebHookActivityTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *WebHookActivityTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// Activity depends on condition.
-	DependsOn []*ActivityDependency `json:"dependsOn,omitempty"`
+	DependsOn []*ActivityDependency
 
 	// Activity description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Activity user properties.
-	UserProperties []*UserProperty `json:"userProperties,omitempty"`
+	UserProperties []*UserProperty
 }
 
 // GetActivity implements the ActivityClassification interface for type WebHookActivity.
@@ -23838,55 +23838,55 @@ func (w *WebHookActivity) GetControlActivity() *ControlActivity {
 // WebHookActivityTypeProperties - WebHook activity type properties.
 type WebHookActivityTypeProperties struct {
 	// REQUIRED; Rest API method for target endpoint.
-	Method *WebHookActivityMethod `json:"method,omitempty"`
+	Method *WebHookActivityMethod
 
 	// REQUIRED; WebHook activity target endpoint and path. Type: string (or Expression with resultType string).
-	URL any `json:"url,omitempty"`
+	URL any
 
 	// Authentication method used for calling the endpoint.
-	Authentication *WebActivityAuthentication `json:"authentication,omitempty"`
+	Authentication *WebActivityAuthentication
 
 	// Represents the payload that will be sent to the endpoint. Required for POST/PUT method, not allowed for GET method Type:
 	// string (or Expression with resultType string).
-	Body any `json:"body,omitempty"`
+	Body any
 
 	// Represents the headers that will be sent to the request. For example, to set the language and type on a request: "headers"
 	// : { "Accept-Language": "en-us", "Content-Type": "application/json" }. Type:
 	// string (or Expression with resultType string).
-	Headers any `json:"headers,omitempty"`
+	Headers any
 
 	// When set to true, statusCode, output and error in callback request body will be consumed by activity. The activity can
 	// be marked as failed by setting statusCode >= 400 in callback request. Default is
 	// false. Type: boolean (or Expression with resultType boolean).
-	ReportStatusOnCallBack any `json:"reportStatusOnCallBack,omitempty"`
+	ReportStatusOnCallBack any
 
 	// The timeout within which the webhook should be called back. If there is no value specified, it defaults to 10 minutes.
 	// Type: string. Pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	Timeout *string `json:"timeout,omitempty"`
+	Timeout *string
 }
 
 // WebLinkedService - Web linked service.
 type WebLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Web linked service properties.
-	TypeProperties WebLinkedServiceTypePropertiesClassification `json:"typeProperties,omitempty"`
+	TypeProperties WebLinkedServiceTypePropertiesClassification
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type WebLinkedService.
@@ -23914,11 +23914,11 @@ type WebLinkedServiceTypePropertiesClassification interface {
 // based on authenticationType, so not flattened in SDK models.
 type WebLinkedServiceTypeProperties struct {
 	// REQUIRED; Type of authentication used to connect to the web table source.
-	AuthenticationType *WebAuthenticationType `json:"authenticationType,omitempty"`
+	AuthenticationType *WebAuthenticationType
 
 	// REQUIRED; The URL of the web service endpoint, e.g. http://www.microsoft.com . Type: string (or Expression with resultType
 	// string).
-	URL any `json:"url,omitempty"`
+	URL any
 }
 
 // GetWebLinkedServiceTypeProperties implements the WebLinkedServiceTypePropertiesClassification interface for type WebLinkedServiceTypeProperties.
@@ -23929,19 +23929,19 @@ func (w *WebLinkedServiceTypeProperties) GetWebLinkedServiceTypeProperties() *We
 // WebSource - A copy activity source for web page table.
 type WebSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type WebSource.
@@ -23958,35 +23958,35 @@ func (w *WebSource) GetCopySource() *CopySource {
 // WebTableDataset - The dataset points to a HTML table in the web page.
 type WebTableDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Web table dataset properties.
-	TypeProperties *WebTableDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *WebTableDatasetTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 }
 
 // GetDataset implements the DatasetClassification interface for type WebTableDataset.
@@ -24008,34 +24008,34 @@ func (w *WebTableDataset) GetDataset() *Dataset {
 type WebTableDatasetTypeProperties struct {
 	// REQUIRED; The zero-based index of the table in the web page. Type: integer (or Expression with resultType integer), minimum:
 	// 0.
-	Index any `json:"index,omitempty"`
+	Index any
 
 	// The relative URL to the web page from the linked service URL. Type: string (or Expression with resultType string).
-	Path any `json:"path,omitempty"`
+	Path any
 }
 
 // Workspace - A workspace
 type Workspace struct {
 	// REQUIRED; The geo-location where the resource lives
-	Location *string `json:"location,omitempty"`
+	Location *string
 
 	// Identity of the workspace
-	Identity *ManagedIdentity `json:"identity,omitempty"`
+	Identity *ManagedIdentity
 
 	// Workspace resource properties
-	Properties *WorkspaceProperties `json:"properties,omitempty"`
+	Properties *WorkspaceProperties
 
 	// Resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// READ-ONLY; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-	ID *string `json:"id,omitempty" azure:"ro"`
+	ID *string
 
 	// READ-ONLY; The name of the resource
-	Name *string `json:"name,omitempty" azure:"ro"`
+	Name *string
 
 	// READ-ONLY; The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-	Type *string `json:"type,omitempty" azure:"ro"`
+	Type *string
 }
 
 // WorkspaceClientGetOptions contains the optional parameters for the WorkspaceClient.Get method.
@@ -24053,140 +24053,140 @@ type WorkspaceGitRepoManagementClientGetGitHubAccessTokenOptions struct {
 // WorkspaceIdentity - Identity properties of the workspace resource.
 type WorkspaceIdentity struct {
 	// REQUIRED; The identity type. Currently the only supported type is 'SystemAssigned'.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// READ-ONLY; The principal id of the identity.
-	PrincipalID *string `json:"principalId,omitempty" azure:"ro"`
+	PrincipalID *string
 
 	// READ-ONLY; The client tenant id of the identity.
-	TenantID *string `json:"tenantId,omitempty" azure:"ro"`
+	TenantID *string
 }
 
 // WorkspaceKeyDetails - Details of the customer managed key associated with the workspace
 type WorkspaceKeyDetails struct {
 	// Workspace Key sub-resource key vault url
-	KeyVaultURL *string `json:"keyVaultUrl,omitempty"`
+	KeyVaultURL *string
 
 	// Workspace Key sub-resource name
-	Name *string `json:"name,omitempty"`
+	Name *string
 }
 
 // WorkspaceProperties - Workspace properties
 type WorkspaceProperties struct {
 	// Connectivity endpoints
-	ConnectivityEndpoints map[string]*string `json:"connectivityEndpoints,omitempty"`
+	ConnectivityEndpoints map[string]*string
 
 	// Workspace default data lake storage account details
-	DefaultDataLakeStorage *DataLakeStorageAccountDetails `json:"defaultDataLakeStorage,omitempty"`
+	DefaultDataLakeStorage *DataLakeStorageAccountDetails
 
 	// The encryption details of the workspace
-	Encryption *EncryptionDetails `json:"encryption,omitempty"`
+	Encryption *EncryptionDetails
 
 	// Workspace managed resource group. The resource group name uniquely identifies the resource group within the user subscriptionId.
 	// The resource group name must be no longer than 90 characters long, and
 	// must be alphanumeric characters (Char.IsLetterOrDigit()) and '-', '_', '(', ')' and'.'. Note that the name cannot end with
 	// '.'
-	ManagedResourceGroupName *string `json:"managedResourceGroupName,omitempty"`
+	ManagedResourceGroupName *string
 
 	// Setting this to 'default' will ensure that all compute for this workspace is in a virtual network managed on behalf of
 	// the user.
-	ManagedVirtualNetwork *string `json:"managedVirtualNetwork,omitempty"`
+	ManagedVirtualNetwork *string
 
 	// Managed Virtual Network Settings
-	ManagedVirtualNetworkSettings *ManagedVirtualNetworkSettings `json:"managedVirtualNetworkSettings,omitempty"`
+	ManagedVirtualNetworkSettings *ManagedVirtualNetworkSettings
 
 	// Private endpoint connections to the workspace
-	PrivateEndpointConnections []*PrivateEndpointConnection `json:"privateEndpointConnections,omitempty"`
+	PrivateEndpointConnections []*PrivateEndpointConnection
 
 	// Purview Configuration
-	PurviewConfiguration *PurviewConfiguration `json:"purviewConfiguration,omitempty"`
+	PurviewConfiguration *PurviewConfiguration
 
 	// Login for workspace SQL active directory administrator
-	SQLAdministratorLogin *string `json:"sqlAdministratorLogin,omitempty"`
+	SQLAdministratorLogin *string
 
 	// SQL administrator login password
-	SQLAdministratorLoginPassword *string `json:"sqlAdministratorLoginPassword,omitempty"`
+	SQLAdministratorLoginPassword *string
 
 	// Virtual Network profile
-	VirtualNetworkProfile *VirtualNetworkProfile `json:"virtualNetworkProfile,omitempty"`
+	VirtualNetworkProfile *VirtualNetworkProfile
 
 	// Git integration settings
-	WorkspaceRepositoryConfiguration *WorkspaceRepositoryConfiguration `json:"workspaceRepositoryConfiguration,omitempty"`
+	WorkspaceRepositoryConfiguration *WorkspaceRepositoryConfiguration
 
 	// READ-ONLY; The ADLA resource ID.
-	AdlaResourceID *string `json:"adlaResourceId,omitempty" azure:"ro"`
+	AdlaResourceID *string
 
 	// READ-ONLY; Workspace level configs and feature flags
-	ExtraProperties map[string]any `json:"extraProperties,omitempty" azure:"ro"`
+	ExtraProperties map[string]any
 
 	// READ-ONLY; Resource provisioning state
-	ProvisioningState *string `json:"provisioningState,omitempty" azure:"ro"`
+	ProvisioningState *string
 
 	// READ-ONLY; The workspace unique identifier
-	WorkspaceUID *string `json:"workspaceUID,omitempty" azure:"ro"`
+	WorkspaceUID *string
 }
 
 // WorkspaceRepositoryConfiguration - Git integration settings
 type WorkspaceRepositoryConfiguration struct {
 	// Account name
-	AccountName *string `json:"accountName,omitempty"`
+	AccountName *string
 
 	// Collaboration branch
-	CollaborationBranch *string `json:"collaborationBranch,omitempty"`
+	CollaborationBranch *string
 
 	// GitHub Enterprise host name. For example: https://github.mydomain.com
-	HostName *string `json:"hostName,omitempty"`
+	HostName *string
 
 	// The last commit ID
-	LastCommitID *string `json:"lastCommitId,omitempty"`
+	LastCommitID *string
 
 	// VSTS project name
-	ProjectName *string `json:"projectName,omitempty"`
+	ProjectName *string
 
 	// Repository name
-	RepositoryName *string `json:"repositoryName,omitempty"`
+	RepositoryName *string
 
 	// Root folder to use in the repository
-	RootFolder *string `json:"rootFolder,omitempty"`
+	RootFolder *string
 
 	// The VSTS tenant ID
-	TenantID *string `json:"tenantId,omitempty"`
+	TenantID *string
 
 	// Type of workspace repositoryID configuration. Example WorkspaceVSTSConfiguration, WorkspaceGitHubConfiguration
-	Type *string `json:"type,omitempty"`
+	Type *string
 }
 
 // WorkspaceUpdateParameters - Parameters for updating a workspace resource.
 type WorkspaceUpdateParameters struct {
 	// Managed service identity of the workspace.
-	Identity *WorkspaceIdentity `json:"identity,omitempty"`
+	Identity *WorkspaceIdentity
 
 	// The resource tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 // XeroLinkedService - Xero Service linked service.
 type XeroLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Xero Service linked service properties.
-	TypeProperties *XeroLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *XeroLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type XeroLinkedService.
@@ -24204,62 +24204,62 @@ func (x *XeroLinkedService) GetLinkedService() *LinkedService {
 // XeroLinkedServiceTypeProperties - Xero Service linked service properties.
 type XeroLinkedServiceTypeProperties struct {
 	// REQUIRED; The endpoint of the Xero server. (i.e. api.xero.com)
-	Host any `json:"host,omitempty"`
+	Host any
 
 	// The consumer key associated with the Xero application.
-	ConsumerKey SecretBaseClassification `json:"consumerKey,omitempty"`
+	ConsumerKey SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// The private key from the .pem file that was generated for your Xero private application. You must include all the text
 	// from the .pem file, including the Unix line endings( ).
-	PrivateKey SecretBaseClassification `json:"privateKey,omitempty"`
+	PrivateKey SecretBaseClassification
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // XeroObjectDataset - Xero Service dataset.
 type XeroObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type XeroObjectDataset.
@@ -24280,25 +24280,25 @@ func (x *XeroObjectDataset) GetDataset() *Dataset {
 // XeroSource - A copy activity Xero Service source.
 type XeroSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type XeroSource.
@@ -24327,25 +24327,25 @@ func (x *XeroSource) GetTabularSource() *TabularSource {
 // ZohoLinkedService - Zoho server linked service.
 type ZohoLinkedService struct {
 	// REQUIRED; Type of linked service.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// REQUIRED; Zoho server linked service properties.
-	TypeProperties *ZohoLinkedServiceTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *ZohoLinkedServiceTypeProperties
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the linked service.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// The integration runtime reference.
-	ConnectVia *IntegrationRuntimeReference `json:"connectVia,omitempty"`
+	ConnectVia *IntegrationRuntimeReference
 
 	// Linked service description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// Parameters for linked service.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 }
 
 // GetLinkedService implements the LinkedServiceClassification interface for type ZohoLinkedService.
@@ -24363,58 +24363,58 @@ func (z *ZohoLinkedService) GetLinkedService() *LinkedService {
 // ZohoLinkedServiceTypeProperties - Zoho server linked service properties.
 type ZohoLinkedServiceTypeProperties struct {
 	// REQUIRED; The endpoint of the Zoho server. (i.e. crm.zoho.com/crm/private)
-	Endpoint any `json:"endpoint,omitempty"`
+	Endpoint any
 
 	// The access token for Zoho authentication.
-	AccessToken SecretBaseClassification `json:"accessToken,omitempty"`
+	AccessToken SecretBaseClassification
 
 	// The encrypted credential used for authentication. Credentials are encrypted using the integration runtime credential manager.
 	// Type: string (or Expression with resultType string).
-	EncryptedCredential any `json:"encryptedCredential,omitempty"`
+	EncryptedCredential any
 
 	// Specifies whether the data source endpoints are encrypted using HTTPS. The default value is true.
-	UseEncryptedEndpoints any `json:"useEncryptedEndpoints,omitempty"`
+	UseEncryptedEndpoints any
 
 	// Specifies whether to require the host name in the server's certificate to match the host name of the server when connecting
 	// over SSL. The default value is true.
-	UseHostVerification any `json:"useHostVerification,omitempty"`
+	UseHostVerification any
 
 	// Specifies whether to verify the identity of the server when connecting over SSL. The default value is true.
-	UsePeerVerification any `json:"usePeerVerification,omitempty"`
+	UsePeerVerification any
 }
 
 // ZohoObjectDataset - Zoho server dataset.
 type ZohoObjectDataset struct {
 	// REQUIRED; Linked service reference.
-	LinkedServiceName *LinkedServiceReference `json:"linkedServiceName,omitempty"`
+	LinkedServiceName *LinkedServiceReference
 
 	// REQUIRED; Type of dataset.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// List of tags that can be used for describing the Dataset.
-	Annotations []any `json:"annotations,omitempty"`
+	Annotations []any
 
 	// Dataset description.
-	Description *string `json:"description,omitempty"`
+	Description *string
 
 	// The folder that this Dataset is in. If not specified, Dataset will appear at the root level.
-	Folder *DatasetFolder `json:"folder,omitempty"`
+	Folder *DatasetFolder
 
 	// Parameters for dataset.
-	Parameters map[string]*ParameterSpecification `json:"parameters,omitempty"`
+	Parameters map[string]*ParameterSpecification
 
 	// Columns that define the physical type schema of the dataset. Type: array (or Expression with resultType array), itemType:
 	// DatasetSchemaDataElement.
-	Schema any `json:"schema,omitempty"`
+	Schema any
 
 	// Columns that define the structure of the dataset. Type: array (or Expression with resultType array), itemType: DatasetDataElement.
-	Structure any `json:"structure,omitempty"`
+	Structure any
 
 	// Properties specific to this dataset type.
-	TypeProperties *GenericDatasetTypeProperties `json:"typeProperties,omitempty"`
+	TypeProperties *GenericDatasetTypeProperties
 }
 
 // GetDataset implements the DatasetClassification interface for type ZohoObjectDataset.
@@ -24435,25 +24435,25 @@ func (z *ZohoObjectDataset) GetDataset() *Dataset {
 // ZohoSource - A copy activity Zoho server source.
 type ZohoSource struct {
 	// REQUIRED; Copy source type.
-	Type *string `json:"type,omitempty"`
+	Type *string
 
 	// OPTIONAL; Contains additional key/value pairs not defined in the schema.
 	AdditionalProperties map[string]any
 
 	// The maximum concurrent connection count for the source data store. Type: integer (or Expression with resultType integer).
-	MaxConcurrentConnections any `json:"maxConcurrentConnections,omitempty"`
+	MaxConcurrentConnections any
 
 	// A query to retrieve data from source. Type: string (or Expression with resultType string).
-	Query any `json:"query,omitempty"`
+	Query any
 
 	// Query timeout. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	QueryTimeout any `json:"queryTimeout,omitempty"`
+	QueryTimeout any
 
 	// Source retry count. Type: integer (or Expression with resultType integer).
-	SourceRetryCount any `json:"sourceRetryCount,omitempty"`
+	SourceRetryCount any
 
 	// Source retry wait. Type: string (or Expression with resultType string), pattern: ((\d+).)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).
-	SourceRetryWait any `json:"sourceRetryWait,omitempty"`
+	SourceRetryWait any
 }
 
 // GetCopySource implements the CopySourceClassification interface for type ZohoSource.

--- a/test/synapse/2019-06-01/azspark/zz_models.go
+++ b/test/synapse/2019-06-01/azspark/zz_models.go
@@ -40,193 +40,193 @@ type BatchClientGetSparkBatchJobsOptions struct {
 
 type BatchJob struct {
 	// REQUIRED; The session Id.
-	ID *int32 `json:"id,omitempty"`
+	ID *int32
 
 	// The application id of this session
-	AppID *string `json:"appId,omitempty"`
+	AppID *string
 
 	// The detailed application info.
-	AppInfo map[string]*string `json:"appInfo,omitempty"`
+	AppInfo map[string]*string
 
 	// The artifact identifier.
-	ArtifactID *string `json:"artifactId,omitempty"`
+	ArtifactID *string
 
 	// The error information.
-	Errors []*ServiceError `json:"errorInfo,omitempty"`
+	Errors []*ServiceError
 
 	// The job type.
-	JobType  *SparkJobType  `json:"jobType,omitempty"`
-	LivyInfo *BatchJobState `json:"livyInfo,omitempty"`
+	JobType  *SparkJobType
+	LivyInfo *BatchJobState
 
 	// The log lines.
-	LogLines []*string `json:"log,omitempty"`
+	LogLines []*string
 
 	// The batch name.
-	Name *string `json:"name,omitempty"`
+	Name *string
 
 	// The plugin information.
-	Plugin *ServicePlugin `json:"pluginInfo,omitempty"`
+	Plugin *ServicePlugin
 
 	// The Spark batch job result.
-	Result *SparkBatchJobResultType `json:"result,omitempty"`
+	Result *SparkBatchJobResultType
 
 	// The scheduler information.
-	Scheduler *Scheduler `json:"schedulerInfo,omitempty"`
+	Scheduler *Scheduler
 
 	// The Spark pool name.
-	SparkPoolName *string `json:"sparkPoolName,omitempty"`
+	SparkPoolName *string
 
 	// The batch state
-	State *string `json:"state,omitempty"`
+	State *string
 
 	// The submitter identifier.
-	SubmitterID *string `json:"submitterId,omitempty"`
+	SubmitterID *string
 
 	// The submitter name.
-	SubmitterName *string `json:"submitterName,omitempty"`
+	SubmitterName *string
 
 	// The tags.
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 
 	// The workspace name.
-	WorkspaceName *string `json:"workspaceName,omitempty"`
+	WorkspaceName *string
 }
 
 // BatchJobCollection - Response for batch list operation.
 type BatchJobCollection struct {
 	// REQUIRED; The start index of fetched sessions.
-	From *int32 `json:"from,omitempty"`
+	From *int32
 
 	// REQUIRED; Number of sessions fetched.
-	Total *int32 `json:"total,omitempty"`
+	Total *int32
 
 	// Batch list
-	Sessions []*BatchJob `json:"sessions,omitempty"`
+	Sessions []*BatchJob
 }
 
 type BatchJobOptions struct {
 	// REQUIRED
-	File *string `json:"file,omitempty"`
+	File *string
 
 	// REQUIRED
-	Name       *string   `json:"name,omitempty"`
-	Archives   []*string `json:"archives,omitempty"`
-	Arguments  []*string `json:"args,omitempty"`
-	ArtifactID *string   `json:"artifactId,omitempty"`
-	ClassName  *string   `json:"className,omitempty"`
+	Name       *string
+	Archives   []*string
+	Arguments  []*string
+	ArtifactID *string
+	ClassName  *string
 
 	// Dictionary of
-	Configuration  map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	Files          []*string          `json:"files,omitempty"`
-	Jars           []*string          `json:"jars,omitempty"`
-	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string
+	DriverCores    *int32
+	DriverMemory   *string
+	ExecutorCores  *int32
+	ExecutorCount  *int32
+	ExecutorMemory *string
+	Files          []*string
+	Jars           []*string
+	PythonFiles    []*string
 
 	// Dictionary of
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 type BatchJobState struct {
 	// the Spark job state.
-	CurrentState *string `json:"currentState,omitempty"`
+	CurrentState *string
 
 	// time that at which "dead" livy state was first seen.
-	DeadAt             *time.Time `json:"deadAt,omitempty"`
-	JobCreationRequest *Request   `json:"jobCreationRequest,omitempty"`
+	DeadAt             *time.Time
+	JobCreationRequest *Request
 
 	// the time that at which "not_started" livy state was first seen.
-	NotStartedAt *time.Time `json:"notStartedAt,omitempty"`
+	NotStartedAt *time.Time
 
 	// the time that at which "recovering" livy state was first seen.
-	RecoveringAt *time.Time `json:"recoveringAt,omitempty"`
+	RecoveringAt *time.Time
 
 	// the time that at which "running" livy state was first seen.
-	RunningAt *time.Time `json:"runningAt,omitempty"`
+	RunningAt *time.Time
 
 	// the time that at which "starting" livy state was first seen.
-	StartingAt *time.Time `json:"startingAt,omitempty"`
+	StartingAt *time.Time
 
 	// the time that at which "success" livy state was first seen.
-	SuccessAt *time.Time `json:"successAt,omitempty"`
+	SuccessAt *time.Time
 
 	// the time that at which "killed" livy state was first seen.
-	TerminatedAt *time.Time `json:"killedAt,omitempty"`
+	TerminatedAt *time.Time
 }
 
 type Request struct {
-	Archives  []*string `json:"archives,omitempty"`
-	Arguments []*string `json:"args,omitempty"`
-	ClassName *string   `json:"className,omitempty"`
+	Archives  []*string
+	Arguments []*string
+	ClassName *string
 
 	// Dictionary of
-	Configuration  map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          []*string          `json:"files,omitempty"`
-	Jars           []*string          `json:"jars,omitempty"`
-	Name           *string            `json:"name,omitempty"`
-	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string
+	DriverCores    *int32
+	DriverMemory   *string
+	ExecutorCores  *int32
+	ExecutorCount  *int32
+	ExecutorMemory *string
+	File           *string
+	Files          []*string
+	Jars           []*string
+	Name           *string
+	PythonFiles    []*string
 }
 
 type Scheduler struct {
-	CancellationRequestedAt *time.Time             `json:"cancellationRequestedAt,omitempty"`
-	CurrentState            *SchedulerCurrentState `json:"currentState,omitempty"`
-	EndedAt                 *time.Time             `json:"endedAt,omitempty"`
-	ScheduledAt             *time.Time             `json:"scheduledAt,omitempty"`
-	SubmittedAt             *time.Time             `json:"submittedAt,omitempty"`
+	CancellationRequestedAt *time.Time
+	CurrentState            *SchedulerCurrentState
+	EndedAt                 *time.Time
+	ScheduledAt             *time.Time
+	SubmittedAt             *time.Time
 }
 
 type ServiceError struct {
-	ErrorCode *string           `json:"errorCode,omitempty"`
-	Message   *string           `json:"message,omitempty"`
-	Source    *SparkErrorSource `json:"source,omitempty"`
+	ErrorCode *string
+	Message   *string
+	Source    *SparkErrorSource
 }
 
 type ServicePlugin struct {
-	CleanupStartedAt             *time.Time          `json:"cleanupStartedAt,omitempty"`
-	CurrentState                 *PluginCurrentState `json:"currentState,omitempty"`
-	MonitoringStartedAt          *time.Time          `json:"monitoringStartedAt,omitempty"`
-	PreparationStartedAt         *time.Time          `json:"preparationStartedAt,omitempty"`
-	ResourceAcquisitionStartedAt *time.Time          `json:"resourceAcquisitionStartedAt,omitempty"`
-	SubmissionStartedAt          *time.Time          `json:"submissionStartedAt,omitempty"`
+	CleanupStartedAt             *time.Time
+	CurrentState                 *PluginCurrentState
+	MonitoringStartedAt          *time.Time
+	PreparationStartedAt         *time.Time
+	ResourceAcquisitionStartedAt *time.Time
+	SubmissionStartedAt          *time.Time
 }
 
 type Session struct {
 	// REQUIRED
-	ID    *int32  `json:"id,omitempty"`
-	AppID *string `json:"appId,omitempty"`
+	ID    *int32
+	AppID *string
 
 	// Dictionary of
-	AppInfo    map[string]*string `json:"appInfo,omitempty"`
-	ArtifactID *string            `json:"artifactId,omitempty"`
+	AppInfo    map[string]*string
+	ArtifactID *string
 
 	// The error information.
-	Errors []*ServiceError `json:"errorInfo,omitempty"`
+	Errors []*ServiceError
 
 	// The job type.
-	JobType       *SparkJobType           `json:"jobType,omitempty"`
-	LivyInfo      *SessionState           `json:"livyInfo,omitempty"`
-	LogLines      []*string               `json:"log,omitempty"`
-	Name          *string                 `json:"name,omitempty"`
-	Plugin        *ServicePlugin          `json:"pluginInfo,omitempty"`
-	Result        *SparkSessionResultType `json:"result,omitempty"`
-	Scheduler     *Scheduler              `json:"schedulerInfo,omitempty"`
-	SparkPoolName *string                 `json:"sparkPoolName,omitempty"`
-	State         *string                 `json:"state,omitempty"`
-	SubmitterID   *string                 `json:"submitterId,omitempty"`
-	SubmitterName *string                 `json:"submitterName,omitempty"`
+	JobType       *SparkJobType
+	LivyInfo      *SessionState
+	LogLines      []*string
+	Name          *string
+	Plugin        *ServicePlugin
+	Result        *SparkSessionResultType
+	Scheduler     *Scheduler
+	SparkPoolName *string
+	State         *string
+	SubmitterID   *string
+	SubmitterName *string
 
 	// Dictionary of
-	Tags          map[string]*string `json:"tags,omitempty"`
-	WorkspaceName *string            `json:"workspaceName,omitempty"`
+	Tags          map[string]*string
+	WorkspaceName *string
 }
 
 // SessionClientCancelSparkSessionOptions contains the optional parameters for the SessionClient.CancelSparkSession method.
@@ -284,83 +284,83 @@ type SessionClientResetSparkSessionTimeoutOptions struct {
 
 type SessionCollection struct {
 	// REQUIRED
-	From *int32 `json:"from,omitempty"`
+	From *int32
 
 	// REQUIRED
-	Total    *int32     `json:"total,omitempty"`
-	Sessions []*Session `json:"sessions,omitempty"`
+	Total    *int32
+	Sessions []*Session
 }
 
 type SessionOptions struct {
 	// REQUIRED
-	Name       *string   `json:"name,omitempty"`
-	Archives   []*string `json:"archives,omitempty"`
-	Arguments  []*string `json:"args,omitempty"`
-	ArtifactID *string   `json:"artifactId,omitempty"`
-	ClassName  *string   `json:"className,omitempty"`
+	Name       *string
+	Archives   []*string
+	Arguments  []*string
+	ArtifactID *string
+	ClassName  *string
 
 	// Dictionary of
-	Configuration  map[string]*string `json:"conf,omitempty"`
-	DriverCores    *int32             `json:"driverCores,omitempty"`
-	DriverMemory   *string            `json:"driverMemory,omitempty"`
-	ExecutorCores  *int32             `json:"executorCores,omitempty"`
-	ExecutorCount  *int32             `json:"numExecutors,omitempty"`
-	ExecutorMemory *string            `json:"executorMemory,omitempty"`
-	File           *string            `json:"file,omitempty"`
-	Files          []*string          `json:"files,omitempty"`
-	Jars           []*string          `json:"jars,omitempty"`
-	PythonFiles    []*string          `json:"pyFiles,omitempty"`
+	Configuration  map[string]*string
+	DriverCores    *int32
+	DriverMemory   *string
+	ExecutorCores  *int32
+	ExecutorCount  *int32
+	ExecutorMemory *string
+	File           *string
+	Files          []*string
+	Jars           []*string
+	PythonFiles    []*string
 
 	// Dictionary of
-	Tags map[string]*string `json:"tags,omitempty"`
+	Tags map[string]*string
 }
 
 type SessionState struct {
-	BusyAt             *time.Time `json:"busyAt,omitempty"`
-	CurrentState       *string    `json:"currentState,omitempty"`
-	DeadAt             *time.Time `json:"deadAt,omitempty"`
-	ErrorAt            *time.Time `json:"errorAt,omitempty"`
-	IdleAt             *time.Time `json:"idleAt,omitempty"`
-	JobCreationRequest *Request   `json:"jobCreationRequest,omitempty"`
-	NotStartedAt       *time.Time `json:"notStartedAt,omitempty"`
-	RecoveringAt       *time.Time `json:"recoveringAt,omitempty"`
-	ShuttingDownAt     *time.Time `json:"shuttingDownAt,omitempty"`
-	StartingAt         *time.Time `json:"startingAt,omitempty"`
-	TerminatedAt       *time.Time `json:"killedAt,omitempty"`
+	BusyAt             *time.Time
+	CurrentState       *string
+	DeadAt             *time.Time
+	ErrorAt            *time.Time
+	IdleAt             *time.Time
+	JobCreationRequest *Request
+	NotStartedAt       *time.Time
+	RecoveringAt       *time.Time
+	ShuttingDownAt     *time.Time
+	StartingAt         *time.Time
+	TerminatedAt       *time.Time
 }
 
 type Statement struct {
 	// REQUIRED
-	ID     *int32           `json:"id,omitempty"`
-	Code   *string          `json:"code,omitempty"`
-	Output *StatementOutput `json:"output,omitempty"`
-	State  *string          `json:"state,omitempty"`
+	ID     *int32
+	Code   *string
+	Output *StatementOutput
+	State  *string
 }
 
 type StatementCancellationResult struct {
 	// The msg property from the Livy API. The value is always "canceled".
-	Message *string `json:"msg,omitempty"`
+	Message *string
 }
 
 type StatementCollection struct {
 	// REQUIRED
-	Total      *int32       `json:"total_statements,omitempty"`
-	Statements []*Statement `json:"statements,omitempty"`
+	Total      *int32
+	Statements []*Statement
 }
 
 type StatementOptions struct {
-	Code *string                     `json:"code,omitempty"`
-	Kind *SparkStatementLanguageType `json:"kind,omitempty"`
+	Code *string
+	Kind *SparkStatementLanguageType
 }
 
 type StatementOutput struct {
 	// REQUIRED
-	ExecutionCount *int32 `json:"execution_count,omitempty"`
+	ExecutionCount *int32
 
 	// Anything
-	Data       any       `json:"data,omitempty"`
-	ErrorName  *string   `json:"ename,omitempty"`
-	ErrorValue *string   `json:"evalue,omitempty"`
-	Status     *string   `json:"status,omitempty"`
-	Traceback  []*string `json:"traceback,omitempty"`
+	Data       any
+	ErrorName  *string
+	ErrorValue *string
+	Status     *string
+	Traceback  []*string
 }

--- a/test/tables/2019-02-02/aztables/zz_models.go
+++ b/test/tables/2019-02-02/aztables/zz_models.go
@@ -204,10 +204,10 @@ type CorsRule struct {
 // EntityQueryResponse - The properties for the table entity query response.
 type EntityQueryResponse struct {
 	// The metadata response of the table.
-	ODataMetadata *string `json:"odata.metadata,omitempty"`
+	ODataMetadata *string
 
 	// List of table entities.
-	Value []map[string]any `json:"value,omitempty"`
+	Value []map[string]any
 }
 
 type GeoReplication struct {
@@ -255,49 +255,49 @@ type Metrics struct {
 // Properties - The properties for creating a table.
 type Properties struct {
 	// The name of the table to create.
-	TableName *string `json:"TableName,omitempty"`
+	TableName *string
 }
 
 // QueryResponse - The properties for the table query response.
 type QueryResponse struct {
 	// The metadata response of the table.
-	ODataMetadata *string `json:"odata.metadata,omitempty"`
+	ODataMetadata *string
 
 	// List of tables.
-	Value []*ResponseProperties `json:"value,omitempty"`
+	Value []*ResponseProperties
 }
 
 // Response - The response for a single table.
 type Response struct {
 	// The edit link of the table.
-	ODataEditLink *string `json:"odata.editLink,omitempty"`
+	ODataEditLink *string
 
 	// The id of the table.
-	ODataID *string `json:"odata.id,omitempty"`
+	ODataID *string
 
 	// The metadata response of the table.
-	ODataMetadata *string `json:"odata.metadata,omitempty"`
+	ODataMetadata *string
 
 	// The odata type of the table.
-	ODataType *string `json:"odata.type,omitempty"`
+	ODataType *string
 
 	// The name of the table.
-	TableName *string `json:"TableName,omitempty"`
+	TableName *string
 }
 
 // ResponseProperties - The properties for the table response.
 type ResponseProperties struct {
 	// The edit link of the table.
-	ODataEditLink *string `json:"odata.editLink,omitempty"`
+	ODataEditLink *string
 
 	// The id of the table.
-	ODataID *string `json:"odata.id,omitempty"`
+	ODataID *string
 
 	// The odata type of the table.
-	ODataType *string `json:"odata.type,omitempty"`
+	ODataType *string
 
 	// The name of the table.
-	TableName *string `json:"TableName,omitempty"`
+	TableName *string
 }
 
 // RetentionPolicy - The retention policy.
@@ -340,7 +340,7 @@ type ServiceClientSetPropertiesOptions struct {
 // ServiceError - Table Service error.
 type ServiceError struct {
 	// The error message.
-	Message *string `json:"Message,omitempty"`
+	Message *string
 }
 
 // ServiceProperties - Table Service Properties.


### PR DESCRIPTION
They aren't used and just cause confusion.