### PR TITLE
Fix spacing in options structs

### DIFF
--- a/packages/autorest.go/src/generator/structs.ts
+++ b/packages/autorest.go/src/generator/structs.ts
@@ -121,6 +121,11 @@ export class StructDef {
         continue;
       }
       if (hasDescription(param.language.go!)) {
+        if (!first) {
+          // add an extra new-line between fields IFF the field
+          // has a comment and it's not the very first one.
+          text += '\n';
+        }
         text += `\t${comment(param.language.go!.description, '// ', undefined, commentLength)}\n`;
       }
       let pointer = '*';
@@ -129,6 +134,7 @@ export class StructDef {
       }
       const typeName = param.schema.language.go!.name;
       text += `\t${capitalize(param.language.go!.name)} ${pointer}${typeName}\n`;
+      first = false;
     }
     text += '}\n\n';
     return text;

--- a/packages/autorest.go/test/acr/azacr/zz_models.go
+++ b/packages/autorest.go/test/acr/azacr/zz_models.go
@@ -99,8 +99,10 @@ type ArtifactTagProperties struct {
 type AuthenticationClientExchangeAADAccessTokenForAcrRefreshTokenOptions struct {
 	// AAD access token, mandatory when granttype is accesstokenrefreshtoken or access_token.
 	AccessToken *string
+
 	// AAD refresh token, mandatory when granttype is accesstokenrefreshtoken or refresh_token
 	RefreshToken *string
+
 	// AAD tenant associated to the AAD credentials.
 	Tenant *string
 }
@@ -231,8 +233,10 @@ type ContainerRegistryClientGetManifestPropertiesOptions struct {
 type ContainerRegistryClientGetManifestsOptions struct {
 	// Query parameter for the last item in previous query. Result set will include values lexically after last.
 	Last *string
+
 	// query parameter for max number of items
 	N *int32
+
 	// orderby query parameter
 	Orderby *string
 }
@@ -248,6 +252,7 @@ type ContainerRegistryClientGetPropertiesOptions struct {
 type ContainerRegistryClientGetRepositoriesOptions struct {
 	// Query parameter for the last item in previous query. Result set will include values lexically after last.
 	Last *string
+
 	// query parameter for max number of items
 	N *int32
 }
@@ -263,10 +268,13 @@ type ContainerRegistryClientGetTagPropertiesOptions struct {
 type ContainerRegistryClientGetTagsOptions struct {
 	// filter by digest
 	Digest *string
+
 	// Query parameter for the last item in previous query. Result set will include values lexically after last.
 	Last *string
+
 	// query parameter for max number of items
 	N *int32
+
 	// orderby query parameter
 	Orderby *string
 }

--- a/packages/autorest.go/test/autorest/azurespecialsgroup/zz_models.go
+++ b/packages/autorest.go/test/autorest/azurespecialsgroup/zz_models.go
@@ -85,8 +85,10 @@ type HeaderClientCustomNamedRequestIDParamGroupingParameters struct {
 type ODataClientGetWithFilterOptions struct {
 	// The filter parameter with value '$filter=id gt 5 and name eq 'foo''.
 	Filter *string
+
 	// The orderby parameter with value id.
 	Orderby *string
+
 	// The top parameter with value 10.
 	Top *int32
 }

--- a/packages/autorest.go/test/autorest/lrogroup/zz_models.go
+++ b/packages/autorest.go/test/autorest/lrogroup/zz_models.go
@@ -34,6 +34,7 @@ type LRORetrysClientBeginDeleteProvisioning202Accepted200SucceededOptions struct
 type LRORetrysClientBeginPost202Retry200Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -43,6 +44,7 @@ type LRORetrysClientBeginPost202Retry200Options struct {
 type LRORetrysClientBeginPostAsyncRelativeRetrySucceededOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -122,6 +124,7 @@ type LROSADsClientBeginDeleteNonRetry400Options struct {
 type LROSADsClientBeginPost202NoLocationOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -131,6 +134,7 @@ type LROSADsClientBeginPost202NoLocationOptions struct {
 type LROSADsClientBeginPost202NonRetry400Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -140,6 +144,7 @@ type LROSADsClientBeginPost202NonRetry400Options struct {
 type LROSADsClientBeginPost202RetryInvalidHeaderOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -149,6 +154,7 @@ type LROSADsClientBeginPost202RetryInvalidHeaderOptions struct {
 type LROSADsClientBeginPostAsyncRelativeRetry400Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -158,6 +164,7 @@ type LROSADsClientBeginPostAsyncRelativeRetry400Options struct {
 type LROSADsClientBeginPostAsyncRelativeRetryInvalidHeaderOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -167,6 +174,7 @@ type LROSADsClientBeginPostAsyncRelativeRetryInvalidHeaderOptions struct {
 type LROSADsClientBeginPostAsyncRelativeRetryInvalidJSONPollingOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -176,6 +184,7 @@ type LROSADsClientBeginPostAsyncRelativeRetryInvalidJSONPollingOptions struct {
 type LROSADsClientBeginPostAsyncRelativeRetryNoPayloadOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -184,6 +193,7 @@ type LROSADsClientBeginPostAsyncRelativeRetryNoPayloadOptions struct {
 type LROSADsClientBeginPostNonRetry400Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -376,6 +386,7 @@ type LROsClientBeginPost202ListOptions struct {
 type LROsClientBeginPost202NoRetry204Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -384,6 +395,7 @@ type LROsClientBeginPost202NoRetry204Options struct {
 type LROsClientBeginPost202Retry200Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -393,6 +405,7 @@ type LROsClientBeginPost202Retry200Options struct {
 type LROsClientBeginPostAsyncNoRetrySucceededOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -402,6 +415,7 @@ type LROsClientBeginPostAsyncNoRetrySucceededOptions struct {
 type LROsClientBeginPostAsyncRetryFailedOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -411,6 +425,7 @@ type LROsClientBeginPostAsyncRetryFailedOptions struct {
 type LROsClientBeginPostAsyncRetrySucceededOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -420,6 +435,7 @@ type LROsClientBeginPostAsyncRetrySucceededOptions struct {
 type LROsClientBeginPostAsyncRetrycanceledOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -570,6 +586,7 @@ type LROsClientBeginPutSubResourceOptions struct {
 type LROsCustomHeaderClientBeginPost202Retry200Options struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -579,6 +596,7 @@ type LROsCustomHeaderClientBeginPost202Retry200Options struct {
 type LROsCustomHeaderClientBeginPostAsyncRetrySucceededOptions struct {
 	// Product to put
 	Product *Product
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }

--- a/packages/autorest.go/test/autorest/paginggroup/zz_models.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_models.go
@@ -12,6 +12,7 @@ package paginggroup
 type CustomParameterGroup struct {
 	// Sets the api version to use.
 	APIVersion string
+
 	// Sets the tenant to use.
 	Tenant string
 }
@@ -25,10 +26,13 @@ type ODataProductResult struct {
 // method.
 type PagingClientBeginGetMultiplePagesLROOptions struct {
 	ClientRequestID *string
+
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }
@@ -72,8 +76,10 @@ type PagingClientGetMultiplePagesFragmentWithGroupingNextLinkOptions struct {
 // PagingClientGetMultiplePagesOptions contains the optional parameters for the PagingClient.NewGetMultiplePagesPager method.
 type PagingClientGetMultiplePagesOptions struct {
 	ClientRequestID *string
+
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }
@@ -94,10 +100,13 @@ type PagingClientGetMultiplePagesRetrySecondOptions struct {
 // method.
 type PagingClientGetMultiplePagesWithOffsetOptions struct {
 	ClientRequestID *string
+
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
+
 	// Offset of return value
 	Offset int32
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }
@@ -118,8 +127,10 @@ type PagingClientGetNullNextLinkNamePagesOptions struct {
 // method.
 type PagingClientGetODataMultiplePagesOptions struct {
 	ClientRequestID *string
+
 	// Sets the maximum number of items to return in the response.
 	Maxresults *int32
+
 	// Sets the maximum time that the server can spend processing the request, in seconds. The default is 30 seconds.
 	Timeout *int32
 }

--- a/packages/autorest.go/test/autorest/paramgroupinggroup/zz_models.go
+++ b/packages/autorest.go/test/autorest/paramgroupinggroup/zz_models.go
@@ -11,6 +11,7 @@ package paramgroupinggroup
 // FirstParameterGroup contains a group of parameters for the ParameterGroupingClient.PostMultiParamGroups method.
 type FirstParameterGroup struct {
 	HeaderOne *string
+
 	// Query parameter with default
 	QueryOne *int32
 }
@@ -25,6 +26,7 @@ type ParameterGroupingClientPostMultiParamGroupsOptions struct {
 // method.
 type ParameterGroupingClientPostMultiParamGroupsSecondParamGroup struct {
 	HeaderTwo *string
+
 	// Query parameter with default
 	QueryTwo *int32
 }
@@ -39,6 +41,7 @@ type ParameterGroupingClientPostOptionalOptions struct {
 // method.
 type ParameterGroupingClientPostOptionalParameters struct {
 	CustomHeader *string
+
 	// Query parameter with default
 	Query *int32
 }
@@ -54,8 +57,10 @@ type ParameterGroupingClientPostRequiredOptions struct {
 type ParameterGroupingClientPostRequiredParameters struct {
 	Body         int32
 	CustomHeader *string
+
 	// Path parameter
 	Path string
+
 	// Query parameter with default
 	Query *int32
 }
@@ -71,6 +76,7 @@ type ParameterGroupingClientPostReservedWordsOptions struct {
 type ParameterGroupingClientPostReservedWordsParameters struct {
 	// 'accept' is a reserved word. Pass in 'yes' to pass.
 	Accept *string
+
 	// 'from' is a reserved word. Pass in 'bob' to pass.
 	From *string
 }

--- a/packages/autorest.go/test/autorest/urlgroup/zz_models.go
+++ b/packages/autorest.go/test/autorest/urlgroup/zz_models.go
@@ -14,6 +14,7 @@ import "time"
 type PathItemsClientGetAllWithValuesOptions struct {
 	// should contain value 'localStringQuery'
 	LocalStringQuery *string
+
 	// A string value 'pathItemStringQuery' that appears as a query parameter
 	PathItemStringQuery *string
 }
@@ -23,6 +24,7 @@ type PathItemsClientGetAllWithValuesOptions struct {
 type PathItemsClientGetGlobalAndLocalQueryNullOptions struct {
 	// should contain null value
 	LocalStringQuery *string
+
 	// A string value 'pathItemStringQuery' that appears as a query parameter
 	PathItemStringQuery *string
 }
@@ -31,6 +33,7 @@ type PathItemsClientGetGlobalAndLocalQueryNullOptions struct {
 type PathItemsClientGetGlobalQueryNullOptions struct {
 	// should contain value 'localStringQuery'
 	LocalStringQuery *string
+
 	// A string value 'pathItemStringQuery' that appears as a query parameter
 	PathItemStringQuery *string
 }
@@ -40,6 +43,7 @@ type PathItemsClientGetGlobalQueryNullOptions struct {
 type PathItemsClientGetLocalPathItemQueryNullOptions struct {
 	// should contain value null
 	LocalStringQuery *string
+
 	// should contain value null
 	PathItemStringQuery *string
 }

--- a/packages/autorest.go/test/compute/armcompute/zz_models.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_models.go
@@ -933,6 +933,7 @@ type CloudServicesClientBeginCreateOrUpdateOptions struct {
 type CloudServicesClientBeginDeleteInstancesOptions struct {
 	// List of cloud service role instance names.
 	Parameters *RoleInstances
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -953,6 +954,7 @@ type CloudServicesClientBeginPowerOffOptions struct {
 type CloudServicesClientBeginRebuildOptions struct {
 	// List of cloud service role instance names.
 	Parameters *RoleInstances
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -961,6 +963,7 @@ type CloudServicesClientBeginRebuildOptions struct {
 type CloudServicesClientBeginReimageOptions struct {
 	// List of cloud service role instance names.
 	Parameters *RoleInstances
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -969,6 +972,7 @@ type CloudServicesClientBeginReimageOptions struct {
 type CloudServicesClientBeginRestartOptions struct {
 	// List of cloud service role instance names.
 	Parameters *RoleInstances
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -2396,6 +2400,7 @@ type GalleriesClientBeginUpdateOptions struct {
 type GalleriesClientGetOptions struct {
 	// The expand query option to apply on the operation.
 	Expand *GalleryExpandParams
+
 	// The select expression to apply on the operation.
 	Select *SelectPermissions
 }
@@ -4540,6 +4545,7 @@ type ResourceSKUZoneDetails struct {
 type ResourceSKUsClientListOptions struct {
 	// The filter to apply on the operation. Only location filter is supported currently.
 	Filter *string
+
 	// To Include Extended Locations information or not in the response.
 	IncludeExtendedLocations *string
 }
@@ -6582,8 +6588,10 @@ type VirtualMachineImagesEdgeZoneClientListOffersOptions struct {
 type VirtualMachineImagesEdgeZoneClientListOptions struct {
 	// The expand expression to apply on the operation.
 	Expand *string
+
 	// Specifies the order of the results returned. Formatted as an OData query.
 	Orderby *string
+
 	// An integer value specifying the number of images to return that matches supplied values.
 	Top *int32
 }
@@ -8552,6 +8560,7 @@ type VirtualMachineScaleSetVMsClientBeginDeallocateOptions struct {
 type VirtualMachineScaleSetVMsClientBeginDeleteOptions struct {
 	// Optional parameter to force delete a virtual machine from a VM scale set. (Feature in Preview)
 	ForceDeletion *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -8568,6 +8577,7 @@ type VirtualMachineScaleSetVMsClientBeginPerformMaintenanceOptions struct {
 type VirtualMachineScaleSetVMsClientBeginPowerOffOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// The parameter to request non-graceful VM shutdown. True value for this flag indicates non-graceful shutdown whereas false
 	// indicates otherwise. Default value for this flag is false if not specified
 	SkipShutdown *bool
@@ -8592,6 +8602,7 @@ type VirtualMachineScaleSetVMsClientBeginReimageAllOptions struct {
 type VirtualMachineScaleSetVMsClientBeginReimageOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// Parameters for the Reimaging Virtual machine in ScaleSet.
 	VMScaleSetVMReimageInput *VirtualMachineScaleSetVMReimageParameters
 }
@@ -8643,10 +8654,12 @@ type VirtualMachineScaleSetVMsClientGetOptions struct {
 type VirtualMachineScaleSetVMsClientListOptions struct {
 	// The expand expression to apply to the operation. Allowed values are 'instanceView'.
 	Expand *string
+
 	// The filter to apply to the operation. Allowed values are 'startswith(instanceView/statuses/code, 'PowerState') eq true',
 	// 'properties/latestModelApplied eq true', 'properties/latestModelApplied eq
 	// false'.
 	Filter *string
+
 	// The list parameters. Allowed values are 'instanceView', 'instanceView/statuses'.
 	Select *string
 }
@@ -8677,6 +8690,7 @@ type VirtualMachineScaleSetsClientBeginCreateOrUpdateOptions struct {
 type VirtualMachineScaleSetsClientBeginDeallocateOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8686,6 +8700,7 @@ type VirtualMachineScaleSetsClientBeginDeallocateOptions struct {
 type VirtualMachineScaleSetsClientBeginDeleteInstancesOptions struct {
 	// Optional parameter to force delete virtual machines from the VM scale set. (Feature in Preview)
 	ForceDeletion *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -8695,6 +8710,7 @@ type VirtualMachineScaleSetsClientBeginDeleteInstancesOptions struct {
 type VirtualMachineScaleSetsClientBeginDeleteOptions struct {
 	// Optional parameter to force delete a VM scale set. (Feature in Preview)
 	ForceDeletion *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -8704,6 +8720,7 @@ type VirtualMachineScaleSetsClientBeginDeleteOptions struct {
 type VirtualMachineScaleSetsClientBeginPerformMaintenanceOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8713,9 +8730,11 @@ type VirtualMachineScaleSetsClientBeginPerformMaintenanceOptions struct {
 type VirtualMachineScaleSetsClientBeginPowerOffOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// The parameter to request non-graceful VM shutdown. True value for this flag indicates non-graceful shutdown whereas false
 	// indicates otherwise. Default value for this flag is false if not specified
 	SkipShutdown *bool
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8725,6 +8744,7 @@ type VirtualMachineScaleSetsClientBeginPowerOffOptions struct {
 type VirtualMachineScaleSetsClientBeginRedeployOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8734,6 +8754,7 @@ type VirtualMachineScaleSetsClientBeginRedeployOptions struct {
 type VirtualMachineScaleSetsClientBeginReimageAllOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8743,6 +8764,7 @@ type VirtualMachineScaleSetsClientBeginReimageAllOptions struct {
 type VirtualMachineScaleSetsClientBeginReimageOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// Parameters for Reimaging VM ScaleSet.
 	VMScaleSetReimageInput *VirtualMachineScaleSetReimageParameters
 }
@@ -8752,6 +8774,7 @@ type VirtualMachineScaleSetsClientBeginReimageOptions struct {
 type VirtualMachineScaleSetsClientBeginRestartOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8768,6 +8791,7 @@ type VirtualMachineScaleSetsClientBeginSetOrchestrationServiceStateOptions struc
 type VirtualMachineScaleSetsClientBeginStartOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// A list of virtual machine instance IDs from the VM scale set.
 	VMInstanceIDs *VirtualMachineScaleSetVMInstanceIDs
 }
@@ -8797,6 +8821,7 @@ type VirtualMachineScaleSetsClientConvertToSinglePlacementGroupOptions struct {
 type VirtualMachineScaleSetsClientForceRecoveryServiceFabricPlatformUpdateDomainWalkOptions struct {
 	// The placement group id for which the manual recovery walk is requested.
 	PlacementGroupID *string
+
 	// The zone in which the manual recovery walk is requested for cross zone virtual machine scale set
 	Zone *string
 }
@@ -8975,6 +9000,7 @@ type VirtualMachinesClientBeginCreateOrUpdateOptions struct {
 type VirtualMachinesClientBeginDeallocateOptions struct {
 	// Optional parameter to hibernate a virtual machine. (Feature in Preview)
 	Hibernate *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -8983,6 +9009,7 @@ type VirtualMachinesClientBeginDeallocateOptions struct {
 type VirtualMachinesClientBeginDeleteOptions struct {
 	// Optional parameter to force delete virtual machines.
 	ForceDeletion *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -9006,6 +9033,7 @@ type VirtualMachinesClientBeginPerformMaintenanceOptions struct {
 type VirtualMachinesClientBeginPowerOffOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// The parameter to request non-graceful VM shutdown. True value for this flag indicates non-graceful shutdown whereas false
 	// indicates otherwise. Default value for this flag is false if not specified
 	SkipShutdown *bool
@@ -9028,6 +9056,7 @@ type VirtualMachinesClientBeginRedeployOptions struct {
 type VirtualMachinesClientBeginReimageOptions struct {
 	// Parameters supplied to the Reimage Virtual Machine operation.
 	Parameters *VirtualMachineReimageParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -9081,6 +9110,7 @@ type VirtualMachinesClientListAllOptions struct {
 	// The system query option to filter VMs returned in the response. Allowed value is 'virtualMachineScaleSet/id' eq
 	// /subscriptions/{subId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Compute/virtualMachineScaleSets/{vmssName}'
 	Filter *string
+
 	// statusOnly=true enables fetching run time status of all Virtual Machines in the subscription.
 	StatusOnly *string
 }

--- a/packages/autorest.go/test/consumption/armconsumption/zz_models.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_models.go
@@ -308,12 +308,15 @@ type ChargesClientListOptions struct {
 	// (specific for Partner Led), or for billingProfile scope by
 	// properties/invoiceSectionId.
 	Apply *string
+
 	// End date
 	EndDate *string
+
 	// May be used to filter charges by properties/usageEnd (Utc time), properties/usageStart (Utc time). The filter supports
 	// 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne',
 	// 'or', or 'not'. Tag filter is a key value pair string where key and value is separated by a colon (:).
 	Filter *string
+
 	// Start date
 	StartDate *string
 }
@@ -1183,10 +1186,12 @@ type MarketplacesClientListOptions struct {
 	// properties/instanceName or properties/instanceId. The filter supports
 	// 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'.
 	Filter *string
+
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that
 	// specifies a starting point to use for subsequent calls.
 	Skiptoken *string
+
 	// May be used to limit the number of results to the most recent N marketplaces.
 	Top *int32
 }
@@ -1852,10 +1857,12 @@ type PriceSheetClientGetByBillingPeriodOptions struct {
 	// May be used to expand the properties/meterDetails within a price sheet. By default, these fields are not included when
 	// returning price sheet.
 	Expand *string
+
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that
 	// specifies a starting point to use for subsequent calls.
 	Skiptoken *string
+
 	// May be used to limit the number of results to the top N results.
 	Top *int32
 }
@@ -1865,10 +1872,12 @@ type PriceSheetClientGetOptions struct {
 	// May be used to expand the properties/meterDetails within a price sheet. By default, these fields are not included when
 	// returning price sheet.
 	Expand *string
+
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that
 	// specifies a starting point to use for subsequent calls.
 	Skiptoken *string
+
 	// May be used to limit the number of results to the top N results.
 	Top *int32
 }
@@ -2371,13 +2380,17 @@ type ReservationsDetailsClientListByReservationOrderOptions struct {
 type ReservationsDetailsClientListOptions struct {
 	// End date. Only applicable when querying with billing profile
 	EndDate *string
+
 	// Filter reservation details by date range. The properties/UsageDate for start date and end date. The filter supports 'le'
 	// and 'ge'. Not applicable when querying with billing profile
 	Filter *string
+
 	// Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation
 	ReservationID *string
+
 	// Reservation Order Id GUID. Required if reservationId is provided. Filter to a specific reservation order
 	ReservationOrderID *string
+
 	// Start date. Only applicable when querying with billing profile
 	StartDate *string
 }
@@ -2401,13 +2414,17 @@ type ReservationsSummariesClientListByReservationOrderOptions struct {
 type ReservationsSummariesClientListOptions struct {
 	// End date. Required only when querying with billing profile
 	EndDate *string
+
 	// The properties/UsageDate for start date and end date. The filter supports 'le' and 'ge'. Not required when querying with
 	// billing profile
 	Filter *string
+
 	// Reservation Id GUID. Only valid if reservationOrderId is also provided. Filter to a specific reservation
 	ReservationID *string
+
 	// Reservation Order Id GUID. Required if reservationId is provided. Filter to a specific reservation order
 	ReservationOrderID *string
+
 	// Start date. Required only when querying with billing profile
 	StartDate *string
 }
@@ -2504,18 +2521,22 @@ type UsageDetailsClientListOptions struct {
 	// May be used to expand the properties/additionalInfo or properties/meterDetails within a list of usage details. By default,
 	// these fields are not included when listing usage details.
 	Expand *string
+
 	// May be used to filter usageDetails by properties/resourceGroup, properties/instanceName, properties/resourceId, properties/chargeType,
 	// properties/reservationId, properties/publisherType or tags. The
 	// filter supports 'eq', 'lt', 'gt', 'le', 'ge', and 'and'. It does not currently support 'ne', 'or', or 'not'. Tag filter
 	// is a key value pair string where key and value is separated by a colon (:).
 	// PublisherType Filter accepts two values azure and marketplace and it is currently supported for Web Direct Offer Type
 	Filter *string
+
 	// Allows to select different type of cost/usage records.
 	Metric *Metrictype
+
 	// Skiptoken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element,
 	// the value of the nextLink element will include a skiptoken parameter that
 	// specifies a starting point to use for subsequent calls.
 	Skiptoken *string
+
 	// May be used to limit the number of results to the most recent N usageDetails.
 	Top *int32
 }

--- a/packages/autorest.go/test/keyvault/azkeyvault/zz_models.go
+++ b/packages/autorest.go/test/keyvault/azkeyvault/zz_models.go
@@ -358,6 +358,7 @@ type ClientBeginFullBackupOptions struct {
 	// This token needs to be valid for at least next 24 hours from the time of making
 	// this call
 	AzureStorageBlobContainerURI *SASTokenParameter
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -491,6 +492,7 @@ type ClientGetCertificateVersionsOptions struct {
 type ClientGetCertificatesOptions struct {
 	// Specifies whether to include certificates which are not completely provisioned.
 	IncludePending *bool
+
 	// Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than
 	// 25 results in error response code 400 (Bad Request). If there are additional
 	// results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service
@@ -509,6 +511,7 @@ type ClientGetDeletedCertificateOptions struct {
 type ClientGetDeletedCertificatesOptions struct {
 	// Specifies whether to include certificates which are not completely provisioned.
 	IncludePending *bool
+
 	// Specifies the maximum number of results to return in a page. Setting maxresults to a value less than 1 or greater than
 	// 25 results in error response code 400 (Bad Request). If there are additional
 	// results to return, then the service returns a nextLink containing a skip token for pagination. In certain cases, the service

--- a/packages/autorest.go/test/maps/azalias/zz_models.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models.go
@@ -28,8 +28,10 @@ type AliasesCreateResponse struct {
 // ClientCreateOptions contains the optional parameters for the Client.Create method.
 type ClientCreateOptions struct {
 	GroupBy []SomethingCount
+
 	// The unique id that references the assigned data item to be aliased.
 	AssignedID *float32
+
 	// The unique id that references a creator data item to be aliased.
 	CreatorID *int32
 }

--- a/packages/autorest.go/test/network/armnetwork/zz_models.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_models.go
@@ -344,6 +344,7 @@ type AdminRuleCollectionsClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -366,6 +367,7 @@ type AdminRuleCollectionsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -384,6 +386,7 @@ type AdminRulesClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -404,6 +407,7 @@ type AdminRulesClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -2092,6 +2096,7 @@ type ApplicationGatewayWebApplicationFirewallConfiguration struct {
 type ApplicationGatewaysClientBeginBackendHealthOnDemandOptions struct {
 	// Expands BackendAddressPool and BackendHttpSettings referenced in backend health.
 	Expand *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -2101,6 +2106,7 @@ type ApplicationGatewaysClientBeginBackendHealthOnDemandOptions struct {
 type ApplicationGatewaysClientBeginBackendHealthOptions struct {
 	// Expands BackendAddressPool and BackendHttpSettings referenced in backend health.
 	Expand *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -3966,6 +3972,7 @@ type ConnectionMonitorWorkspaceSettings struct {
 type ConnectionMonitorsClientBeginCreateOrUpdateOptions struct {
 	// Value indicating whether connection monitor V1 should be migrated to V2 format.
 	Migrate *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -4122,6 +4129,7 @@ type ConnectivityConfigurationsClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -4145,6 +4153,7 @@ type ConnectivityConfigurationsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -7521,6 +7530,7 @@ type GroupsClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -7543,6 +7553,7 @@ type GroupsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -9647,6 +9658,7 @@ type ManagementGroupNetworkManagerConnectionsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -9860,6 +9872,7 @@ type ManagersClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -9881,6 +9894,7 @@ type ManagersClientListBySubscriptionOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -9891,6 +9905,7 @@ type ManagersClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -12593,6 +12608,7 @@ type ScopeConnectionsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -12645,6 +12661,7 @@ type SecurityAdminConfigurationsClientBeginDeleteOptions struct {
 	// Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service
 	// will do a cleanup deployment in the background, prior to the delete.
 	Force *bool
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -12668,6 +12685,7 @@ type SecurityAdminConfigurationsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -13283,6 +13301,7 @@ type ServiceTagInformation struct {
 type ServiceTagInformationClientListOptions struct {
 	// Do not return address prefixes for the tag(s).
 	NoAddressPrefixes *bool
+
 	// Return tag information for a particular tag.
 	TagName *string
 }
@@ -13488,6 +13507,7 @@ type StaticMembersClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -13679,6 +13699,7 @@ type SubscriptionNetworkManagerConnectionsClientListOptions struct {
 	// the value of the nextLink element will include a skipToken parameter that
 	// specifies a starting point to use for subsequent calls.
 	SkipToken *string
+
 	// An optional query parameter which specifies the maximum number of records to be returned by the server.
 	Top *int32
 }
@@ -14280,6 +14301,7 @@ type VPNConnectionsClientBeginDeleteOptions struct {
 type VPNConnectionsClientBeginStartPacketCaptureOptions struct {
 	// Vpn Connection packet capture parameters supplied to start packet capture on gateway connection.
 	Parameters *VPNConnectionPacketCaptureStartParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -14289,6 +14311,7 @@ type VPNConnectionsClientBeginStartPacketCaptureOptions struct {
 type VPNConnectionsClientBeginStopPacketCaptureOptions struct {
 	// Vpn Connection packet capture parameters supplied to stop packet capture on gateway connection.
 	Parameters *VPNConnectionPacketCaptureStopParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -14456,6 +14479,7 @@ type VPNGatewaysClientBeginDeleteOptions struct {
 type VPNGatewaysClientBeginResetOptions struct {
 	// VpnGateway ipConfigurationId to specify the gateway instance.
 	IPConfigurationID *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -14465,6 +14489,7 @@ type VPNGatewaysClientBeginResetOptions struct {
 type VPNGatewaysClientBeginStartPacketCaptureOptions struct {
 	// Vpn gateway packet capture parameters supplied to start packet capture on vpn gateway.
 	Parameters *VPNGatewayPacketCaptureStartParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -14474,6 +14499,7 @@ type VPNGatewaysClientBeginStartPacketCaptureOptions struct {
 type VPNGatewaysClientBeginStopPacketCaptureOptions struct {
 	// Vpn gateway packet capture parameters supplied to stop packet capture on vpn gateway.
 	Parameters *VPNGatewayPacketCaptureStopParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -15595,6 +15621,7 @@ type VirtualHubsClientBeginDeleteOptions struct {
 type VirtualHubsClientBeginGetEffectiveVirtualHubRoutesOptions struct {
 	// Parameters supplied to get the effective routes for a specific resource.
 	EffectiveRoutesParameters *EffectiveRoutesParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -15985,6 +16012,7 @@ type VirtualNetworkGatewayConnectionsClientBeginSetSharedKeyOptions struct {
 type VirtualNetworkGatewayConnectionsClientBeginStartPacketCaptureOptions struct {
 	// Virtual network gateway packet capture parameters supplied to start packet capture on gateway connection.
 	Parameters *VPNPacketCaptureStartParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -16317,6 +16345,7 @@ type VirtualNetworkGatewaysClientBeginGetAdvertisedRoutesOptions struct {
 type VirtualNetworkGatewaysClientBeginGetBgpPeerStatusOptions struct {
 	// The IP address of the peer to retrieve the status of.
 	Peer *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -16354,6 +16383,7 @@ type VirtualNetworkGatewaysClientBeginGetVpnclientIPSecParametersOptions struct 
 type VirtualNetworkGatewaysClientBeginResetOptions struct {
 	// Virtual network gateway vip address supplied to the begin reset of the active-active feature enabled gateway.
 	GatewayVip *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -16377,6 +16407,7 @@ type VirtualNetworkGatewaysClientBeginSetVpnclientIPSecParametersOptions struct 
 type VirtualNetworkGatewaysClientBeginStartPacketCaptureOptions struct {
 	// Virtual network gateway packet capture parameters supplied to start packet capture on gateway.
 	Parameters *VPNPacketCaptureStartParameters
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -16525,6 +16556,7 @@ type VirtualNetworkPeeringPropertiesFormat struct {
 type VirtualNetworkPeeringsClientBeginCreateOrUpdateOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// Parameter indicates the intention to sync the peering with the current address space on the remote vNet after it's updated.
 	SyncRemoteAddressSpace *SyncRemoteAddressSpace
 }
@@ -16729,8 +16761,10 @@ type VirtualNetworksClientBeginDeleteOptions struct {
 type VirtualNetworksClientBeginListDdosProtectionStatusOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
+
 	// The skipToken that is given with nextLink.
 	SkipToken *string
+
 	// The max number of ip addresses to return.
 	Top *int32
 }

--- a/packages/autorest.go/test/storage/azblob/zz_models.go
+++ b/packages/autorest.go/test/storage/azblob/zz_models.go
@@ -27,18 +27,24 @@ type AccessPolicy struct {
 type AppendBlobClientAppendBlockFromURLOptions struct {
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
 	SourceContentMD5 []byte
+
 	// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
 	SourceContentcrc64 []byte
+
 	// Bytes of source data in the specified range.
 	SourceRange *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -48,11 +54,14 @@ type AppendBlobClientAppendBlockOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -61,12 +70,16 @@ type AppendBlobClientAppendBlockOptions struct {
 type AppendBlobClientCreateOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -74,9 +87,11 @@ type AppendBlobClientCreateOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -87,6 +102,7 @@ type AppendBlobClientSealOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -98,6 +114,7 @@ type AppendPositionAccessConditions struct {
 	// Append Block will succeed only if the append position is equal to this number. If
 	// it is not, the request will fail with the AppendPositionConditionNotMet error (HTTP status code 412 - Precondition Failed).
 	AppendPosition *int64
+
 	// Optional conditional header. The max length in bytes permitted for the append blob. If the Append Block operation would
 	// cause the blob to exceed that limit or if the blob size is already greater than
 	// the value specified in this header, the request will fail with MaxBlobSizeConditionNotMet error (HTTP status code 412 -
@@ -124,17 +141,22 @@ type ArrowField struct {
 type BlobHTTPHeaders struct {
 	// Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.
 	BlobCacheControl *string
+
 	// Optional. Sets the blob's Content-Disposition header.
 	BlobContentDisposition *string
+
 	// Optional. Sets the blob's content encoding. If specified, this property is stored with the blob and returned with a read
 	// request.
 	BlobContentEncoding *string
+
 	// Optional. Set the blob's content language. If specified, this property is stored with the blob and returned with a read
 	// request.
 	BlobContentLanguage *string
+
 	// Optional. An MD5 hash of the blob content. Note that this hash is not validated, as the hashes for the individual blocks
 	// were validated when each was uploaded.
 	BlobContentMD5 []byte
+
 	// Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.
 	BlobContentType *string
 }
@@ -152,12 +174,16 @@ type Block struct {
 type BlockBlobClientCommitBlockListOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -165,16 +191,21 @@ type BlockBlobClientCommitBlockListOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Optional. Indicates the tier to be set on the blob.
 	Tier *AccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -184,10 +215,12 @@ type BlockBlobClientGetBlockListOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -197,12 +230,16 @@ type BlockBlobClientGetBlockListOptions struct {
 type BlockBlobClientPutBlobFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+
 	// Optional, default is true. Indicates if properties from the source blob should be copied.
 	CopySourceBlobProperties *bool
+
 	// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
 	CopySourceTags *BlobCopySourceTags
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -210,16 +247,21 @@ type BlockBlobClientPutBlobFromURLOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
 	SourceContentMD5 []byte
+
 	// Optional. Indicates the tier to be set on the blob.
 	Tier *AccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -228,15 +270,20 @@ type BlockBlobClientPutBlobFromURLOptions struct {
 type BlockBlobClientStageBlockFromURLOptions struct {
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
 	SourceContentMD5 []byte
+
 	// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
 	SourceContentcrc64 []byte
+
 	// Bytes of source data in the specified range.
 	SourceRange *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -247,11 +294,14 @@ type BlockBlobClientStageBlockOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -260,12 +310,16 @@ type BlockBlobClientStageBlockOptions struct {
 type BlockBlobClientUploadOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -273,16 +327,21 @@ type BlockBlobClientUploadOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Optional. Indicates the tier to be set on the blob.
 	Tier *AccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -311,6 +370,7 @@ type ClientAbortCopyFromURLOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -322,13 +382,16 @@ type ClientAcquireLeaseOptions struct {
 	// can be between 15 and 60 seconds. A lease duration cannot be changed using
 	// renew or change.
 	Duration *int32
+
 	// Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is
 	// not in the correct format. See Guid Constructor (String) for a list of valid GUID
 	// string formats.
 	ProposedLeaseID *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -343,9 +406,11 @@ type ClientBreakLeaseOptions struct {
 	// header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses,
 	// and an infinite lease breaks immediately.
 	BreakPeriod *int32
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -356,6 +421,7 @@ type ClientChangeLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -365,16 +431,22 @@ type ClientChangeLeaseOptions struct {
 type ClientCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+
 	// Optional, default 'replace'. Indicates if source tags should be copied or replaced with the tags specified by x-ms-tags.
 	CopySourceTags *BlobCopySourceTags
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -382,13 +454,17 @@ type ClientCopyFromURLOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
 	SourceContentMD5 []byte
+
 	// Optional. Indicates the tier to be set on the blob.
 	Tier *AccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -403,9 +479,11 @@ type ClientCreateSnapshotOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -416,6 +494,7 @@ type ClientDeleteImmutabilityPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -426,20 +505,25 @@ type ClientDeleteOptions struct {
 	// Optional. Only possible value is 'permanent', which specifies to permanently delete a blob if blob soft delete is enabled..
 	// Specifying any value will set the value to Permanent.
 	BlobDeleteType *string
+
 	// Required if the blob has associated snapshots. Specify one of the following two options: include: Delete the base blob
 	// and all of its snapshots. only: Delete only the blob's snapshots and not the blob
 	// itself
 	DeleteSnapshots *DeleteSnapshotsOptionType
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -449,22 +533,28 @@ type ClientDeleteOptions struct {
 type ClientDownloadOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
+
 	// When set to true and specified together with the Range, the service returns the CRC64 hash for the range, as long as the
 	// range is less than or equal to 4 MB in size.
 	RangeGetContentCRC64 *bool
+
 	// When set to true and specified together with the Range, the service returns the MD5 hash for the range, as long as the
 	// range is less than or equal to 4 MB in size.
 	RangeGetContentMD5 *bool
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -480,13 +570,16 @@ type ClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -497,13 +590,16 @@ type ClientGetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -513,13 +609,16 @@ type ClientGetTagsOptions struct {
 type ClientQueryOptions struct {
 	// the query request
 	QueryRequest *QueryRequest
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -530,6 +629,7 @@ type ClientReleaseLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -540,6 +640,7 @@ type ClientRenewLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -549,9 +650,11 @@ type ClientRenewLeaseOptions struct {
 type ClientSetExpiryOptions struct {
 	// The time to set the blob to expiry
 	ExpiresOn *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -562,6 +665,7 @@ type ClientSetHTTPHeadersOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -571,11 +675,14 @@ type ClientSetHTTPHeadersOptions struct {
 type ClientSetImmutabilityPolicyOptions struct {
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -586,6 +693,7 @@ type ClientSetLegalHoldOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -600,9 +708,11 @@ type ClientSetMetadataOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -613,15 +723,20 @@ type ClientSetTagsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Blob tags
 	Tags *Tags
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -631,16 +746,20 @@ type ClientSetTagsOptions struct {
 type ClientSetTierOptions struct {
 	// Optional: Indicates the priority with which to rehydrate an archived blob.
 	RehydratePriority *RehydratePriority
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// The version id parameter is an opaque DateTime value that, when present, specifies the version of the blob to operate on.
 	// It's for service version 2019-10-10 and newer.
 	VersionID *string
@@ -650,12 +769,16 @@ type ClientSetTierOptions struct {
 type ClientStartCopyFromURLOptions struct {
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -663,15 +786,20 @@ type ClientStartCopyFromURLOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Optional: Indicates the priority with which to rehydrate an archived blob.
 	RehydratePriority *RehydratePriority
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Overrides the sealed state of the destination blob. Service version 2019-12-12 and newer.
 	SealBlob *bool
+
 	// Optional. Indicates the tier to be set on the blob.
 	Tier *AccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -682,6 +810,7 @@ type ClientUndeleteOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -693,13 +822,16 @@ type ContainerClientAcquireLeaseOptions struct {
 	// can be between 15 and 60 seconds. A lease duration cannot be changed using
 	// renew or change.
 	Duration *int32
+
 	// Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is
 	// not in the correct format. See Guid Constructor (String) for a list of valid GUID
 	// string formats.
 	ProposedLeaseID *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -714,9 +846,11 @@ type ContainerClientBreakLeaseOptions struct {
 	// header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses,
 	// and an infinite lease breaks immediately.
 	BreakPeriod *int32
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -727,6 +861,7 @@ type ContainerClientChangeLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -736,6 +871,7 @@ type ContainerClientChangeLeaseOptions struct {
 type ContainerClientCreateOptions struct {
 	// Specifies whether data in the container may be accessed publicly and the level of access
 	Access *PublicAccessType
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -743,9 +879,11 @@ type ContainerClientCreateOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -756,6 +894,7 @@ type ContainerClientDeleteOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -765,24 +904,29 @@ type ContainerClientDeleteOptions struct {
 type ContainerClientFilterBlobsOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
 	Include []FilterBlobsIncludeItem
+
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
 	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Filters the results to return only to return only blobs whose tags match the specified expression.
 	Where *string
 }
@@ -792,6 +936,7 @@ type ContainerClientGetAccessPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -807,6 +952,7 @@ type ContainerClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -817,23 +963,28 @@ type ContainerClientGetPropertiesOptions struct {
 type ContainerClientListBlobFlatSegmentOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
 	Include []ListBlobsIncludeItem
+
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
 	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -844,23 +995,28 @@ type ContainerClientListBlobFlatSegmentOptions struct {
 type ContainerClientListBlobHierarchySegmentOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
 	Include []ListBlobsIncludeItem
+
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
 	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -871,6 +1027,7 @@ type ContainerClientReleaseLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -881,8 +1038,10 @@ type ContainerClientRenameOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// A lease ID for the source path. If specified, the source path must have an active lease and the lease ID must match.
 	SourceLeaseID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -893,6 +1052,7 @@ type ContainerClientRenewLeaseOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -902,11 +1062,14 @@ type ContainerClientRenewLeaseOptions struct {
 type ContainerClientRestoreOptions struct {
 	// Optional. Version 2019-12-12 and later. Specifies the name of the deleted container to restore.
 	DeletedContainerName *string
+
 	// Optional. Version 2019-12-12 and later. Specifies the version of the deleted container to restore.
 	DeletedContainerVersion *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -916,11 +1079,14 @@ type ContainerClientRestoreOptions struct {
 type ContainerClientSetAccessPolicyOptions struct {
 	// Specifies whether data in the container may be accessed publicly and the level of access
 	Access *PublicAccessType
+
 	// the acls for the container
 	ContainerACL []*SignedIdentifier
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -935,9 +1101,11 @@ type ContainerClientSetMetadataOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -948,6 +1116,7 @@ type ContainerClientSubmitBatchOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -958,6 +1127,7 @@ type ContainerCpkScopeInfo struct {
 	// Optional. Version 2019-07-07 and later. Specifies the default encryption scope to set on the container and use for all
 	// future writes.
 	DefaultEncryptionScope *string
+
 	// Optional. Version 2019-07-07 and newer. If true, prevents any request from specifying a different encryption scope than
 	// the scope set on the container.
 	PreventEncryptionScopeOverride *bool
@@ -1029,10 +1199,12 @@ type CpkInfo struct {
 	// The algorithm used to produce the encryption key hash. Currently, the only accepted value is "AES256". Must be provided
 	// if the x-ms-encryption-key header is provided.. Specifying any value will set the value to AES256.
 	EncryptionAlgorithm *string
+
 	// Optional. Specifies the encryption key to use to encrypt the data provided in the request. If not specified, encryption
 	// is performed with the root account encryption key. For more information, see
 	// Encryption at Rest for Azure Storage Services.
 	EncryptionKey *string
+
 	// The SHA-256 hash of the provided encryption key. Must be provided if the x-ms-encryption-key header is provided.
 	EncryptionKeySHA256 *string
 }
@@ -1247,12 +1419,16 @@ type Metrics struct {
 type ModifiedAccessConditions struct {
 	// Specify an ETag value to operate only on blobs with a matching value.
 	IfMatch *string
+
 	// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
 	IfModifiedSince *time.Time
+
 	// Specify an ETag value to operate only on blobs without a matching value.
 	IfNoneMatch *string
+
 	// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
 	IfTags *string
+
 	// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
 	IfUnmodifiedSince *time.Time
 }
@@ -1269,9 +1445,11 @@ type Name struct {
 type PageBlobClientClearPagesOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1282,6 +1460,7 @@ type PageBlobClientCopyIncrementalOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1292,14 +1471,19 @@ type PageBlobClientCreateOptions struct {
 	// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value of
 	// the sequence number must be between 0 and 2^63 - 1.
 	BlobSequenceNumber *int64
+
 	// Optional. Used to set blob tags in various blob operations.
 	BlobTagsString *string
+
 	// Specifies the date time when the blobs immutability policy is set to expire.
 	ImmutabilityPolicyExpiry *time.Time
+
 	// Specifies the immutability policy mode to set on the blob.
 	ImmutabilityPolicyMode *BlobImmutabilityPolicyMode
+
 	// Specified if a legal hold should be set on the blob.
 	LegalHold *bool
+
 	// Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the
 	// operation will copy the metadata from the source blob or file to the destination
 	// blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata
@@ -1307,11 +1491,14 @@ type PageBlobClientCreateOptions struct {
 	// version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers,
 	// Blobs, and Metadata for more information.
 	Metadata map[string]*string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Optional. Indicates the tier to be set on the page blob.
 	Tier *PremiumPageBlobAccessTier
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1326,31 +1513,38 @@ type PageBlobClientGetPageRangesDiffOptions struct {
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Optional. This header is only supported in service versions 2019-04-19 and after and specifies the URL of a previous snapshot
 	// of the target blob. The response will only contain pages that were changed
 	// between the target blob and its previous snapshot.
 	PrevSnapshotURL *string
+
 	// Optional in version 2015-07-08 and newer. The prevsnapshot parameter is a DateTime value that specifies that the response
 	// will contain only pages that were changed between target blob and previous
 	// snapshot. Changed pages include both updated and cleared pages. The target blob may be a snapshot, as long as the snapshot
 	// specified by prevsnapshot is the older of the two. Note that incremental
 	// snapshots are currently supported only for blobs created on or after January 1, 2016.
 	Prevsnapshot *string
+
 	// Return only the bytes of the blob in the specified range.
 	Range *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1364,21 +1558,26 @@ type PageBlobClientGetPageRangesOptions struct {
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Return only the bytes of the blob in the specified range.
 	Range *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more
 	// information on working with blob snapshots, see Creating a Snapshot of a Blob.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob]
 	Snapshot *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1389,6 +1588,7 @@ type PageBlobClientResizeOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1400,9 +1600,11 @@ type PageBlobClientUpdateSequenceNumberOptions struct {
 	// Set for page blobs only. The sequence number is a user-controlled value that you can use to track requests. The value of
 	// the sequence number must be between 0 and 2^63 - 1.
 	BlobSequenceNumber *int64
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1412,13 +1614,17 @@ type PageBlobClientUpdateSequenceNumberOptions struct {
 type PageBlobClientUploadPagesFromURLOptions struct {
 	// Only Bearer type is supported. Credentials should be a valid OAuth access token to copy source.
 	CopySourceAuthorization *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// Specify the md5 calculated for the range of bytes that must be read from the copy source.
 	SourceContentMD5 []byte
+
 	// Specify the crc64 calculated for the range of bytes that must be read from the copy source.
 	SourceContentcrc64 []byte
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1428,14 +1634,18 @@ type PageBlobClientUploadPagesFromURLOptions struct {
 type PageBlobClientUploadPagesOptions struct {
 	// Return only the bytes of the blob in the specified range.
 	Range *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Specify the transactional crc64 for the body, to be validated by the service.
 	TransactionalContentCRC64 []byte
+
 	// Specify the transactional md5 for the body, to be validated by the service.
 	TransactionalContentMD5 []byte
 }
@@ -1564,8 +1774,10 @@ type RetentionPolicy struct {
 type SequenceNumberAccessConditions struct {
 	// Specify this header value to operate only on a blob if it has the specified sequence number.
 	IfSequenceNumberEqualTo *int64
+
 	// Specify this header value to operate only on a blob if it has a sequence number less than the specified.
 	IfSequenceNumberLessThan *int64
+
 	// Specify this header value to operate only on a blob if it has a sequence number less than or equal to the specified.
 	IfSequenceNumberLessThanOrEqualTo *int64
 }
@@ -1574,24 +1786,29 @@ type SequenceNumberAccessConditions struct {
 type ServiceClientFilterBlobsOptions struct {
 	// Include this parameter to specify one or more datasets to include in the response.
 	Include []FilterBlobsIncludeItem
+
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
 	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
+
 	// Filters the results to return only to return only blobs whose tags match the specified expression.
 	Where *string
 }
@@ -1606,6 +1823,7 @@ type ServiceClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1616,6 +1834,7 @@ type ServiceClientGetStatisticsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1626,6 +1845,7 @@ type ServiceClientGetUserDelegationKeyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1636,23 +1856,28 @@ type ServiceClientGetUserDelegationKeyOptions struct {
 type ServiceClientListContainersSegmentOptions struct {
 	// Include this parameter to specify that the container's metadata be returned as part of the response body.
 	Include []ListContainersIncludeType
+
 	// A string value that identifies the portion of the list of containers to be returned with the next listing operation. The
 	// operation returns the NextMarker value within the response body if the listing
 	// operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used
 	// as the value for the marker parameter in a subsequent call to request the next
 	// page of list items. The marker value is opaque to the client.
 	Marker *string
+
 	// Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value
 	// greater than 5000, the server will return up to 5000 items. Note that if the
 	// listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder
 	// of the results. For this reason, it is possible that the service will
 	// return fewer results than specified by maxresults, or than the default of 5000.
 	Maxresults *int32
+
 	// Filters the results to return only containers whose name begins with the specified prefix.
 	Prefix *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1663,6 +1888,7 @@ type ServiceClientSetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1673,6 +1899,7 @@ type ServiceClientSubmitBatchOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage
 	// analytics logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
 	// [https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations]
 	Timeout *int32
@@ -1691,12 +1918,16 @@ type SignedIdentifier struct {
 type SourceModifiedAccessConditions struct {
 	// Specify an ETag value to operate only on blobs with a matching value.
 	SourceIfMatch *string
+
 	// Specify this header value to operate only on a blob if it has been modified since the specified date/time.
 	SourceIfModifiedSince *time.Time
+
 	// Specify an ETag value to operate only on blobs without a matching value.
 	SourceIfNoneMatch *string
+
 	// Specify a SQL where clause on blob tags to operate only on blobs with a matching value.
 	SourceIfTags *string
+
 	// Specify this header value to operate only on a blob if it has not been modified since the specified date/time.
 	SourceIfUnmodifiedSince *time.Time
 }

--- a/packages/autorest.go/test/synapse/azartifacts/zz_models.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_models.go
@@ -7682,6 +7682,7 @@ type DataFlowClientBeginCreateOrUpdateDataFlowOptions struct {
 	// ETag of the data flow entity. Should only be specified for update, for which it should match existing entity or can be
 	// * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -8391,6 +8392,7 @@ type DatasetClientBeginCreateOrUpdateDatasetOptions struct {
 	// ETag of the dataset entity. Should only be specified for update, for which it should match existing entity or can be *
 	// for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -15687,6 +15689,7 @@ type LinkedServiceClientBeginCreateOrUpdateLinkedServiceOptions struct {
 	// ETag of the linkedService entity. Should only be specified for update, for which it should match existing entity or can
 	// be * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -17652,6 +17655,7 @@ type NotebookClientBeginCreateOrUpdateNotebookOptions struct {
 	// ETag of the Note book entity. Should only be specified for update, for which it should match existing entity or can be
 	// * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -19501,6 +19505,7 @@ type PipelineClientBeginCreateOrUpdatePipelineOptions struct {
 	// ETag of the pipeline entity. Should only be specified for update, for which it should match existing entity or can be *
 	// for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -19522,10 +19527,13 @@ type PipelineClientCreatePipelineRunOptions struct {
 	// Recovery mode flag. If recovery mode is set to true, the specified referenced pipeline run and the new run will be grouped
 	// under the same groupId.
 	IsRecovery *bool
+
 	// Parameters of the pipeline run. These parameters will be used only if the runId is not specified.
 	Parameters map[string]any
+
 	// The pipeline run identifier. If run ID is specified the parameters of the specified run will be used to create a new run.
 	ReferencePipelineRunID *string
+
 	// In recovery mode, the rerun will start from this activity. If not specified, all activities will run.
 	StartActivityName *string
 }
@@ -21607,6 +21615,7 @@ type SQLScriptClientBeginCreateOrUpdateSQLScriptOptions struct {
 	// ETag of the SQL script entity. Should only be specified for update, for which it should match existing entity or can be
 	// * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -25662,6 +25671,7 @@ type SparkConfigurationClientBeginCreateOrUpdateSparkConfigurationOptions struct
 	// ETag of the sparkConfiguration entity. Should only be specified for update, for which it should match existing entity or
 	// can be * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -25784,6 +25794,7 @@ type SparkJobDefinitionClientBeginCreateOrUpdateSparkJobDefinitionOptions struct
 	// ETag of the Spark Job Definition entity. Should only be specified for update, for which it should match existing entity
 	// or can be * for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
@@ -27443,6 +27454,7 @@ type TriggerClientBeginCreateOrUpdateTriggerOptions struct {
 	// ETag of the trigger entity. Should only be specified for update, for which it should match existing entity or can be *
 	// for unconditional update.
 	IfMatch *string
+
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }

--- a/packages/autorest.go/test/synapse/azspark/zz_models.go
+++ b/packages/autorest.go/test/synapse/azspark/zz_models.go
@@ -31,8 +31,10 @@ type BatchClientGetSparkBatchJobOptions struct {
 type BatchClientGetSparkBatchJobsOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
+
 	// Optional param specifying which index the list should begin from.
 	From *int32
+
 	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
 	Size *int32
 }
@@ -259,8 +261,10 @@ type SessionClientGetSparkSessionOptions struct {
 type SessionClientGetSparkSessionsOptions struct {
 	// Optional query param specifying whether detailed response is returned beyond plain livy.
 	Detailed *bool
+
 	// Optional param specifying which index the list should begin from.
 	From *int32
+
 	// Optional param specifying the size of the returned list. By default it is 20 and that is the maximum.
 	Size *int32
 }

--- a/packages/autorest.go/test/tables/aztables/zz_models.go
+++ b/packages/autorest.go/test/tables/aztables/zz_models.go
@@ -26,9 +26,11 @@ type AccessPolicy struct {
 type ClientCreateOptions struct {
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content
 	// and return-content.
 	ResponsePreference *ResponseFormat
@@ -38,9 +40,11 @@ type ClientCreateOptions struct {
 type ClientDeleteEntityOptions struct {
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -57,6 +61,7 @@ type ClientGetAccessPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -65,14 +70,18 @@ type ClientGetAccessPolicyOptions struct {
 type ClientInsertEntityOptions struct {
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// Specifies whether the response should include the inserted entity in the payload. Possible values are return-no-content
 	// and return-content.
 	ResponsePreference *ResponseFormat
+
 	// The properties for the table entity.
 	TableEntityProperties map[string]any
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -81,14 +90,17 @@ type ClientInsertEntityOptions struct {
 type ClientMergeEntityOptions struct {
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised.
 	// To force an unconditional update, set to the wildcard character (*). If not
 	// specified, an insert will be performed when no existing entity is found to update and a merge will be performed if an existing
 	// entity is found.
 	IfMatch *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -97,20 +109,27 @@ type ClientMergeEntityOptions struct {
 type ClientQueryEntitiesOptions struct {
 	// OData filter expression.
 	Filter *string
+
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// An entity query continuation token from a previous call.
 	NextPartitionKey *string
+
 	// An entity query continuation token from a previous call.
 	NextRowKey *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId,
 	// ResourceId".
 	Select *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
+
 	// Maximum number of records to return.
 	Top *int32
 }
@@ -120,14 +139,18 @@ type ClientQueryEntitiesOptions struct {
 type ClientQueryEntityWithPartitionAndRowKeyOptions struct {
 	// OData filter expression.
 	Filter *string
+
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId,
 	// ResourceId".
 	Select *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -136,16 +159,21 @@ type ClientQueryEntityWithPartitionAndRowKeyOptions struct {
 type ClientQueryOptions struct {
 	// OData filter expression.
 	Filter *string
+
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// A table query continuation token from a previous call.
 	NextTableName *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// Select expression using OData notation. Limits the columns on each record to just those requested, e.g. "$select=PolicyAssignmentId,
 	// ResourceId".
 	Select *string
+
 	// Maximum number of records to return.
 	Top *int32
 }
@@ -155,6 +183,7 @@ type ClientSetAccessPolicyOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -163,14 +192,17 @@ type ClientSetAccessPolicyOptions struct {
 type ClientUpdateEntityOptions struct {
 	// Specifies the media type for the response.
 	Format *ODataMetadataFormat
+
 	// Match condition for an entity to be updated. If specified and a matching entity is not found, an error will be raised.
 	// To force an unconditional update, set to the wildcard character (*). If not
 	// specified, an insert will be performed when no existing entity is found to update and a replace will be performed if an
 	// existing entity is found.
 	IfMatch *string
+
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -314,6 +346,7 @@ type ServiceClientGetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -323,6 +356,7 @@ type ServiceClientGetStatisticsOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }
@@ -332,6 +366,7 @@ type ServiceClientSetPropertiesOptions struct {
 	// Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when analytics
 	// logging is enabled.
 	RequestID *string
+
 	// The timeout parameter is expressed in seconds.
 	Timeout *int32
 }


### PR DESCRIPTION
It was fixed for models but missed for options.