### PR TITLE
Add back vscode setting for debug attach

### DIFF
--- a/packages/autorest.go/.vscode/launch.json
+++ b/packages/autorest.go/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach",
+            "address": "127.0.0.1",
+            "port": 9229,
+            "smartStep" : true,
+            "skipFiles": ["<node_internals/**/*.js"]
+        },
+    ]
+}


### PR DESCRIPTION
This was inadvertently removed when the sources were moved.