### PR TITLE
Fix populating any type

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -100,7 +100,7 @@ const network = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/22
 generateFromReadme("armnetwork", network, 'package-2020-03', 'test/network/2020-03-01/armnetwork', '--module=armnetwork --azure-arm=true --remove-unreferenced-types');
 
 const compute = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/compute/resource-manager/readme.md';
-generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types --rawjson-as-bytes');
+generateFromReadme("armcompute", compute, 'package-2019-12-01', 'test/compute/2019-12-01/armcompute', '--module=armcompute --azure-arm=true --remove-unreferenced-types');
 
 const synapseArtifacts = 'https://raw.githubusercontent.com/Azure/azure-rest-api-specs/228cf296647f6e41182cee7d1a403990e6a8fe3c/specification/synapse/data-plane/readme.md';
 generateFromReadme("azartifacts", synapseArtifacts, 'package-artifacts-2019-06-01-preview', 'test/synapse/2019-06-01/azartifacts', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azartifacts" --openapi-type="data-plane"');
@@ -123,7 +123,7 @@ generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/da
 const acr = 'https://github.com/Azure/azure-rest-api-specs/blob/195cd610db0accd0422c3e00a72df739ab4de677/specification/containerregistry/data-plane/Azure.ContainerRegistry/stable/2021-07-01/containerregistry.json';
 generate("azacr", acr, 'test/acr/2021-07-01/azacr', '--module="azacr" --openapi-type="data-plane" --rawjson-as-bytes');
 
-generate("azalias", 'test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --openapi-type="data-plane" --rawjson-as-bytes');
+generate("azalias", 'test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --openapi-type="data-plane"');
 
 function should_generate(name) {
     if (filter !== undefined) {

--- a/src/generator/structs.ts
+++ b/src/generator/structs.ts
@@ -26,6 +26,7 @@ export class StructDef {
   readonly Methods: StructMethod[];
   readonly ComposedOf: string[];
   HasJSONByteArray: boolean;
+  HasAny: boolean;
 
   constructor(language: Language, props?: Property[], params?: Parameter[]) {
     this.Language = language;
@@ -41,6 +42,7 @@ export class StructDef {
     this.Methods = new Array<StructMethod>();
     this.ComposedOf = new Array<string>();
     this.HasJSONByteArray = false;
+    this.HasAny = false;
   }
 
   text(): string {
@@ -167,6 +169,8 @@ export function generateStruct(imports: ImportManager, lang: Language, props?: P
     imports.addImportForSchemaType(prop.schema);
     if (prop.language.go!.embeddedType) {
       st.ComposedOf.push(prop.schema.language.go!.name);
+    } else if (prop.schema.type === SchemaType.Any && !prop.schema.language.go!.rawJSONAsBytes) {
+      st.HasAny = true;
     }
   }
   return st;

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.47",
+  "version": "4.0.0-preview.48",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/test/compute/2019-12-01/armcompute/zz_models.go
+++ b/test/compute/2019-12-01/armcompute/zz_models.go
@@ -3685,10 +3685,10 @@ type VirtualMachineCaptureResult struct {
 	ContentVersion *string
 
 	// READ-ONLY; parameters of the captured virtual machine
-	Parameters []byte
+	Parameters any
 
 	// READ-ONLY; a list of resource items of the captured virtual machine
-	Resources []byte
+	Resources []any
 
 	// READ-ONLY; the schema of the captured virtual machine
 	Schema *string
@@ -3821,13 +3821,13 @@ type VirtualMachineExtensionProperties struct {
 	InstanceView *VirtualMachineExtensionInstanceView
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte
+	ProtectedSettings any
 
 	// The name of the extension handler publisher.
 	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte
+	Settings any
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string
@@ -3859,13 +3859,13 @@ type VirtualMachineExtensionUpdateProperties struct {
 	ForceUpdateTag *string
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte
+	ProtectedSettings any
 
 	// The name of the extension handler publisher.
 	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte
+	Settings any
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string
@@ -4302,7 +4302,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	ForceUpdateTag *string
 
 	// The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all.
-	ProtectedSettings []byte
+	ProtectedSettings any
 
 	// Collection of extension names after which this extension needs to be provisioned.
 	ProvisionAfterExtensions []*string
@@ -4311,7 +4311,7 @@ type VirtualMachineScaleSetExtensionProperties struct {
 	Publisher *string
 
 	// Json formatted public settings for the extension.
-	Settings []byte
+	Settings any
 
 	// Specifies the type of the extension; an example is "CustomScriptExtension".
 	Type *string

--- a/test/compute/2019-12-01/armcompute/zz_models_serde.go
+++ b/test/compute/2019-12-01/armcompute/zz_models_serde.go
@@ -7611,8 +7611,8 @@ func (v VirtualMachineCaptureResult) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "contentVersion", v.ContentVersion)
 	populate(objectMap, "id", v.ID)
-	populate(objectMap, "parameters", json.RawMessage(v.Parameters))
-	populate(objectMap, "resources", json.RawMessage(v.Resources))
+	populateAny(objectMap, "parameters", v.Parameters)
+	populate(objectMap, "resources", v.Resources)
 	populate(objectMap, "$schema", v.Schema)
 	return json.Marshal(objectMap)
 }
@@ -7633,10 +7633,10 @@ func (v *VirtualMachineCaptureResult) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &v.ID)
 			delete(rawMsg, key)
 		case "parameters":
-			v.Parameters = val
+			err = unpopulate(val, "Parameters", &v.Parameters)
 			delete(rawMsg, key)
 		case "resources":
-			v.Resources = val
+			err = unpopulate(val, "Resources", &v.Resources)
 			delete(rawMsg, key)
 		case "$schema":
 			err = unpopulate(val, "Schema", &v.Schema)
@@ -7870,10 +7870,10 @@ func (v VirtualMachineExtensionProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
 	populate(objectMap, "instanceView", v.InstanceView)
-	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
+	populateAny(objectMap, "protectedSettings", v.ProtectedSettings)
 	populate(objectMap, "provisioningState", v.ProvisioningState)
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", json.RawMessage(v.Settings))
+	populateAny(objectMap, "settings", v.Settings)
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -7898,7 +7898,7 @@ func (v *VirtualMachineExtensionProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "InstanceView", &v.InstanceView)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			v.ProtectedSettings = val
+			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
 			delete(rawMsg, key)
 		case "provisioningState":
 			err = unpopulate(val, "ProvisioningState", &v.ProvisioningState)
@@ -7907,7 +7907,7 @@ func (v *VirtualMachineExtensionProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			v.Settings = val
+			err = unpopulate(val, "Settings", &v.Settings)
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)
@@ -7959,9 +7959,9 @@ func (v VirtualMachineExtensionUpdateProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
-	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
+	populateAny(objectMap, "protectedSettings", v.ProtectedSettings)
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", json.RawMessage(v.Settings))
+	populateAny(objectMap, "settings", v.Settings)
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -7983,13 +7983,13 @@ func (v *VirtualMachineExtensionUpdateProperties) UnmarshalJSON(data []byte) err
 			err = unpopulate(val, "ForceUpdateTag", &v.ForceUpdateTag)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			v.ProtectedSettings = val
+			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
 			delete(rawMsg, key)
 		case "publisher":
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			v.Settings = val
+			err = unpopulate(val, "Settings", &v.Settings)
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)
@@ -8671,11 +8671,11 @@ func (v VirtualMachineScaleSetExtensionProperties) MarshalJSON() ([]byte, error)
 	objectMap := make(map[string]any)
 	populate(objectMap, "autoUpgradeMinorVersion", v.AutoUpgradeMinorVersion)
 	populate(objectMap, "forceUpdateTag", v.ForceUpdateTag)
-	populate(objectMap, "protectedSettings", json.RawMessage(v.ProtectedSettings))
+	populateAny(objectMap, "protectedSettings", v.ProtectedSettings)
 	populate(objectMap, "provisionAfterExtensions", v.ProvisionAfterExtensions)
 	populate(objectMap, "provisioningState", v.ProvisioningState)
 	populate(objectMap, "publisher", v.Publisher)
-	populate(objectMap, "settings", json.RawMessage(v.Settings))
+	populateAny(objectMap, "settings", v.Settings)
 	populate(objectMap, "type", v.Type)
 	populate(objectMap, "typeHandlerVersion", v.TypeHandlerVersion)
 	return json.Marshal(objectMap)
@@ -8697,7 +8697,7 @@ func (v *VirtualMachineScaleSetExtensionProperties) UnmarshalJSON(data []byte) e
 			err = unpopulate(val, "ForceUpdateTag", &v.ForceUpdateTag)
 			delete(rawMsg, key)
 		case "protectedSettings":
-			v.ProtectedSettings = val
+			err = unpopulate(val, "ProtectedSettings", &v.ProtectedSettings)
 			delete(rawMsg, key)
 		case "provisionAfterExtensions":
 			err = unpopulate(val, "ProvisionAfterExtensions", &v.ProvisionAfterExtensions)
@@ -8709,7 +8709,7 @@ func (v *VirtualMachineScaleSetExtensionProperties) UnmarshalJSON(data []byte) e
 			err = unpopulate(val, "Publisher", &v.Publisher)
 			delete(rawMsg, key)
 		case "settings":
-			v.Settings = val
+			err = unpopulate(val, "Settings", &v.Settings)
 			delete(rawMsg, key)
 		case "type":
 			err = unpopulate(val, "Type", &v.Type)
@@ -11025,6 +11025,16 @@ func populate(m map[string]any, k string, v any) {
 	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}
+
+func populateAny(m map[string]any, k string, v any) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else {
 		m[k] = v
 	}
 }

--- a/test/maps/azalias/models_test.go
+++ b/test/maps/azalias/models_test.go
@@ -15,16 +15,13 @@ func TestPolicyAssignmentProperties(t *testing.T) {
 		t.Fatal(err)
 	}
 	var s string
-	if err := json.Unmarshal(paprops.Parameters["effect"].Value, &s); err != nil {
-		t.Fatal(err)
-	}
+	s, ok := paprops.Parameters["effect"].Value.(string)
+	require.True(t, ok)
 	if s != "Audit" {
 		t.Fatalf("got %s, want Audit", s)
 	}
-	sl := []string{}
-	if err := json.Unmarshal(paprops.Parameters["listOfResourceTypesNotAllowed"].Value, &sl); err != nil {
-		t.Fatal(err)
-	}
+	sl, ok := paprops.Parameters["listOfResourceTypesNotAllowed"].Value.([]any)
+	require.True(t, ok)
 	if len(sl) != 1 {
 		t.Fatal("unexpected slice len")
 	}
@@ -35,10 +32,8 @@ func TestPolicyAssignmentProperties(t *testing.T) {
 	if !ok {
 		t.Fatal("missing one")
 	}
-	mm := map[string]any{}
-	if err := json.Unmarshal(m.Value, &mm); err != nil {
-		t.Fatal(err)
-	}
+	mm, ok := m.Value.(map[string]any)
+	require.True(t, ok)
 	if v := mm["key"]; v != "value" {
 		t.Fatalf("got %s want value", v)
 	}

--- a/test/maps/azalias/polymorphic_helpers_test.go
+++ b/test/maps/azalias/polymorphic_helpers_test.go
@@ -166,5 +166,5 @@ func TestInterfaceJSONNull(t *testing.T) {
 	b, err := json.Marshal(props1)
 	require.NoError(t, err)
 	require.Contains(t, string(b), `"anyObject":null`)
-	require.NotContains(t, string(b), `"anything":null`)
+	require.NotContains(t, string(b), "anything")
 }

--- a/test/maps/azalias/polymorphic_helpers_test.go
+++ b/test/maps/azalias/polymorphic_helpers_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGeoObjectNamedCollectionRoundTrip(t *testing.T) {
@@ -96,7 +98,7 @@ func TestInterfaceRoundTrip(t *testing.T) {
 	props1 := ScheduleCreateOrUpdateProperties{
 		Aliases:     []*string{to.Ptr("foo")},
 		Description: to.Ptr("funky"),
-		Interval:    []byte("false"),
+		Interval:    false,
 		StartTime:   to.Ptr(time.Now().UTC()),
 	}
 	b, err := json.Marshal(props1)
@@ -114,8 +116,10 @@ func TestInterfaceRoundTrip(t *testing.T) {
 	if *props1.Description != *props2.Description {
 		t.Fatalf("expected %v, got %v", *props1.Description, *props2.Description)
 	}
-	i1 := string(props1.Interval)
-	i2 := string(props2.Interval)
+	i1, ok := props1.Interval.(bool)
+	require.True(t, ok)
+	i2, ok := props2.Interval.(bool)
+	require.True(t, ok)
 	if i1 != i2 {
 		t.Fatalf("expected %v, got %v", props1.Interval, props2.Interval)
 	}
@@ -153,4 +157,15 @@ func TestInterfaceNil(t *testing.T) {
 	if props2.Aliases != nil {
 		t.Fatal("expected nil Aliases")
 	}
+}
+
+func TestInterfaceJSONNull(t *testing.T) {
+	props1 := ScheduleCreateOrUpdateProperties{
+		Description: to.Ptr("funky"),
+		StartTime:   to.Ptr(time.Now().UTC()),
+		Interval:    azcore.NullValue[*any](),
+	}
+	b, err := json.Marshal(props1)
+	require.NoError(t, err)
+	require.Contains(t, string(b), `"interval":null`)
 }

--- a/test/maps/azalias/polymorphic_helpers_test.go
+++ b/test/maps/azalias/polymorphic_helpers_test.go
@@ -160,12 +160,11 @@ func TestInterfaceNil(t *testing.T) {
 }
 
 func TestInterfaceJSONNull(t *testing.T) {
-	props1 := ScheduleCreateOrUpdateProperties{
-		Description: to.Ptr("funky"),
-		StartTime:   to.Ptr(time.Now().UTC()),
-		Interval:    azcore.NullValue[*any](),
+	props1 := TypeWithRawJSON{
+		AnyObject: azcore.NullValue[*any](),
 	}
 	b, err := json.Marshal(props1)
 	require.NoError(t, err)
-	require.Contains(t, string(b), `"interval":null`)
+	require.Contains(t, string(b), `"anyObject":null`)
+	require.NotContains(t, string(b), `"anything":null`)
 }

--- a/test/maps/azalias/zz_models.go
+++ b/test/maps/azalias/zz_models.go
@@ -75,7 +75,7 @@ type GeoJSONFeature struct {
 	ID *string
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties []byte
+	Properties any
 
 	// test enum with a default
 	Setting *DataSetting
@@ -98,7 +98,7 @@ type GeoJSONFeatureData struct {
 	ID *string
 
 	// Properties can contain any additional metadata about the Feature. Value can be any JSON object or a JSON null value
-	Properties []byte
+	Properties any
 
 	// test enum with a default
 	Setting *DataSetting
@@ -153,13 +153,13 @@ type ListResponse struct {
 
 type ParameterMetadataValue struct {
 	// a JSON object
-	Value []byte
+	Value any
 }
 
 // ParameterValuesValue - The value of a parameter.
 type ParameterValuesValue struct {
 	// The value of the parameter.
-	Value []byte
+	Value any
 }
 
 type PolicyAssignmentProperties struct {
@@ -182,7 +182,7 @@ type ScheduleCreateOrUpdateProperties struct {
 	Description *string
 
 	// Gets or sets the interval of the schedule.
-	Interval []byte
+	Interval any
 
 	// Gets or sets the start time of the schedule.
 	StartTime *time.Time
@@ -190,8 +190,8 @@ type ScheduleCreateOrUpdateProperties struct {
 
 type TypeWithRawJSON struct {
 	// any JSON object
-	AnyObject []byte
+	AnyObject any
 
 	// any valid JSON
-	Anything []byte
+	Anything any
 }

--- a/test/maps/azalias/zz_models_serde.go
+++ b/test/maps/azalias/zz_models_serde.go
@@ -95,7 +95,7 @@ func (g GeoJSONFeature) MarshalJSON() ([]byte, error) {
 	}
 	populate(objectMap, "featureType", g.FeatureType)
 	populate(objectMap, "id", g.ID)
-	populate(objectMap, "properties", json.RawMessage(g.Properties))
+	populateAny(objectMap, "properties", g.Properties)
 	if g.Setting == nil {
 		g.Setting = to.Ptr(DataSettingTwo)
 	}
@@ -120,7 +120,7 @@ func (g *GeoJSONFeature) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &g.ID)
 			delete(rawMsg, key)
 		case "properties":
-			g.Properties = val
+			err = unpopulate(val, "Properties", &g.Properties)
 			delete(rawMsg, key)
 		case "setting":
 			err = unpopulate(val, "Setting", &g.Setting)
@@ -144,7 +144,7 @@ func (g GeoJSONFeatureData) MarshalJSON() ([]byte, error) {
 	}
 	populate(objectMap, "featureType", g.FeatureType)
 	populate(objectMap, "id", g.ID)
-	populate(objectMap, "properties", json.RawMessage(g.Properties))
+	populateAny(objectMap, "properties", g.Properties)
 	if g.Setting == nil {
 		g.Setting = to.Ptr(DataSettingTwo)
 	}
@@ -168,7 +168,7 @@ func (g *GeoJSONFeatureData) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "ID", &g.ID)
 			delete(rawMsg, key)
 		case "properties":
-			g.Properties = val
+			err = unpopulate(val, "Properties", &g.Properties)
 			delete(rawMsg, key)
 		case "setting":
 			err = unpopulate(val, "Setting", &g.Setting)
@@ -285,7 +285,7 @@ func (l *ListResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParameterMetadataValue.
 func (p ParameterMetadataValue) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", json.RawMessage(p.Value))
+	populateAny(objectMap, "value", p.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -299,7 +299,7 @@ func (p *ParameterMetadataValue) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "value":
-			p.Value = val
+			err = unpopulate(val, "Value", &p.Value)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -312,7 +312,7 @@ func (p *ParameterMetadataValue) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParameterValuesValue.
 func (p ParameterValuesValue) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", json.RawMessage(p.Value))
+	populateAny(objectMap, "value", p.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -326,7 +326,7 @@ func (p *ParameterValuesValue) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "value":
-			p.Value = val
+			err = unpopulate(val, "Value", &p.Value)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -376,7 +376,7 @@ func (s ScheduleCreateOrUpdateProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "aliases", s.Aliases)
 	populate(objectMap, "description", s.Description)
-	populate(objectMap, "interval", json.RawMessage(s.Interval))
+	populateAny(objectMap, "interval", s.Interval)
 	populateTimeRFC3339(objectMap, "startTime", s.StartTime)
 	return json.Marshal(objectMap)
 }
@@ -397,7 +397,7 @@ func (s *ScheduleCreateOrUpdateProperties) UnmarshalJSON(data []byte) error {
 			err = unpopulate(val, "Description", &s.Description)
 			delete(rawMsg, key)
 		case "interval":
-			s.Interval = val
+			err = unpopulate(val, "Interval", &s.Interval)
 			delete(rawMsg, key)
 		case "startTime":
 			err = unpopulateTimeRFC3339(val, "StartTime", &s.StartTime)
@@ -413,8 +413,8 @@ func (s *ScheduleCreateOrUpdateProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TypeWithRawJSON.
 func (t TypeWithRawJSON) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "anyObject", json.RawMessage(t.AnyObject))
-	populate(objectMap, "anything", json.RawMessage(t.Anything))
+	populateAny(objectMap, "anyObject", t.AnyObject)
+	populateAny(objectMap, "anything", t.Anything)
 	return json.Marshal(objectMap)
 }
 
@@ -428,10 +428,10 @@ func (t *TypeWithRawJSON) UnmarshalJSON(data []byte) error {
 		var err error
 		switch key {
 		case "anyObject":
-			t.AnyObject = val
+			err = unpopulate(val, "AnyObject", &t.AnyObject)
 			delete(rawMsg, key)
 		case "anything":
-			t.Anything = val
+			err = unpopulate(val, "Anything", &t.Anything)
 			delete(rawMsg, key)
 		}
 		if err != nil {
@@ -447,6 +447,16 @@ func populate(m map[string]any, k string, v any) {
 	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}
+
+func populateAny(m map[string]any, k string, v any) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else {
 		m[k] = v
 	}
 }

--- a/test/network/2020-03-01/armnetwork/zz_models_serde.go
+++ b/test/network/2020-03-01/armnetwork/zz_models_serde.go
@@ -4722,7 +4722,7 @@ func (b BastionActiveSession) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "resourceType", b.ResourceType)
 	populate(objectMap, "sessionDurationInMins", b.SessionDurationInMins)
 	populate(objectMap, "sessionId", b.SessionID)
-	populate(objectMap, "startTime", &b.StartTime)
+	populateAny(objectMap, "startTime", b.StartTime)
 	populate(objectMap, "targetHostName", b.TargetHostName)
 	populate(objectMap, "targetIpAddress", b.TargetIPAddress)
 	populate(objectMap, "targetResourceGroup", b.TargetResourceGroup)
@@ -23733,6 +23733,16 @@ func populate(m map[string]any, k string, v any) {
 	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}
+
+func populateAny(m map[string]any, k string, v any) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else {
 		m[k] = v
 	}
 }

--- a/test/synapse/2019-06-01/azartifacts/zz_models_serde.go
+++ b/test/synapse/2019-06-01/azartifacts/zz_models_serde.go
@@ -123,11 +123,11 @@ func (a *ActivityDependency) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ActivityPolicy.
 func (a ActivityPolicy) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "retry", &a.Retry)
+	populateAny(objectMap, "retry", a.Retry)
 	populate(objectMap, "retryIntervalInSeconds", a.RetryIntervalInSeconds)
 	populate(objectMap, "secureInput", a.SecureInput)
 	populate(objectMap, "secureOutput", a.SecureOutput)
-	populate(objectMap, "timeout", &a.Timeout)
+	populateAny(objectMap, "timeout", a.Timeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -187,10 +187,10 @@ func (a ActivityRun) MarshalJSON() ([]byte, error) {
 	populateTimeRFC3339(objectMap, "activityRunStart", a.ActivityRunStart)
 	populate(objectMap, "activityType", a.ActivityType)
 	populate(objectMap, "durationInMs", a.DurationInMs)
-	populate(objectMap, "error", &a.Error)
-	populate(objectMap, "input", &a.Input)
+	populateAny(objectMap, "error", a.Error)
+	populateAny(objectMap, "input", a.Input)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
-	populate(objectMap, "output", &a.Output)
+	populateAny(objectMap, "output", a.Output)
 	populate(objectMap, "pipelineName", a.PipelineName)
 	populate(objectMap, "pipelineRunId", a.PipelineRunID)
 	populate(objectMap, "status", a.Status)
@@ -391,16 +391,16 @@ func (a *AmazonMWSLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonMWSLinkedServiceTypeProperties.
 func (a AmazonMWSLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accessKeyId", &a.AccessKeyID)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "endpoint", &a.Endpoint)
-	populate(objectMap, "marketplaceID", &a.MarketplaceID)
+	populateAny(objectMap, "accessKeyId", a.AccessKeyID)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "endpoint", a.Endpoint)
+	populateAny(objectMap, "marketplaceID", a.MarketplaceID)
 	populate(objectMap, "mwsAuthToken", a.MwsAuthToken)
 	populate(objectMap, "secretKey", a.SecretKey)
-	populate(objectMap, "sellerID", &a.SellerID)
-	populate(objectMap, "useEncryptedEndpoints", &a.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &a.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &a.UsePeerVerification)
+	populateAny(objectMap, "sellerID", a.SellerID)
+	populateAny(objectMap, "useEncryptedEndpoints", a.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", a.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", a.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -459,8 +459,8 @@ func (a AmazonMWSObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AmazonMWSObject"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -528,11 +528,11 @@ func (a *AmazonMWSObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonMWSSource.
 func (a AmazonMWSSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AmazonMWSSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -652,12 +652,12 @@ func (a *AmazonRedshiftLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonRedshiftLinkedServiceTypeProperties.
 func (a AmazonRedshiftLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "database", &a.Database)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "database", a.Database)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
-	populate(objectMap, "port", &a.Port)
-	populate(objectMap, "server", &a.Server)
-	populate(objectMap, "username", &a.Username)
+	populateAny(objectMap, "port", a.Port)
+	populateAny(objectMap, "server", a.Server)
+	populateAny(objectMap, "username", a.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -699,12 +699,12 @@ func (a *AmazonRedshiftLinkedServiceTypeProperties) UnmarshalJSON(data []byte) e
 // MarshalJSON implements the json.Marshaller interface for type AmazonRedshiftSource.
 func (a AmazonRedshiftSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
 	populate(objectMap, "redshiftUnloadSettings", a.RedshiftUnloadSettings)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AmazonRedshiftSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -770,8 +770,8 @@ func (a AmazonRedshiftTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AmazonRedshiftTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -839,9 +839,9 @@ func (a *AmazonRedshiftTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonRedshiftTableDatasetTypeProperties.
 func (a AmazonRedshiftTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -936,10 +936,10 @@ func (a *AmazonS3LinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonS3LinkedServiceTypeProperties.
 func (a AmazonS3LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accessKeyId", &a.AccessKeyID)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "accessKeyId", a.AccessKeyID)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "secretAccessKey", a.SecretAccessKey)
-	populate(objectMap, "serviceUrl", &a.ServiceURL)
+	populateAny(objectMap, "serviceUrl", a.ServiceURL)
 	return json.Marshal(objectMap)
 }
 
@@ -975,11 +975,11 @@ func (a *AmazonS3LinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AmazonS3Location.
 func (a AmazonS3Location) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "bucketName", &a.BucketName)
-	populate(objectMap, "fileName", &a.FileName)
-	populate(objectMap, "folderPath", &a.FolderPath)
+	populateAny(objectMap, "bucketName", a.BucketName)
+	populateAny(objectMap, "fileName", a.FileName)
+	populateAny(objectMap, "folderPath", a.FolderPath)
 	objectMap["type"] = "AmazonS3Location"
-	populate(objectMap, "version", &a.Version)
+	populateAny(objectMap, "version", a.Version)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -1034,14 +1034,14 @@ func (a *AmazonS3Location) UnmarshalJSON(data []byte) error {
 func (a AmazonS3ReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", a.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &a.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &a.ModifiedDatetimeStart)
-	populate(objectMap, "prefix", &a.Prefix)
-	populate(objectMap, "recursive", &a.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", a.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", a.ModifiedDatetimeStart)
+	populateAny(objectMap, "prefix", a.Prefix)
+	populateAny(objectMap, "recursive", a.Recursive)
 	objectMap["type"] = "AmazonS3ReadSettings"
-	populate(objectMap, "wildcardFileName", &a.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &a.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", a.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", a.WildcardFolderPath)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -1169,7 +1169,7 @@ func (a *AppendVariableActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AppendVariableActivityTypeProperties.
 func (a AppendVariableActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", &a.Value)
+	populateAny(objectMap, "value", a.Value)
 	populate(objectMap, "variableName", a.VariableName)
 	return json.Marshal(objectMap)
 }
@@ -1298,8 +1298,8 @@ func (a AvroDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "Avro"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -1402,8 +1402,8 @@ func (a *AvroDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AvroFormat.
 func (a AvroFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "deserializer", &a.Deserializer)
-	populate(objectMap, "serializer", &a.Serializer)
+	populateAny(objectMap, "deserializer", a.Deserializer)
+	populateAny(objectMap, "serializer", a.Serializer)
 	objectMap["type"] = "AvroFormat"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -1453,13 +1453,13 @@ func (a *AvroFormat) UnmarshalJSON(data []byte) error {
 func (a AvroSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "formatSettings", a.FormatSettings)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	populate(objectMap, "storeSettings", a.StoreSettings)
 	objectMap["type"] = "AvroSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -1522,9 +1522,9 @@ func (a *AvroSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AvroSource.
 func (a AvroSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	populate(objectMap, "storeSettings", a.StoreSettings)
 	objectMap["type"] = "AvroSource"
 	if a.AdditionalProperties != nil {
@@ -1693,11 +1693,11 @@ func (a *AzureBatchLinkedService) UnmarshalJSON(data []byte) error {
 func (a AzureBatchLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessKey", a.AccessKey)
-	populate(objectMap, "accountName", &a.AccountName)
-	populate(objectMap, "batchUri", &a.BatchURI)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "accountName", a.AccountName)
+	populateAny(objectMap, "batchUri", a.BatchURI)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
-	populate(objectMap, "poolName", &a.PoolName)
+	populateAny(objectMap, "poolName", a.PoolName)
 	return json.Marshal(objectMap)
 }
 
@@ -1801,12 +1801,12 @@ func (a *AzureBlobFSLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobFSLinkedServiceTypeProperties.
 func (a AzureBlobFSLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accountKey", &a.AccountKey)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "accountKey", a.AccountKey)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
-	populate(objectMap, "url", &a.URL)
+	populateAny(objectMap, "tenant", a.Tenant)
+	populateAny(objectMap, "url", a.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -1848,9 +1848,9 @@ func (a *AzureBlobFSLinkedServiceTypeProperties) UnmarshalJSON(data []byte) erro
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobFSLocation.
 func (a AzureBlobFSLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &a.FileName)
-	populate(objectMap, "fileSystem", &a.FileSystem)
-	populate(objectMap, "folderPath", &a.FolderPath)
+	populateAny(objectMap, "fileName", a.FileName)
+	populateAny(objectMap, "fileSystem", a.FileSystem)
+	populateAny(objectMap, "folderPath", a.FolderPath)
 	objectMap["type"] = "AzureBlobFSLocation"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -1903,13 +1903,13 @@ func (a *AzureBlobFSLocation) UnmarshalJSON(data []byte) error {
 func (a AzureBlobFSReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", a.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &a.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &a.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &a.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", a.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", a.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", a.Recursive)
 	objectMap["type"] = "AzureBlobFSReadSettings"
-	populate(objectMap, "wildcardFileName", &a.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &a.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", a.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", a.WildcardFolderPath)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -1972,13 +1972,13 @@ func (a *AzureBlobFSReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobFSSink.
 func (a AzureBlobFSSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &a.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "copyBehavior", a.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureBlobFSSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -2038,12 +2038,12 @@ func (a *AzureBlobFSSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobFSSource.
 func (a AzureBlobFSSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &a.Recursive)
-	populate(objectMap, "skipHeaderLineCount", &a.SkipHeaderLineCount)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
-	populate(objectMap, "treatEmptyAsNull", &a.TreatEmptyAsNull)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", a.Recursive)
+	populateAny(objectMap, "skipHeaderLineCount", a.SkipHeaderLineCount)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
+	populateAny(objectMap, "treatEmptyAsNull", a.TreatEmptyAsNull)
 	objectMap["type"] = "AzureBlobFSSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -2104,9 +2104,9 @@ func (a *AzureBlobFSSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobFSWriteSettings.
 func (a AzureBlobFSWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "blockSizeInMB", &a.BlockSizeInMB)
-	populate(objectMap, "copyBehavior", &a.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
+	populateAny(objectMap, "blockSizeInMB", a.BlockSizeInMB)
+	populateAny(objectMap, "copyBehavior", a.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
 	objectMap["type"] = "AzureBlobFSWriteSettings"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -2221,14 +2221,14 @@ func (a *AzureBlobStorageLinkedService) UnmarshalJSON(data []byte) error {
 func (a AzureBlobStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accountKey", a.AccountKey)
-	populate(objectMap, "connectionString", &a.ConnectionString)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
 	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "sasToken", a.SasToken)
-	populate(objectMap, "sasUri", &a.SasURI)
+	populateAny(objectMap, "sasUri", a.SasURI)
 	populate(objectMap, "serviceEndpoint", a.ServiceEndpoint)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -2279,9 +2279,9 @@ func (a *AzureBlobStorageLinkedServiceTypeProperties) UnmarshalJSON(data []byte)
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobStorageLocation.
 func (a AzureBlobStorageLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "container", &a.Container)
-	populate(objectMap, "fileName", &a.FileName)
-	populate(objectMap, "folderPath", &a.FolderPath)
+	populateAny(objectMap, "container", a.Container)
+	populateAny(objectMap, "fileName", a.FileName)
+	populateAny(objectMap, "folderPath", a.FolderPath)
 	objectMap["type"] = "AzureBlobStorageLocation"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -2334,14 +2334,14 @@ func (a *AzureBlobStorageLocation) UnmarshalJSON(data []byte) error {
 func (a AzureBlobStorageReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", a.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &a.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &a.ModifiedDatetimeStart)
-	populate(objectMap, "prefix", &a.Prefix)
-	populate(objectMap, "recursive", &a.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", a.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", a.ModifiedDatetimeStart)
+	populateAny(objectMap, "prefix", a.Prefix)
+	populateAny(objectMap, "recursive", a.Recursive)
 	objectMap["type"] = "AzureBlobStorageReadSettings"
-	populate(objectMap, "wildcardFileName", &a.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &a.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", a.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", a.WildcardFolderPath)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -2407,9 +2407,9 @@ func (a *AzureBlobStorageReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureBlobStorageWriteSettings.
 func (a AzureBlobStorageWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "blockSizeInMB", &a.BlockSizeInMB)
-	populate(objectMap, "copyBehavior", &a.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
+	populateAny(objectMap, "blockSizeInMB", a.BlockSizeInMB)
+	populateAny(objectMap, "copyBehavior", a.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
 	objectMap["type"] = "AzureBlobStorageWriteSettings"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -2531,8 +2531,8 @@ func (a *AzureDataExplorerCommandActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerCommandActivityTypeProperties.
 func (a AzureDataExplorerCommandActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "command", &a.Command)
-	populate(objectMap, "commandTimeout", &a.CommandTimeout)
+	populateAny(objectMap, "command", a.Command)
+	populateAny(objectMap, "commandTimeout", a.CommandTimeout)
 	return json.Marshal(objectMap)
 }
 
@@ -2562,7 +2562,7 @@ func (a *AzureDataExplorerCommandActivityTypeProperties) UnmarshalJSON(data []by
 // MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerDatasetTypeProperties.
 func (a AzureDataExplorerDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "table", &a.Table)
+	populateAny(objectMap, "table", a.Table)
 	return json.Marshal(objectMap)
 }
 
@@ -2651,11 +2651,11 @@ func (a *AzureDataExplorerLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerLinkedServiceTypeProperties.
 func (a AzureDataExplorerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "database", &a.Database)
-	populate(objectMap, "endpoint", &a.Endpoint)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "database", a.Database)
+	populateAny(objectMap, "endpoint", a.Endpoint)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -2694,15 +2694,15 @@ func (a *AzureDataExplorerLinkedServiceTypeProperties) UnmarshalJSON(data []byte
 // MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerSink.
 func (a AzureDataExplorerSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "flushImmediately", &a.FlushImmediately)
-	populate(objectMap, "ingestionMappingAsJson", &a.IngestionMappingAsJSON)
-	populate(objectMap, "ingestionMappingName", &a.IngestionMappingName)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "flushImmediately", a.FlushImmediately)
+	populateAny(objectMap, "ingestionMappingAsJson", a.IngestionMappingAsJSON)
+	populateAny(objectMap, "ingestionMappingName", a.IngestionMappingName)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureDataExplorerSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -2768,12 +2768,12 @@ func (a *AzureDataExplorerSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataExplorerSource.
 func (a AzureDataExplorerSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "noTruncation", &a.NoTruncation)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "noTruncation", a.NoTruncation)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzureDataExplorerSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -2839,8 +2839,8 @@ func (a AzureDataExplorerTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureDataExplorerTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -2970,14 +2970,14 @@ func (a *AzureDataLakeAnalyticsLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeAnalyticsLinkedServiceTypeProperties.
 func (a AzureDataLakeAnalyticsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accountName", &a.AccountName)
-	populate(objectMap, "dataLakeAnalyticsUri", &a.DataLakeAnalyticsURI)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "resourceGroupName", &a.ResourceGroupName)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "accountName", a.AccountName)
+	populateAny(objectMap, "dataLakeAnalyticsUri", a.DataLakeAnalyticsURI)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "subscriptionId", &a.SubscriptionID)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "subscriptionId", a.SubscriptionID)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -3087,14 +3087,14 @@ func (a *AzureDataLakeStoreLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreLinkedServiceTypeProperties.
 func (a AzureDataLakeStoreLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accountName", &a.AccountName)
-	populate(objectMap, "dataLakeStoreUri", &a.DataLakeStoreURI)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "resourceGroupName", &a.ResourceGroupName)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "accountName", a.AccountName)
+	populateAny(objectMap, "dataLakeStoreUri", a.DataLakeStoreURI)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "subscriptionId", &a.SubscriptionID)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "subscriptionId", a.SubscriptionID)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -3142,8 +3142,8 @@ func (a *AzureDataLakeStoreLinkedServiceTypeProperties) UnmarshalJSON(data []byt
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreLocation.
 func (a AzureDataLakeStoreLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &a.FileName)
-	populate(objectMap, "folderPath", &a.FolderPath)
+	populateAny(objectMap, "fileName", a.FileName)
+	populateAny(objectMap, "folderPath", a.FolderPath)
 	objectMap["type"] = "AzureDataLakeStoreLocation"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -3193,13 +3193,13 @@ func (a *AzureDataLakeStoreLocation) UnmarshalJSON(data []byte) error {
 func (a AzureDataLakeStoreReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", a.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &a.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &a.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &a.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", a.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", a.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", a.Recursive)
 	objectMap["type"] = "AzureDataLakeStoreReadSettings"
-	populate(objectMap, "wildcardFileName", &a.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &a.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", a.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", a.WildcardFolderPath)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -3262,14 +3262,14 @@ func (a *AzureDataLakeStoreReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreSink.
 func (a AzureDataLakeStoreSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &a.CopyBehavior)
-	populate(objectMap, "enableAdlsSingleFileParallel", &a.EnableAdlsSingleFileParallel)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "copyBehavior", a.CopyBehavior)
+	populateAny(objectMap, "enableAdlsSingleFileParallel", a.EnableAdlsSingleFileParallel)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureDataLakeStoreSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -3332,10 +3332,10 @@ func (a *AzureDataLakeStoreSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreSource.
 func (a AzureDataLakeStoreSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &a.Recursive)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", a.Recursive)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzureDataLakeStoreSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -3390,8 +3390,8 @@ func (a *AzureDataLakeStoreSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureDataLakeStoreWriteSettings.
 func (a AzureDataLakeStoreWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &a.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
+	populateAny(objectMap, "copyBehavior", a.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
 	objectMap["type"] = "AzureDataLakeStoreWriteSettings"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -3503,19 +3503,19 @@ func (a *AzureDatabricksLinkedService) UnmarshalJSON(data []byte) error {
 func (a AzureDatabricksLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", a.AccessToken)
-	populate(objectMap, "domain", &a.Domain)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "existingClusterId", &a.ExistingClusterID)
-	populate(objectMap, "instancePoolId", &a.InstancePoolID)
+	populateAny(objectMap, "domain", a.Domain)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "existingClusterId", a.ExistingClusterID)
+	populateAny(objectMap, "instancePoolId", a.InstancePoolID)
 	populate(objectMap, "newClusterCustomTags", a.NewClusterCustomTags)
-	populate(objectMap, "newClusterDriverNodeType", &a.NewClusterDriverNodeType)
-	populate(objectMap, "newClusterEnableElasticDisk", &a.NewClusterEnableElasticDisk)
-	populate(objectMap, "newClusterInitScripts", &a.NewClusterInitScripts)
-	populate(objectMap, "newClusterNodeType", &a.NewClusterNodeType)
-	populate(objectMap, "newClusterNumOfWorker", &a.NewClusterNumOfWorker)
+	populateAny(objectMap, "newClusterDriverNodeType", a.NewClusterDriverNodeType)
+	populateAny(objectMap, "newClusterEnableElasticDisk", a.NewClusterEnableElasticDisk)
+	populateAny(objectMap, "newClusterInitScripts", a.NewClusterInitScripts)
+	populateAny(objectMap, "newClusterNodeType", a.NewClusterNodeType)
+	populateAny(objectMap, "newClusterNumOfWorker", a.NewClusterNumOfWorker)
 	populate(objectMap, "newClusterSparkConf", a.NewClusterSparkConf)
 	populate(objectMap, "newClusterSparkEnvVars", a.NewClusterSparkEnvVars)
-	populate(objectMap, "newClusterVersion", &a.NewClusterVersion)
+	populateAny(objectMap, "newClusterVersion", a.NewClusterVersion)
 	return json.Marshal(objectMap)
 }
 
@@ -3682,10 +3682,10 @@ func (a *AzureFileStorageLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureFileStorageLinkedServiceTypeProperties.
 func (a AzureFileStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "host", &a.Host)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "host", a.Host)
 	populate(objectMap, "password", a.Password)
-	populate(objectMap, "userId", &a.UserID)
+	populateAny(objectMap, "userId", a.UserID)
 	return json.Marshal(objectMap)
 }
 
@@ -3721,8 +3721,8 @@ func (a *AzureFileStorageLinkedServiceTypeProperties) UnmarshalJSON(data []byte)
 // MarshalJSON implements the json.Marshaller interface for type AzureFileStorageLocation.
 func (a AzureFileStorageLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &a.FileName)
-	populate(objectMap, "folderPath", &a.FolderPath)
+	populateAny(objectMap, "fileName", a.FileName)
+	populateAny(objectMap, "folderPath", a.FolderPath)
 	objectMap["type"] = "AzureFileStorageLocation"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -3772,13 +3772,13 @@ func (a *AzureFileStorageLocation) UnmarshalJSON(data []byte) error {
 func (a AzureFileStorageReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", a.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &a.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &a.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &a.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", a.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", a.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", a.Recursive)
 	objectMap["type"] = "AzureFileStorageReadSettings"
-	populate(objectMap, "wildcardFileName", &a.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &a.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", a.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", a.WildcardFolderPath)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -3911,9 +3911,9 @@ func (a *AzureFunctionActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureFunctionActivityTypeProperties.
 func (a AzureFunctionActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "body", &a.Body)
-	populate(objectMap, "functionName", &a.FunctionName)
-	populate(objectMap, "headers", &a.Headers)
+	populateAny(objectMap, "body", a.Body)
+	populateAny(objectMap, "functionName", a.FunctionName)
+	populateAny(objectMap, "headers", a.Headers)
 	populate(objectMap, "method", a.Method)
 	return json.Marshal(objectMap)
 }
@@ -4012,8 +4012,8 @@ func (a *AzureFunctionLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureFunctionLinkedServiceTypeProperties.
 func (a AzureFunctionLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "functionAppUrl", &a.FunctionAppURL)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "functionAppUrl", a.FunctionAppURL)
 	populate(objectMap, "functionKey", a.FunctionKey)
 	return json.Marshal(objectMap)
 }
@@ -4109,7 +4109,7 @@ func (a *AzureKeyVaultLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureKeyVaultLinkedServiceTypeProperties.
 func (a AzureKeyVaultLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "baseUrl", &a.BaseURL)
+	populateAny(objectMap, "baseUrl", a.BaseURL)
 	return json.Marshal(objectMap)
 }
 
@@ -4136,8 +4136,8 @@ func (a *AzureKeyVaultLinkedServiceTypeProperties) UnmarshalJSON(data []byte) er
 // MarshalJSON implements the json.Marshaller interface for type AzureKeyVaultSecretReference.
 func (a AzureKeyVaultSecretReference) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "secretName", &a.SecretName)
-	populate(objectMap, "secretVersion", &a.SecretVersion)
+	populateAny(objectMap, "secretName", a.SecretName)
+	populateAny(objectMap, "secretVersion", a.SecretVersion)
 	populate(objectMap, "store", a.Store)
 	objectMap["type"] = "AzureKeyVaultSecret"
 	return json.Marshal(objectMap)
@@ -4350,11 +4350,11 @@ func (a *AzureMLExecutePipelineActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMLExecutePipelineActivityTypeProperties.
 func (a AzureMLExecutePipelineActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "continueOnStepFailure", &a.ContinueOnStepFailure)
-	populate(objectMap, "experimentName", &a.ExperimentName)
-	populate(objectMap, "mlParentRunId", &a.MlParentRunID)
-	populate(objectMap, "mlPipelineId", &a.MlPipelineID)
-	populate(objectMap, "mlPipelineParameters", &a.MlPipelineParameters)
+	populateAny(objectMap, "continueOnStepFailure", a.ContinueOnStepFailure)
+	populateAny(objectMap, "experimentName", a.ExperimentName)
+	populateAny(objectMap, "mlParentRunId", a.MlParentRunID)
+	populateAny(objectMap, "mlPipelineId", a.MlPipelineID)
+	populateAny(objectMap, "mlPipelineParameters", a.MlPipelineParameters)
 	return json.Marshal(objectMap)
 }
 
@@ -4456,12 +4456,12 @@ func (a *AzureMLLinkedService) UnmarshalJSON(data []byte) error {
 func (a AzureMLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "apiKey", a.APIKey)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "mlEndpoint", &a.MlEndpoint)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "mlEndpoint", a.MlEndpoint)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
-	populate(objectMap, "updateResourceEndpoint", &a.UpdateResourceEndpoint)
+	populateAny(objectMap, "tenant", a.Tenant)
+	populateAny(objectMap, "updateResourceEndpoint", a.UpdateResourceEndpoint)
 	return json.Marshal(objectMap)
 }
 
@@ -4568,13 +4568,13 @@ func (a *AzureMLServiceLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMLServiceLinkedServiceTypeProperties.
 func (a AzureMLServiceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
-	populate(objectMap, "mlWorkspaceName", &a.MlWorkspaceName)
-	populate(objectMap, "resourceGroupName", &a.ResourceGroupName)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
+	populateAny(objectMap, "mlWorkspaceName", a.MlWorkspaceName)
+	populateAny(objectMap, "resourceGroupName", a.ResourceGroupName)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "subscriptionId", &a.SubscriptionID)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "subscriptionId", a.SubscriptionID)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -4689,9 +4689,9 @@ func (a *AzureMLUpdateResourceActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMLUpdateResourceActivityTypeProperties.
 func (a AzureMLUpdateResourceActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "trainedModelFilePath", &a.TrainedModelFilePath)
+	populateAny(objectMap, "trainedModelFilePath", a.TrainedModelFilePath)
 	populate(objectMap, "trainedModelLinkedServiceName", a.TrainedModelLinkedServiceName)
-	populate(objectMap, "trainedModelName", &a.TrainedModelName)
+	populateAny(objectMap, "trainedModelName", a.TrainedModelName)
 	return json.Marshal(objectMap)
 }
 
@@ -4724,7 +4724,7 @@ func (a *AzureMLUpdateResourceActivityTypeProperties) UnmarshalJSON(data []byte)
 // MarshalJSON implements the json.Marshaller interface for type AzureMLWebServiceFile.
 func (a AzureMLWebServiceFile) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "filePath", &a.FilePath)
+	populateAny(objectMap, "filePath", a.FilePath)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	return json.Marshal(objectMap)
 }
@@ -4817,8 +4817,8 @@ func (a *AzureMariaDBLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMariaDBLinkedServiceTypeProperties.
 func (a AzureMariaDBLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "pwd", a.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -4852,11 +4852,11 @@ func (a *AzureMariaDBLinkedServiceTypeProperties) UnmarshalJSON(data []byte) err
 // MarshalJSON implements the json.Marshaller interface for type AzureMariaDBSource.
 func (a AzureMariaDBSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzureMariaDBSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -4919,8 +4919,8 @@ func (a AzureMariaDBTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureMariaDBTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -5050,8 +5050,8 @@ func (a *AzureMySQLLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMySQLLinkedServiceTypeProperties.
 func (a AzureMySQLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
 	return json.Marshal(objectMap)
 }
@@ -5085,13 +5085,13 @@ func (a *AzureMySQLLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type AzureMySQLSink.
 func (a AzureMySQLSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &a.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", a.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureMySqlSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -5151,11 +5151,11 @@ func (a *AzureMySQLSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMySQLSource.
 func (a AzureMySQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzureMySqlSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -5218,8 +5218,8 @@ func (a AzureMySQLTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureMySqlTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -5287,8 +5287,8 @@ func (a *AzureMySQLTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureMySQLTableDatasetTypeProperties.
 func (a AzureMySQLTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -5380,8 +5380,8 @@ func (a *AzurePostgreSQLLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzurePostgreSQLLinkedServiceTypeProperties.
 func (a AzurePostgreSQLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
 	return json.Marshal(objectMap)
 }
@@ -5415,13 +5415,13 @@ func (a *AzurePostgreSQLLinkedServiceTypeProperties) UnmarshalJSON(data []byte) 
 // MarshalJSON implements the json.Marshaller interface for type AzurePostgreSQLSink.
 func (a AzurePostgreSQLSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &a.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", a.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzurePostgreSqlSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -5481,11 +5481,11 @@ func (a *AzurePostgreSQLSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzurePostgreSQLSource.
 func (a AzurePostgreSQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "query", &a.Query)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "query", a.Query)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzurePostgreSqlSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -5548,8 +5548,8 @@ func (a AzurePostgreSQLTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzurePostgreSqlTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -5617,9 +5617,9 @@ func (a *AzurePostgreSQLTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzurePostgreSQLTableDatasetTypeProperties.
 func (a AzurePostgreSQLTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -5652,12 +5652,12 @@ func (a *AzurePostgreSQLTableDatasetTypeProperties) UnmarshalJSON(data []byte) e
 // MarshalJSON implements the json.Marshaller interface for type AzureQueueSink.
 func (a AzureQueueSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureQueueSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -5776,12 +5776,12 @@ func (a *AzureSQLDWLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLDWLinkedServiceTypeProperties.
 func (a AzureSQLDWLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -5828,8 +5828,8 @@ func (a AzureSQLDWTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureSqlDWTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -5897,9 +5897,9 @@ func (a *AzureSQLDWTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLDWTableDatasetTypeProperties.
 func (a AzureSQLDWTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -5994,12 +5994,12 @@ func (a *AzureSQLDatabaseLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLDatabaseLinkedServiceTypeProperties.
 func (a AzureSQLDatabaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -6103,12 +6103,12 @@ func (a *AzureSQLMILinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLMILinkedServiceTypeProperties.
 func (a AzureSQLMILinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &a.ConnectionString)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "password", a.Password)
-	populate(objectMap, "servicePrincipalId", &a.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", a.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", a.ServicePrincipalKey)
-	populate(objectMap, "tenant", &a.Tenant)
+	populateAny(objectMap, "tenant", a.Tenant)
 	return json.Marshal(objectMap)
 }
 
@@ -6155,8 +6155,8 @@ func (a AzureSQLMITableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureSqlMITable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -6224,9 +6224,9 @@ func (a *AzureSQLMITableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLMITableDatasetTypeProperties.
 func (a AzureSQLMITableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -6259,18 +6259,18 @@ func (a *AzureSQLMITableDatasetTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLSink.
 func (a AzureSQLSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &a.PreCopyScript)
-	populate(objectMap, "sqlWriterStoredProcedureName", &a.SQLWriterStoredProcedureName)
-	populate(objectMap, "sqlWriterTableType", &a.SQLWriterTableType)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", a.PreCopyScript)
+	populateAny(objectMap, "sqlWriterStoredProcedureName", a.SQLWriterStoredProcedureName)
+	populateAny(objectMap, "sqlWriterTableType", a.SQLWriterTableType)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	populate(objectMap, "storedProcedureParameters", a.StoredProcedureParameters)
-	populate(objectMap, "storedProcedureTableTypeParameterName", &a.StoredProcedureTableTypeParameterName)
-	populate(objectMap, "tableOption", &a.TableOption)
+	populateAny(objectMap, "storedProcedureTableTypeParameterName", a.StoredProcedureTableTypeParameterName)
+	populateAny(objectMap, "tableOption", a.TableOption)
 	objectMap["type"] = "AzureSqlSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -6345,13 +6345,13 @@ func (a *AzureSQLSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLSource.
 func (a AzureSQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "produceAdditionalTypes", &a.ProduceAdditionalTypes)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sqlReaderQuery", &a.SQLReaderQuery)
-	populate(objectMap, "sqlReaderStoredProcedureName", &a.SQLReaderStoredProcedureName)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "produceAdditionalTypes", a.ProduceAdditionalTypes)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sqlReaderQuery", a.SQLReaderQuery)
+	populateAny(objectMap, "sqlReaderStoredProcedureName", a.SQLReaderStoredProcedureName)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	populate(objectMap, "storedProcedureParameters", a.StoredProcedureParameters)
 	objectMap["type"] = "AzureSqlSource"
 	if a.AdditionalProperties != nil {
@@ -6424,8 +6424,8 @@ func (a AzureSQLTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureSqlTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -6493,9 +6493,9 @@ func (a *AzureSQLTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSQLTableDatasetTypeProperties.
 func (a AzureSQLTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "table", &a.Table)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "table", a.Table)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -6533,8 +6533,8 @@ func (a AzureSearchIndexDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureSearchIndex"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -6602,7 +6602,7 @@ func (a *AzureSearchIndexDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSearchIndexDatasetTypeProperties.
 func (a AzureSearchIndexDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "indexName", &a.IndexName)
+	populateAny(objectMap, "indexName", a.IndexName)
 	return json.Marshal(objectMap)
 }
 
@@ -6629,12 +6629,12 @@ func (a *AzureSearchIndexDatasetTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type AzureSearchIndexSink.
 func (a AzureSearchIndexSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureSearchIndexSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", a.WriteBehavior)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -6757,9 +6757,9 @@ func (a *AzureSearchLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureSearchLinkedServiceTypeProperties.
 func (a AzureSearchLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &a.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "key", a.Key)
-	populate(objectMap, "url", &a.URL)
+	populateAny(objectMap, "url", a.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -6855,10 +6855,10 @@ func (a *AzureStorageLinkedService) UnmarshalJSON(data []byte) error {
 func (a AzureStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accountKey", a.AccountKey)
-	populate(objectMap, "connectionString", &a.ConnectionString)
+	populateAny(objectMap, "connectionString", a.ConnectionString)
 	populate(objectMap, "encryptedCredential", a.EncryptedCredential)
 	populate(objectMap, "sasToken", a.SasToken)
-	populate(objectMap, "sasUri", &a.SasURI)
+	populateAny(objectMap, "sasUri", a.SasURI)
 	return json.Marshal(objectMap)
 }
 
@@ -6902,8 +6902,8 @@ func (a AzureTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", a.Folder)
 	populate(objectMap, "linkedServiceName", a.LinkedServiceName)
 	populate(objectMap, "parameters", a.Parameters)
-	populate(objectMap, "schema", &a.Schema)
-	populate(objectMap, "structure", &a.Structure)
+	populateAny(objectMap, "schema", a.Schema)
+	populateAny(objectMap, "structure", a.Structure)
 	objectMap["type"] = "AzureTable"
 	populate(objectMap, "typeProperties", a.TypeProperties)
 	if a.AdditionalProperties != nil {
@@ -6971,7 +6971,7 @@ func (a *AzureTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureTableDatasetTypeProperties.
 func (a AzureTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &a.TableName)
+	populateAny(objectMap, "tableName", a.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -6998,16 +6998,16 @@ func (a *AzureTableDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureTableSink.
 func (a AzureTableSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "azureTableDefaultPartitionKeyValue", &a.AzureTableDefaultPartitionKeyValue)
-	populate(objectMap, "azureTableInsertType", &a.AzureTableInsertType)
-	populate(objectMap, "azureTablePartitionKeyName", &a.AzureTablePartitionKeyName)
-	populate(objectMap, "azureTableRowKeyName", &a.AzureTableRowKeyName)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &a.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &a.SinkRetryWait)
+	populateAny(objectMap, "azureTableDefaultPartitionKeyValue", a.AzureTableDefaultPartitionKeyValue)
+	populateAny(objectMap, "azureTableInsertType", a.AzureTableInsertType)
+	populateAny(objectMap, "azureTablePartitionKeyName", a.AzureTablePartitionKeyName)
+	populateAny(objectMap, "azureTableRowKeyName", a.AzureTableRowKeyName)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", a.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", a.SinkRetryWait)
 	objectMap["type"] = "AzureTableSink"
-	populate(objectMap, "writeBatchSize", &a.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &a.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", a.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", a.WriteBatchTimeout)
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
 			objectMap[key] = val
@@ -7076,12 +7076,12 @@ func (a *AzureTableSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type AzureTableSource.
 func (a AzureTableSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "azureTableSourceIgnoreTableNotFound", &a.AzureTableSourceIgnoreTableNotFound)
-	populate(objectMap, "azureTableSourceQuery", &a.AzureTableSourceQuery)
-	populate(objectMap, "maxConcurrentConnections", &a.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &a.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &a.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &a.SourceRetryWait)
+	populateAny(objectMap, "azureTableSourceIgnoreTableNotFound", a.AzureTableSourceIgnoreTableNotFound)
+	populateAny(objectMap, "azureTableSourceQuery", a.AzureTableSourceQuery)
+	populateAny(objectMap, "maxConcurrentConnections", a.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", a.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", a.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", a.SourceRetryWait)
 	objectMap["type"] = "AzureTableSource"
 	if a.AdditionalProperties != nil {
 		for key, val := range a.AdditionalProperties {
@@ -7413,8 +7413,8 @@ func (b BinaryDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", b.Folder)
 	populate(objectMap, "linkedServiceName", b.LinkedServiceName)
 	populate(objectMap, "parameters", b.Parameters)
-	populate(objectMap, "schema", &b.Schema)
-	populate(objectMap, "structure", &b.Structure)
+	populateAny(objectMap, "schema", b.Schema)
+	populateAny(objectMap, "structure", b.Structure)
 	objectMap["type"] = "Binary"
 	populate(objectMap, "typeProperties", b.TypeProperties)
 	if b.AdditionalProperties != nil {
@@ -7513,13 +7513,13 @@ func (b *BinaryDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type BinarySink.
 func (b BinarySink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &b.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &b.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &b.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", b.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", b.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", b.SinkRetryWait)
 	populate(objectMap, "storeSettings", b.StoreSettings)
 	objectMap["type"] = "BinarySink"
-	populate(objectMap, "writeBatchSize", &b.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &b.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", b.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", b.WriteBatchTimeout)
 	if b.AdditionalProperties != nil {
 		for key, val := range b.AdditionalProperties {
 			objectMap[key] = val
@@ -7579,9 +7579,9 @@ func (b *BinarySink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type BinarySource.
 func (b BinarySource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &b.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &b.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &b.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", b.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", b.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", b.SourceRetryWait)
 	populate(objectMap, "storeSettings", b.StoreSettings)
 	objectMap["type"] = "BinarySource"
 	if b.AdditionalProperties != nil {
@@ -7742,16 +7742,16 @@ func (b *BlobEventsTriggerTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type BlobSink.
 func (b BlobSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "blobWriterAddHeader", &b.BlobWriterAddHeader)
-	populate(objectMap, "blobWriterDateTimeFormat", &b.BlobWriterDateTimeFormat)
-	populate(objectMap, "blobWriterOverwriteFiles", &b.BlobWriterOverwriteFiles)
-	populate(objectMap, "copyBehavior", &b.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &b.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &b.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &b.SinkRetryWait)
+	populateAny(objectMap, "blobWriterAddHeader", b.BlobWriterAddHeader)
+	populateAny(objectMap, "blobWriterDateTimeFormat", b.BlobWriterDateTimeFormat)
+	populateAny(objectMap, "blobWriterOverwriteFiles", b.BlobWriterOverwriteFiles)
+	populateAny(objectMap, "copyBehavior", b.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", b.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", b.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", b.SinkRetryWait)
 	objectMap["type"] = "BlobSink"
-	populate(objectMap, "writeBatchSize", &b.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &b.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", b.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", b.WriteBatchTimeout)
 	if b.AdditionalProperties != nil {
 		for key, val := range b.AdditionalProperties {
 			objectMap[key] = val
@@ -7820,12 +7820,12 @@ func (b *BlobSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type BlobSource.
 func (b BlobSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &b.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &b.Recursive)
-	populate(objectMap, "skipHeaderLineCount", &b.SkipHeaderLineCount)
-	populate(objectMap, "sourceRetryCount", &b.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &b.SourceRetryWait)
-	populate(objectMap, "treatEmptyAsNull", &b.TreatEmptyAsNull)
+	populateAny(objectMap, "maxConcurrentConnections", b.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", b.Recursive)
+	populateAny(objectMap, "skipHeaderLineCount", b.SkipHeaderLineCount)
+	populateAny(objectMap, "sourceRetryCount", b.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", b.SourceRetryWait)
+	populateAny(objectMap, "treatEmptyAsNull", b.TreatEmptyAsNull)
 	objectMap["type"] = "BlobSource"
 	if b.AdditionalProperties != nil {
 		for key, val := range b.AdditionalProperties {
@@ -8045,12 +8045,12 @@ func (c *CassandraLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CassandraLinkedServiceTypeProperties.
 func (c CassandraLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "authenticationType", &c.AuthenticationType)
-	populate(objectMap, "encryptedCredential", &c.EncryptedCredential)
-	populate(objectMap, "host", &c.Host)
+	populateAny(objectMap, "authenticationType", c.AuthenticationType)
+	populateAny(objectMap, "encryptedCredential", c.EncryptedCredential)
+	populateAny(objectMap, "host", c.Host)
 	populate(objectMap, "password", c.Password)
-	populate(objectMap, "port", &c.Port)
-	populate(objectMap, "username", &c.Username)
+	populateAny(objectMap, "port", c.Port)
+	populateAny(objectMap, "username", c.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -8093,11 +8093,11 @@ func (c *CassandraLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 func (c CassandraSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "consistencyLevel", c.ConsistencyLevel)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "query", &c.Query)
-	populate(objectMap, "queryTimeout", &c.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "query", c.Query)
+	populateAny(objectMap, "queryTimeout", c.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "CassandraSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -8163,8 +8163,8 @@ func (c CassandraTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CassandraTable"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -8232,8 +8232,8 @@ func (c *CassandraTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CassandraTableDatasetTypeProperties.
 func (c CassandraTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "keyspace", &c.Keyspace)
-	populate(objectMap, "tableName", &c.TableName)
+	populateAny(objectMap, "keyspace", c.Keyspace)
+	populateAny(objectMap, "tableName", c.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -8361,8 +8361,8 @@ func (c CommonDataServiceForAppsEntityDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CommonDataServiceForAppsEntity"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -8430,7 +8430,7 @@ func (c *CommonDataServiceForAppsEntityDataset) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type CommonDataServiceForAppsEntityDatasetTypeProperties.
 func (c CommonDataServiceForAppsEntityDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "entityName", &c.EntityName)
+	populateAny(objectMap, "entityName", c.EntityName)
 	return json.Marshal(objectMap)
 }
 
@@ -8521,16 +8521,16 @@ func (c CommonDataServiceForAppsLinkedServiceTypeProperties) MarshalJSON() ([]by
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", c.AuthenticationType)
 	populate(objectMap, "deploymentType", c.DeploymentType)
-	populate(objectMap, "encryptedCredential", &c.EncryptedCredential)
-	populate(objectMap, "hostName", &c.HostName)
-	populate(objectMap, "organizationName", &c.OrganizationName)
+	populateAny(objectMap, "encryptedCredential", c.EncryptedCredential)
+	populateAny(objectMap, "hostName", c.HostName)
+	populateAny(objectMap, "organizationName", c.OrganizationName)
 	populate(objectMap, "password", c.Password)
-	populate(objectMap, "port", &c.Port)
+	populateAny(objectMap, "port", c.Port)
 	populate(objectMap, "servicePrincipalCredential", c.ServicePrincipalCredential)
 	populate(objectMap, "servicePrincipalCredentialType", c.ServicePrincipalCredentialType)
-	populate(objectMap, "servicePrincipalId", &c.ServicePrincipalID)
-	populate(objectMap, "serviceUri", &c.ServiceURI)
-	populate(objectMap, "username", &c.Username)
+	populateAny(objectMap, "servicePrincipalId", c.ServicePrincipalID)
+	populateAny(objectMap, "serviceUri", c.ServiceURI)
+	populateAny(objectMap, "username", c.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -8590,14 +8590,14 @@ func (c *CommonDataServiceForAppsLinkedServiceTypeProperties) UnmarshalJSON(data
 // MarshalJSON implements the json.Marshaller interface for type CommonDataServiceForAppsSink.
 func (c CommonDataServiceForAppsSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "alternateKeyName", &c.AlternateKeyName)
-	populate(objectMap, "ignoreNullValues", &c.IgnoreNullValues)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &c.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &c.SinkRetryWait)
+	populateAny(objectMap, "alternateKeyName", c.AlternateKeyName)
+	populateAny(objectMap, "ignoreNullValues", c.IgnoreNullValues)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", c.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", c.SinkRetryWait)
 	objectMap["type"] = "CommonDataServiceForAppsSink"
-	populate(objectMap, "writeBatchSize", &c.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &c.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", c.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", c.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", c.WriteBehavior)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -8664,10 +8664,10 @@ func (c *CommonDataServiceForAppsSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CommonDataServiceForAppsSource.
 func (c CommonDataServiceForAppsSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "query", &c.Query)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "query", c.Query)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "CommonDataServiceForAppsSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -8784,13 +8784,13 @@ func (c *ConcurLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ConcurLinkedServiceTypeProperties.
 func (c ConcurLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &c.ClientID)
-	populate(objectMap, "encryptedCredential", &c.EncryptedCredential)
+	populateAny(objectMap, "clientId", c.ClientID)
+	populateAny(objectMap, "encryptedCredential", c.EncryptedCredential)
 	populate(objectMap, "password", c.Password)
-	populate(objectMap, "useEncryptedEndpoints", &c.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &c.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &c.UsePeerVerification)
-	populate(objectMap, "username", &c.Username)
+	populateAny(objectMap, "useEncryptedEndpoints", c.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", c.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", c.UsePeerVerification)
+	populateAny(objectMap, "username", c.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -8840,8 +8840,8 @@ func (c ConcurObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "ConcurObject"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -8909,11 +8909,11 @@ func (c *ConcurObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ConcurSource.
 func (c ConcurSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "query", &c.Query)
-	populate(objectMap, "queryTimeout", &c.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "query", c.Query)
+	populateAny(objectMap, "queryTimeout", c.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "ConcurSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -9107,17 +9107,17 @@ func (c *CopyActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CopyActivityTypeProperties.
 func (c CopyActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "dataIntegrationUnits", &c.DataIntegrationUnits)
-	populate(objectMap, "enableSkipIncompatibleRow", &c.EnableSkipIncompatibleRow)
-	populate(objectMap, "enableStaging", &c.EnableStaging)
-	populate(objectMap, "parallelCopies", &c.ParallelCopies)
+	populateAny(objectMap, "dataIntegrationUnits", c.DataIntegrationUnits)
+	populateAny(objectMap, "enableSkipIncompatibleRow", c.EnableSkipIncompatibleRow)
+	populateAny(objectMap, "enableStaging", c.EnableStaging)
+	populateAny(objectMap, "parallelCopies", c.ParallelCopies)
 	populate(objectMap, "preserve", c.Preserve)
 	populate(objectMap, "preserveRules", c.PreserveRules)
 	populate(objectMap, "redirectIncompatibleRowSettings", c.RedirectIncompatibleRowSettings)
 	populate(objectMap, "sink", c.Sink)
 	populate(objectMap, "source", c.Source)
 	populate(objectMap, "stagingSettings", c.StagingSettings)
-	populate(objectMap, "translator", &c.Translator)
+	populateAny(objectMap, "translator", c.Translator)
 	return json.Marshal(objectMap)
 }
 
@@ -9174,12 +9174,12 @@ func (c *CopyActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CopySink.
 func (c CopySink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &c.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &c.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", c.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", c.SinkRetryWait)
 	objectMap["type"] = c.Type
-	populate(objectMap, "writeBatchSize", &c.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &c.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", c.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", c.WriteBatchTimeout)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
@@ -9236,9 +9236,9 @@ func (c *CopySink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CopySource.
 func (c CopySource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = c.Type
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -9394,11 +9394,11 @@ func (c *CosmosDbLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbLinkedServiceTypeProperties.
 func (c CosmosDbLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accountEndpoint", &c.AccountEndpoint)
+	populateAny(objectMap, "accountEndpoint", c.AccountEndpoint)
 	populate(objectMap, "accountKey", c.AccountKey)
-	populate(objectMap, "connectionString", &c.ConnectionString)
-	populate(objectMap, "database", &c.Database)
-	populate(objectMap, "encryptedCredential", &c.EncryptedCredential)
+	populateAny(objectMap, "connectionString", c.ConnectionString)
+	populateAny(objectMap, "database", c.Database)
+	populateAny(objectMap, "encryptedCredential", c.EncryptedCredential)
 	return json.Marshal(objectMap)
 }
 
@@ -9442,8 +9442,8 @@ func (c CosmosDbMongoDbAPICollectionDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CosmosDbMongoDbApiCollection"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -9511,7 +9511,7 @@ func (c *CosmosDbMongoDbAPICollectionDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbMongoDbAPICollectionDatasetTypeProperties.
 func (c CosmosDbMongoDbAPICollectionDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collection", &c.Collection)
+	populateAny(objectMap, "collection", c.Collection)
 	return json.Marshal(objectMap)
 }
 
@@ -9600,8 +9600,8 @@ func (c *CosmosDbMongoDbAPILinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbMongoDbAPILinkedServiceTypeProperties.
 func (c CosmosDbMongoDbAPILinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &c.ConnectionString)
-	populate(objectMap, "database", &c.Database)
+	populateAny(objectMap, "connectionString", c.ConnectionString)
+	populateAny(objectMap, "database", c.Database)
 	return json.Marshal(objectMap)
 }
 
@@ -9631,13 +9631,13 @@ func (c *CosmosDbMongoDbAPILinkedServiceTypeProperties) UnmarshalJSON(data []byt
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbMongoDbAPISink.
 func (c CosmosDbMongoDbAPISink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &c.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &c.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", c.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", c.SinkRetryWait)
 	objectMap["type"] = "CosmosDbMongoDbApiSink"
-	populate(objectMap, "writeBatchSize", &c.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &c.WriteBatchTimeout)
-	populate(objectMap, "writeBehavior", &c.WriteBehavior)
+	populateAny(objectMap, "writeBatchSize", c.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", c.WriteBatchTimeout)
+	populateAny(objectMap, "writeBehavior", c.WriteBehavior)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
@@ -9697,13 +9697,13 @@ func (c *CosmosDbMongoDbAPISink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbMongoDbAPISource.
 func (c CosmosDbMongoDbAPISource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "batchSize", &c.BatchSize)
+	populateAny(objectMap, "batchSize", c.BatchSize)
 	populate(objectMap, "cursorMethods", c.CursorMethods)
-	populate(objectMap, "filter", &c.Filter)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &c.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "filter", c.Filter)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", c.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "CosmosDbMongoDbApiSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -9772,8 +9772,8 @@ func (c CosmosDbSQLAPICollectionDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CosmosDbSqlApiCollection"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -9841,7 +9841,7 @@ func (c *CosmosDbSQLAPICollectionDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbSQLAPICollectionDatasetTypeProperties.
 func (c CosmosDbSQLAPICollectionDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collectionName", &c.CollectionName)
+	populateAny(objectMap, "collectionName", c.CollectionName)
 	return json.Marshal(objectMap)
 }
 
@@ -9868,13 +9868,13 @@ func (c *CosmosDbSQLAPICollectionDatasetTypeProperties) UnmarshalJSON(data []byt
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbSQLAPISink.
 func (c CosmosDbSQLAPISink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &c.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &c.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", c.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", c.SinkRetryWait)
 	objectMap["type"] = "CosmosDbSqlApiSink"
-	populate(objectMap, "writeBatchSize", &c.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &c.WriteBatchTimeout)
-	populate(objectMap, "writeBehavior", &c.WriteBehavior)
+	populateAny(objectMap, "writeBatchSize", c.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", c.WriteBatchTimeout)
+	populateAny(objectMap, "writeBehavior", c.WriteBehavior)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
@@ -9934,12 +9934,12 @@ func (c *CosmosDbSQLAPISink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CosmosDbSQLAPISource.
 func (c CosmosDbSQLAPISource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "pageSize", &c.PageSize)
-	populate(objectMap, "preferredRegions", &c.PreferredRegions)
-	populate(objectMap, "query", &c.Query)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "pageSize", c.PageSize)
+	populateAny(objectMap, "preferredRegions", c.PreferredRegions)
+	populateAny(objectMap, "query", c.Query)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "CosmosDbSqlApiSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -10062,9 +10062,9 @@ func (c *CouchbaseLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CouchbaseLinkedServiceTypeProperties.
 func (c CouchbaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &c.ConnectionString)
+	populateAny(objectMap, "connectionString", c.ConnectionString)
 	populate(objectMap, "credString", c.CredString)
-	populate(objectMap, "encryptedCredential", &c.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", c.EncryptedCredential)
 	return json.Marshal(objectMap)
 }
 
@@ -10097,11 +10097,11 @@ func (c *CouchbaseLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type CouchbaseSource.
 func (c CouchbaseSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &c.MaxConcurrentConnections)
-	populate(objectMap, "query", &c.Query)
-	populate(objectMap, "queryTimeout", &c.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &c.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &c.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", c.MaxConcurrentConnections)
+	populateAny(objectMap, "query", c.Query)
+	populateAny(objectMap, "queryTimeout", c.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", c.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", c.SourceRetryWait)
 	objectMap["type"] = "CouchbaseSource"
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
@@ -10164,8 +10164,8 @@ func (c CouchbaseTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CouchbaseTable"
 	populate(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
@@ -10435,12 +10435,12 @@ func (c *CustomActivityReferenceObject) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type CustomActivityTypeProperties.
 func (c CustomActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "command", &c.Command)
+	populateAny(objectMap, "command", c.Command)
 	populate(objectMap, "extendedProperties", c.ExtendedProperties)
-	populate(objectMap, "folderPath", &c.FolderPath)
+	populateAny(objectMap, "folderPath", c.FolderPath)
 	populate(objectMap, "referenceObjects", c.ReferenceObjects)
 	populate(objectMap, "resourceLinkedService", c.ResourceLinkedService)
-	populate(objectMap, "retentionTimeInDays", &c.RetentionTimeInDays)
+	populateAny(objectMap, "retentionTimeInDays", c.RetentionTimeInDays)
 	return json.Marshal(objectMap)
 }
 
@@ -10487,7 +10487,7 @@ func (c CustomDataSourceLinkedService) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "description", c.Description)
 	populate(objectMap, "parameters", c.Parameters)
 	objectMap["type"] = "CustomDataSource"
-	populate(objectMap, "typeProperties", &c.TypeProperties)
+	populateAny(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
@@ -10549,10 +10549,10 @@ func (c CustomDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", c.Folder)
 	populate(objectMap, "linkedServiceName", c.LinkedServiceName)
 	populate(objectMap, "parameters", c.Parameters)
-	populate(objectMap, "schema", &c.Schema)
-	populate(objectMap, "structure", &c.Structure)
+	populateAny(objectMap, "schema", c.Schema)
+	populateAny(objectMap, "structure", c.Structure)
 	objectMap["type"] = "CustomDataset"
-	populate(objectMap, "typeProperties", &c.TypeProperties)
+	populateAny(objectMap, "typeProperties", c.TypeProperties)
 	if c.AdditionalProperties != nil {
 		for key, val := range c.AdditionalProperties {
 			objectMap[key] = val
@@ -10676,8 +10676,8 @@ func (c *CustomerManagedKeyDetails) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DWCopyCommandDefaultValue.
 func (d DWCopyCommandDefaultValue) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "columnName", &d.ColumnName)
-	populate(objectMap, "defaultValue", &d.DefaultValue)
+	populateAny(objectMap, "columnName", d.ColumnName)
+	populateAny(objectMap, "defaultValue", d.DefaultValue)
 	return json.Marshal(objectMap)
 }
 
@@ -10778,7 +10778,7 @@ func (d *DataFlow) UnmarshalJSON(data []byte) error {
 func (d DataFlowDebugCommandRequest) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "commandName", d.CommandName)
-	populate(objectMap, "commandPayload", &d.CommandPayload)
+	populateAny(objectMap, "commandPayload", d.CommandPayload)
 	populate(objectMap, "dataFlowName", d.DataFlowName)
 	populate(objectMap, "sessionId", d.SessionID)
 	return json.Marshal(objectMap)
@@ -10909,7 +10909,7 @@ func (d *DataFlowDebugPackage) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DataFlowDebugPackageDebugSettings.
 func (d DataFlowDebugPackageDebugSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "datasetParameters", &d.DatasetParameters)
+	populateAny(objectMap, "datasetParameters", d.DatasetParameters)
 	populate(objectMap, "parameters", d.Parameters)
 	populate(objectMap, "sourceSettings", d.SourceSettings)
 	return json.Marshal(objectMap)
@@ -11243,7 +11243,7 @@ func (d *DataFlowListResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DataFlowReference.
 func (d DataFlowReference) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "datasetParameters", &d.DatasetParameters)
+	populateAny(objectMap, "datasetParameters", d.DatasetParameters)
 	populate(objectMap, "referenceName", d.ReferenceName)
 	populate(objectMap, "type", d.Type)
 	if d.AdditionalProperties != nil {
@@ -11553,13 +11553,13 @@ func (d *DataLakeAnalyticsUSQLActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DataLakeAnalyticsUSQLActivityTypeProperties.
 func (d DataLakeAnalyticsUSQLActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "compilationMode", &d.CompilationMode)
-	populate(objectMap, "degreeOfParallelism", &d.DegreeOfParallelism)
+	populateAny(objectMap, "compilationMode", d.CompilationMode)
+	populateAny(objectMap, "degreeOfParallelism", d.DegreeOfParallelism)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "priority", &d.Priority)
-	populate(objectMap, "runtimeVersion", &d.RuntimeVersion)
+	populateAny(objectMap, "priority", d.Priority)
+	populateAny(objectMap, "runtimeVersion", d.RuntimeVersion)
 	populate(objectMap, "scriptLinkedService", d.ScriptLinkedService)
-	populate(objectMap, "scriptPath", &d.ScriptPath)
+	populateAny(objectMap, "scriptPath", d.ScriptPath)
 	return json.Marshal(objectMap)
 }
 
@@ -11707,7 +11707,7 @@ func (d DatabricksNotebookActivityTypeProperties) MarshalJSON() ([]byte, error) 
 	objectMap := make(map[string]any)
 	populate(objectMap, "baseParameters", d.BaseParameters)
 	populate(objectMap, "libraries", d.Libraries)
-	populate(objectMap, "notebookPath", &d.NotebookPath)
+	populateAny(objectMap, "notebookPath", d.NotebookPath)
 	return json.Marshal(objectMap)
 }
 
@@ -11811,7 +11811,7 @@ func (d *DatabricksSparkJarActivity) UnmarshalJSON(data []byte) error {
 func (d DatabricksSparkJarActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "libraries", d.Libraries)
-	populate(objectMap, "mainClassName", &d.MainClassName)
+	populateAny(objectMap, "mainClassName", d.MainClassName)
 	populate(objectMap, "parameters", d.Parameters)
 	return json.Marshal(objectMap)
 }
@@ -11917,7 +11917,7 @@ func (d DatabricksSparkPythonActivityTypeProperties) MarshalJSON() ([]byte, erro
 	objectMap := make(map[string]any)
 	populate(objectMap, "libraries", d.Libraries)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "pythonFile", &d.PythonFile)
+	populateAny(objectMap, "pythonFile", d.PythonFile)
 	return json.Marshal(objectMap)
 }
 
@@ -11955,8 +11955,8 @@ func (d Dataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -12104,8 +12104,8 @@ func (d *DatasetCompression) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DatasetDataElement.
 func (d DatasetDataElement) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "name", &d.Name)
-	populate(objectMap, "type", &d.Type)
+	populateAny(objectMap, "name", d.Name)
+	populateAny(objectMap, "type", d.Type)
 	return json.Marshal(objectMap)
 }
 
@@ -12316,8 +12316,8 @@ func (d *DatasetListResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DatasetLocation.
 func (d DatasetLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &d.FileName)
-	populate(objectMap, "folderPath", &d.FolderPath)
+	populateAny(objectMap, "fileName", d.FileName)
+	populateAny(objectMap, "folderPath", d.FolderPath)
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -12444,8 +12444,8 @@ func (d *DatasetResource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DatasetSchemaDataElement.
 func (d DatasetSchemaDataElement) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "name", &d.Name)
-	populate(objectMap, "type", &d.Type)
+	populateAny(objectMap, "name", d.Name)
+	populateAny(objectMap, "type", d.Type)
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
@@ -12490,8 +12490,8 @@ func (d *DatasetSchemaDataElement) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DatasetStorageFormat.
 func (d DatasetStorageFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "deserializer", &d.Deserializer)
-	populate(objectMap, "serializer", &d.Serializer)
+	populateAny(objectMap, "deserializer", d.Deserializer)
+	populateAny(objectMap, "serializer", d.Serializer)
 	objectMap["type"] = d.Type
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -12649,13 +12649,13 @@ func (d *Db2LinkedService) UnmarshalJSON(data []byte) error {
 func (d Db2LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", d.AuthenticationType)
-	populate(objectMap, "certificateCommonName", &d.CertificateCommonName)
-	populate(objectMap, "database", &d.Database)
-	populate(objectMap, "encryptedCredential", &d.EncryptedCredential)
-	populate(objectMap, "packageCollection", &d.PackageCollection)
+	populateAny(objectMap, "certificateCommonName", d.CertificateCommonName)
+	populateAny(objectMap, "database", d.Database)
+	populateAny(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populateAny(objectMap, "packageCollection", d.PackageCollection)
 	populate(objectMap, "password", d.Password)
-	populate(objectMap, "server", &d.Server)
-	populate(objectMap, "username", &d.Username)
+	populateAny(objectMap, "server", d.Server)
+	populateAny(objectMap, "username", d.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -12703,11 +12703,11 @@ func (d *Db2LinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type Db2Source.
 func (d Db2Source) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "queryTimeout", &d.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "queryTimeout", d.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "Db2Source"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -12770,8 +12770,8 @@ func (d Db2TableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "Db2Table"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -12839,9 +12839,9 @@ func (d *Db2TableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type Db2TableDatasetTypeProperties.
 func (d Db2TableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "table", &d.Table)
-	populate(objectMap, "tableName", &d.TableName)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "table", d.Table)
+	populateAny(objectMap, "tableName", d.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -12945,10 +12945,10 @@ func (d *DeleteActivity) UnmarshalJSON(data []byte) error {
 func (d DeleteActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "dataset", d.Dataset)
-	populate(objectMap, "enableLogging", &d.EnableLogging)
+	populateAny(objectMap, "enableLogging", d.EnableLogging)
 	populate(objectMap, "logStorageSettings", d.LogStorageSettings)
 	populate(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &d.Recursive)
+	populateAny(objectMap, "recursive", d.Recursive)
 	return json.Marshal(objectMap)
 }
 
@@ -13023,8 +13023,8 @@ func (d DelimitedTextDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DelimitedText"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -13092,16 +13092,16 @@ func (d *DelimitedTextDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DelimitedTextDatasetTypeProperties.
 func (d DelimitedTextDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "columnDelimiter", &d.ColumnDelimiter)
+	populateAny(objectMap, "columnDelimiter", d.ColumnDelimiter)
 	populate(objectMap, "compressionCodec", d.CompressionCodec)
 	populate(objectMap, "compressionLevel", d.CompressionLevel)
-	populate(objectMap, "encodingName", &d.EncodingName)
-	populate(objectMap, "escapeChar", &d.EscapeChar)
-	populate(objectMap, "firstRowAsHeader", &d.FirstRowAsHeader)
+	populateAny(objectMap, "encodingName", d.EncodingName)
+	populateAny(objectMap, "escapeChar", d.EscapeChar)
+	populateAny(objectMap, "firstRowAsHeader", d.FirstRowAsHeader)
 	populate(objectMap, "location", d.Location)
-	populate(objectMap, "nullValue", &d.NullValue)
-	populate(objectMap, "quoteChar", &d.QuoteChar)
-	populate(objectMap, "rowDelimiter", &d.RowDelimiter)
+	populateAny(objectMap, "nullValue", d.NullValue)
+	populateAny(objectMap, "quoteChar", d.QuoteChar)
+	populateAny(objectMap, "rowDelimiter", d.RowDelimiter)
 	return json.Marshal(objectMap)
 }
 
@@ -13155,7 +13155,7 @@ func (d *DelimitedTextDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DelimitedTextReadSettings.
 func (d DelimitedTextReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "skipLineCount", &d.SkipLineCount)
+	populateAny(objectMap, "skipLineCount", d.SkipLineCount)
 	objectMap["type"] = "DelimitedTextReadSettings"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -13202,13 +13202,13 @@ func (d *DelimitedTextReadSettings) UnmarshalJSON(data []byte) error {
 func (d DelimitedTextSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "formatSettings", d.FormatSettings)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &d.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &d.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", d.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", d.SinkRetryWait)
 	populate(objectMap, "storeSettings", d.StoreSettings)
 	objectMap["type"] = "DelimitedTextSink"
-	populate(objectMap, "writeBatchSize", &d.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &d.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", d.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", d.WriteBatchTimeout)
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
@@ -13272,9 +13272,9 @@ func (d *DelimitedTextSink) UnmarshalJSON(data []byte) error {
 func (d DelimitedTextSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "formatSettings", d.FormatSettings)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	populate(objectMap, "storeSettings", d.StoreSettings)
 	objectMap["type"] = "DelimitedTextSource"
 	if d.AdditionalProperties != nil {
@@ -13333,8 +13333,8 @@ func (d *DelimitedTextSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DelimitedTextWriteSettings.
 func (d DelimitedTextWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileExtension", &d.FileExtension)
-	populate(objectMap, "quoteAllText", &d.QuoteAllText)
+	populateAny(objectMap, "fileExtension", d.FileExtension)
+	populateAny(objectMap, "quoteAllText", d.QuoteAllText)
 	objectMap["type"] = "DelimitedTextWriteSettings"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -13410,9 +13410,9 @@ func (d *DependencyReference) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DistcpSettings.
 func (d DistcpSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "distcpOptions", &d.DistcpOptions)
-	populate(objectMap, "resourceManagerEndpoint", &d.ResourceManagerEndpoint)
-	populate(objectMap, "tempScriptPath", &d.TempScriptPath)
+	populateAny(objectMap, "distcpOptions", d.DistcpOptions)
+	populateAny(objectMap, "resourceManagerEndpoint", d.ResourceManagerEndpoint)
+	populateAny(objectMap, "tempScriptPath", d.TempScriptPath)
 	return json.Marshal(objectMap)
 }
 
@@ -13450,8 +13450,8 @@ func (d DocumentDbCollectionDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DocumentDbCollection"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -13519,7 +13519,7 @@ func (d *DocumentDbCollectionDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DocumentDbCollectionDatasetTypeProperties.
 func (d DocumentDbCollectionDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collectionName", &d.CollectionName)
+	populateAny(objectMap, "collectionName", d.CollectionName)
 	return json.Marshal(objectMap)
 }
 
@@ -13546,14 +13546,14 @@ func (d *DocumentDbCollectionDatasetTypeProperties) UnmarshalJSON(data []byte) e
 // MarshalJSON implements the json.Marshaller interface for type DocumentDbCollectionSink.
 func (d DocumentDbCollectionSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "nestingSeparator", &d.NestingSeparator)
-	populate(objectMap, "sinkRetryCount", &d.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &d.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "nestingSeparator", d.NestingSeparator)
+	populateAny(objectMap, "sinkRetryCount", d.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", d.SinkRetryWait)
 	objectMap["type"] = "DocumentDbCollectionSink"
-	populate(objectMap, "writeBatchSize", &d.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &d.WriteBatchTimeout)
-	populate(objectMap, "writeBehavior", &d.WriteBehavior)
+	populateAny(objectMap, "writeBatchSize", d.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", d.WriteBatchTimeout)
+	populateAny(objectMap, "writeBehavior", d.WriteBehavior)
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
 			objectMap[key] = val
@@ -13616,12 +13616,12 @@ func (d *DocumentDbCollectionSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DocumentDbCollectionSource.
 func (d DocumentDbCollectionSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "nestingSeparator", &d.NestingSeparator)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "queryTimeout", &d.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "nestingSeparator", d.NestingSeparator)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "queryTimeout", d.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "DocumentDbCollectionSource"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -13682,9 +13682,9 @@ func (d *DocumentDbCollectionSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DrillDatasetTypeProperties.
 func (d DrillDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "table", &d.Table)
-	populate(objectMap, "tableName", &d.TableName)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "table", d.Table)
+	populateAny(objectMap, "tableName", d.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -13779,8 +13779,8 @@ func (d *DrillLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DrillLinkedServiceTypeProperties.
 func (d DrillLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &d.ConnectionString)
-	populate(objectMap, "encryptedCredential", &d.EncryptedCredential)
+	populateAny(objectMap, "connectionString", d.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", d.EncryptedCredential)
 	populate(objectMap, "pwd", d.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -13814,11 +13814,11 @@ func (d *DrillLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DrillSource.
 func (d DrillSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "queryTimeout", &d.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "queryTimeout", d.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "DrillSource"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -13881,8 +13881,8 @@ func (d DrillTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DrillTable"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -14039,12 +14039,12 @@ func (d *DynamicsAXLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsAXLinkedServiceTypeProperties.
 func (d DynamicsAXLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "aadResourceId", &d.AADResourceID)
-	populate(objectMap, "encryptedCredential", &d.EncryptedCredential)
-	populate(objectMap, "servicePrincipalId", &d.ServicePrincipalID)
+	populateAny(objectMap, "aadResourceId", d.AADResourceID)
+	populateAny(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populateAny(objectMap, "servicePrincipalId", d.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", d.ServicePrincipalKey)
-	populate(objectMap, "tenant", &d.Tenant)
-	populate(objectMap, "url", &d.URL)
+	populateAny(objectMap, "tenant", d.Tenant)
+	populateAny(objectMap, "url", d.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -14091,8 +14091,8 @@ func (d DynamicsAXResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DynamicsAXResource"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -14160,7 +14160,7 @@ func (d *DynamicsAXResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsAXResourceDatasetTypeProperties.
 func (d DynamicsAXResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "path", &d.Path)
+	populateAny(objectMap, "path", d.Path)
 	return json.Marshal(objectMap)
 }
 
@@ -14187,11 +14187,11 @@ func (d *DynamicsAXResourceDatasetTypeProperties) UnmarshalJSON(data []byte) err
 // MarshalJSON implements the json.Marshaller interface for type DynamicsAXSource.
 func (d DynamicsAXSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "queryTimeout", &d.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "queryTimeout", d.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "DynamicsAXSource"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -14254,8 +14254,8 @@ func (d DynamicsCrmEntityDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DynamicsCrmEntity"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -14323,7 +14323,7 @@ func (d *DynamicsCrmEntityDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsCrmEntityDatasetTypeProperties.
 func (d DynamicsCrmEntityDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "entityName", &d.EntityName)
+	populateAny(objectMap, "entityName", d.EntityName)
 	return json.Marshal(objectMap)
 }
 
@@ -14414,16 +14414,16 @@ func (d DynamicsCrmLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", d.AuthenticationType)
 	populate(objectMap, "deploymentType", d.DeploymentType)
-	populate(objectMap, "encryptedCredential", &d.EncryptedCredential)
-	populate(objectMap, "hostName", &d.HostName)
-	populate(objectMap, "organizationName", &d.OrganizationName)
+	populateAny(objectMap, "encryptedCredential", d.EncryptedCredential)
+	populateAny(objectMap, "hostName", d.HostName)
+	populateAny(objectMap, "organizationName", d.OrganizationName)
 	populate(objectMap, "password", d.Password)
-	populate(objectMap, "port", &d.Port)
+	populateAny(objectMap, "port", d.Port)
 	populate(objectMap, "servicePrincipalCredential", d.ServicePrincipalCredential)
 	populate(objectMap, "servicePrincipalCredentialType", d.ServicePrincipalCredentialType)
-	populate(objectMap, "servicePrincipalId", &d.ServicePrincipalID)
-	populate(objectMap, "serviceUri", &d.ServiceURI)
-	populate(objectMap, "username", &d.Username)
+	populateAny(objectMap, "servicePrincipalId", d.ServicePrincipalID)
+	populateAny(objectMap, "serviceUri", d.ServiceURI)
+	populateAny(objectMap, "username", d.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -14483,14 +14483,14 @@ func (d *DynamicsCrmLinkedServiceTypeProperties) UnmarshalJSON(data []byte) erro
 // MarshalJSON implements the json.Marshaller interface for type DynamicsCrmSink.
 func (d DynamicsCrmSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "alternateKeyName", &d.AlternateKeyName)
-	populate(objectMap, "ignoreNullValues", &d.IgnoreNullValues)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &d.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &d.SinkRetryWait)
+	populateAny(objectMap, "alternateKeyName", d.AlternateKeyName)
+	populateAny(objectMap, "ignoreNullValues", d.IgnoreNullValues)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", d.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", d.SinkRetryWait)
 	objectMap["type"] = "DynamicsCrmSink"
-	populate(objectMap, "writeBatchSize", &d.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &d.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", d.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", d.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", d.WriteBehavior)
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -14557,10 +14557,10 @@ func (d *DynamicsCrmSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsCrmSource.
 func (d DynamicsCrmSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "DynamicsCrmSource"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -14620,8 +14620,8 @@ func (d DynamicsEntityDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", d.Folder)
 	populate(objectMap, "linkedServiceName", d.LinkedServiceName)
 	populate(objectMap, "parameters", d.Parameters)
-	populate(objectMap, "schema", &d.Schema)
-	populate(objectMap, "structure", &d.Structure)
+	populateAny(objectMap, "schema", d.Schema)
+	populateAny(objectMap, "structure", d.Structure)
 	objectMap["type"] = "DynamicsEntity"
 	populate(objectMap, "typeProperties", d.TypeProperties)
 	if d.AdditionalProperties != nil {
@@ -14689,7 +14689,7 @@ func (d *DynamicsEntityDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsEntityDatasetTypeProperties.
 func (d DynamicsEntityDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "entityName", &d.EntityName)
+	populateAny(objectMap, "entityName", d.EntityName)
 	return json.Marshal(objectMap)
 }
 
@@ -14780,16 +14780,16 @@ func (d DynamicsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", d.AuthenticationType)
 	populate(objectMap, "deploymentType", d.DeploymentType)
-	populate(objectMap, "encryptedCredential", &d.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", d.EncryptedCredential)
 	populate(objectMap, "hostName", d.HostName)
 	populate(objectMap, "organizationName", d.OrganizationName)
 	populate(objectMap, "password", d.Password)
 	populate(objectMap, "port", d.Port)
 	populate(objectMap, "servicePrincipalCredential", d.ServicePrincipalCredential)
 	populate(objectMap, "servicePrincipalCredentialType", d.ServicePrincipalCredentialType)
-	populate(objectMap, "servicePrincipalId", &d.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", d.ServicePrincipalID)
 	populate(objectMap, "serviceUri", d.ServiceURI)
-	populate(objectMap, "username", &d.Username)
+	populateAny(objectMap, "username", d.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -14849,14 +14849,14 @@ func (d *DynamicsLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsSink.
 func (d DynamicsSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "alternateKeyName", &d.AlternateKeyName)
-	populate(objectMap, "ignoreNullValues", &d.IgnoreNullValues)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &d.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &d.SinkRetryWait)
+	populateAny(objectMap, "alternateKeyName", d.AlternateKeyName)
+	populateAny(objectMap, "ignoreNullValues", d.IgnoreNullValues)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", d.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", d.SinkRetryWait)
 	objectMap["type"] = "DynamicsSink"
-	populate(objectMap, "writeBatchSize", &d.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &d.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", d.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", d.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", d.WriteBehavior)
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -14923,10 +14923,10 @@ func (d *DynamicsSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type DynamicsSource.
 func (d DynamicsSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &d.MaxConcurrentConnections)
-	populate(objectMap, "query", &d.Query)
-	populate(objectMap, "sourceRetryCount", &d.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &d.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", d.MaxConcurrentConnections)
+	populateAny(objectMap, "query", d.Query)
+	populateAny(objectMap, "sourceRetryCount", d.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", d.SourceRetryWait)
 	objectMap["type"] = "DynamicsSource"
 	if d.AdditionalProperties != nil {
 		for key, val := range d.AdditionalProperties {
@@ -15043,13 +15043,13 @@ func (e *EloquaLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type EloquaLinkedServiceTypeProperties.
 func (e EloquaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &e.EncryptedCredential)
-	populate(objectMap, "endpoint", &e.Endpoint)
+	populateAny(objectMap, "encryptedCredential", e.EncryptedCredential)
+	populateAny(objectMap, "endpoint", e.Endpoint)
 	populate(objectMap, "password", e.Password)
-	populate(objectMap, "useEncryptedEndpoints", &e.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &e.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &e.UsePeerVerification)
-	populate(objectMap, "username", &e.Username)
+	populateAny(objectMap, "useEncryptedEndpoints", e.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", e.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", e.UsePeerVerification)
+	populateAny(objectMap, "username", e.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -15099,8 +15099,8 @@ func (e EloquaObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", e.Folder)
 	populate(objectMap, "linkedServiceName", e.LinkedServiceName)
 	populate(objectMap, "parameters", e.Parameters)
-	populate(objectMap, "schema", &e.Schema)
-	populate(objectMap, "structure", &e.Structure)
+	populateAny(objectMap, "schema", e.Schema)
+	populateAny(objectMap, "structure", e.Structure)
 	objectMap["type"] = "EloquaObject"
 	populate(objectMap, "typeProperties", e.TypeProperties)
 	if e.AdditionalProperties != nil {
@@ -15168,11 +15168,11 @@ func (e *EloquaObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type EloquaSource.
 func (e EloquaSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &e.MaxConcurrentConnections)
-	populate(objectMap, "query", &e.Query)
-	populate(objectMap, "queryTimeout", &e.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &e.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &e.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", e.MaxConcurrentConnections)
+	populateAny(objectMap, "query", e.Query)
+	populateAny(objectMap, "queryTimeout", e.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", e.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", e.SourceRetryWait)
 	objectMap["type"] = "EloquaSource"
 	if e.AdditionalProperties != nil {
 		for key, val := range e.AdditionalProperties {
@@ -15292,7 +15292,7 @@ func (e *EntityReference) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ErrorAdditionalInfo.
 func (e ErrorAdditionalInfo) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "info", &e.Info)
+	populateAny(objectMap, "info", e.Info)
 	populate(objectMap, "type", e.Type)
 	return json.Marshal(objectMap)
 }
@@ -15744,17 +15744,17 @@ func (e *ExecuteSSISPackageActivity) UnmarshalJSON(data []byte) error {
 func (e ExecuteSSISPackageActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "connectVia", e.ConnectVia)
-	populate(objectMap, "environmentPath", &e.EnvironmentPath)
+	populateAny(objectMap, "environmentPath", e.EnvironmentPath)
 	populate(objectMap, "executionCredential", e.ExecutionCredential)
 	populate(objectMap, "logLocation", e.LogLocation)
-	populate(objectMap, "loggingLevel", &e.LoggingLevel)
+	populateAny(objectMap, "loggingLevel", e.LoggingLevel)
 	populate(objectMap, "packageConnectionManagers", e.PackageConnectionManagers)
 	populate(objectMap, "packageLocation", e.PackageLocation)
 	populate(objectMap, "packageParameters", e.PackageParameters)
 	populate(objectMap, "projectConnectionManagers", e.ProjectConnectionManagers)
 	populate(objectMap, "projectParameters", e.ProjectParameters)
 	populate(objectMap, "propertyOverrides", e.PropertyOverrides)
-	populate(objectMap, "runtime", &e.Runtime)
+	populateAny(objectMap, "runtime", e.Runtime)
 	return json.Marshal(objectMap)
 }
 
@@ -16035,10 +16035,10 @@ func (f *FileServerLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type FileServerLinkedServiceTypeProperties.
 func (f FileServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &f.EncryptedCredential)
-	populate(objectMap, "host", &f.Host)
+	populateAny(objectMap, "encryptedCredential", f.EncryptedCredential)
+	populateAny(objectMap, "host", f.Host)
 	populate(objectMap, "password", f.Password)
-	populate(objectMap, "userId", &f.UserID)
+	populateAny(objectMap, "userId", f.UserID)
 	return json.Marshal(objectMap)
 }
 
@@ -16074,8 +16074,8 @@ func (f *FileServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type FileServerLocation.
 func (f FileServerLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &f.FileName)
-	populate(objectMap, "folderPath", &f.FolderPath)
+	populateAny(objectMap, "fileName", f.FileName)
+	populateAny(objectMap, "folderPath", f.FolderPath)
 	objectMap["type"] = "FileServerLocation"
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
@@ -16125,13 +16125,13 @@ func (f *FileServerLocation) UnmarshalJSON(data []byte) error {
 func (f FileServerReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", f.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &f.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &f.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &f.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &f.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", f.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", f.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", f.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", f.Recursive)
 	objectMap["type"] = "FileServerReadSettings"
-	populate(objectMap, "wildcardFileName", &f.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &f.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", f.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", f.WildcardFolderPath)
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
 			objectMap[key] = val
@@ -16194,8 +16194,8 @@ func (f *FileServerReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type FileServerWriteSettings.
 func (f FileServerWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &f.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &f.MaxConcurrentConnections)
+	populateAny(objectMap, "copyBehavior", f.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", f.MaxConcurrentConnections)
 	objectMap["type"] = "FileServerWriteSettings"
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
@@ -16244,13 +16244,13 @@ func (f *FileServerWriteSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type FileSystemSink.
 func (f FileSystemSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &f.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &f.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &f.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &f.SinkRetryWait)
+	populateAny(objectMap, "copyBehavior", f.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", f.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", f.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", f.SinkRetryWait)
 	objectMap["type"] = "FileSystemSink"
-	populate(objectMap, "writeBatchSize", &f.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &f.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", f.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", f.WriteBatchTimeout)
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
 			objectMap[key] = val
@@ -16310,10 +16310,10 @@ func (f *FileSystemSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type FileSystemSource.
 func (f FileSystemSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &f.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &f.Recursive)
-	populate(objectMap, "sourceRetryCount", &f.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &f.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", f.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", f.Recursive)
+	populateAny(objectMap, "sourceRetryCount", f.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", f.SourceRetryWait)
 	objectMap["type"] = "FileSystemSource"
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
@@ -16646,12 +16646,12 @@ func (f *FormatWriteSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type FtpReadSettings.
 func (f FtpReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &f.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &f.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", f.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", f.Recursive)
 	objectMap["type"] = "FtpReadSettings"
 	populate(objectMap, "useBinaryTransfer", f.UseBinaryTransfer)
-	populate(objectMap, "wildcardFileName", &f.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &f.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", f.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", f.WildcardFolderPath)
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
 			objectMap[key] = val
@@ -16771,13 +16771,13 @@ func (f *FtpServerLinkedService) UnmarshalJSON(data []byte) error {
 func (f FtpServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", f.AuthenticationType)
-	populate(objectMap, "enableSsl", &f.EnableSSL)
-	populate(objectMap, "enableServerCertificateValidation", &f.EnableServerCertificateValidation)
-	populate(objectMap, "encryptedCredential", &f.EncryptedCredential)
-	populate(objectMap, "host", &f.Host)
+	populateAny(objectMap, "enableSsl", f.EnableSSL)
+	populateAny(objectMap, "enableServerCertificateValidation", f.EnableServerCertificateValidation)
+	populateAny(objectMap, "encryptedCredential", f.EncryptedCredential)
+	populateAny(objectMap, "host", f.Host)
 	populate(objectMap, "password", f.Password)
-	populate(objectMap, "port", &f.Port)
-	populate(objectMap, "userName", &f.UserName)
+	populateAny(objectMap, "port", f.Port)
+	populateAny(objectMap, "userName", f.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -16825,8 +16825,8 @@ func (f *FtpServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type FtpServerLocation.
 func (f FtpServerLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &f.FileName)
-	populate(objectMap, "folderPath", &f.FolderPath)
+	populateAny(objectMap, "fileName", f.FileName)
+	populateAny(objectMap, "folderPath", f.FolderPath)
 	objectMap["type"] = "FtpServerLocation"
 	if f.AdditionalProperties != nil {
 		for key, val := range f.AdditionalProperties {
@@ -16875,7 +16875,7 @@ func (f *FtpServerLocation) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GenericDatasetTypeProperties.
 func (g GenericDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &g.TableName)
+	populateAny(objectMap, "tableName", g.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -17155,16 +17155,16 @@ func (g *GoogleAdWordsLinkedService) UnmarshalJSON(data []byte) error {
 func (g GoogleAdWordsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", g.AuthenticationType)
-	populate(objectMap, "clientCustomerID", &g.ClientCustomerID)
-	populate(objectMap, "clientId", &g.ClientID)
+	populateAny(objectMap, "clientCustomerID", g.ClientCustomerID)
+	populateAny(objectMap, "clientId", g.ClientID)
 	populate(objectMap, "clientSecret", g.ClientSecret)
 	populate(objectMap, "developerToken", g.DeveloperToken)
-	populate(objectMap, "email", &g.Email)
-	populate(objectMap, "encryptedCredential", &g.EncryptedCredential)
-	populate(objectMap, "keyFilePath", &g.KeyFilePath)
+	populateAny(objectMap, "email", g.Email)
+	populateAny(objectMap, "encryptedCredential", g.EncryptedCredential)
+	populateAny(objectMap, "keyFilePath", g.KeyFilePath)
 	populate(objectMap, "refreshToken", g.RefreshToken)
-	populate(objectMap, "trustedCertPath", &g.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &g.UseSystemTrustStore)
+	populateAny(objectMap, "trustedCertPath", g.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", g.UseSystemTrustStore)
 	return json.Marshal(objectMap)
 }
 
@@ -17226,8 +17226,8 @@ func (g GoogleAdWordsObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", g.Folder)
 	populate(objectMap, "linkedServiceName", g.LinkedServiceName)
 	populate(objectMap, "parameters", g.Parameters)
-	populate(objectMap, "schema", &g.Schema)
-	populate(objectMap, "structure", &g.Structure)
+	populateAny(objectMap, "schema", g.Schema)
+	populateAny(objectMap, "structure", g.Structure)
 	objectMap["type"] = "GoogleAdWordsObject"
 	populate(objectMap, "typeProperties", g.TypeProperties)
 	if g.AdditionalProperties != nil {
@@ -17295,11 +17295,11 @@ func (g *GoogleAdWordsObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GoogleAdWordsSource.
 func (g GoogleAdWordsSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &g.MaxConcurrentConnections)
-	populate(objectMap, "query", &g.Query)
-	populate(objectMap, "queryTimeout", &g.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &g.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &g.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", g.MaxConcurrentConnections)
+	populateAny(objectMap, "query", g.Query)
+	populateAny(objectMap, "queryTimeout", g.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", g.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", g.SourceRetryWait)
 	objectMap["type"] = "GoogleAdWordsSource"
 	if g.AdditionalProperties != nil {
 		for key, val := range g.AdditionalProperties {
@@ -17357,9 +17357,9 @@ func (g *GoogleAdWordsSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GoogleBigQueryDatasetTypeProperties.
 func (g GoogleBigQueryDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "dataset", &g.Dataset)
-	populate(objectMap, "table", &g.Table)
-	populate(objectMap, "tableName", &g.TableName)
+	populateAny(objectMap, "dataset", g.Dataset)
+	populateAny(objectMap, "table", g.Table)
+	populateAny(objectMap, "tableName", g.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -17454,18 +17454,18 @@ func (g *GoogleBigQueryLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GoogleBigQueryLinkedServiceTypeProperties.
 func (g GoogleBigQueryLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "additionalProjects", &g.AdditionalProjects)
+	populateAny(objectMap, "additionalProjects", g.AdditionalProjects)
 	populate(objectMap, "authenticationType", g.AuthenticationType)
-	populate(objectMap, "clientId", &g.ClientID)
+	populateAny(objectMap, "clientId", g.ClientID)
 	populate(objectMap, "clientSecret", g.ClientSecret)
-	populate(objectMap, "email", &g.Email)
-	populate(objectMap, "encryptedCredential", &g.EncryptedCredential)
-	populate(objectMap, "keyFilePath", &g.KeyFilePath)
-	populate(objectMap, "project", &g.Project)
+	populateAny(objectMap, "email", g.Email)
+	populateAny(objectMap, "encryptedCredential", g.EncryptedCredential)
+	populateAny(objectMap, "keyFilePath", g.KeyFilePath)
+	populateAny(objectMap, "project", g.Project)
 	populate(objectMap, "refreshToken", g.RefreshToken)
-	populate(objectMap, "requestGoogleDriveScope", &g.RequestGoogleDriveScope)
-	populate(objectMap, "trustedCertPath", &g.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &g.UseSystemTrustStore)
+	populateAny(objectMap, "requestGoogleDriveScope", g.RequestGoogleDriveScope)
+	populateAny(objectMap, "trustedCertPath", g.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", g.UseSystemTrustStore)
 	return json.Marshal(objectMap)
 }
 
@@ -17530,8 +17530,8 @@ func (g GoogleBigQueryObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", g.Folder)
 	populate(objectMap, "linkedServiceName", g.LinkedServiceName)
 	populate(objectMap, "parameters", g.Parameters)
-	populate(objectMap, "schema", &g.Schema)
-	populate(objectMap, "structure", &g.Structure)
+	populateAny(objectMap, "schema", g.Schema)
+	populateAny(objectMap, "structure", g.Structure)
 	objectMap["type"] = "GoogleBigQueryObject"
 	populate(objectMap, "typeProperties", g.TypeProperties)
 	if g.AdditionalProperties != nil {
@@ -17599,11 +17599,11 @@ func (g *GoogleBigQueryObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GoogleBigQuerySource.
 func (g GoogleBigQuerySource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &g.MaxConcurrentConnections)
-	populate(objectMap, "query", &g.Query)
-	populate(objectMap, "queryTimeout", &g.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &g.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &g.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", g.MaxConcurrentConnections)
+	populateAny(objectMap, "query", g.Query)
+	populateAny(objectMap, "queryTimeout", g.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", g.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", g.SourceRetryWait)
 	objectMap["type"] = "GoogleBigQuerySource"
 	if g.AdditionalProperties != nil {
 		for key, val := range g.AdditionalProperties {
@@ -17723,10 +17723,10 @@ func (g *GoogleCloudStorageLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GoogleCloudStorageLinkedServiceTypeProperties.
 func (g GoogleCloudStorageLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "accessKeyId", &g.AccessKeyID)
-	populate(objectMap, "encryptedCredential", &g.EncryptedCredential)
+	populateAny(objectMap, "accessKeyId", g.AccessKeyID)
+	populateAny(objectMap, "encryptedCredential", g.EncryptedCredential)
 	populate(objectMap, "secretAccessKey", g.SecretAccessKey)
-	populate(objectMap, "serviceUrl", &g.ServiceURL)
+	populateAny(objectMap, "serviceUrl", g.ServiceURL)
 	return json.Marshal(objectMap)
 }
 
@@ -17762,11 +17762,11 @@ func (g *GoogleCloudStorageLinkedServiceTypeProperties) UnmarshalJSON(data []byt
 // MarshalJSON implements the json.Marshaller interface for type GoogleCloudStorageLocation.
 func (g GoogleCloudStorageLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "bucketName", &g.BucketName)
-	populate(objectMap, "fileName", &g.FileName)
-	populate(objectMap, "folderPath", &g.FolderPath)
+	populateAny(objectMap, "bucketName", g.BucketName)
+	populateAny(objectMap, "fileName", g.FileName)
+	populateAny(objectMap, "folderPath", g.FolderPath)
 	objectMap["type"] = "GoogleCloudStorageLocation"
-	populate(objectMap, "version", &g.Version)
+	populateAny(objectMap, "version", g.Version)
 	if g.AdditionalProperties != nil {
 		for key, val := range g.AdditionalProperties {
 			objectMap[key] = val
@@ -17821,14 +17821,14 @@ func (g *GoogleCloudStorageLocation) UnmarshalJSON(data []byte) error {
 func (g GoogleCloudStorageReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "enablePartitionDiscovery", g.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &g.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &g.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &g.ModifiedDatetimeStart)
-	populate(objectMap, "prefix", &g.Prefix)
-	populate(objectMap, "recursive", &g.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", g.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", g.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", g.ModifiedDatetimeStart)
+	populateAny(objectMap, "prefix", g.Prefix)
+	populateAny(objectMap, "recursive", g.Recursive)
 	objectMap["type"] = "GoogleCloudStorageReadSettings"
-	populate(objectMap, "wildcardFileName", &g.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &g.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", g.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", g.WildcardFolderPath)
 	if g.AdditionalProperties != nil {
 		for key, val := range g.AdditionalProperties {
 			objectMap[key] = val
@@ -17894,9 +17894,9 @@ func (g *GoogleCloudStorageReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GreenplumDatasetTypeProperties.
 func (g GreenplumDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &g.Schema)
-	populate(objectMap, "table", &g.Table)
-	populate(objectMap, "tableName", &g.TableName)
+	populateAny(objectMap, "schema", g.Schema)
+	populateAny(objectMap, "table", g.Table)
+	populateAny(objectMap, "tableName", g.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -17991,8 +17991,8 @@ func (g *GreenplumLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type GreenplumLinkedServiceTypeProperties.
 func (g GreenplumLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &g.ConnectionString)
-	populate(objectMap, "encryptedCredential", &g.EncryptedCredential)
+	populateAny(objectMap, "connectionString", g.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", g.EncryptedCredential)
 	populate(objectMap, "pwd", g.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -18026,11 +18026,11 @@ func (g *GreenplumLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type GreenplumSource.
 func (g GreenplumSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &g.MaxConcurrentConnections)
-	populate(objectMap, "query", &g.Query)
-	populate(objectMap, "queryTimeout", &g.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &g.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &g.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", g.MaxConcurrentConnections)
+	populateAny(objectMap, "query", g.Query)
+	populateAny(objectMap, "queryTimeout", g.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", g.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", g.SourceRetryWait)
 	objectMap["type"] = "GreenplumSource"
 	if g.AdditionalProperties != nil {
 		for key, val := range g.AdditionalProperties {
@@ -18093,8 +18093,8 @@ func (g GreenplumTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", g.Folder)
 	populate(objectMap, "linkedServiceName", g.LinkedServiceName)
 	populate(objectMap, "parameters", g.Parameters)
-	populate(objectMap, "schema", &g.Schema)
-	populate(objectMap, "structure", &g.Structure)
+	populateAny(objectMap, "schema", g.Schema)
+	populateAny(objectMap, "structure", g.Structure)
 	objectMap["type"] = "GreenplumTable"
 	populate(objectMap, "typeProperties", g.TypeProperties)
 	if g.AdditionalProperties != nil {
@@ -18224,17 +18224,17 @@ func (h *HBaseLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HBaseLinkedServiceTypeProperties.
 func (h HBaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &h.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &h.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", h.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", h.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", h.AuthenticationType)
-	populate(objectMap, "enableSsl", &h.EnableSSL)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
-	populate(objectMap, "httpPath", &h.HTTPPath)
-	populate(objectMap, "host", &h.Host)
+	populateAny(objectMap, "enableSsl", h.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populateAny(objectMap, "httpPath", h.HTTPPath)
+	populateAny(objectMap, "host", h.Host)
 	populate(objectMap, "password", h.Password)
-	populate(objectMap, "port", &h.Port)
-	populate(objectMap, "trustedCertPath", &h.TrustedCertPath)
-	populate(objectMap, "username", &h.Username)
+	populateAny(objectMap, "port", h.Port)
+	populateAny(objectMap, "trustedCertPath", h.TrustedCertPath)
+	populateAny(objectMap, "username", h.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -18296,8 +18296,8 @@ func (h HBaseObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", h.Folder)
 	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
 	populate(objectMap, "parameters", h.Parameters)
-	populate(objectMap, "schema", &h.Schema)
-	populate(objectMap, "structure", &h.Structure)
+	populateAny(objectMap, "schema", h.Schema)
+	populateAny(objectMap, "structure", h.Structure)
 	objectMap["type"] = "HBaseObject"
 	populate(objectMap, "typeProperties", h.TypeProperties)
 	if h.AdditionalProperties != nil {
@@ -18365,11 +18365,11 @@ func (h *HBaseObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HBaseSource.
 func (h HBaseSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "query", &h.Query)
-	populate(objectMap, "queryTimeout", &h.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &h.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &h.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "query", h.Query)
+	populateAny(objectMap, "queryTimeout", h.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", h.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", h.SourceRetryWait)
 	objectMap["type"] = "HBaseSource"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -18502,7 +18502,7 @@ func (h HDInsightHiveActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
 	populate(objectMap, "queryTimeout", h.QueryTimeout)
 	populate(objectMap, "scriptLinkedService", h.ScriptLinkedService)
-	populate(objectMap, "scriptPath", &h.ScriptPath)
+	populateAny(objectMap, "scriptPath", h.ScriptPath)
 	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
 	populate(objectMap, "variables", h.Variables)
 	return json.Marshal(objectMap)
@@ -18614,14 +18614,14 @@ func (h *HDInsightLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HDInsightLinkedServiceTypeProperties.
 func (h HDInsightLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clusterUri", &h.ClusterURI)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
-	populate(objectMap, "fileSystem", &h.FileSystem)
+	populateAny(objectMap, "clusterUri", h.ClusterURI)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populateAny(objectMap, "fileSystem", h.FileSystem)
 	populate(objectMap, "hcatalogLinkedServiceName", h.HcatalogLinkedServiceName)
-	populate(objectMap, "isEspEnabled", &h.IsEspEnabled)
+	populateAny(objectMap, "isEspEnabled", h.IsEspEnabled)
 	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
 	populate(objectMap, "password", h.Password)
-	populate(objectMap, "userName", &h.UserName)
+	populateAny(objectMap, "userName", h.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -18740,10 +18740,10 @@ func (h *HDInsightMapReduceActivity) UnmarshalJSON(data []byte) error {
 func (h HDInsightMapReduceActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "arguments", h.Arguments)
-	populate(objectMap, "className", &h.ClassName)
+	populateAny(objectMap, "className", h.ClassName)
 	populate(objectMap, "defines", h.Defines)
 	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
-	populate(objectMap, "jarFilePath", &h.JarFilePath)
+	populateAny(objectMap, "jarFilePath", h.JarFilePath)
 	populate(objectMap, "jarLibs", h.JarLibs)
 	populate(objectMap, "jarLinkedService", h.JarLinkedService)
 	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
@@ -18857,38 +18857,38 @@ func (h *HDInsightOnDemandLinkedService) UnmarshalJSON(data []byte) error {
 func (h HDInsightOnDemandLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "additionalLinkedServiceNames", h.AdditionalLinkedServiceNames)
-	populate(objectMap, "clusterNamePrefix", &h.ClusterNamePrefix)
+	populateAny(objectMap, "clusterNamePrefix", h.ClusterNamePrefix)
 	populate(objectMap, "clusterPassword", h.ClusterPassword)
-	populate(objectMap, "clusterResourceGroup", &h.ClusterResourceGroup)
+	populateAny(objectMap, "clusterResourceGroup", h.ClusterResourceGroup)
 	populate(objectMap, "clusterSshPassword", h.ClusterSSHPassword)
-	populate(objectMap, "clusterSshUserName", &h.ClusterSSHUserName)
-	populate(objectMap, "clusterSize", &h.ClusterSize)
-	populate(objectMap, "clusterType", &h.ClusterType)
-	populate(objectMap, "clusterUserName", &h.ClusterUserName)
-	populate(objectMap, "coreConfiguration", &h.CoreConfiguration)
-	populate(objectMap, "dataNodeSize", &h.DataNodeSize)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
-	populate(objectMap, "hBaseConfiguration", &h.HBaseConfiguration)
+	populateAny(objectMap, "clusterSshUserName", h.ClusterSSHUserName)
+	populateAny(objectMap, "clusterSize", h.ClusterSize)
+	populateAny(objectMap, "clusterType", h.ClusterType)
+	populateAny(objectMap, "clusterUserName", h.ClusterUserName)
+	populateAny(objectMap, "coreConfiguration", h.CoreConfiguration)
+	populateAny(objectMap, "dataNodeSize", h.DataNodeSize)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populateAny(objectMap, "hBaseConfiguration", h.HBaseConfiguration)
 	populate(objectMap, "hcatalogLinkedServiceName", h.HcatalogLinkedServiceName)
-	populate(objectMap, "hdfsConfiguration", &h.HdfsConfiguration)
-	populate(objectMap, "headNodeSize", &h.HeadNodeSize)
-	populate(objectMap, "hiveConfiguration", &h.HiveConfiguration)
-	populate(objectMap, "hostSubscriptionId", &h.HostSubscriptionID)
+	populateAny(objectMap, "hdfsConfiguration", h.HdfsConfiguration)
+	populateAny(objectMap, "headNodeSize", h.HeadNodeSize)
+	populateAny(objectMap, "hiveConfiguration", h.HiveConfiguration)
+	populateAny(objectMap, "hostSubscriptionId", h.HostSubscriptionID)
 	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
-	populate(objectMap, "mapReduceConfiguration", &h.MapReduceConfiguration)
-	populate(objectMap, "oozieConfiguration", &h.OozieConfiguration)
+	populateAny(objectMap, "mapReduceConfiguration", h.MapReduceConfiguration)
+	populateAny(objectMap, "oozieConfiguration", h.OozieConfiguration)
 	populate(objectMap, "scriptActions", h.ScriptActions)
-	populate(objectMap, "servicePrincipalId", &h.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", h.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", h.ServicePrincipalKey)
-	populate(objectMap, "sparkVersion", &h.SparkVersion)
-	populate(objectMap, "stormConfiguration", &h.StormConfiguration)
-	populate(objectMap, "subnetName", &h.SubnetName)
-	populate(objectMap, "tenant", &h.Tenant)
-	populate(objectMap, "timeToLive", &h.TimeToLive)
-	populate(objectMap, "version", &h.Version)
-	populate(objectMap, "virtualNetworkId", &h.VirtualNetworkID)
-	populate(objectMap, "yarnConfiguration", &h.YarnConfiguration)
-	populate(objectMap, "zookeeperNodeSize", &h.ZookeeperNodeSize)
+	populateAny(objectMap, "sparkVersion", h.SparkVersion)
+	populateAny(objectMap, "stormConfiguration", h.StormConfiguration)
+	populateAny(objectMap, "subnetName", h.SubnetName)
+	populateAny(objectMap, "tenant", h.Tenant)
+	populateAny(objectMap, "timeToLive", h.TimeToLive)
+	populateAny(objectMap, "version", h.Version)
+	populateAny(objectMap, "virtualNetworkId", h.VirtualNetworkID)
+	populateAny(objectMap, "yarnConfiguration", h.YarnConfiguration)
+	populateAny(objectMap, "zookeeperNodeSize", h.ZookeeperNodeSize)
 	return json.Marshal(objectMap)
 }
 
@@ -19081,11 +19081,11 @@ func (h *HDInsightPigActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HDInsightPigActivityTypeProperties.
 func (h HDInsightPigActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "arguments", &h.Arguments)
+	populateAny(objectMap, "arguments", h.Arguments)
 	populate(objectMap, "defines", h.Defines)
 	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
 	populate(objectMap, "scriptLinkedService", h.ScriptLinkedService)
-	populate(objectMap, "scriptPath", &h.ScriptPath)
+	populateAny(objectMap, "scriptPath", h.ScriptPath)
 	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
 	return json.Marshal(objectMap)
 }
@@ -19200,10 +19200,10 @@ func (h HDInsightSparkActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "arguments", h.Arguments)
 	populate(objectMap, "className", h.ClassName)
-	populate(objectMap, "entryFilePath", &h.EntryFilePath)
+	populateAny(objectMap, "entryFilePath", h.EntryFilePath)
 	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
-	populate(objectMap, "proxyUser", &h.ProxyUser)
-	populate(objectMap, "rootPath", &h.RootPath)
+	populateAny(objectMap, "proxyUser", h.ProxyUser)
+	populateAny(objectMap, "rootPath", h.RootPath)
 	populate(objectMap, "sparkConfig", h.SparkConfig)
 	populate(objectMap, "sparkJobLinkedService", h.SparkJobLinkedService)
 	return json.Marshal(objectMap)
@@ -19324,16 +19324,16 @@ func (h *HDInsightStreamingActivity) UnmarshalJSON(data []byte) error {
 func (h HDInsightStreamingActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "arguments", h.Arguments)
-	populate(objectMap, "combiner", &h.Combiner)
+	populateAny(objectMap, "combiner", h.Combiner)
 	populate(objectMap, "commandEnvironment", h.CommandEnvironment)
 	populate(objectMap, "defines", h.Defines)
 	populate(objectMap, "fileLinkedService", h.FileLinkedService)
 	populate(objectMap, "filePaths", h.FilePaths)
 	populate(objectMap, "getDebugInfo", h.GetDebugInfo)
-	populate(objectMap, "input", &h.Input)
-	populate(objectMap, "mapper", &h.Mapper)
-	populate(objectMap, "output", &h.Output)
-	populate(objectMap, "reducer", &h.Reducer)
+	populateAny(objectMap, "input", h.Input)
+	populateAny(objectMap, "mapper", h.Mapper)
+	populateAny(objectMap, "output", h.Output)
+	populateAny(objectMap, "reducer", h.Reducer)
 	populate(objectMap, "storageLinkedServices", h.StorageLinkedServices)
 	return json.Marshal(objectMap)
 }
@@ -19457,13 +19457,13 @@ func (h *HTTPLinkedService) UnmarshalJSON(data []byte) error {
 func (h HTTPLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", h.AuthenticationType)
-	populate(objectMap, "certThumbprint", &h.CertThumbprint)
-	populate(objectMap, "embeddedCertData", &h.EmbeddedCertData)
-	populate(objectMap, "enableServerCertificateValidation", &h.EnableServerCertificateValidation)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
+	populateAny(objectMap, "certThumbprint", h.CertThumbprint)
+	populateAny(objectMap, "embeddedCertData", h.EmbeddedCertData)
+	populateAny(objectMap, "enableServerCertificateValidation", h.EnableServerCertificateValidation)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
 	populate(objectMap, "password", h.Password)
-	populate(objectMap, "url", &h.URL)
-	populate(objectMap, "userName", &h.UserName)
+	populateAny(objectMap, "url", h.URL)
+	populateAny(objectMap, "userName", h.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -19511,11 +19511,11 @@ func (h *HTTPLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HTTPReadSettings.
 func (h HTTPReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "additionalHeaders", &h.AdditionalHeaders)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "requestBody", &h.RequestBody)
-	populate(objectMap, "requestMethod", &h.RequestMethod)
-	populate(objectMap, "requestTimeout", &h.RequestTimeout)
+	populateAny(objectMap, "additionalHeaders", h.AdditionalHeaders)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "requestBody", h.RequestBody)
+	populateAny(objectMap, "requestMethod", h.RequestMethod)
+	populateAny(objectMap, "requestTimeout", h.RequestTimeout)
 	objectMap["type"] = "HttpReadSettings"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -19573,9 +19573,9 @@ func (h *HTTPReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HTTPServerLocation.
 func (h HTTPServerLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &h.FileName)
-	populate(objectMap, "folderPath", &h.FolderPath)
-	populate(objectMap, "relativeUrl", &h.RelativeURL)
+	populateAny(objectMap, "fileName", h.FileName)
+	populateAny(objectMap, "folderPath", h.FolderPath)
+	populateAny(objectMap, "relativeUrl", h.RelativeURL)
 	objectMap["type"] = "HttpServerLocation"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -19627,10 +19627,10 @@ func (h *HTTPServerLocation) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HTTPSource.
 func (h HTTPSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "httpRequestTimeout", &h.HTTPRequestTimeout)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &h.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &h.SourceRetryWait)
+	populateAny(objectMap, "httpRequestTimeout", h.HTTPRequestTimeout)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", h.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", h.SourceRetryWait)
 	objectMap["type"] = "HttpSource"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -19747,11 +19747,11 @@ func (h *HdfsLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HdfsLinkedServiceTypeProperties.
 func (h HdfsLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "authenticationType", &h.AuthenticationType)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
+	populateAny(objectMap, "authenticationType", h.AuthenticationType)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
 	populate(objectMap, "password", h.Password)
-	populate(objectMap, "url", &h.URL)
-	populate(objectMap, "userName", &h.UserName)
+	populateAny(objectMap, "url", h.URL)
+	populateAny(objectMap, "userName", h.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -19790,8 +19790,8 @@ func (h *HdfsLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HdfsLocation.
 func (h HdfsLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &h.FileName)
-	populate(objectMap, "folderPath", &h.FolderPath)
+	populateAny(objectMap, "fileName", h.FileName)
+	populateAny(objectMap, "folderPath", h.FolderPath)
 	objectMap["type"] = "HdfsLocation"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -19842,13 +19842,13 @@ func (h HdfsReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "distcpSettings", h.DistcpSettings)
 	populate(objectMap, "enablePartitionDiscovery", h.EnablePartitionDiscovery)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &h.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &h.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &h.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", h.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", h.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", h.Recursive)
 	objectMap["type"] = "HdfsReadSettings"
-	populate(objectMap, "wildcardFileName", &h.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &h.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", h.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", h.WildcardFolderPath)
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
 			objectMap[key] = val
@@ -19915,10 +19915,10 @@ func (h *HdfsReadSettings) UnmarshalJSON(data []byte) error {
 func (h HdfsSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "distcpSettings", h.DistcpSettings)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "recursive", &h.Recursive)
-	populate(objectMap, "sourceRetryCount", &h.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &h.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "recursive", h.Recursive)
+	populateAny(objectMap, "sourceRetryCount", h.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", h.SourceRetryWait)
 	objectMap["type"] = "HdfsSource"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -19976,9 +19976,9 @@ func (h *HdfsSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HiveDatasetTypeProperties.
 func (h HiveDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &h.Schema)
-	populate(objectMap, "table", &h.Table)
-	populate(objectMap, "tableName", &h.TableName)
+	populateAny(objectMap, "schema", h.Schema)
+	populateAny(objectMap, "table", h.Table)
+	populateAny(objectMap, "tableName", h.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -20073,23 +20073,23 @@ func (h *HiveLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HiveLinkedServiceTypeProperties.
 func (h HiveLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &h.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &h.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", h.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", h.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", h.AuthenticationType)
-	populate(objectMap, "enableSsl", &h.EnableSSL)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
-	populate(objectMap, "httpPath", &h.HTTPPath)
-	populate(objectMap, "host", &h.Host)
+	populateAny(objectMap, "enableSsl", h.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
+	populateAny(objectMap, "httpPath", h.HTTPPath)
+	populateAny(objectMap, "host", h.Host)
 	populate(objectMap, "password", h.Password)
-	populate(objectMap, "port", &h.Port)
+	populateAny(objectMap, "port", h.Port)
 	populate(objectMap, "serverType", h.ServerType)
-	populate(objectMap, "serviceDiscoveryMode", &h.ServiceDiscoveryMode)
+	populateAny(objectMap, "serviceDiscoveryMode", h.ServiceDiscoveryMode)
 	populate(objectMap, "thriftTransportProtocol", h.ThriftTransportProtocol)
-	populate(objectMap, "trustedCertPath", &h.TrustedCertPath)
-	populate(objectMap, "useNativeQuery", &h.UseNativeQuery)
-	populate(objectMap, "useSystemTrustStore", &h.UseSystemTrustStore)
-	populate(objectMap, "username", &h.Username)
-	populate(objectMap, "zooKeeperNameSpace", &h.ZooKeeperNameSpace)
+	populateAny(objectMap, "trustedCertPath", h.TrustedCertPath)
+	populateAny(objectMap, "useNativeQuery", h.UseNativeQuery)
+	populateAny(objectMap, "useSystemTrustStore", h.UseSystemTrustStore)
+	populateAny(objectMap, "username", h.Username)
+	populateAny(objectMap, "zooKeeperNameSpace", h.ZooKeeperNameSpace)
 	return json.Marshal(objectMap)
 }
 
@@ -20169,8 +20169,8 @@ func (h HiveObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", h.Folder)
 	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
 	populate(objectMap, "parameters", h.Parameters)
-	populate(objectMap, "schema", &h.Schema)
-	populate(objectMap, "structure", &h.Structure)
+	populateAny(objectMap, "schema", h.Schema)
+	populateAny(objectMap, "structure", h.Structure)
 	objectMap["type"] = "HiveObject"
 	populate(objectMap, "typeProperties", h.TypeProperties)
 	if h.AdditionalProperties != nil {
@@ -20238,11 +20238,11 @@ func (h *HiveObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HiveSource.
 func (h HiveSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "query", &h.Query)
-	populate(objectMap, "queryTimeout", &h.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &h.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &h.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "query", h.Query)
+	populateAny(objectMap, "queryTimeout", h.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", h.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", h.SourceRetryWait)
 	objectMap["type"] = "HiveSource"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -20363,13 +20363,13 @@ func (h *HubspotLinkedService) UnmarshalJSON(data []byte) error {
 func (h HubspotLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", h.AccessToken)
-	populate(objectMap, "clientId", &h.ClientID)
+	populateAny(objectMap, "clientId", h.ClientID)
 	populate(objectMap, "clientSecret", h.ClientSecret)
-	populate(objectMap, "encryptedCredential", &h.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", h.EncryptedCredential)
 	populate(objectMap, "refreshToken", h.RefreshToken)
-	populate(objectMap, "useEncryptedEndpoints", &h.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &h.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &h.UsePeerVerification)
+	populateAny(objectMap, "useEncryptedEndpoints", h.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", h.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", h.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -20422,8 +20422,8 @@ func (h HubspotObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", h.Folder)
 	populate(objectMap, "linkedServiceName", h.LinkedServiceName)
 	populate(objectMap, "parameters", h.Parameters)
-	populate(objectMap, "schema", &h.Schema)
-	populate(objectMap, "structure", &h.Structure)
+	populateAny(objectMap, "schema", h.Schema)
+	populateAny(objectMap, "structure", h.Structure)
 	objectMap["type"] = "HubspotObject"
 	populate(objectMap, "typeProperties", h.TypeProperties)
 	if h.AdditionalProperties != nil {
@@ -20491,11 +20491,11 @@ func (h *HubspotObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type HubspotSource.
 func (h HubspotSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &h.MaxConcurrentConnections)
-	populate(objectMap, "query", &h.Query)
-	populate(objectMap, "queryTimeout", &h.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &h.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &h.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", h.MaxConcurrentConnections)
+	populateAny(objectMap, "query", h.Query)
+	populateAny(objectMap, "queryTimeout", h.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", h.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", h.SourceRetryWait)
 	objectMap["type"] = "HubspotSource"
 	if h.AdditionalProperties != nil {
 		for key, val := range h.AdditionalProperties {
@@ -20650,9 +20650,9 @@ func (i *IfConditionActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ImpalaDatasetTypeProperties.
 func (i ImpalaDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &i.Schema)
-	populate(objectMap, "table", &i.Table)
-	populate(objectMap, "tableName", &i.TableName)
+	populateAny(objectMap, "schema", i.Schema)
+	populateAny(objectMap, "table", i.Table)
+	populateAny(objectMap, "tableName", i.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -20747,17 +20747,17 @@ func (i *ImpalaLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ImpalaLinkedServiceTypeProperties.
 func (i ImpalaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &i.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &i.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", i.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", i.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", i.AuthenticationType)
-	populate(objectMap, "enableSsl", &i.EnableSSL)
-	populate(objectMap, "encryptedCredential", &i.EncryptedCredential)
-	populate(objectMap, "host", &i.Host)
+	populateAny(objectMap, "enableSsl", i.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", i.EncryptedCredential)
+	populateAny(objectMap, "host", i.Host)
 	populate(objectMap, "password", i.Password)
-	populate(objectMap, "port", &i.Port)
-	populate(objectMap, "trustedCertPath", &i.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &i.UseSystemTrustStore)
-	populate(objectMap, "username", &i.Username)
+	populateAny(objectMap, "port", i.Port)
+	populateAny(objectMap, "trustedCertPath", i.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", i.UseSystemTrustStore)
+	populateAny(objectMap, "username", i.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -20819,8 +20819,8 @@ func (i ImpalaObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", i.Folder)
 	populate(objectMap, "linkedServiceName", i.LinkedServiceName)
 	populate(objectMap, "parameters", i.Parameters)
-	populate(objectMap, "schema", &i.Schema)
-	populate(objectMap, "structure", &i.Structure)
+	populateAny(objectMap, "schema", i.Schema)
+	populateAny(objectMap, "structure", i.Structure)
 	objectMap["type"] = "ImpalaObject"
 	populate(objectMap, "typeProperties", i.TypeProperties)
 	if i.AdditionalProperties != nil {
@@ -20888,11 +20888,11 @@ func (i *ImpalaObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ImpalaSource.
 func (i ImpalaSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &i.MaxConcurrentConnections)
-	populate(objectMap, "query", &i.Query)
-	populate(objectMap, "queryTimeout", &i.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &i.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &i.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", i.MaxConcurrentConnections)
+	populateAny(objectMap, "query", i.Query)
+	populateAny(objectMap, "queryTimeout", i.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", i.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", i.SourceRetryWait)
 	objectMap["type"] = "ImpalaSource"
 	if i.AdditionalProperties != nil {
 		for key, val := range i.AdditionalProperties {
@@ -21012,12 +21012,12 @@ func (i *InformixLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type InformixLinkedServiceTypeProperties.
 func (i InformixLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "authenticationType", &i.AuthenticationType)
-	populate(objectMap, "connectionString", &i.ConnectionString)
+	populateAny(objectMap, "authenticationType", i.AuthenticationType)
+	populateAny(objectMap, "connectionString", i.ConnectionString)
 	populate(objectMap, "credential", i.Credential)
-	populate(objectMap, "encryptedCredential", &i.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", i.EncryptedCredential)
 	populate(objectMap, "password", i.Password)
-	populate(objectMap, "userName", &i.UserName)
+	populateAny(objectMap, "userName", i.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -21059,13 +21059,13 @@ func (i *InformixLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type InformixSink.
 func (i InformixSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &i.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &i.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &i.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &i.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", i.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", i.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", i.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", i.SinkRetryWait)
 	objectMap["type"] = "InformixSink"
-	populate(objectMap, "writeBatchSize", &i.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &i.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", i.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", i.WriteBatchTimeout)
 	if i.AdditionalProperties != nil {
 		for key, val := range i.AdditionalProperties {
 			objectMap[key] = val
@@ -21125,11 +21125,11 @@ func (i *InformixSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type InformixSource.
 func (i InformixSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &i.MaxConcurrentConnections)
-	populate(objectMap, "query", &i.Query)
-	populate(objectMap, "queryTimeout", &i.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &i.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &i.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", i.MaxConcurrentConnections)
+	populateAny(objectMap, "query", i.Query)
+	populateAny(objectMap, "queryTimeout", i.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", i.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", i.SourceRetryWait)
 	objectMap["type"] = "InformixSource"
 	if i.AdditionalProperties != nil {
 		for key, val := range i.AdditionalProperties {
@@ -21192,8 +21192,8 @@ func (i InformixTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", i.Folder)
 	populate(objectMap, "linkedServiceName", i.LinkedServiceName)
 	populate(objectMap, "parameters", i.Parameters)
-	populate(objectMap, "schema", &i.Schema)
-	populate(objectMap, "structure", &i.Structure)
+	populateAny(objectMap, "schema", i.Schema)
+	populateAny(objectMap, "structure", i.Structure)
 	objectMap["type"] = "InformixTable"
 	populate(objectMap, "typeProperties", i.TypeProperties)
 	if i.AdditionalProperties != nil {
@@ -21261,7 +21261,7 @@ func (i *InformixTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type InformixTableDatasetTypeProperties.
 func (i InformixTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &i.TableName)
+	populateAny(objectMap, "tableName", i.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -21792,8 +21792,8 @@ func (j JSONDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", j.Folder)
 	populate(objectMap, "linkedServiceName", j.LinkedServiceName)
 	populate(objectMap, "parameters", j.Parameters)
-	populate(objectMap, "schema", &j.Schema)
-	populate(objectMap, "structure", &j.Structure)
+	populateAny(objectMap, "schema", j.Schema)
+	populateAny(objectMap, "structure", j.Structure)
 	objectMap["type"] = "Json"
 	populate(objectMap, "typeProperties", j.TypeProperties)
 	if j.AdditionalProperties != nil {
@@ -21862,7 +21862,7 @@ func (j *JSONDataset) UnmarshalJSON(data []byte) error {
 func (j JSONDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "compression", j.Compression)
-	populate(objectMap, "encodingName", &j.EncodingName)
+	populateAny(objectMap, "encodingName", j.EncodingName)
 	populate(objectMap, "location", j.Location)
 	return json.Marshal(objectMap)
 }
@@ -21896,13 +21896,13 @@ func (j *JSONDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type JSONFormat.
 func (j JSONFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "deserializer", &j.Deserializer)
-	populate(objectMap, "encodingName", &j.EncodingName)
+	populateAny(objectMap, "deserializer", j.Deserializer)
+	populateAny(objectMap, "encodingName", j.EncodingName)
 	populate(objectMap, "filePattern", j.FilePattern)
-	populate(objectMap, "jsonNodeReference", &j.JSONNodeReference)
-	populate(objectMap, "jsonPathDefinition", &j.JSONPathDefinition)
-	populate(objectMap, "nestingSeparator", &j.NestingSeparator)
-	populate(objectMap, "serializer", &j.Serializer)
+	populateAny(objectMap, "jsonNodeReference", j.JSONNodeReference)
+	populateAny(objectMap, "jsonPathDefinition", j.JSONPathDefinition)
+	populateAny(objectMap, "nestingSeparator", j.NestingSeparator)
+	populateAny(objectMap, "serializer", j.Serializer)
 	objectMap["type"] = "JsonFormat"
 	if j.AdditionalProperties != nil {
 		for key, val := range j.AdditionalProperties {
@@ -21967,13 +21967,13 @@ func (j *JSONFormat) UnmarshalJSON(data []byte) error {
 func (j JSONSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "formatSettings", j.FormatSettings)
-	populate(objectMap, "maxConcurrentConnections", &j.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &j.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &j.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", j.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", j.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", j.SinkRetryWait)
 	populate(objectMap, "storeSettings", j.StoreSettings)
 	objectMap["type"] = "JsonSink"
-	populate(objectMap, "writeBatchSize", &j.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &j.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", j.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", j.WriteBatchTimeout)
 	if j.AdditionalProperties != nil {
 		for key, val := range j.AdditionalProperties {
 			objectMap[key] = val
@@ -22036,9 +22036,9 @@ func (j *JSONSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type JSONSource.
 func (j JSONSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &j.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &j.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &j.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", j.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", j.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", j.SourceRetryWait)
 	populate(objectMap, "storeSettings", j.StoreSettings)
 	objectMap["type"] = "JsonSource"
 	if j.AdditionalProperties != nil {
@@ -22202,14 +22202,14 @@ func (j *JiraLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type JiraLinkedServiceTypeProperties.
 func (j JiraLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &j.EncryptedCredential)
-	populate(objectMap, "host", &j.Host)
+	populateAny(objectMap, "encryptedCredential", j.EncryptedCredential)
+	populateAny(objectMap, "host", j.Host)
 	populate(objectMap, "password", j.Password)
-	populate(objectMap, "port", &j.Port)
-	populate(objectMap, "useEncryptedEndpoints", &j.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &j.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &j.UsePeerVerification)
-	populate(objectMap, "username", &j.Username)
+	populateAny(objectMap, "port", j.Port)
+	populateAny(objectMap, "useEncryptedEndpoints", j.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", j.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", j.UsePeerVerification)
+	populateAny(objectMap, "username", j.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -22262,8 +22262,8 @@ func (j JiraObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", j.Folder)
 	populate(objectMap, "linkedServiceName", j.LinkedServiceName)
 	populate(objectMap, "parameters", j.Parameters)
-	populate(objectMap, "schema", &j.Schema)
-	populate(objectMap, "structure", &j.Structure)
+	populateAny(objectMap, "schema", j.Schema)
+	populateAny(objectMap, "structure", j.Structure)
 	objectMap["type"] = "JiraObject"
 	populate(objectMap, "typeProperties", j.TypeProperties)
 	if j.AdditionalProperties != nil {
@@ -22331,11 +22331,11 @@ func (j *JiraObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type JiraSource.
 func (j JiraSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &j.MaxConcurrentConnections)
-	populate(objectMap, "query", &j.Query)
-	populate(objectMap, "queryTimeout", &j.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &j.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &j.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", j.MaxConcurrentConnections)
+	populateAny(objectMap, "query", j.Query)
+	populateAny(objectMap, "queryTimeout", j.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", j.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", j.SourceRetryWait)
 	objectMap["type"] = "JiraSource"
 	if j.AdditionalProperties != nil {
 		for key, val := range j.AdditionalProperties {
@@ -22951,7 +22951,7 @@ func (l *LinkedServiceResource) UnmarshalJSON(data []byte) error {
 func (l LogStorageSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "linkedServiceName", l.LinkedServiceName)
-	populate(objectMap, "path", &l.Path)
+	populateAny(objectMap, "path", l.Path)
 	if l.AdditionalProperties != nil {
 		for key, val := range l.AdditionalProperties {
 			objectMap[key] = val
@@ -23067,7 +23067,7 @@ func (l *LookupActivity) UnmarshalJSON(data []byte) error {
 func (l LookupActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "dataset", l.Dataset)
-	populate(objectMap, "firstRowOnly", &l.FirstRowOnly)
+	populateAny(objectMap, "firstRowOnly", l.FirstRowOnly)
 	populate(objectMap, "source", l.Source)
 	return json.Marshal(objectMap)
 }
@@ -23164,11 +23164,11 @@ func (m *MagentoLinkedService) UnmarshalJSON(data []byte) error {
 func (m MagentoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", m.AccessToken)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
-	populate(objectMap, "host", &m.Host)
-	populate(objectMap, "useEncryptedEndpoints", &m.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &m.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &m.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populateAny(objectMap, "host", m.Host)
+	populateAny(objectMap, "useEncryptedEndpoints", m.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", m.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", m.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -23215,8 +23215,8 @@ func (m MagentoObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MagentoObject"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -23284,11 +23284,11 @@ func (m *MagentoObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MagentoSource.
 func (m MagentoSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "queryTimeout", &m.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "queryTimeout", m.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MagentoSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -23645,8 +23645,8 @@ func (m *MariaDBLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MariaDBLinkedServiceTypeProperties.
 func (m MariaDBLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &m.ConnectionString)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
+	populateAny(objectMap, "connectionString", m.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
 	populate(objectMap, "pwd", m.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -23680,11 +23680,11 @@ func (m *MariaDBLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MariaDBSource.
 func (m MariaDBSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "queryTimeout", &m.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "queryTimeout", m.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MariaDBSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -23747,8 +23747,8 @@ func (m MariaDBTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MariaDBTable"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -23878,13 +23878,13 @@ func (m *MarketoLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MarketoLinkedServiceTypeProperties.
 func (m MarketoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &m.ClientID)
+	populateAny(objectMap, "clientId", m.ClientID)
 	populate(objectMap, "clientSecret", m.ClientSecret)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
-	populate(objectMap, "endpoint", &m.Endpoint)
-	populate(objectMap, "useEncryptedEndpoints", &m.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &m.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &m.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
+	populateAny(objectMap, "endpoint", m.Endpoint)
+	populateAny(objectMap, "useEncryptedEndpoints", m.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", m.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", m.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -23934,8 +23934,8 @@ func (m MarketoObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MarketoObject"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -24003,11 +24003,11 @@ func (m *MarketoObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MarketoSource.
 func (m MarketoSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "queryTimeout", &m.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "queryTimeout", m.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MarketoSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -24127,12 +24127,12 @@ func (m *MicrosoftAccessLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MicrosoftAccessLinkedServiceTypeProperties.
 func (m MicrosoftAccessLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "authenticationType", &m.AuthenticationType)
-	populate(objectMap, "connectionString", &m.ConnectionString)
+	populateAny(objectMap, "authenticationType", m.AuthenticationType)
+	populateAny(objectMap, "connectionString", m.ConnectionString)
 	populate(objectMap, "credential", m.Credential)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
 	populate(objectMap, "password", m.Password)
-	populate(objectMap, "userName", &m.UserName)
+	populateAny(objectMap, "userName", m.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -24174,13 +24174,13 @@ func (m *MicrosoftAccessLinkedServiceTypeProperties) UnmarshalJSON(data []byte) 
 // MarshalJSON implements the json.Marshaller interface for type MicrosoftAccessSink.
 func (m MicrosoftAccessSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &m.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &m.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &m.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", m.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", m.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", m.SinkRetryWait)
 	objectMap["type"] = "MicrosoftAccessSink"
-	populate(objectMap, "writeBatchSize", &m.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &m.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", m.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", m.WriteBatchTimeout)
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
 			objectMap[key] = val
@@ -24240,10 +24240,10 @@ func (m *MicrosoftAccessSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MicrosoftAccessSource.
 func (m MicrosoftAccessSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MicrosoftAccessSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -24303,8 +24303,8 @@ func (m MicrosoftAccessTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MicrosoftAccessTable"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -24372,7 +24372,7 @@ func (m *MicrosoftAccessTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MicrosoftAccessTableDatasetTypeProperties.
 func (m MicrosoftAccessTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &m.TableName)
+	populateAny(objectMap, "tableName", m.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -24404,8 +24404,8 @@ func (m MongoDbCollectionDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MongoDbCollection"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -24473,7 +24473,7 @@ func (m *MongoDbCollectionDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MongoDbCollectionDatasetTypeProperties.
 func (m MongoDbCollectionDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collectionName", &m.CollectionName)
+	populateAny(objectMap, "collectionName", m.CollectionName)
 	return json.Marshal(objectMap)
 }
 
@@ -24500,10 +24500,10 @@ func (m *MongoDbCollectionDatasetTypeProperties) UnmarshalJSON(data []byte) erro
 // MarshalJSON implements the json.Marshaller interface for type MongoDbCursorMethodsProperties.
 func (m MongoDbCursorMethodsProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "limit", &m.Limit)
-	populate(objectMap, "project", &m.Project)
-	populate(objectMap, "skip", &m.Skip)
-	populate(objectMap, "sort", &m.Sort)
+	populateAny(objectMap, "limit", m.Limit)
+	populateAny(objectMap, "project", m.Project)
+	populateAny(objectMap, "skip", m.Skip)
+	populateAny(objectMap, "sort", m.Sort)
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
 			objectMap[key] = val
@@ -24616,16 +24616,16 @@ func (m *MongoDbLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MongoDbLinkedServiceTypeProperties.
 func (m MongoDbLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowSelfSignedServerCert", &m.AllowSelfSignedServerCert)
-	populate(objectMap, "authSource", &m.AuthSource)
+	populateAny(objectMap, "allowSelfSignedServerCert", m.AllowSelfSignedServerCert)
+	populateAny(objectMap, "authSource", m.AuthSource)
 	populate(objectMap, "authenticationType", m.AuthenticationType)
-	populate(objectMap, "databaseName", &m.DatabaseName)
-	populate(objectMap, "enableSsl", &m.EnableSSL)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
+	populateAny(objectMap, "databaseName", m.DatabaseName)
+	populateAny(objectMap, "enableSsl", m.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
 	populate(objectMap, "password", m.Password)
-	populate(objectMap, "port", &m.Port)
-	populate(objectMap, "server", &m.Server)
-	populate(objectMap, "username", &m.Username)
+	populateAny(objectMap, "port", m.Port)
+	populateAny(objectMap, "server", m.Server)
+	populateAny(objectMap, "username", m.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -24679,10 +24679,10 @@ func (m *MongoDbLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MongoDbSource.
 func (m MongoDbSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MongoDbSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -24742,8 +24742,8 @@ func (m MongoDbV2CollectionDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MongoDbV2Collection"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -24811,7 +24811,7 @@ func (m *MongoDbV2CollectionDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MongoDbV2CollectionDatasetTypeProperties.
 func (m MongoDbV2CollectionDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collection", &m.Collection)
+	populateAny(objectMap, "collection", m.Collection)
 	return json.Marshal(objectMap)
 }
 
@@ -24900,8 +24900,8 @@ func (m *MongoDbV2LinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MongoDbV2LinkedServiceTypeProperties.
 func (m MongoDbV2LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &m.ConnectionString)
-	populate(objectMap, "database", &m.Database)
+	populateAny(objectMap, "connectionString", m.ConnectionString)
+	populateAny(objectMap, "database", m.Database)
 	return json.Marshal(objectMap)
 }
 
@@ -24931,13 +24931,13 @@ func (m *MongoDbV2LinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type MongoDbV2Source.
 func (m MongoDbV2Source) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "batchSize", &m.BatchSize)
+	populateAny(objectMap, "batchSize", m.BatchSize)
 	populate(objectMap, "cursorMethods", m.CursorMethods)
-	populate(objectMap, "filter", &m.Filter)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &m.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "filter", m.Filter)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", m.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MongoDbV2Source"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -25121,8 +25121,8 @@ func (m *MySQLLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MySQLLinkedServiceTypeProperties.
 func (m MySQLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &m.ConnectionString)
-	populate(objectMap, "encryptedCredential", &m.EncryptedCredential)
+	populateAny(objectMap, "connectionString", m.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", m.EncryptedCredential)
 	populate(objectMap, "password", m.Password)
 	return json.Marshal(objectMap)
 }
@@ -25156,11 +25156,11 @@ func (m *MySQLLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MySQLSource.
 func (m MySQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &m.MaxConcurrentConnections)
-	populate(objectMap, "query", &m.Query)
-	populate(objectMap, "queryTimeout", &m.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &m.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &m.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", m.MaxConcurrentConnections)
+	populateAny(objectMap, "query", m.Query)
+	populateAny(objectMap, "queryTimeout", m.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", m.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", m.SourceRetryWait)
 	objectMap["type"] = "MySqlSource"
 	if m.AdditionalProperties != nil {
 		for key, val := range m.AdditionalProperties {
@@ -25223,8 +25223,8 @@ func (m MySQLTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", m.Folder)
 	populate(objectMap, "linkedServiceName", m.LinkedServiceName)
 	populate(objectMap, "parameters", m.Parameters)
-	populate(objectMap, "schema", &m.Schema)
-	populate(objectMap, "structure", &m.Structure)
+	populateAny(objectMap, "schema", m.Schema)
+	populateAny(objectMap, "structure", m.Structure)
 	objectMap["type"] = "MySqlTable"
 	populate(objectMap, "typeProperties", m.TypeProperties)
 	if m.AdditionalProperties != nil {
@@ -25292,7 +25292,7 @@ func (m *MySQLTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type MySQLTableDatasetTypeProperties.
 func (m MySQLTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &m.TableName)
+	populateAny(objectMap, "tableName", m.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -25381,8 +25381,8 @@ func (n *NetezzaLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NetezzaLinkedServiceTypeProperties.
 func (n NetezzaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &n.ConnectionString)
-	populate(objectMap, "encryptedCredential", &n.EncryptedCredential)
+	populateAny(objectMap, "connectionString", n.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", n.EncryptedCredential)
 	populate(objectMap, "pwd", n.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -25416,9 +25416,9 @@ func (n *NetezzaLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NetezzaPartitionSettings.
 func (n NetezzaPartitionSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "partitionColumnName", &n.PartitionColumnName)
-	populate(objectMap, "partitionLowerBound", &n.PartitionLowerBound)
-	populate(objectMap, "partitionUpperBound", &n.PartitionUpperBound)
+	populateAny(objectMap, "partitionColumnName", n.PartitionColumnName)
+	populateAny(objectMap, "partitionLowerBound", n.PartitionLowerBound)
+	populateAny(objectMap, "partitionUpperBound", n.PartitionUpperBound)
 	return json.Marshal(objectMap)
 }
 
@@ -25451,13 +25451,13 @@ func (n *NetezzaPartitionSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NetezzaSource.
 func (n NetezzaSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &n.MaxConcurrentConnections)
+	populateAny(objectMap, "maxConcurrentConnections", n.MaxConcurrentConnections)
 	populate(objectMap, "partitionOption", n.PartitionOption)
 	populate(objectMap, "partitionSettings", n.PartitionSettings)
-	populate(objectMap, "query", &n.Query)
-	populate(objectMap, "queryTimeout", &n.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &n.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &n.SourceRetryWait)
+	populateAny(objectMap, "query", n.Query)
+	populateAny(objectMap, "queryTimeout", n.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", n.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", n.SourceRetryWait)
 	objectMap["type"] = "NetezzaSource"
 	if n.AdditionalProperties != nil {
 		for key, val := range n.AdditionalProperties {
@@ -25526,8 +25526,8 @@ func (n NetezzaTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", n.Folder)
 	populate(objectMap, "linkedServiceName", n.LinkedServiceName)
 	populate(objectMap, "parameters", n.Parameters)
-	populate(objectMap, "schema", &n.Schema)
-	populate(objectMap, "structure", &n.Structure)
+	populateAny(objectMap, "schema", n.Schema)
+	populateAny(objectMap, "structure", n.Structure)
 	objectMap["type"] = "NetezzaTable"
 	populate(objectMap, "typeProperties", n.TypeProperties)
 	if n.AdditionalProperties != nil {
@@ -25595,9 +25595,9 @@ func (n *NetezzaTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NetezzaTableDatasetTypeProperties.
 func (n NetezzaTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &n.Schema)
-	populate(objectMap, "table", &n.Table)
-	populate(objectMap, "tableName", &n.TableName)
+	populateAny(objectMap, "schema", n.Schema)
+	populateAny(objectMap, "table", n.Table)
+	populateAny(objectMap, "tableName", n.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -25696,9 +25696,9 @@ func (n *Notebook) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NotebookCell.
 func (n NotebookCell) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "attachments", &n.Attachments)
+	populateAny(objectMap, "attachments", n.Attachments)
 	populate(objectMap, "cell_type", n.CellType)
-	populate(objectMap, "metadata", &n.Metadata)
+	populateAny(objectMap, "metadata", n.Metadata)
 	populate(objectMap, "outputs", n.Outputs)
 	populate(objectMap, "source", n.Source)
 	if n.AdditionalProperties != nil {
@@ -25754,12 +25754,12 @@ func (n *NotebookCell) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type NotebookCellOutputItem.
 func (n NotebookCellOutputItem) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "data", &n.Data)
+	populateAny(objectMap, "data", n.Data)
 	populate(objectMap, "execution_count", n.ExecutionCount)
-	populate(objectMap, "metadata", &n.Metadata)
+	populateAny(objectMap, "metadata", n.Metadata)
 	populate(objectMap, "name", n.Name)
 	populate(objectMap, "output_type", n.OutputType)
-	populate(objectMap, "text", &n.Text)
+	populateAny(objectMap, "text", n.Text)
 	return json.Marshal(objectMap)
 }
 
@@ -26118,18 +26118,18 @@ func (o *ODataLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ODataLinkedServiceTypeProperties.
 func (o ODataLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "aadResourceId", &o.AADResourceID)
+	populateAny(objectMap, "aadResourceId", o.AADResourceID)
 	populate(objectMap, "aadServicePrincipalCredentialType", o.AADServicePrincipalCredentialType)
 	populate(objectMap, "authenticationType", o.AuthenticationType)
-	populate(objectMap, "encryptedCredential", &o.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", o.EncryptedCredential)
 	populate(objectMap, "password", o.Password)
 	populate(objectMap, "servicePrincipalEmbeddedCert", o.ServicePrincipalEmbeddedCert)
 	populate(objectMap, "servicePrincipalEmbeddedCertPassword", o.ServicePrincipalEmbeddedCertPassword)
-	populate(objectMap, "servicePrincipalId", &o.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", o.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", o.ServicePrincipalKey)
-	populate(objectMap, "tenant", &o.Tenant)
-	populate(objectMap, "url", &o.URL)
-	populate(objectMap, "userName", &o.UserName)
+	populateAny(objectMap, "tenant", o.Tenant)
+	populateAny(objectMap, "url", o.URL)
+	populateAny(objectMap, "userName", o.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -26194,8 +26194,8 @@ func (o ODataResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "ODataResource"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -26263,7 +26263,7 @@ func (o *ODataResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ODataResourceDatasetTypeProperties.
 func (o ODataResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "path", &o.Path)
+	populateAny(objectMap, "path", o.Path)
 	return json.Marshal(objectMap)
 }
 
@@ -26290,10 +26290,10 @@ func (o *ODataResourceDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ODataSource.
 func (o ODataSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "query", &o.Query)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "query", o.Query)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
 	objectMap["type"] = "ODataSource"
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
@@ -26410,12 +26410,12 @@ func (o *OdbcLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OdbcLinkedServiceTypeProperties.
 func (o OdbcLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "authenticationType", &o.AuthenticationType)
-	populate(objectMap, "connectionString", &o.ConnectionString)
+	populateAny(objectMap, "authenticationType", o.AuthenticationType)
+	populateAny(objectMap, "connectionString", o.ConnectionString)
 	populate(objectMap, "credential", o.Credential)
-	populate(objectMap, "encryptedCredential", &o.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", o.EncryptedCredential)
 	populate(objectMap, "password", o.Password)
-	populate(objectMap, "userName", &o.UserName)
+	populateAny(objectMap, "userName", o.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -26457,13 +26457,13 @@ func (o *OdbcLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OdbcSink.
 func (o OdbcSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &o.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &o.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &o.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", o.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", o.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", o.SinkRetryWait)
 	objectMap["type"] = "OdbcSink"
-	populate(objectMap, "writeBatchSize", &o.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &o.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", o.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", o.WriteBatchTimeout)
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
 			objectMap[key] = val
@@ -26523,11 +26523,11 @@ func (o *OdbcSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OdbcSource.
 func (o OdbcSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "query", &o.Query)
-	populate(objectMap, "queryTimeout", &o.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "query", o.Query)
+	populateAny(objectMap, "queryTimeout", o.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
 	objectMap["type"] = "OdbcSource"
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
@@ -26590,8 +26590,8 @@ func (o OdbcTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "OdbcTable"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -26659,7 +26659,7 @@ func (o *OdbcTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OdbcTableDatasetTypeProperties.
 func (o OdbcTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &o.TableName)
+	populateAny(objectMap, "tableName", o.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -26691,8 +26691,8 @@ func (o Office365Dataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "Office365Table"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -26760,8 +26760,8 @@ func (o *Office365Dataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type Office365DatasetTypeProperties.
 func (o Office365DatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "predicate", &o.Predicate)
-	populate(objectMap, "tableName", &o.TableName)
+	populateAny(objectMap, "predicate", o.Predicate)
+	populateAny(objectMap, "tableName", o.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -26853,11 +26853,11 @@ func (o *Office365LinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type Office365LinkedServiceTypeProperties.
 func (o Office365LinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &o.EncryptedCredential)
-	populate(objectMap, "office365TenantId", &o.Office365TenantID)
-	populate(objectMap, "servicePrincipalId", &o.ServicePrincipalID)
+	populateAny(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populateAny(objectMap, "office365TenantId", o.Office365TenantID)
+	populateAny(objectMap, "servicePrincipalId", o.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", o.ServicePrincipalKey)
-	populate(objectMap, "servicePrincipalTenantId", &o.ServicePrincipalTenantID)
+	populateAny(objectMap, "servicePrincipalTenantId", o.ServicePrincipalTenantID)
 	return json.Marshal(objectMap)
 }
 
@@ -26896,16 +26896,16 @@ func (o *Office365LinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type Office365Source.
 func (o Office365Source) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowedGroups", &o.AllowedGroups)
-	populate(objectMap, "dateFilterColumn", &o.DateFilterColumn)
-	populate(objectMap, "endTime", &o.EndTime)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "outputColumns", &o.OutputColumns)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
-	populate(objectMap, "startTime", &o.StartTime)
+	populateAny(objectMap, "allowedGroups", o.AllowedGroups)
+	populateAny(objectMap, "dateFilterColumn", o.DateFilterColumn)
+	populateAny(objectMap, "endTime", o.EndTime)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "outputColumns", o.OutputColumns)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
+	populateAny(objectMap, "startTime", o.StartTime)
 	objectMap["type"] = "Office365Source"
-	populate(objectMap, "userScopeFilterUri", &o.UserScopeFilterURI)
+	populateAny(objectMap, "userScopeFilterUri", o.UserScopeFilterURI)
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
 			objectMap[key] = val
@@ -27067,8 +27067,8 @@ func (o *OracleLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleLinkedServiceTypeProperties.
 func (o OracleLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &o.ConnectionString)
-	populate(objectMap, "encryptedCredential", &o.EncryptedCredential)
+	populateAny(objectMap, "connectionString", o.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", o.EncryptedCredential)
 	populate(objectMap, "password", o.Password)
 	return json.Marshal(objectMap)
 }
@@ -27102,10 +27102,10 @@ func (o *OracleLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OraclePartitionSettings.
 func (o OraclePartitionSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "partitionColumnName", &o.PartitionColumnName)
-	populate(objectMap, "partitionLowerBound", &o.PartitionLowerBound)
-	populate(objectMap, "partitionNames", &o.PartitionNames)
-	populate(objectMap, "partitionUpperBound", &o.PartitionUpperBound)
+	populateAny(objectMap, "partitionColumnName", o.PartitionColumnName)
+	populateAny(objectMap, "partitionLowerBound", o.PartitionLowerBound)
+	populateAny(objectMap, "partitionNames", o.PartitionNames)
+	populateAny(objectMap, "partitionUpperBound", o.PartitionUpperBound)
 	return json.Marshal(objectMap)
 }
 
@@ -27203,13 +27203,13 @@ func (o *OracleServiceCloudLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleServiceCloudLinkedServiceTypeProperties.
 func (o OracleServiceCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &o.EncryptedCredential)
-	populate(objectMap, "host", &o.Host)
+	populateAny(objectMap, "encryptedCredential", o.EncryptedCredential)
+	populateAny(objectMap, "host", o.Host)
 	populate(objectMap, "password", o.Password)
-	populate(objectMap, "useEncryptedEndpoints", &o.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &o.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &o.UsePeerVerification)
-	populate(objectMap, "username", &o.Username)
+	populateAny(objectMap, "useEncryptedEndpoints", o.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", o.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", o.UsePeerVerification)
+	populateAny(objectMap, "username", o.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -27259,8 +27259,8 @@ func (o OracleServiceCloudObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "OracleServiceCloudObject"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -27328,11 +27328,11 @@ func (o *OracleServiceCloudObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleServiceCloudSource.
 func (o OracleServiceCloudSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "query", &o.Query)
-	populate(objectMap, "queryTimeout", &o.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "query", o.Query)
+	populateAny(objectMap, "queryTimeout", o.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
 	objectMap["type"] = "OracleServiceCloudSource"
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
@@ -27390,13 +27390,13 @@ func (o *OracleServiceCloudSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleSink.
 func (o OracleSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &o.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &o.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &o.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", o.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", o.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", o.SinkRetryWait)
 	objectMap["type"] = "OracleSink"
-	populate(objectMap, "writeBatchSize", &o.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &o.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", o.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", o.WriteBatchTimeout)
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
 			objectMap[key] = val
@@ -27456,13 +27456,13 @@ func (o *OracleSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleSource.
 func (o OracleSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "oracleReaderQuery", &o.OracleReaderQuery)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "oracleReaderQuery", o.OracleReaderQuery)
 	populate(objectMap, "partitionOption", o.PartitionOption)
 	populate(objectMap, "partitionSettings", o.PartitionSettings)
-	populate(objectMap, "queryTimeout", &o.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
+	populateAny(objectMap, "queryTimeout", o.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
 	objectMap["type"] = "OracleSource"
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
@@ -27531,8 +27531,8 @@ func (o OracleTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "OracleTable"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -27600,9 +27600,9 @@ func (o *OracleTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OracleTableDatasetTypeProperties.
 func (o OracleTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "table", &o.Table)
-	populate(objectMap, "tableName", &o.TableName)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "table", o.Table)
+	populateAny(objectMap, "tableName", o.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -27640,8 +27640,8 @@ func (o OrcDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", o.Folder)
 	populate(objectMap, "linkedServiceName", o.LinkedServiceName)
 	populate(objectMap, "parameters", o.Parameters)
-	populate(objectMap, "schema", &o.Schema)
-	populate(objectMap, "structure", &o.Structure)
+	populateAny(objectMap, "schema", o.Schema)
+	populateAny(objectMap, "structure", o.Structure)
 	objectMap["type"] = "Orc"
 	populate(objectMap, "typeProperties", o.TypeProperties)
 	if o.AdditionalProperties != nil {
@@ -27740,8 +27740,8 @@ func (o *OrcDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OrcFormat.
 func (o OrcFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "deserializer", &o.Deserializer)
-	populate(objectMap, "serializer", &o.Serializer)
+	populateAny(objectMap, "deserializer", o.Deserializer)
+	populateAny(objectMap, "serializer", o.Serializer)
 	objectMap["type"] = "OrcFormat"
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
@@ -27790,13 +27790,13 @@ func (o *OrcFormat) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OrcSink.
 func (o OrcSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &o.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &o.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", o.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", o.SinkRetryWait)
 	populate(objectMap, "storeSettings", o.StoreSettings)
 	objectMap["type"] = "OrcSink"
-	populate(objectMap, "writeBatchSize", &o.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &o.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", o.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", o.WriteBatchTimeout)
 	if o.AdditionalProperties != nil {
 		for key, val := range o.AdditionalProperties {
 			objectMap[key] = val
@@ -27856,9 +27856,9 @@ func (o *OrcSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type OrcSource.
 func (o OrcSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &o.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &o.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &o.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", o.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", o.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", o.SourceRetryWait)
 	populate(objectMap, "storeSettings", o.StoreSettings)
 	objectMap["type"] = "OrcSource"
 	if o.AdditionalProperties != nil {
@@ -27914,7 +27914,7 @@ func (o *OrcSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParameterSpecification.
 func (p ParameterSpecification) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "defaultValue", &p.DefaultValue)
+	populateAny(objectMap, "defaultValue", p.DefaultValue)
 	populate(objectMap, "type", p.Type)
 	return json.Marshal(objectMap)
 }
@@ -27950,8 +27950,8 @@ func (p ParquetDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", p.Folder)
 	populate(objectMap, "linkedServiceName", p.LinkedServiceName)
 	populate(objectMap, "parameters", p.Parameters)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "structure", &p.Structure)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "structure", p.Structure)
 	objectMap["type"] = "Parquet"
 	populate(objectMap, "typeProperties", p.TypeProperties)
 	if p.AdditionalProperties != nil {
@@ -28050,8 +28050,8 @@ func (p *ParquetDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParquetFormat.
 func (p ParquetFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "deserializer", &p.Deserializer)
-	populate(objectMap, "serializer", &p.Serializer)
+	populateAny(objectMap, "deserializer", p.Deserializer)
+	populateAny(objectMap, "serializer", p.Serializer)
 	objectMap["type"] = "ParquetFormat"
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
@@ -28100,13 +28100,13 @@ func (p *ParquetFormat) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParquetSink.
 func (p ParquetSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &p.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &p.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", p.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", p.SinkRetryWait)
 	populate(objectMap, "storeSettings", p.StoreSettings)
 	objectMap["type"] = "ParquetSink"
-	populate(objectMap, "writeBatchSize", &p.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &p.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", p.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", p.WriteBatchTimeout)
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
@@ -28166,9 +28166,9 @@ func (p *ParquetSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ParquetSource.
 func (p ParquetSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &p.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &p.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", p.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", p.SourceRetryWait)
 	populate(objectMap, "storeSettings", p.StoreSettings)
 	objectMap["type"] = "ParquetSource"
 	if p.AdditionalProperties != nil {
@@ -28286,13 +28286,13 @@ func (p *PaypalLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PaypalLinkedServiceTypeProperties.
 func (p PaypalLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &p.ClientID)
+	populateAny(objectMap, "clientId", p.ClientID)
 	populate(objectMap, "clientSecret", p.ClientSecret)
-	populate(objectMap, "encryptedCredential", &p.EncryptedCredential)
-	populate(objectMap, "host", &p.Host)
-	populate(objectMap, "useEncryptedEndpoints", &p.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &p.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &p.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populateAny(objectMap, "host", p.Host)
+	populateAny(objectMap, "useEncryptedEndpoints", p.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", p.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", p.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -28342,8 +28342,8 @@ func (p PaypalObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", p.Folder)
 	populate(objectMap, "linkedServiceName", p.LinkedServiceName)
 	populate(objectMap, "parameters", p.Parameters)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "structure", &p.Structure)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "structure", p.Structure)
 	objectMap["type"] = "PaypalObject"
 	populate(objectMap, "typeProperties", p.TypeProperties)
 	if p.AdditionalProperties != nil {
@@ -28411,11 +28411,11 @@ func (p *PaypalObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PaypalSource.
 func (p PaypalSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "query", &p.Query)
-	populate(objectMap, "queryTimeout", &p.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &p.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &p.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "query", p.Query)
+	populateAny(objectMap, "queryTimeout", p.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", p.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", p.SourceRetryWait)
 	objectMap["type"] = "PaypalSource"
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
@@ -28473,9 +28473,9 @@ func (p *PaypalSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PhoenixDatasetTypeProperties.
 func (p PhoenixDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "table", &p.Table)
-	populate(objectMap, "tableName", &p.TableName)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "table", p.Table)
+	populateAny(objectMap, "tableName", p.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -28570,18 +28570,18 @@ func (p *PhoenixLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PhoenixLinkedServiceTypeProperties.
 func (p PhoenixLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &p.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &p.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", p.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", p.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", p.AuthenticationType)
-	populate(objectMap, "enableSsl", &p.EnableSSL)
-	populate(objectMap, "encryptedCredential", &p.EncryptedCredential)
-	populate(objectMap, "httpPath", &p.HTTPPath)
-	populate(objectMap, "host", &p.Host)
+	populateAny(objectMap, "enableSsl", p.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populateAny(objectMap, "httpPath", p.HTTPPath)
+	populateAny(objectMap, "host", p.Host)
 	populate(objectMap, "password", p.Password)
-	populate(objectMap, "port", &p.Port)
-	populate(objectMap, "trustedCertPath", &p.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &p.UseSystemTrustStore)
-	populate(objectMap, "username", &p.Username)
+	populateAny(objectMap, "port", p.Port)
+	populateAny(objectMap, "trustedCertPath", p.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", p.UseSystemTrustStore)
+	populateAny(objectMap, "username", p.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -28646,8 +28646,8 @@ func (p PhoenixObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", p.Folder)
 	populate(objectMap, "linkedServiceName", p.LinkedServiceName)
 	populate(objectMap, "parameters", p.Parameters)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "structure", &p.Structure)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "structure", p.Structure)
 	objectMap["type"] = "PhoenixObject"
 	populate(objectMap, "typeProperties", p.TypeProperties)
 	if p.AdditionalProperties != nil {
@@ -28715,11 +28715,11 @@ func (p *PhoenixObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PhoenixSource.
 func (p PhoenixSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "query", &p.Query)
-	populate(objectMap, "queryTimeout", &p.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &p.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &p.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "query", p.Query)
+	populateAny(objectMap, "queryTimeout", p.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", p.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", p.SourceRetryWait)
 	objectMap["type"] = "PhoenixSource"
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
@@ -29135,10 +29135,10 @@ func (p *PipelineRunsQueryResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PolybaseSettings.
 func (p PolybaseSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "rejectSampleValue", &p.RejectSampleValue)
+	populateAny(objectMap, "rejectSampleValue", p.RejectSampleValue)
 	populate(objectMap, "rejectType", p.RejectType)
-	populate(objectMap, "rejectValue", &p.RejectValue)
-	populate(objectMap, "useTypeDefault", &p.UseTypeDefault)
+	populateAny(objectMap, "rejectValue", p.RejectValue)
+	populateAny(objectMap, "useTypeDefault", p.UseTypeDefault)
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
 			objectMap[key] = val
@@ -29251,8 +29251,8 @@ func (p *PostgreSQLLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PostgreSQLLinkedServiceTypeProperties.
 func (p PostgreSQLLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &p.ConnectionString)
-	populate(objectMap, "encryptedCredential", &p.EncryptedCredential)
+	populateAny(objectMap, "connectionString", p.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", p.EncryptedCredential)
 	populate(objectMap, "password", p.Password)
 	return json.Marshal(objectMap)
 }
@@ -29286,11 +29286,11 @@ func (p *PostgreSQLLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type PostgreSQLSource.
 func (p PostgreSQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "query", &p.Query)
-	populate(objectMap, "queryTimeout", &p.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &p.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &p.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "query", p.Query)
+	populateAny(objectMap, "queryTimeout", p.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", p.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", p.SourceRetryWait)
 	objectMap["type"] = "PostgreSqlSource"
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
@@ -29353,8 +29353,8 @@ func (p PostgreSQLTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", p.Folder)
 	populate(objectMap, "linkedServiceName", p.LinkedServiceName)
 	populate(objectMap, "parameters", p.Parameters)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "structure", &p.Structure)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "structure", p.Structure)
 	objectMap["type"] = "PostgreSqlTable"
 	populate(objectMap, "typeProperties", p.TypeProperties)
 	if p.AdditionalProperties != nil {
@@ -29422,9 +29422,9 @@ func (p *PostgreSQLTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PostgreSQLTableDatasetTypeProperties.
 func (p PostgreSQLTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "table", &p.Table)
-	populate(objectMap, "tableName", &p.TableName)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "table", p.Table)
+	populateAny(objectMap, "tableName", p.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -29457,9 +29457,9 @@ func (p *PostgreSQLTableDatasetTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type PrestoDatasetTypeProperties.
 func (p PrestoDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "table", &p.Table)
-	populate(objectMap, "tableName", &p.TableName)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "table", p.Table)
+	populateAny(objectMap, "tableName", p.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -29554,20 +29554,20 @@ func (p *PrestoLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PrestoLinkedServiceTypeProperties.
 func (p PrestoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &p.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &p.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", p.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", p.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", p.AuthenticationType)
-	populate(objectMap, "catalog", &p.Catalog)
-	populate(objectMap, "enableSsl", &p.EnableSSL)
-	populate(objectMap, "encryptedCredential", &p.EncryptedCredential)
-	populate(objectMap, "host", &p.Host)
+	populateAny(objectMap, "catalog", p.Catalog)
+	populateAny(objectMap, "enableSsl", p.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", p.EncryptedCredential)
+	populateAny(objectMap, "host", p.Host)
 	populate(objectMap, "password", p.Password)
-	populate(objectMap, "port", &p.Port)
-	populate(objectMap, "serverVersion", &p.ServerVersion)
-	populate(objectMap, "timeZoneID", &p.TimeZoneID)
-	populate(objectMap, "trustedCertPath", &p.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &p.UseSystemTrustStore)
-	populate(objectMap, "username", &p.Username)
+	populateAny(objectMap, "port", p.Port)
+	populateAny(objectMap, "serverVersion", p.ServerVersion)
+	populateAny(objectMap, "timeZoneID", p.TimeZoneID)
+	populateAny(objectMap, "trustedCertPath", p.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", p.UseSystemTrustStore)
+	populateAny(objectMap, "username", p.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -29638,8 +29638,8 @@ func (p PrestoObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", p.Folder)
 	populate(objectMap, "linkedServiceName", p.LinkedServiceName)
 	populate(objectMap, "parameters", p.Parameters)
-	populate(objectMap, "schema", &p.Schema)
-	populate(objectMap, "structure", &p.Structure)
+	populateAny(objectMap, "schema", p.Schema)
+	populateAny(objectMap, "structure", p.Structure)
 	objectMap["type"] = "PrestoObject"
 	populate(objectMap, "typeProperties", p.TypeProperties)
 	if p.AdditionalProperties != nil {
@@ -29707,11 +29707,11 @@ func (p *PrestoObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type PrestoSource.
 func (p PrestoSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &p.MaxConcurrentConnections)
-	populate(objectMap, "query", &p.Query)
-	populate(objectMap, "queryTimeout", &p.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &p.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &p.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", p.MaxConcurrentConnections)
+	populateAny(objectMap, "query", p.Query)
+	populateAny(objectMap, "queryTimeout", p.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", p.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", p.SourceRetryWait)
 	objectMap["type"] = "PrestoSource"
 	if p.AdditionalProperties != nil {
 		for key, val := range p.AdditionalProperties {
@@ -30062,12 +30062,12 @@ func (q QuickBooksLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", q.AccessToken)
 	populate(objectMap, "accessTokenSecret", q.AccessTokenSecret)
-	populate(objectMap, "companyId", &q.CompanyID)
-	populate(objectMap, "consumerKey", &q.ConsumerKey)
+	populateAny(objectMap, "companyId", q.CompanyID)
+	populateAny(objectMap, "consumerKey", q.ConsumerKey)
 	populate(objectMap, "consumerSecret", q.ConsumerSecret)
-	populate(objectMap, "encryptedCredential", &q.EncryptedCredential)
-	populate(objectMap, "endpoint", &q.Endpoint)
-	populate(objectMap, "useEncryptedEndpoints", &q.UseEncryptedEndpoints)
+	populateAny(objectMap, "encryptedCredential", q.EncryptedCredential)
+	populateAny(objectMap, "endpoint", q.Endpoint)
+	populateAny(objectMap, "useEncryptedEndpoints", q.UseEncryptedEndpoints)
 	return json.Marshal(objectMap)
 }
 
@@ -30120,8 +30120,8 @@ func (q QuickBooksObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", q.Folder)
 	populate(objectMap, "linkedServiceName", q.LinkedServiceName)
 	populate(objectMap, "parameters", q.Parameters)
-	populate(objectMap, "schema", &q.Schema)
-	populate(objectMap, "structure", &q.Structure)
+	populateAny(objectMap, "schema", q.Schema)
+	populateAny(objectMap, "structure", q.Structure)
 	objectMap["type"] = "QuickBooksObject"
 	populate(objectMap, "typeProperties", q.TypeProperties)
 	if q.AdditionalProperties != nil {
@@ -30189,11 +30189,11 @@ func (q *QuickBooksObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type QuickBooksSource.
 func (q QuickBooksSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &q.MaxConcurrentConnections)
-	populate(objectMap, "query", &q.Query)
-	populate(objectMap, "queryTimeout", &q.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &q.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &q.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", q.MaxConcurrentConnections)
+	populateAny(objectMap, "query", q.Query)
+	populateAny(objectMap, "queryTimeout", q.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", q.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", q.SourceRetryWait)
 	objectMap["type"] = "QuickBooksSource"
 	if q.AdditionalProperties != nil {
 		for key, val := range q.AdditionalProperties {
@@ -30355,8 +30355,8 @@ func (r *RecurrenceScheduleOccurrence) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RedirectIncompatibleRowSettings.
 func (r RedirectIncompatibleRowSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "linkedServiceName", &r.LinkedServiceName)
-	populate(objectMap, "path", &r.Path)
+	populateAny(objectMap, "linkedServiceName", r.LinkedServiceName)
+	populateAny(objectMap, "path", r.Path)
 	if r.AdditionalProperties != nil {
 		for key, val := range r.AdditionalProperties {
 			objectMap[key] = val
@@ -30401,7 +30401,7 @@ func (r *RedirectIncompatibleRowSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RedshiftUnloadSettings.
 func (r RedshiftUnloadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "bucketName", &r.BucketName)
+	populateAny(objectMap, "bucketName", r.BucketName)
 	populate(objectMap, "s3LinkedServiceName", r.S3LinkedServiceName)
 	return json.Marshal(objectMap)
 }
@@ -30432,10 +30432,10 @@ func (r *RedshiftUnloadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RelationalSource.
 func (r RelationalSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &r.MaxConcurrentConnections)
-	populate(objectMap, "query", &r.Query)
-	populate(objectMap, "sourceRetryCount", &r.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &r.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", r.MaxConcurrentConnections)
+	populateAny(objectMap, "query", r.Query)
+	populateAny(objectMap, "sourceRetryCount", r.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", r.SourceRetryWait)
 	objectMap["type"] = "RelationalSource"
 	if r.AdditionalProperties != nil {
 		for key, val := range r.AdditionalProperties {
@@ -30495,8 +30495,8 @@ func (r RelationalTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", r.Folder)
 	populate(objectMap, "linkedServiceName", r.LinkedServiceName)
 	populate(objectMap, "parameters", r.Parameters)
-	populate(objectMap, "schema", &r.Schema)
-	populate(objectMap, "structure", &r.Structure)
+	populateAny(objectMap, "schema", r.Schema)
+	populateAny(objectMap, "structure", r.Structure)
 	objectMap["type"] = "RelationalTable"
 	populate(objectMap, "typeProperties", r.TypeProperties)
 	if r.AdditionalProperties != nil {
@@ -30564,7 +30564,7 @@ func (r *RelationalTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RelationalTableDatasetTypeProperties.
 func (r RelationalTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &r.TableName)
+	populateAny(objectMap, "tableName", r.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -30759,7 +30759,7 @@ func (r *RerunTumblingWindowTriggerActionParameters) UnmarshalJSON(data []byte) 
 func (r RerunTumblingWindowTriggerTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "maxConcurrency", r.MaxConcurrency)
-	populate(objectMap, "parentTrigger", &r.ParentTrigger)
+	populateAny(objectMap, "parentTrigger", r.ParentTrigger)
 	populateTimeRFC3339(objectMap, "requestedEndTime", r.RequestedEndTime)
 	populateTimeRFC3339(objectMap, "requestedStartTime", r.RequestedStartTime)
 	return json.Marshal(objectMap)
@@ -30894,13 +30894,13 @@ func (r *ResponsysLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ResponsysLinkedServiceTypeProperties.
 func (r ResponsysLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &r.ClientID)
+	populateAny(objectMap, "clientId", r.ClientID)
 	populate(objectMap, "clientSecret", r.ClientSecret)
-	populate(objectMap, "encryptedCredential", &r.EncryptedCredential)
-	populate(objectMap, "endpoint", &r.Endpoint)
-	populate(objectMap, "useEncryptedEndpoints", &r.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &r.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &r.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", r.EncryptedCredential)
+	populateAny(objectMap, "endpoint", r.Endpoint)
+	populateAny(objectMap, "useEncryptedEndpoints", r.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", r.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", r.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -30950,8 +30950,8 @@ func (r ResponsysObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", r.Folder)
 	populate(objectMap, "linkedServiceName", r.LinkedServiceName)
 	populate(objectMap, "parameters", r.Parameters)
-	populate(objectMap, "schema", &r.Schema)
-	populate(objectMap, "structure", &r.Structure)
+	populateAny(objectMap, "schema", r.Schema)
+	populateAny(objectMap, "structure", r.Structure)
 	objectMap["type"] = "ResponsysObject"
 	populate(objectMap, "typeProperties", r.TypeProperties)
 	if r.AdditionalProperties != nil {
@@ -31019,11 +31019,11 @@ func (r *ResponsysObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ResponsysSource.
 func (r ResponsysSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &r.MaxConcurrentConnections)
-	populate(objectMap, "query", &r.Query)
-	populate(objectMap, "queryTimeout", &r.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &r.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &r.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", r.MaxConcurrentConnections)
+	populateAny(objectMap, "query", r.Query)
+	populateAny(objectMap, "queryTimeout", r.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", r.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", r.SourceRetryWait)
 	objectMap["type"] = "ResponsysSource"
 	if r.AdditionalProperties != nil {
 		for key, val := range r.AdditionalProperties {
@@ -31086,8 +31086,8 @@ func (r RestResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", r.Folder)
 	populate(objectMap, "linkedServiceName", r.LinkedServiceName)
 	populate(objectMap, "parameters", r.Parameters)
-	populate(objectMap, "schema", &r.Schema)
-	populate(objectMap, "structure", &r.Structure)
+	populateAny(objectMap, "schema", r.Schema)
+	populateAny(objectMap, "structure", r.Structure)
 	objectMap["type"] = "RestResource"
 	populate(objectMap, "typeProperties", r.TypeProperties)
 	if r.AdditionalProperties != nil {
@@ -31155,11 +31155,11 @@ func (r *RestResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RestResourceDatasetTypeProperties.
 func (r RestResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "additionalHeaders", &r.AdditionalHeaders)
-	populate(objectMap, "paginationRules", &r.PaginationRules)
-	populate(objectMap, "relativeUrl", &r.RelativeURL)
-	populate(objectMap, "requestBody", &r.RequestBody)
-	populate(objectMap, "requestMethod", &r.RequestMethod)
+	populateAny(objectMap, "additionalHeaders", r.AdditionalHeaders)
+	populateAny(objectMap, "paginationRules", r.PaginationRules)
+	populateAny(objectMap, "relativeUrl", r.RelativeURL)
+	populateAny(objectMap, "requestBody", r.RequestBody)
+	populateAny(objectMap, "requestMethod", r.RequestMethod)
 	return json.Marshal(objectMap)
 }
 
@@ -31260,16 +31260,16 @@ func (r *RestServiceLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RestServiceLinkedServiceTypeProperties.
 func (r RestServiceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "aadResourceId", &r.AADResourceID)
+	populateAny(objectMap, "aadResourceId", r.AADResourceID)
 	populate(objectMap, "authenticationType", r.AuthenticationType)
-	populate(objectMap, "enableServerCertificateValidation", &r.EnableServerCertificateValidation)
-	populate(objectMap, "encryptedCredential", &r.EncryptedCredential)
+	populateAny(objectMap, "enableServerCertificateValidation", r.EnableServerCertificateValidation)
+	populateAny(objectMap, "encryptedCredential", r.EncryptedCredential)
 	populate(objectMap, "password", r.Password)
-	populate(objectMap, "servicePrincipalId", &r.ServicePrincipalID)
+	populateAny(objectMap, "servicePrincipalId", r.ServicePrincipalID)
 	populate(objectMap, "servicePrincipalKey", r.ServicePrincipalKey)
-	populate(objectMap, "tenant", &r.Tenant)
-	populate(objectMap, "url", &r.URL)
-	populate(objectMap, "userName", &r.UserName)
+	populateAny(objectMap, "tenant", r.Tenant)
+	populateAny(objectMap, "url", r.URL)
+	populateAny(objectMap, "userName", r.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -31323,15 +31323,15 @@ func (r *RestServiceLinkedServiceTypeProperties) UnmarshalJSON(data []byte) erro
 // MarshalJSON implements the json.Marshaller interface for type RestSource.
 func (r RestSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "additionalHeaders", &r.AdditionalHeaders)
-	populate(objectMap, "httpRequestTimeout", &r.HTTPRequestTimeout)
-	populate(objectMap, "maxConcurrentConnections", &r.MaxConcurrentConnections)
-	populate(objectMap, "paginationRules", &r.PaginationRules)
-	populate(objectMap, "requestBody", &r.RequestBody)
-	populate(objectMap, "requestInterval", &r.RequestInterval)
-	populate(objectMap, "requestMethod", &r.RequestMethod)
-	populate(objectMap, "sourceRetryCount", &r.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &r.SourceRetryWait)
+	populateAny(objectMap, "additionalHeaders", r.AdditionalHeaders)
+	populateAny(objectMap, "httpRequestTimeout", r.HTTPRequestTimeout)
+	populateAny(objectMap, "maxConcurrentConnections", r.MaxConcurrentConnections)
+	populateAny(objectMap, "paginationRules", r.PaginationRules)
+	populateAny(objectMap, "requestBody", r.RequestBody)
+	populateAny(objectMap, "requestInterval", r.RequestInterval)
+	populateAny(objectMap, "requestMethod", r.RequestMethod)
+	populateAny(objectMap, "sourceRetryCount", r.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", r.SourceRetryWait)
 	objectMap["type"] = "RestSource"
 	if r.AdditionalProperties != nil {
 		for key, val := range r.AdditionalProperties {
@@ -31401,7 +31401,7 @@ func (r *RestSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type RetryPolicy.
 func (r RetryPolicy) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "count", &r.Count)
+	populateAny(objectMap, "count", r.Count)
 	populate(objectMap, "intervalInSeconds", r.IntervalInSeconds)
 	return json.Marshal(objectMap)
 }
@@ -31622,18 +31622,18 @@ func (s *SQLConnection) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLDWSink.
 func (s SQLDWSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowCopyCommand", &s.AllowCopyCommand)
-	populate(objectMap, "allowPolyBase", &s.AllowPolyBase)
+	populateAny(objectMap, "allowCopyCommand", s.AllowCopyCommand)
+	populateAny(objectMap, "allowPolyBase", s.AllowPolyBase)
 	populate(objectMap, "copyCommandSettings", s.CopyCommandSettings)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
 	populate(objectMap, "polyBaseSettings", s.PolyBaseSettings)
-	populate(objectMap, "preCopyScript", &s.PreCopyScript)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
-	populate(objectMap, "tableOption", &s.TableOption)
+	populateAny(objectMap, "preCopyScript", s.PreCopyScript)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
+	populateAny(objectMap, "tableOption", s.TableOption)
 	objectMap["type"] = "SqlDWSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -31708,13 +31708,13 @@ func (s *SQLDWSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLDWSource.
 func (s SQLDWSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sqlReaderQuery", &s.SQLReaderQuery)
-	populate(objectMap, "sqlReaderStoredProcedureName", &s.SQLReaderStoredProcedureName)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
-	populate(objectMap, "storedProcedureParameters", &s.StoredProcedureParameters)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sqlReaderQuery", s.SQLReaderQuery)
+	populateAny(objectMap, "sqlReaderStoredProcedureName", s.SQLReaderStoredProcedureName)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
+	populateAny(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	objectMap["type"] = "SqlDWSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -31778,18 +31778,18 @@ func (s *SQLDWSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLMISink.
 func (s SQLMISink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &s.PreCopyScript)
-	populate(objectMap, "sqlWriterStoredProcedureName", &s.SQLWriterStoredProcedureName)
-	populate(objectMap, "sqlWriterTableType", &s.SQLWriterTableType)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", s.PreCopyScript)
+	populateAny(objectMap, "sqlWriterStoredProcedureName", s.SQLWriterStoredProcedureName)
+	populateAny(objectMap, "sqlWriterTableType", s.SQLWriterTableType)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
-	populate(objectMap, "storedProcedureTableTypeParameterName", &s.StoredProcedureTableTypeParameterName)
-	populate(objectMap, "tableOption", &s.TableOption)
+	populateAny(objectMap, "storedProcedureTableTypeParameterName", s.StoredProcedureTableTypeParameterName)
+	populateAny(objectMap, "tableOption", s.TableOption)
 	objectMap["type"] = "SqlMISink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -31864,13 +31864,13 @@ func (s *SQLMISink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLMISource.
 func (s SQLMISource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "produceAdditionalTypes", &s.ProduceAdditionalTypes)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sqlReaderQuery", &s.SQLReaderQuery)
-	populate(objectMap, "sqlReaderStoredProcedureName", &s.SQLReaderStoredProcedureName)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "produceAdditionalTypes", s.ProduceAdditionalTypes)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sqlReaderQuery", s.SQLReaderQuery)
+	populateAny(objectMap, "sqlReaderStoredProcedureName", s.SQLReaderStoredProcedureName)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	objectMap["type"] = "SqlMISource"
 	if s.AdditionalProperties != nil {
@@ -32176,7 +32176,7 @@ func (s *SQLPoolStoredProcedureActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLPoolStoredProcedureActivityTypeProperties.
 func (s SQLPoolStoredProcedureActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "storedProcedureName", &s.StoredProcedureName)
+	populateAny(objectMap, "storedProcedureName", s.StoredProcedureName)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	return json.Marshal(objectMap)
 }
@@ -32485,10 +32485,10 @@ func (s *SQLServerLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLServerLinkedServiceTypeProperties.
 func (s SQLServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &s.ConnectionString)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
+	populateAny(objectMap, "connectionString", s.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -32524,18 +32524,18 @@ func (s *SQLServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error 
 // MarshalJSON implements the json.Marshaller interface for type SQLServerSink.
 func (s SQLServerSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &s.PreCopyScript)
-	populate(objectMap, "sqlWriterStoredProcedureName", &s.SQLWriterStoredProcedureName)
-	populate(objectMap, "sqlWriterTableType", &s.SQLWriterTableType)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", s.PreCopyScript)
+	populateAny(objectMap, "sqlWriterStoredProcedureName", s.SQLWriterStoredProcedureName)
+	populateAny(objectMap, "sqlWriterTableType", s.SQLWriterTableType)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
-	populate(objectMap, "storedProcedureTableTypeParameterName", &s.StoredProcedureTableTypeParameterName)
-	populate(objectMap, "tableOption", &s.TableOption)
+	populateAny(objectMap, "storedProcedureTableTypeParameterName", s.StoredProcedureTableTypeParameterName)
+	populateAny(objectMap, "tableOption", s.TableOption)
 	objectMap["type"] = "SqlServerSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -32610,13 +32610,13 @@ func (s *SQLServerSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLServerSource.
 func (s SQLServerSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "produceAdditionalTypes", &s.ProduceAdditionalTypes)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sqlReaderQuery", &s.SQLReaderQuery)
-	populate(objectMap, "sqlReaderStoredProcedureName", &s.SQLReaderStoredProcedureName)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "produceAdditionalTypes", s.ProduceAdditionalTypes)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sqlReaderQuery", s.SQLReaderQuery)
+	populateAny(objectMap, "sqlReaderStoredProcedureName", s.SQLReaderStoredProcedureName)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	objectMap["type"] = "SqlServerSource"
 	if s.AdditionalProperties != nil {
@@ -32754,7 +32754,7 @@ func (s *SQLServerStoredProcedureActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLServerStoredProcedureActivityTypeProperties.
 func (s SQLServerStoredProcedureActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "storedProcedureName", &s.StoredProcedureName)
+	populateAny(objectMap, "storedProcedureName", s.StoredProcedureName)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	return json.Marshal(objectMap)
 }
@@ -32790,8 +32790,8 @@ func (s SQLServerTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SqlServerTable"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -32859,9 +32859,9 @@ func (s *SQLServerTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLServerTableDatasetTypeProperties.
 func (s SQLServerTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "table", &s.Table)
-	populate(objectMap, "tableName", &s.TableName)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "table", s.Table)
+	populateAny(objectMap, "tableName", s.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -32894,18 +32894,18 @@ func (s *SQLServerTableDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLSink.
 func (s SQLSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "preCopyScript", &s.PreCopyScript)
-	populate(objectMap, "sqlWriterStoredProcedureName", &s.SQLWriterStoredProcedureName)
-	populate(objectMap, "sqlWriterTableType", &s.SQLWriterTableType)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "preCopyScript", s.PreCopyScript)
+	populateAny(objectMap, "sqlWriterStoredProcedureName", s.SQLWriterStoredProcedureName)
+	populateAny(objectMap, "sqlWriterTableType", s.SQLWriterTableType)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
-	populate(objectMap, "storedProcedureTableTypeParameterName", &s.StoredProcedureTableTypeParameterName)
-	populate(objectMap, "tableOption", &s.TableOption)
+	populateAny(objectMap, "storedProcedureTableTypeParameterName", s.StoredProcedureTableTypeParameterName)
+	populateAny(objectMap, "tableOption", s.TableOption)
 	objectMap["type"] = "SqlSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -32980,12 +32980,12 @@ func (s *SQLSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SQLSource.
 func (s SQLSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sqlReaderQuery", &s.SQLReaderQuery)
-	populate(objectMap, "sqlReaderStoredProcedureName", &s.SQLReaderStoredProcedureName)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sqlReaderQuery", s.SQLReaderQuery)
+	populateAny(objectMap, "sqlReaderStoredProcedureName", s.SQLReaderStoredProcedureName)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	populate(objectMap, "storedProcedureParameters", s.StoredProcedureParameters)
 	objectMap["type"] = "SqlSource"
 	if s.AdditionalProperties != nil {
@@ -33050,9 +33050,9 @@ func (s *SQLSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISAccessCredential.
 func (s SSISAccessCredential) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "domain", &s.Domain)
+	populateAny(objectMap, "domain", s.Domain)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -33085,10 +33085,10 @@ func (s *SSISAccessCredential) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISChildPackage.
 func (s SSISChildPackage) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "packageContent", &s.PackageContent)
+	populateAny(objectMap, "packageContent", s.PackageContent)
 	populate(objectMap, "packageLastModifiedDate", s.PackageLastModifiedDate)
 	populate(objectMap, "packageName", s.PackageName)
-	populate(objectMap, "packagePath", &s.PackagePath)
+	populateAny(objectMap, "packagePath", s.PackagePath)
 	return json.Marshal(objectMap)
 }
 
@@ -33124,9 +33124,9 @@ func (s *SSISChildPackage) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISExecutionCredential.
 func (s SSISExecutionCredential) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "domain", &s.Domain)
+	populateAny(objectMap, "domain", s.Domain)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -33159,7 +33159,7 @@ func (s *SSISExecutionCredential) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISExecutionParameter.
 func (s SSISExecutionParameter) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", &s.Value)
+	populateAny(objectMap, "value", s.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -33186,7 +33186,7 @@ func (s *SSISExecutionParameter) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISLogLocation.
 func (s SSISLogLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "logPath", &s.LogPath)
+	populateAny(objectMap, "logPath", s.LogPath)
 	populate(objectMap, "type", s.Type)
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	return json.Marshal(objectMap)
@@ -33222,7 +33222,7 @@ func (s *SSISLogLocation) UnmarshalJSON(data []byte) error {
 func (s SSISLogLocationTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessCredential", s.AccessCredential)
-	populate(objectMap, "logRefreshInterval", &s.LogRefreshInterval)
+	populateAny(objectMap, "logRefreshInterval", s.LogRefreshInterval)
 	return json.Marshal(objectMap)
 }
 
@@ -33252,7 +33252,7 @@ func (s *SSISLogLocationTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SSISPackageLocation.
 func (s SSISPackageLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "packagePath", &s.PackagePath)
+	populateAny(objectMap, "packagePath", s.PackagePath)
 	populate(objectMap, "type", s.Type)
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	return json.Marshal(objectMap)
@@ -33289,8 +33289,8 @@ func (s SSISPackageLocationTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessCredential", s.AccessCredential)
 	populate(objectMap, "childPackages", s.ChildPackages)
-	populate(objectMap, "configurationPath", &s.ConfigurationPath)
-	populate(objectMap, "packageContent", &s.PackageContent)
+	populateAny(objectMap, "configurationPath", s.ConfigurationPath)
+	populateAny(objectMap, "packageContent", s.PackageContent)
 	populate(objectMap, "packageLastModifiedDate", s.PackageLastModifiedDate)
 	populate(objectMap, "packageName", s.PackageName)
 	populate(objectMap, "packagePassword", s.PackagePassword)
@@ -33339,7 +33339,7 @@ func (s *SSISPackageLocationTypeProperties) UnmarshalJSON(data []byte) error {
 func (s SSISPropertyOverride) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "isSensitive", s.IsSensitive)
-	populate(objectMap, "value", &s.Value)
+	populateAny(objectMap, "value", s.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -33431,11 +33431,11 @@ func (s *SalesforceLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceLinkedServiceTypeProperties.
 func (s SalesforceLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "environmentUrl", &s.EnvironmentURL)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "environmentUrl", s.EnvironmentURL)
 	populate(objectMap, "password", s.Password)
 	populate(objectMap, "securityToken", s.SecurityToken)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -33536,12 +33536,12 @@ func (s *SalesforceMarketingCloudLinkedService) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type SalesforceMarketingCloudLinkedServiceTypeProperties.
 func (s SalesforceMarketingCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &s.ClientID)
+	populateAny(objectMap, "clientId", s.ClientID)
 	populate(objectMap, "clientSecret", s.ClientSecret)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "useEncryptedEndpoints", &s.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &s.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &s.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", s.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", s.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -33588,8 +33588,8 @@ func (s SalesforceMarketingCloudObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SalesforceMarketingCloudObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -33657,11 +33657,11 @@ func (s *SalesforceMarketingCloudObjectDataset) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type SalesforceMarketingCloudSource.
 func (s SalesforceMarketingCloudSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SalesforceMarketingCloudSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -33724,8 +33724,8 @@ func (s SalesforceObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SalesforceObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -33793,7 +33793,7 @@ func (s *SalesforceObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceObjectDatasetTypeProperties.
 func (s SalesforceObjectDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "objectApiName", &s.ObjectAPIName)
+	populateAny(objectMap, "objectApiName", s.ObjectAPIName)
 	return json.Marshal(objectMap)
 }
 
@@ -33882,12 +33882,12 @@ func (s *SalesforceServiceCloudLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceServiceCloudLinkedServiceTypeProperties.
 func (s SalesforceServiceCloudLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "environmentUrl", &s.EnvironmentURL)
-	populate(objectMap, "extendedProperties", &s.ExtendedProperties)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "environmentUrl", s.EnvironmentURL)
+	populateAny(objectMap, "extendedProperties", s.ExtendedProperties)
 	populate(objectMap, "password", s.Password)
 	populate(objectMap, "securityToken", s.SecurityToken)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -33934,8 +33934,8 @@ func (s SalesforceServiceCloudObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SalesforceServiceCloudObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -34003,7 +34003,7 @@ func (s *SalesforceServiceCloudObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceServiceCloudObjectDatasetTypeProperties.
 func (s SalesforceServiceCloudObjectDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "objectApiName", &s.ObjectAPIName)
+	populateAny(objectMap, "objectApiName", s.ObjectAPIName)
 	return json.Marshal(objectMap)
 }
 
@@ -34030,14 +34030,14 @@ func (s *SalesforceServiceCloudObjectDatasetTypeProperties) UnmarshalJSON(data [
 // MarshalJSON implements the json.Marshaller interface for type SalesforceServiceCloudSink.
 func (s SalesforceServiceCloudSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "externalIdFieldName", &s.ExternalIDFieldName)
-	populate(objectMap, "ignoreNullValues", &s.IgnoreNullValues)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "externalIdFieldName", s.ExternalIDFieldName)
+	populateAny(objectMap, "ignoreNullValues", s.IgnoreNullValues)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	objectMap["type"] = "SalesforceServiceCloudSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", s.WriteBehavior)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34104,11 +34104,11 @@ func (s *SalesforceServiceCloudSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceServiceCloudSource.
 func (s SalesforceServiceCloudSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
 	populate(objectMap, "readBehavior", s.ReadBehavior)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SalesforceServiceCloudSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34166,14 +34166,14 @@ func (s *SalesforceServiceCloudSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceSink.
 func (s SalesforceSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "externalIdFieldName", &s.ExternalIDFieldName)
-	populate(objectMap, "ignoreNullValues", &s.IgnoreNullValues)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "externalIdFieldName", s.ExternalIDFieldName)
+	populateAny(objectMap, "ignoreNullValues", s.IgnoreNullValues)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	objectMap["type"] = "SalesforceSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", s.WriteBehavior)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34240,12 +34240,12 @@ func (s *SalesforceSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SalesforceSource.
 func (s SalesforceSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
 	populate(objectMap, "readBehavior", s.ReadBehavior)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SalesforceSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34368,12 +34368,12 @@ func (s *SapBWLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapBWLinkedServiceTypeProperties.
 func (s SapBWLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &s.ClientID)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
+	populateAny(objectMap, "clientId", s.ClientID)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "server", &s.Server)
-	populate(objectMap, "systemNumber", &s.SystemNumber)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "server", s.Server)
+	populateAny(objectMap, "systemNumber", s.SystemNumber)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -34420,8 +34420,8 @@ func (s SapBwCubeDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapBwCube"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34485,11 +34485,11 @@ func (s *SapBwCubeDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapBwSource.
 func (s SapBwSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapBwSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34609,10 +34609,10 @@ func (s *SapCloudForCustomerLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapCloudForCustomerLinkedServiceTypeProperties.
 func (s SapCloudForCustomerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "url", &s.URL)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "url", s.URL)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -34653,8 +34653,8 @@ func (s SapCloudForCustomerResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapCloudForCustomerResource"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -34722,7 +34722,7 @@ func (s *SapCloudForCustomerResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapCloudForCustomerResourceDatasetTypeProperties.
 func (s SapCloudForCustomerResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "path", &s.Path)
+	populateAny(objectMap, "path", s.Path)
 	return json.Marshal(objectMap)
 }
 
@@ -34749,12 +34749,12 @@ func (s *SapCloudForCustomerResourceDatasetTypeProperties) UnmarshalJSON(data []
 // MarshalJSON implements the json.Marshaller interface for type SapCloudForCustomerSink.
 func (s SapCloudForCustomerSink) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "sinkRetryCount", &s.SinkRetryCount)
-	populate(objectMap, "sinkRetryWait", &s.SinkRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "sinkRetryCount", s.SinkRetryCount)
+	populateAny(objectMap, "sinkRetryWait", s.SinkRetryWait)
 	objectMap["type"] = "SapCloudForCustomerSink"
-	populate(objectMap, "writeBatchSize", &s.WriteBatchSize)
-	populate(objectMap, "writeBatchTimeout", &s.WriteBatchTimeout)
+	populateAny(objectMap, "writeBatchSize", s.WriteBatchSize)
+	populateAny(objectMap, "writeBatchTimeout", s.WriteBatchTimeout)
 	populate(objectMap, "writeBehavior", s.WriteBehavior)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34815,11 +34815,11 @@ func (s *SapCloudForCustomerSink) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapCloudForCustomerSource.
 func (s SapCloudForCustomerSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapCloudForCustomerSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -34983,8 +34983,8 @@ func (s SapEccResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapEccResource"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -35052,7 +35052,7 @@ func (s *SapEccResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapEccResourceDatasetTypeProperties.
 func (s SapEccResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "path", &s.Path)
+	populateAny(objectMap, "path", s.Path)
 	return json.Marshal(objectMap)
 }
 
@@ -35079,11 +35079,11 @@ func (s *SapEccResourceDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapEccSource.
 func (s SapEccSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapEccSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -35204,11 +35204,11 @@ func (s *SapHanaLinkedService) UnmarshalJSON(data []byte) error {
 func (s SapHanaLinkedServiceProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", s.AuthenticationType)
-	populate(objectMap, "connectionString", &s.ConnectionString)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
+	populateAny(objectMap, "connectionString", s.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "server", &s.Server)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "server", s.Server)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -35250,7 +35250,7 @@ func (s *SapHanaLinkedServiceProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapHanaPartitionSettings.
 func (s SapHanaPartitionSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "partitionColumnName", &s.PartitionColumnName)
+	populateAny(objectMap, "partitionColumnName", s.PartitionColumnName)
 	return json.Marshal(objectMap)
 }
 
@@ -35277,14 +35277,14 @@ func (s *SapHanaPartitionSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapHanaSource.
 func (s SapHanaSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "packetSize", &s.PacketSize)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "packetSize", s.PacketSize)
 	populate(objectMap, "partitionOption", s.PartitionOption)
 	populate(objectMap, "partitionSettings", s.PartitionSettings)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapHanaSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -35356,8 +35356,8 @@ func (s SapHanaTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapHanaTable"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -35425,8 +35425,8 @@ func (s *SapHanaTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapHanaTableDatasetTypeProperties.
 func (s SapHanaTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "table", &s.Table)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "table", s.Table)
 	return json.Marshal(objectMap)
 }
 
@@ -35518,13 +35518,13 @@ func (s *SapOpenHubLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapOpenHubLinkedServiceTypeProperties.
 func (s SapOpenHubLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &s.ClientID)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "language", &s.Language)
+	populateAny(objectMap, "clientId", s.ClientID)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "language", s.Language)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "server", &s.Server)
-	populate(objectMap, "systemNumber", &s.SystemNumber)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "server", s.Server)
+	populateAny(objectMap, "systemNumber", s.SystemNumber)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -35569,12 +35569,12 @@ func (s *SapOpenHubLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type SapOpenHubSource.
 func (s SapOpenHubSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "baseRequestId", &s.BaseRequestID)
-	populate(objectMap, "excludeLastRequest", &s.ExcludeLastRequest)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "baseRequestId", s.BaseRequestID)
+	populateAny(objectMap, "excludeLastRequest", s.ExcludeLastRequest)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapOpenHubSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -35640,8 +35640,8 @@ func (s SapOpenHubTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapOpenHubTable"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -35709,9 +35709,9 @@ func (s *SapOpenHubTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapOpenHubTableDatasetTypeProperties.
 func (s SapOpenHubTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "baseRequestId", &s.BaseRequestID)
-	populate(objectMap, "excludeLastRequest", &s.ExcludeLastRequest)
-	populate(objectMap, "openHubDestinationName", &s.OpenHubDestinationName)
+	populateAny(objectMap, "baseRequestId", s.BaseRequestID)
+	populateAny(objectMap, "excludeLastRequest", s.ExcludeLastRequest)
+	populateAny(objectMap, "openHubDestinationName", s.OpenHubDestinationName)
 	return json.Marshal(objectMap)
 }
 
@@ -35806,22 +35806,22 @@ func (s *SapTableLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapTableLinkedServiceTypeProperties.
 func (s SapTableLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &s.ClientID)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "language", &s.Language)
-	populate(objectMap, "logonGroup", &s.LogonGroup)
-	populate(objectMap, "messageServer", &s.MessageServer)
-	populate(objectMap, "messageServerService", &s.MessageServerService)
+	populateAny(objectMap, "clientId", s.ClientID)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "language", s.Language)
+	populateAny(objectMap, "logonGroup", s.LogonGroup)
+	populateAny(objectMap, "messageServer", s.MessageServer)
+	populateAny(objectMap, "messageServerService", s.MessageServerService)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "server", &s.Server)
-	populate(objectMap, "sncLibraryPath", &s.SncLibraryPath)
-	populate(objectMap, "sncMode", &s.SncMode)
-	populate(objectMap, "sncMyName", &s.SncMyName)
-	populate(objectMap, "sncPartnerName", &s.SncPartnerName)
-	populate(objectMap, "sncQop", &s.SncQop)
-	populate(objectMap, "systemId", &s.SystemID)
-	populate(objectMap, "systemNumber", &s.SystemNumber)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "server", s.Server)
+	populateAny(objectMap, "sncLibraryPath", s.SncLibraryPath)
+	populateAny(objectMap, "sncMode", s.SncMode)
+	populateAny(objectMap, "sncMyName", s.SncMyName)
+	populateAny(objectMap, "sncPartnerName", s.SncPartnerName)
+	populateAny(objectMap, "sncQop", s.SncQop)
+	populateAny(objectMap, "systemId", s.SystemID)
+	populateAny(objectMap, "systemNumber", s.SystemNumber)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -35893,10 +35893,10 @@ func (s *SapTableLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapTablePartitionSettings.
 func (s SapTablePartitionSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxPartitionsNumber", &s.MaxPartitionsNumber)
-	populate(objectMap, "partitionColumnName", &s.PartitionColumnName)
-	populate(objectMap, "partitionLowerBound", &s.PartitionLowerBound)
-	populate(objectMap, "partitionUpperBound", &s.PartitionUpperBound)
+	populateAny(objectMap, "maxPartitionsNumber", s.MaxPartitionsNumber)
+	populateAny(objectMap, "partitionColumnName", s.PartitionColumnName)
+	populateAny(objectMap, "partitionLowerBound", s.PartitionLowerBound)
+	populateAny(objectMap, "partitionUpperBound", s.PartitionUpperBound)
 	return json.Marshal(objectMap)
 }
 
@@ -35937,8 +35937,8 @@ func (s SapTableResourceDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SapTableResource"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -36006,7 +36006,7 @@ func (s *SapTableResourceDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SapTableResourceDatasetTypeProperties.
 func (s SapTableResourceDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &s.TableName)
+	populateAny(objectMap, "tableName", s.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -36033,18 +36033,18 @@ func (s *SapTableResourceDatasetTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type SapTableSource.
 func (s SapTableSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "batchSize", &s.BatchSize)
-	populate(objectMap, "customRfcReadTableFunctionModule", &s.CustomRFCReadTableFunctionModule)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
+	populateAny(objectMap, "batchSize", s.BatchSize)
+	populateAny(objectMap, "customRfcReadTableFunctionModule", s.CustomRFCReadTableFunctionModule)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
 	populate(objectMap, "partitionOption", s.PartitionOption)
 	populate(objectMap, "partitionSettings", s.PartitionSettings)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "rfcTableFields", &s.RFCTableFields)
-	populate(objectMap, "rfcTableOptions", &s.RFCTableOptions)
-	populate(objectMap, "rowCount", &s.RowCount)
-	populate(objectMap, "rowSkips", &s.RowSkips)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "rfcTableFields", s.RFCTableFields)
+	populateAny(objectMap, "rfcTableOptions", s.RFCTableOptions)
+	populateAny(objectMap, "rowCount", s.RowCount)
+	populateAny(objectMap, "rowSkips", s.RowSkips)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SapTableSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -36546,15 +36546,15 @@ func (s *ServiceNowLinkedService) UnmarshalJSON(data []byte) error {
 func (s ServiceNowLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", s.AuthenticationType)
-	populate(objectMap, "clientId", &s.ClientID)
+	populateAny(objectMap, "clientId", s.ClientID)
 	populate(objectMap, "clientSecret", s.ClientSecret)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "endpoint", &s.Endpoint)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "endpoint", s.Endpoint)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "useEncryptedEndpoints", &s.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &s.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &s.UsePeerVerification)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", s.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", s.UsePeerVerification)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -36613,8 +36613,8 @@ func (s ServiceNowObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "ServiceNowObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -36682,11 +36682,11 @@ func (s *ServiceNowObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ServiceNowSource.
 func (s ServiceNowSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "ServiceNowSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -36806,7 +36806,7 @@ func (s *SetVariableActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SetVariableActivityTypeProperties.
 func (s SetVariableActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "value", &s.Value)
+	populateAny(objectMap, "value", s.Value)
 	populate(objectMap, "variableName", s.VariableName)
 	return json.Marshal(objectMap)
 }
@@ -36837,8 +36837,8 @@ func (s *SetVariableActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SftpLocation.
 func (s SftpLocation) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "fileName", &s.FileName)
-	populate(objectMap, "folderPath", &s.FolderPath)
+	populateAny(objectMap, "fileName", s.FileName)
+	populateAny(objectMap, "folderPath", s.FolderPath)
 	objectMap["type"] = "SftpLocation"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -36887,13 +36887,13 @@ func (s *SftpLocation) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SftpReadSettings.
 func (s SftpReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "modifiedDatetimeEnd", &s.ModifiedDatetimeEnd)
-	populate(objectMap, "modifiedDatetimeStart", &s.ModifiedDatetimeStart)
-	populate(objectMap, "recursive", &s.Recursive)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "modifiedDatetimeEnd", s.ModifiedDatetimeEnd)
+	populateAny(objectMap, "modifiedDatetimeStart", s.ModifiedDatetimeStart)
+	populateAny(objectMap, "recursive", s.Recursive)
 	objectMap["type"] = "SftpReadSettings"
-	populate(objectMap, "wildcardFileName", &s.WildcardFileName)
-	populate(objectMap, "wildcardFolderPath", &s.WildcardFolderPath)
+	populateAny(objectMap, "wildcardFileName", s.WildcardFileName)
+	populateAny(objectMap, "wildcardFolderPath", s.WildcardFolderPath)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -37016,16 +37016,16 @@ func (s *SftpServerLinkedService) UnmarshalJSON(data []byte) error {
 func (s SftpServerLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", s.AuthenticationType)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "host", &s.Host)
-	populate(objectMap, "hostKeyFingerprint", &s.HostKeyFingerprint)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "host", s.Host)
+	populateAny(objectMap, "hostKeyFingerprint", s.HostKeyFingerprint)
 	populate(objectMap, "passPhrase", s.PassPhrase)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "port", &s.Port)
+	populateAny(objectMap, "port", s.Port)
 	populate(objectMap, "privateKeyContent", s.PrivateKeyContent)
-	populate(objectMap, "privateKeyPath", &s.PrivateKeyPath)
-	populate(objectMap, "skipHostKeyValidation", &s.SkipHostKeyValidation)
-	populate(objectMap, "userName", &s.UserName)
+	populateAny(objectMap, "privateKeyPath", s.PrivateKeyPath)
+	populateAny(objectMap, "skipHostKeyValidation", s.SkipHostKeyValidation)
+	populateAny(objectMap, "userName", s.UserName)
 	return json.Marshal(objectMap)
 }
 
@@ -37082,9 +37082,9 @@ func (s *SftpServerLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error
 // MarshalJSON implements the json.Marshaller interface for type SftpWriteSettings.
 func (s SftpWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &s.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "operationTimeout", &s.OperationTimeout)
+	populateAny(objectMap, "copyBehavior", s.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "operationTimeout", s.OperationTimeout)
 	objectMap["type"] = "SftpWriteSettings"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -37199,11 +37199,11 @@ func (s *ShopifyLinkedService) UnmarshalJSON(data []byte) error {
 func (s ShopifyLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", s.AccessToken)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "host", &s.Host)
-	populate(objectMap, "useEncryptedEndpoints", &s.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &s.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &s.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "host", s.Host)
+	populateAny(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", s.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", s.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -37250,8 +37250,8 @@ func (s ShopifyObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "ShopifyObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -37319,11 +37319,11 @@ func (s *ShopifyObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ShopifySource.
 func (s ShopifySource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "ShopifySource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -37535,9 +37535,9 @@ func (s *SparkBatchJobState) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SparkDatasetTypeProperties.
 func (s SparkDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "table", &s.Table)
-	populate(objectMap, "tableName", &s.TableName)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "table", s.Table)
+	populateAny(objectMap, "tableName", s.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -37705,7 +37705,7 @@ func (s SparkJobProperties) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "archives", s.Archives)
 	populate(objectMap, "args", s.Args)
 	populate(objectMap, "className", s.ClassName)
-	populate(objectMap, "conf", &s.Conf)
+	populateAny(objectMap, "conf", s.Conf)
 	populate(objectMap, "driverCores", s.DriverCores)
 	populate(objectMap, "driverMemory", s.DriverMemory)
 	populate(objectMap, "executorCores", s.ExecutorCores)
@@ -37854,20 +37854,20 @@ func (s *SparkLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SparkLinkedServiceTypeProperties.
 func (s SparkLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "allowHostNameCNMismatch", &s.AllowHostNameCNMismatch)
-	populate(objectMap, "allowSelfSignedServerCert", &s.AllowSelfSignedServerCert)
+	populateAny(objectMap, "allowHostNameCNMismatch", s.AllowHostNameCNMismatch)
+	populateAny(objectMap, "allowSelfSignedServerCert", s.AllowSelfSignedServerCert)
 	populate(objectMap, "authenticationType", s.AuthenticationType)
-	populate(objectMap, "enableSsl", &s.EnableSSL)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "httpPath", &s.HTTPPath)
-	populate(objectMap, "host", &s.Host)
+	populateAny(objectMap, "enableSsl", s.EnableSSL)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "httpPath", s.HTTPPath)
+	populateAny(objectMap, "host", s.Host)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "port", &s.Port)
+	populateAny(objectMap, "port", s.Port)
 	populate(objectMap, "serverType", s.ServerType)
 	populate(objectMap, "thriftTransportProtocol", s.ThriftTransportProtocol)
-	populate(objectMap, "trustedCertPath", &s.TrustedCertPath)
-	populate(objectMap, "useSystemTrustStore", &s.UseSystemTrustStore)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "trustedCertPath", s.TrustedCertPath)
+	populateAny(objectMap, "useSystemTrustStore", s.UseSystemTrustStore)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -37938,8 +37938,8 @@ func (s SparkObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SparkObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -38211,11 +38211,11 @@ func (s *SparkServicePlugin) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SparkSource.
 func (s SparkSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SparkSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -38335,14 +38335,14 @@ func (s *SquareLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SquareLinkedServiceTypeProperties.
 func (s SquareLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "clientId", &s.ClientID)
+	populateAny(objectMap, "clientId", s.ClientID)
 	populate(objectMap, "clientSecret", s.ClientSecret)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
-	populate(objectMap, "host", &s.Host)
-	populate(objectMap, "redirectUri", &s.RedirectURI)
-	populate(objectMap, "useEncryptedEndpoints", &s.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &s.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &s.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
+	populateAny(objectMap, "host", s.Host)
+	populateAny(objectMap, "redirectUri", s.RedirectURI)
+	populateAny(objectMap, "useEncryptedEndpoints", s.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", s.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", s.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -38395,8 +38395,8 @@ func (s SquareObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SquareObject"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -38464,11 +38464,11 @@ func (s *SquareObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SquareSource.
 func (s SquareSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SquareSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -38565,9 +38565,9 @@ func (s *SsisObjectMetadataStatusResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type StagingSettings.
 func (s StagingSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "enableCompression", &s.EnableCompression)
+	populateAny(objectMap, "enableCompression", s.EnableCompression)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
-	populate(objectMap, "path", &s.Path)
+	populateAny(objectMap, "path", s.Path)
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
 			objectMap[key] = val
@@ -38617,11 +38617,11 @@ func (s StartDataFlowDebugSessionRequest) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "dataFlow", s.DataFlow)
 	populate(objectMap, "datasets", s.Datasets)
-	populate(objectMap, "debugSettings", &s.DebugSettings)
+	populateAny(objectMap, "debugSettings", s.DebugSettings)
 	populate(objectMap, "incrementalDebug", s.IncrementalDebug)
 	populate(objectMap, "linkedServices", s.LinkedServices)
 	populate(objectMap, "sessionId", s.SessionID)
-	populate(objectMap, "staging", &s.Staging)
+	populateAny(objectMap, "staging", s.Staging)
 	return json.Marshal(objectMap)
 }
 
@@ -38693,7 +38693,7 @@ func (s *StartDataFlowDebugSessionResponse) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type StoreReadSettings.
 func (s StoreReadSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
 	objectMap["type"] = s.Type
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -38739,8 +38739,8 @@ func (s *StoreReadSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type StoreWriteSettings.
 func (s StoreWriteSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "copyBehavior", &s.CopyBehavior)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
+	populateAny(objectMap, "copyBehavior", s.CopyBehavior)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
 	objectMap["type"] = s.Type
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -38790,7 +38790,7 @@ func (s *StoreWriteSettings) UnmarshalJSON(data []byte) error {
 func (s StoredProcedureParameter) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "type", s.Type)
-	populate(objectMap, "value", &s.Value)
+	populateAny(objectMap, "value", s.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -39077,12 +39077,12 @@ func (s *SybaseLinkedService) UnmarshalJSON(data []byte) error {
 func (s SybaseLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", s.AuthenticationType)
-	populate(objectMap, "database", &s.Database)
-	populate(objectMap, "encryptedCredential", &s.EncryptedCredential)
+	populateAny(objectMap, "database", s.Database)
+	populateAny(objectMap, "encryptedCredential", s.EncryptedCredential)
 	populate(objectMap, "password", s.Password)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "server", &s.Server)
-	populate(objectMap, "username", &s.Username)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "server", s.Server)
+	populateAny(objectMap, "username", s.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -39127,11 +39127,11 @@ func (s *SybaseLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SybaseSource.
 func (s SybaseSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &s.MaxConcurrentConnections)
-	populate(objectMap, "query", &s.Query)
-	populate(objectMap, "queryTimeout", &s.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &s.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &s.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", s.MaxConcurrentConnections)
+	populateAny(objectMap, "query", s.Query)
+	populateAny(objectMap, "queryTimeout", s.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", s.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", s.SourceRetryWait)
 	objectMap["type"] = "SybaseSource"
 	if s.AdditionalProperties != nil {
 		for key, val := range s.AdditionalProperties {
@@ -39194,8 +39194,8 @@ func (s SybaseTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", s.Folder)
 	populate(objectMap, "linkedServiceName", s.LinkedServiceName)
 	populate(objectMap, "parameters", s.Parameters)
-	populate(objectMap, "schema", &s.Schema)
-	populate(objectMap, "structure", &s.Structure)
+	populateAny(objectMap, "schema", s.Schema)
+	populateAny(objectMap, "structure", s.Structure)
 	objectMap["type"] = "SybaseTable"
 	populate(objectMap, "typeProperties", s.TypeProperties)
 	if s.AdditionalProperties != nil {
@@ -39263,7 +39263,7 @@ func (s *SybaseTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type SybaseTableDatasetTypeProperties.
 func (s SybaseTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "tableName", &s.TableName)
+	populateAny(objectMap, "tableName", s.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -39550,10 +39550,10 @@ func (s *SynapseSparkJobReference) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TabularSource.
 func (t TabularSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &t.MaxConcurrentConnections)
-	populate(objectMap, "queryTimeout", &t.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &t.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &t.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", t.MaxConcurrentConnections)
+	populateAny(objectMap, "queryTimeout", t.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", t.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", t.SourceRetryWait)
 	objectMap["type"] = "TabularSource"
 	if t.AdditionalProperties != nil {
 		for key, val := range t.AdditionalProperties {
@@ -39608,11 +39608,11 @@ func (t *TabularSource) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TabularTranslator.
 func (t TabularTranslator) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "collectionReference", &t.CollectionReference)
-	populate(objectMap, "columnMappings", &t.ColumnMappings)
-	populate(objectMap, "mapComplexValuesToString", &t.MapComplexValuesToString)
-	populate(objectMap, "mappings", &t.Mappings)
-	populate(objectMap, "schemaMapping", &t.SchemaMapping)
+	populateAny(objectMap, "collectionReference", t.CollectionReference)
+	populateAny(objectMap, "columnMappings", t.ColumnMappings)
+	populateAny(objectMap, "mapComplexValuesToString", t.MapComplexValuesToString)
+	populateAny(objectMap, "mappings", t.Mappings)
+	populateAny(objectMap, "schemaMapping", t.SchemaMapping)
 	objectMap["type"] = "TabularTranslator"
 	if t.AdditionalProperties != nil {
 		for key, val := range t.AdditionalProperties {
@@ -39733,11 +39733,11 @@ func (t *TeradataLinkedService) UnmarshalJSON(data []byte) error {
 func (t TeradataLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authenticationType", t.AuthenticationType)
-	populate(objectMap, "connectionString", &t.ConnectionString)
-	populate(objectMap, "encryptedCredential", &t.EncryptedCredential)
+	populateAny(objectMap, "connectionString", t.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", t.EncryptedCredential)
 	populate(objectMap, "password", t.Password)
-	populate(objectMap, "server", &t.Server)
-	populate(objectMap, "username", &t.Username)
+	populateAny(objectMap, "server", t.Server)
+	populateAny(objectMap, "username", t.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -39779,9 +39779,9 @@ func (t *TeradataLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TeradataPartitionSettings.
 func (t TeradataPartitionSettings) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "partitionColumnName", &t.PartitionColumnName)
-	populate(objectMap, "partitionLowerBound", &t.PartitionLowerBound)
-	populate(objectMap, "partitionUpperBound", &t.PartitionUpperBound)
+	populateAny(objectMap, "partitionColumnName", t.PartitionColumnName)
+	populateAny(objectMap, "partitionLowerBound", t.PartitionLowerBound)
+	populateAny(objectMap, "partitionUpperBound", t.PartitionUpperBound)
 	return json.Marshal(objectMap)
 }
 
@@ -39814,13 +39814,13 @@ func (t *TeradataPartitionSettings) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TeradataSource.
 func (t TeradataSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &t.MaxConcurrentConnections)
+	populateAny(objectMap, "maxConcurrentConnections", t.MaxConcurrentConnections)
 	populate(objectMap, "partitionOption", t.PartitionOption)
 	populate(objectMap, "partitionSettings", t.PartitionSettings)
-	populate(objectMap, "query", &t.Query)
-	populate(objectMap, "queryTimeout", &t.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &t.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &t.SourceRetryWait)
+	populateAny(objectMap, "query", t.Query)
+	populateAny(objectMap, "queryTimeout", t.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", t.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", t.SourceRetryWait)
 	objectMap["type"] = "TeradataSource"
 	if t.AdditionalProperties != nil {
 		for key, val := range t.AdditionalProperties {
@@ -39889,8 +39889,8 @@ func (t TeradataTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", t.Folder)
 	populate(objectMap, "linkedServiceName", t.LinkedServiceName)
 	populate(objectMap, "parameters", t.Parameters)
-	populate(objectMap, "schema", &t.Schema)
-	populate(objectMap, "structure", &t.Structure)
+	populateAny(objectMap, "schema", t.Schema)
+	populateAny(objectMap, "structure", t.Structure)
 	objectMap["type"] = "TeradataTable"
 	populate(objectMap, "typeProperties", t.TypeProperties)
 	if t.AdditionalProperties != nil {
@@ -39958,8 +39958,8 @@ func (t *TeradataTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TeradataTableDatasetTypeProperties.
 func (t TeradataTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "database", &t.Database)
-	populate(objectMap, "table", &t.Table)
+	populateAny(objectMap, "database", t.Database)
+	populateAny(objectMap, "table", t.Table)
 	return json.Marshal(objectMap)
 }
 
@@ -39989,17 +39989,17 @@ func (t *TeradataTableDatasetTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type TextFormat.
 func (t TextFormat) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "columnDelimiter", &t.ColumnDelimiter)
-	populate(objectMap, "deserializer", &t.Deserializer)
-	populate(objectMap, "encodingName", &t.EncodingName)
-	populate(objectMap, "escapeChar", &t.EscapeChar)
-	populate(objectMap, "firstRowAsHeader", &t.FirstRowAsHeader)
-	populate(objectMap, "nullValue", &t.NullValue)
-	populate(objectMap, "quoteChar", &t.QuoteChar)
-	populate(objectMap, "rowDelimiter", &t.RowDelimiter)
-	populate(objectMap, "serializer", &t.Serializer)
-	populate(objectMap, "skipLineCount", &t.SkipLineCount)
-	populate(objectMap, "treatEmptyAsNull", &t.TreatEmptyAsNull)
+	populateAny(objectMap, "columnDelimiter", t.ColumnDelimiter)
+	populateAny(objectMap, "deserializer", t.Deserializer)
+	populateAny(objectMap, "encodingName", t.EncodingName)
+	populateAny(objectMap, "escapeChar", t.EscapeChar)
+	populateAny(objectMap, "firstRowAsHeader", t.FirstRowAsHeader)
+	populateAny(objectMap, "nullValue", t.NullValue)
+	populateAny(objectMap, "quoteChar", t.QuoteChar)
+	populateAny(objectMap, "rowDelimiter", t.RowDelimiter)
+	populateAny(objectMap, "serializer", t.Serializer)
+	populateAny(objectMap, "skipLineCount", t.SkipLineCount)
+	populateAny(objectMap, "treatEmptyAsNull", t.TreatEmptyAsNull)
 	objectMap["type"] = "TextFormat"
 	if t.AdditionalProperties != nil {
 		for key, val := range t.AdditionalProperties {
@@ -40634,7 +40634,7 @@ func (t *TumblingWindowTriggerDependencyReference) UnmarshalJSON(data []byte) er
 // MarshalJSON implements the json.Marshaller interface for type TumblingWindowTriggerTypeProperties.
 func (t TumblingWindowTriggerTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "delay", &t.Delay)
+	populateAny(objectMap, "delay", t.Delay)
 	populate(objectMap, "dependsOn", t.DependsOn)
 	populateTimeRFC3339(objectMap, "endTime", t.EndTime)
 	populate(objectMap, "frequency", t.Frequency)
@@ -40753,7 +40753,7 @@ func (u UntilActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "activities", u.Activities)
 	populate(objectMap, "expression", u.Expression)
-	populate(objectMap, "timeout", &u.Timeout)
+	populateAny(objectMap, "timeout", u.Timeout)
 	return json.Marshal(objectMap)
 }
 
@@ -40787,7 +40787,7 @@ func (u *UntilActivityTypeProperties) UnmarshalJSON(data []byte) error {
 func (u UserProperty) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "name", u.Name)
-	populate(objectMap, "value", &u.Value)
+	populateAny(objectMap, "value", u.Value)
 	return json.Marshal(objectMap)
 }
 
@@ -40879,11 +40879,11 @@ func (v *ValidationActivity) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ValidationActivityTypeProperties.
 func (v ValidationActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "childItems", &v.ChildItems)
+	populateAny(objectMap, "childItems", v.ChildItems)
 	populate(objectMap, "dataset", v.Dataset)
-	populate(objectMap, "minimumSize", &v.MinimumSize)
-	populate(objectMap, "sleep", &v.Sleep)
-	populate(objectMap, "timeout", &v.Timeout)
+	populateAny(objectMap, "minimumSize", v.MinimumSize)
+	populateAny(objectMap, "sleep", v.Sleep)
+	populateAny(objectMap, "timeout", v.Timeout)
 	return json.Marshal(objectMap)
 }
 
@@ -40922,7 +40922,7 @@ func (v *ValidationActivityTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type VariableSpecification.
 func (v VariableSpecification) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "defaultValue", &v.DefaultValue)
+	populateAny(objectMap, "defaultValue", v.DefaultValue)
 	populate(objectMap, "type", v.Type)
 	return json.Marshal(objectMap)
 }
@@ -40953,9 +40953,9 @@ func (v *VariableSpecification) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type VerticaDatasetTypeProperties.
 func (v VerticaDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "schema", &v.Schema)
-	populate(objectMap, "table", &v.Table)
-	populate(objectMap, "tableName", &v.TableName)
+	populateAny(objectMap, "schema", v.Schema)
+	populateAny(objectMap, "table", v.Table)
+	populateAny(objectMap, "tableName", v.TableName)
 	return json.Marshal(objectMap)
 }
 
@@ -41050,8 +41050,8 @@ func (v *VerticaLinkedService) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type VerticaLinkedServiceTypeProperties.
 func (v VerticaLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "connectionString", &v.ConnectionString)
-	populate(objectMap, "encryptedCredential", &v.EncryptedCredential)
+	populateAny(objectMap, "connectionString", v.ConnectionString)
+	populateAny(objectMap, "encryptedCredential", v.EncryptedCredential)
 	populate(objectMap, "pwd", v.Pwd)
 	return json.Marshal(objectMap)
 }
@@ -41085,11 +41085,11 @@ func (v *VerticaLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type VerticaSource.
 func (v VerticaSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &v.MaxConcurrentConnections)
-	populate(objectMap, "query", &v.Query)
-	populate(objectMap, "queryTimeout", &v.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &v.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &v.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", v.MaxConcurrentConnections)
+	populateAny(objectMap, "query", v.Query)
+	populateAny(objectMap, "queryTimeout", v.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", v.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", v.SourceRetryWait)
 	objectMap["type"] = "VerticaSource"
 	if v.AdditionalProperties != nil {
 		for key, val := range v.AdditionalProperties {
@@ -41152,8 +41152,8 @@ func (v VerticaTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", v.Folder)
 	populate(objectMap, "linkedServiceName", v.LinkedServiceName)
 	populate(objectMap, "parameters", v.Parameters)
-	populate(objectMap, "schema", &v.Schema)
-	populate(objectMap, "structure", &v.Structure)
+	populateAny(objectMap, "schema", v.Schema)
+	populateAny(objectMap, "structure", v.Structure)
 	objectMap["type"] = "VerticaTable"
 	populate(objectMap, "typeProperties", v.TypeProperties)
 	if v.AdditionalProperties != nil {
@@ -41451,13 +41451,13 @@ func (w *WebActivityAuthentication) UnmarshalJSON(data []byte) error {
 func (w WebActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authentication", w.Authentication)
-	populate(objectMap, "body", &w.Body)
+	populateAny(objectMap, "body", w.Body)
 	populate(objectMap, "connectVia", w.ConnectVia)
 	populate(objectMap, "datasets", w.Datasets)
-	populate(objectMap, "headers", &w.Headers)
+	populateAny(objectMap, "headers", w.Headers)
 	populate(objectMap, "linkedServices", w.LinkedServices)
 	populate(objectMap, "method", w.Method)
-	populate(objectMap, "url", &w.URL)
+	populateAny(objectMap, "url", w.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -41506,7 +41506,7 @@ func (w *WebActivityTypeProperties) UnmarshalJSON(data []byte) error {
 func (w WebAnonymousAuthentication) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	objectMap["authenticationType"] = WebAuthenticationTypeAnonymous
-	populate(objectMap, "url", &w.URL)
+	populateAny(objectMap, "url", w.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -41538,8 +41538,8 @@ func (w WebBasicAuthentication) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	objectMap["authenticationType"] = WebAuthenticationTypeBasic
 	populate(objectMap, "password", w.Password)
-	populate(objectMap, "url", &w.URL)
-	populate(objectMap, "username", &w.Username)
+	populateAny(objectMap, "url", w.URL)
+	populateAny(objectMap, "username", w.Username)
 	return json.Marshal(objectMap)
 }
 
@@ -41578,7 +41578,7 @@ func (w WebClientCertificateAuthentication) MarshalJSON() ([]byte, error) {
 	objectMap["authenticationType"] = WebAuthenticationTypeClientCertificate
 	populate(objectMap, "password", w.Password)
 	populate(objectMap, "pfx", w.Pfx)
-	populate(objectMap, "url", &w.URL)
+	populateAny(objectMap, "url", w.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -41677,12 +41677,12 @@ func (w *WebHookActivity) UnmarshalJSON(data []byte) error {
 func (w WebHookActivityTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "authentication", w.Authentication)
-	populate(objectMap, "body", &w.Body)
-	populate(objectMap, "headers", &w.Headers)
+	populateAny(objectMap, "body", w.Body)
+	populateAny(objectMap, "headers", w.Headers)
 	populate(objectMap, "method", w.Method)
-	populate(objectMap, "reportStatusOnCallBack", &w.ReportStatusOnCallBack)
+	populateAny(objectMap, "reportStatusOnCallBack", w.ReportStatusOnCallBack)
 	populate(objectMap, "timeout", w.Timeout)
-	populate(objectMap, "url", &w.URL)
+	populateAny(objectMap, "url", w.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -41790,7 +41790,7 @@ func (w *WebLinkedService) UnmarshalJSON(data []byte) error {
 func (w WebLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	objectMap["authenticationType"] = w.AuthenticationType
-	populate(objectMap, "url", &w.URL)
+	populateAny(objectMap, "url", w.URL)
 	return json.Marshal(objectMap)
 }
 
@@ -41820,9 +41820,9 @@ func (w *WebLinkedServiceTypeProperties) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type WebSource.
 func (w WebSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &w.MaxConcurrentConnections)
-	populate(objectMap, "sourceRetryCount", &w.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &w.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", w.MaxConcurrentConnections)
+	populateAny(objectMap, "sourceRetryCount", w.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", w.SourceRetryWait)
 	objectMap["type"] = "WebSource"
 	if w.AdditionalProperties != nil {
 		for key, val := range w.AdditionalProperties {
@@ -41879,8 +41879,8 @@ func (w WebTableDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", w.Folder)
 	populate(objectMap, "linkedServiceName", w.LinkedServiceName)
 	populate(objectMap, "parameters", w.Parameters)
-	populate(objectMap, "schema", &w.Schema)
-	populate(objectMap, "structure", &w.Structure)
+	populateAny(objectMap, "schema", w.Schema)
+	populateAny(objectMap, "structure", w.Structure)
 	objectMap["type"] = "WebTable"
 	populate(objectMap, "typeProperties", w.TypeProperties)
 	if w.AdditionalProperties != nil {
@@ -41948,8 +41948,8 @@ func (w *WebTableDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type WebTableDatasetTypeProperties.
 func (w WebTableDatasetTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "index", &w.Index)
-	populate(objectMap, "path", &w.Path)
+	populateAny(objectMap, "index", w.Index)
+	populateAny(objectMap, "path", w.Path)
 	return json.Marshal(objectMap)
 }
 
@@ -42336,12 +42336,12 @@ func (x *XeroLinkedService) UnmarshalJSON(data []byte) error {
 func (x XeroLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "consumerKey", x.ConsumerKey)
-	populate(objectMap, "encryptedCredential", &x.EncryptedCredential)
-	populate(objectMap, "host", &x.Host)
+	populateAny(objectMap, "encryptedCredential", x.EncryptedCredential)
+	populateAny(objectMap, "host", x.Host)
 	populate(objectMap, "privateKey", x.PrivateKey)
-	populate(objectMap, "useEncryptedEndpoints", &x.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &x.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &x.UsePeerVerification)
+	populateAny(objectMap, "useEncryptedEndpoints", x.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", x.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", x.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -42391,8 +42391,8 @@ func (x XeroObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", x.Folder)
 	populate(objectMap, "linkedServiceName", x.LinkedServiceName)
 	populate(objectMap, "parameters", x.Parameters)
-	populate(objectMap, "schema", &x.Schema)
-	populate(objectMap, "structure", &x.Structure)
+	populateAny(objectMap, "schema", x.Schema)
+	populateAny(objectMap, "structure", x.Structure)
 	objectMap["type"] = "XeroObject"
 	populate(objectMap, "typeProperties", x.TypeProperties)
 	if x.AdditionalProperties != nil {
@@ -42460,11 +42460,11 @@ func (x *XeroObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type XeroSource.
 func (x XeroSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &x.MaxConcurrentConnections)
-	populate(objectMap, "query", &x.Query)
-	populate(objectMap, "queryTimeout", &x.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &x.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &x.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", x.MaxConcurrentConnections)
+	populateAny(objectMap, "query", x.Query)
+	populateAny(objectMap, "queryTimeout", x.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", x.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", x.SourceRetryWait)
 	objectMap["type"] = "XeroSource"
 	if x.AdditionalProperties != nil {
 		for key, val := range x.AdditionalProperties {
@@ -42585,11 +42585,11 @@ func (z *ZohoLinkedService) UnmarshalJSON(data []byte) error {
 func (z ZohoLinkedServiceTypeProperties) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
 	populate(objectMap, "accessToken", z.AccessToken)
-	populate(objectMap, "encryptedCredential", &z.EncryptedCredential)
-	populate(objectMap, "endpoint", &z.Endpoint)
-	populate(objectMap, "useEncryptedEndpoints", &z.UseEncryptedEndpoints)
-	populate(objectMap, "useHostVerification", &z.UseHostVerification)
-	populate(objectMap, "usePeerVerification", &z.UsePeerVerification)
+	populateAny(objectMap, "encryptedCredential", z.EncryptedCredential)
+	populateAny(objectMap, "endpoint", z.Endpoint)
+	populateAny(objectMap, "useEncryptedEndpoints", z.UseEncryptedEndpoints)
+	populateAny(objectMap, "useHostVerification", z.UseHostVerification)
+	populateAny(objectMap, "usePeerVerification", z.UsePeerVerification)
 	return json.Marshal(objectMap)
 }
 
@@ -42636,8 +42636,8 @@ func (z ZohoObjectDataset) MarshalJSON() ([]byte, error) {
 	populate(objectMap, "folder", z.Folder)
 	populate(objectMap, "linkedServiceName", z.LinkedServiceName)
 	populate(objectMap, "parameters", z.Parameters)
-	populate(objectMap, "schema", &z.Schema)
-	populate(objectMap, "structure", &z.Structure)
+	populateAny(objectMap, "schema", z.Schema)
+	populateAny(objectMap, "structure", z.Structure)
 	objectMap["type"] = "ZohoObject"
 	populate(objectMap, "typeProperties", z.TypeProperties)
 	if z.AdditionalProperties != nil {
@@ -42705,11 +42705,11 @@ func (z *ZohoObjectDataset) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type ZohoSource.
 func (z ZohoSource) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "maxConcurrentConnections", &z.MaxConcurrentConnections)
-	populate(objectMap, "query", &z.Query)
-	populate(objectMap, "queryTimeout", &z.QueryTimeout)
-	populate(objectMap, "sourceRetryCount", &z.SourceRetryCount)
-	populate(objectMap, "sourceRetryWait", &z.SourceRetryWait)
+	populateAny(objectMap, "maxConcurrentConnections", z.MaxConcurrentConnections)
+	populateAny(objectMap, "query", z.Query)
+	populateAny(objectMap, "queryTimeout", z.QueryTimeout)
+	populateAny(objectMap, "sourceRetryCount", z.SourceRetryCount)
+	populateAny(objectMap, "sourceRetryWait", z.SourceRetryWait)
 	objectMap["type"] = "ZohoSource"
 	if z.AdditionalProperties != nil {
 		for key, val := range z.AdditionalProperties {
@@ -42770,6 +42770,16 @@ func populate(m map[string]any, k string, v any) {
 	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}
+
+func populateAny(m map[string]any, k string, v any) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else {
 		m[k] = v
 	}
 }

--- a/test/synapse/2019-06-01/azspark/zz_models_serde.go
+++ b/test/synapse/2019-06-01/azspark/zz_models_serde.go
@@ -911,7 +911,7 @@ func (s *StatementOptions) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaller interface for type StatementOutput.
 func (s StatementOutput) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "data", &s.Data)
+	populateAny(objectMap, "data", s.Data)
 	populate(objectMap, "ename", s.ErrorName)
 	populate(objectMap, "evalue", s.ErrorValue)
 	populate(objectMap, "execution_count", s.ExecutionCount)
@@ -961,6 +961,16 @@ func populate(m map[string]any, k string, v any) {
 	} else if azcore.IsNullValue(v) {
 		m[k] = nil
 	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}
+
+func populateAny(m map[string]any, k string, v any) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else {
 		m[k] = v
 	}
 }


### PR DESCRIPTION
Strcuts with fields of any type were always sending a JSON null as the address of the field was never nil.
Reverted rawjson-as-bytes for some test cases to see and test changes.

Fixes https://github.com/Azure/autorest.go/issues/946