### PR TITLE
Remove doc for export-clients option

### DIFF
--- a/src/autorest-configuration.md
+++ b/src/autorest-configuration.md
@@ -68,9 +68,6 @@ help-content:
       - key: file-prefix
         type: string
         description: Optional prefix to file names. For example, if you set your file prefix to "zzz_", all generated code files will begin with "zzz_".
-      - key: export-clients
-        type: boolean
-        description: Indicates if generated clients are to be exported.  Default is true.
       - key: module-version
         description: When --azure-arm is true, semantic version to include in generated telemetryInfo constant without the leading 'v' (e.g. 1.2.3).
         type: string


### PR DESCRIPTION
The feature was removed with the removal of data-plane clients.  Just need to remove the docs for it.