### PR TITLE
Only include method params when evaluating for the options bag

### DIFF
--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -568,7 +568,7 @@ async function processOperationRequests(session: Session<CodeModel>) {
           } else if (dupe.schema !== param.schema) {
             throw new Error(`parameter group ${paramGroupName} contains overlapping parameters with different schemas`);
           }
-        } else if (param.required !== true && !(param.schema.type === SchemaType.Constant && param.protocol.http!.in === 'body')) {
+        } else if (param.implementation === ImplementationLocation.Method && param.required !== true && !(param.schema.type === SchemaType.Constant && param.protocol.http!.in === 'body')) {
           // include non-required constants that aren't body params in the optional values struct.
           (<GroupProperty>op.language.go!.optionalParamGroup).originalParameter.push(param);
           // associate the group with the param

--- a/packages/autorest.go/test/autorest/optionalgroup/zz_options.go
+++ b/packages/autorest.go/test/autorest/optionalgroup/zz_options.go
@@ -157,6 +157,7 @@ type ExplicitClientPutRequiredBinaryBodyOptions struct {
 // ImplicitClientGetOptionalGlobalQueryOptions contains the optional parameters for the ImplicitClient.GetOptionalGlobalQuery
 // method.
 type ImplicitClientGetOptionalGlobalQueryOptions struct {
+	// placeholder for future optional parameters
 }
 
 // ImplicitClientGetRequiredGlobalPathOptions contains the optional parameters for the ImplicitClient.GetRequiredGlobalPath


### PR DESCRIPTION
This adds vestigial metadata to the param and can cause options types to omit their placeholder comment as the client params are skipped during emitting.