### PR TITLE
Make the ResumeToken a real parameter

### DIFF
--- a/packages/autorest.go/src/generator/fake/servers.ts
+++ b/packages/autorest.go/src/generator/fake/servers.ts
@@ -492,6 +492,10 @@ function createParamGroupParams(clientPkg: string, op: Operation, imports: Impor
       continue;
     }
     if (param.language.go!.paramGroup) {
+      if (param.language.go!.isResumeToken) {
+        // skip the ResumeToken param as we don't send that back to the caller
+        continue;
+      }
       if (!paramGroups.has(param.language.go!.paramGroup)) {
         paramGroups.set(param.language.go!.paramGroup, new Array<Parameter>());
       }
@@ -715,8 +719,8 @@ function populateApiParams(clientPkg: string, op: Operation, imports: ImportMana
   for (const param of values(consolidateHostParams(getMethodParameters(op)))) {
     if (param === op.language.go!.optionalParamGroup) {
       // this is the optional params type. in some cases we just pass nil
-      const countParams = values((<GroupProperty>op.language.go!.optionalParamGroup).originalParameter).where((each: Parameter) => { return each.implementation === ImplementationLocation.Method; }).count();
-      if (countParams === 0 || (isLROOperation(op) && countParams === 1)) {
+      const countParams = values((<GroupProperty>op.language.go!.optionalParamGroup).originalParameter).where((each: Parameter) => { return each.implementation === ImplementationLocation.Method && !each.language.go!.isResumeToken; }).count();
+      if (countParams === 0) {
         // if the options param is empty or only contains the resume token param just pass nil
         params.push('nil');
         continue;

--- a/packages/autorest.go/src/generator/operations.ts
+++ b/packages/autorest.go/src/generator/operations.ts
@@ -510,7 +510,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   } else {
     throw new Error(`no host or endpoint defined for method ${group.language.go!.clientName}.${op.language.go!.name}`);
   }
-  const hasPathParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'path'; }).any();
+  const hasPathParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'path'; }).any();
   // storage needs the client.u to be the source-of-truth for the full path.
   // however, swagger requires that all operations specify a path, which is at odds with storage.
   // to work around this, storage specifies x-ms-path paths with path params but doesn't
@@ -527,7 +527,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     // swagger defines path params, emit path and replace tokens
     imports.add('strings');
     // replace path parameters
-    for (const pp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'path'; })) {
+    for (const pp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'path'; })) {
       // emit check to ensure path param isn't an empty string.  we only need
       // to do this for params that have an underlying type of string.
       const choiceIsString = function (schema: Schema): boolean {
@@ -559,7 +559,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';
-  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'query'; }).any();
+  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'query'; }).any();
   // helper to build nil checks for param groups
   const emitParamGroupCheck = function (gp: GroupProperty, param: Parameter): string {
     if (param.implementation === ImplementationLocation.Client) {
@@ -576,7 +576,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     // add query parameters
     const encodedParams = new Array<Parameter>();
     const unencodedParams = new Array<Parameter>();
-    for (const qp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'query'; })) {
+    for (const qp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'query'; })) {
       if (skipURLEncoding(qp)) {
         unencodedParams.push(qp);
       } else {
@@ -671,7 +671,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     text += '\truntime.SkipBodyDownload(req)\n';
   }
   // add specific request headers
-  const headerParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined; }).where((each: Parameter) => { return each.protocol.http?.in === 'header'; });
+  const headerParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'header'; });
   headerParam.forEach(header => {
     const emitHeaderSet = function (headerParam: Parameter, prefix: string): string {
       if (headerParam.clientDefaultValue && headerParam.implementation === ImplementationLocation.Method) {

--- a/packages/autorest.go/src/generator/operations.ts
+++ b/packages/autorest.go/src/generator/operations.ts
@@ -496,7 +496,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     }
     // check for any method local host params
     for (const param of values(op.parameters)) {
-      if (param.implementation === ImplementationLocation.Method && param.protocol.http!.in === 'uri') {
+      if (param.implementation === ImplementationLocation.Method && param.protocol.http?.in === 'uri') {
         text += `\thost = strings.ReplaceAll(host, "{${param.language.go!.serializedName}}", ${param.language.go!.name})\n`;
       }
     }
@@ -510,7 +510,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   } else {
     throw new Error(`no host or endpoint defined for method ${group.language.go!.clientName}.${op.language.go!.name}`);
   }
-  const hasPathParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'path'; }).any();
+  const hasPathParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'path'; }).any();
   // storage needs the client.u to be the source-of-truth for the full path.
   // however, swagger requires that all operations specify a path, which is at odds with storage.
   // to work around this, storage specifies x-ms-path paths with path params but doesn't
@@ -527,7 +527,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     // swagger defines path params, emit path and replace tokens
     imports.add('strings');
     // replace path parameters
-    for (const pp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'path'; })) {
+    for (const pp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'path'; })) {
       // emit check to ensure path param isn't an empty string.  we only need
       // to do this for params that have an underlying type of string.
       const choiceIsString = function (schema: Schema): boolean {
@@ -559,7 +559,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   text += '\tif err != nil {\n';
   text += '\t\treturn nil, err\n';
   text += '\t}\n';
-  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'query'; }).any();
+  const hasQueryParams = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'query'; }).any();
   // helper to build nil checks for param groups
   const emitParamGroupCheck = function (gp: GroupProperty, param: Parameter): string {
     if (param.implementation === ImplementationLocation.Client) {
@@ -576,7 +576,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     // add query parameters
     const encodedParams = new Array<Parameter>();
     const unencodedParams = new Array<Parameter>();
-    for (const qp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http!.in === 'query'; })) {
+    for (const qp of values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined && each.protocol.http?.in === 'query'; })) {
       if (skipURLEncoding(qp)) {
         unencodedParams.push(qp);
       } else {
@@ -671,7 +671,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
     text += '\truntime.SkipBodyDownload(req)\n';
   }
   // add specific request headers
-  const headerParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined; }).where((each: Parameter) => { return each.protocol.http!.in === 'header'; });
+  const headerParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http !== undefined; }).where((each: Parameter) => { return each.protocol.http?.in === 'header'; });
   headerParam.forEach(header => {
     const emitHeaderSet = function (headerParam: Parameter, prefix: string): string {
       if (headerParam.clientDefaultValue && headerParam.implementation === ImplementationLocation.Method) {
@@ -702,7 +702,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   };
   const mediaType = getMediaType(op.requests![0].protocol);
   if (mediaType === 'JSON' || mediaType === 'XML') {
-    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
     // default to the body param name
     let body = getParamName(bodyParam!);
     if (bodyParam!.schema.type === SchemaType.Constant) {
@@ -778,7 +778,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
         }
       }
     }
-    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
     if (bodyParam!.required) {
       text += `\t${emitSetBodyWithErrCheck(`req.SetBody(${bodyParam?.language.go!.name}, ${contentType})`)}`;
       text += '\treturn req, nil\n';
@@ -792,7 +792,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
   } else if (mediaType === 'Text') {
     imports.add('strings');
     imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
-    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+    const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
     const contentType = `"${op.requests![0].protocol.http!.mediaTypes[0]}"`;
     if (bodyParam!.required) {
       text += `\tbody := streaming.NopCloser(strings.NewReader(${bodyParam!.language.go!.name}))\n`;

--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -583,12 +583,16 @@ async function processOperationRequests(session: Session<CodeModel>) {
         // add the ResumeToken to the optional params type
         const tokenParam = newParameter('ResumeToken', 'Resumes the LRO from the provided token.', newString('string', ''));
         tokenParam.language.go!.byValue = true;
+        tokenParam.language.go!.isResumeToken = true;
+        tokenParam.required = false;
+        op.parameters?.push(tokenParam);
+        tokenParam.language.go!.paramGroup = op.language.go!.optionalParamGroup;
         (<GroupProperty>op.language.go!.optionalParamGroup).originalParameter.push(tokenParam);
       }
       // recursively add the marshalling format to the body param if applicable
       const marshallingFormat = getMarshallingFormat(op.requests![0].protocol);
       if (marshallingFormat !== 'na') {
-        const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http!.in === 'body'; }).first();
+        const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
         if (bodyParam) {
           recursiveAddMarshallingFormat(bodyParam.schema, marshallingFormat);
           if (marshallingFormat === 'xml' && bodyParam.schema.serialization?.xml?.name) {


### PR DESCRIPTION
Add it to the list of parameters for the operation so it's treated like any other optional parameter.
Use conditional operator for checking a param's protocol implementation. Added a flag to the resume token instead of relying on a heuristic.