### PR TITLE
Don't treat optional, constant, body params as required

### DIFF
--- a/packages/autorest.go/src/generator/fake/servers.ts
+++ b/packages/autorest.go/src/generator/fake/servers.ts
@@ -361,14 +361,14 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, op: O
     // nothing to do for binary media type
   } else if (mediaType === 'Text') {
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
-    if (bodyParam && bodyParam.schema.type !== SchemaType.Constant) {
+    if (bodyParam && !(bodyParam.required === true && bodyParam.schema.type === SchemaType.Constant)) {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
       content += '\tbody, err := server.UnmarshalRequestAsText(req)\n';
       content += '\tif err != nil {\n\t\treturn nil, err\n\t}\n';
     }
   } else if (mediaType === 'JSON' || mediaType === 'XML') {
     const bodyParam = values(aggregateParameters(op)).where((each: Parameter) => { return each.protocol.http?.in === 'body'; }).first();
-    if (bodyParam && bodyParam.schema.type !== SchemaType.Constant) {
+    if (bodyParam && !(bodyParam.required === true && bodyParam.schema.type === SchemaType.Constant)) {
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/fake', 'azfake');
       if (bodyParam.schema.type === SchemaType.ByteArray) {
         let format = 'Std';

--- a/packages/autorest.go/src/generator/operations.ts
+++ b/packages/autorest.go/src/generator/operations.ts
@@ -757,7 +757,7 @@ function createProtocolRequest(group: OperationGroup, op: Operation, imports: Im
       imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
       setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${mediaType.toLowerCase()}")`;
     }
-    if (bodyParam!.required || bodyParam!.schema.type === SchemaType.Constant) {
+    if (bodyParam!.required) {
       text += `\t${emitSetBodyWithErrCheck(setBody)}`;
       text += '\treturn req, nil\n';
     } else {

--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -572,8 +572,8 @@ async function processOperationRequests(session: Session<CodeModel>) {
           } else if (dupe.schema !== param.schema) {
             throw new Error(`parameter group ${paramGroupName} contains overlapping parameters with different schemas`);
           }
-        } else if (param.implementation === ImplementationLocation.Method && param.required !== true && !(param.schema.type === SchemaType.Constant && param.protocol.http!.in === 'body')) {
-          // include non-required constants that aren't body params in the optional values struct.
+        } else if (param.implementation === ImplementationLocation.Method && param.required !== true) {
+          // include all non-required method params in the optional values struct.
           (<GroupProperty>op.language.go!.optionalParamGroup).originalParameter.push(param);
           // associate the group with the param
           param.language.go!.paramGroup = op.language.go!.optionalParamGroup;

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpclientfailure_server.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpclientfailure_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"reflect"
 )
 
 // HTTPClientFailureServer is a fake server for instances of the httpinfrastructuregroup.HTTPClientFailureClient type.
@@ -218,7 +219,17 @@ func (h *HTTPClientFailureServerTransport) dispatchDelete400(req *http.Request) 
 	if h.srv.Delete400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete400 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete400(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientDelete400Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientDelete400Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete400(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -237,7 +248,17 @@ func (h *HTTPClientFailureServerTransport) dispatchDelete407(req *http.Request) 
 	if h.srv.Delete407 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete407 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete407(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientDelete407Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientDelete407Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete407(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -256,7 +277,17 @@ func (h *HTTPClientFailureServerTransport) dispatchDelete417(req *http.Request) 
 	if h.srv.Delete417 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete417 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete417(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientDelete417Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientDelete417Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete417(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -579,7 +610,17 @@ func (h *HTTPClientFailureServerTransport) dispatchPost400(req *http.Request) (*
 	if h.srv.Post400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post400 not implemented")}
 	}
-	respr, errRespr := h.srv.Post400(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientPost400Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientPost400Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post400(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -598,7 +639,17 @@ func (h *HTTPClientFailureServerTransport) dispatchPost406(req *http.Request) (*
 	if h.srv.Post406 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post406 not implemented")}
 	}
-	respr, errRespr := h.srv.Post406(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientPost406Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientPost406Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post406(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -617,7 +668,17 @@ func (h *HTTPClientFailureServerTransport) dispatchPost415(req *http.Request) (*
 	if h.srv.Post415 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post415 not implemented")}
 	}
-	respr, errRespr := h.srv.Post415(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPClientFailureClientPost415Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPClientFailureClientPost415Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post415(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpredirects_server.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpredirects_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"reflect"
 )
 
 // HTTPRedirectsServer is a fake server for instances of the httpinfrastructuregroup.HTTPRedirectsClient type.
@@ -158,7 +159,17 @@ func (h *HTTPRedirectsServerTransport) dispatchDelete307(req *http.Request) (*ht
 	if h.srv.Delete307 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete307 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete307(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPRedirectsClientDelete307Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPRedirectsClientDelete307Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete307(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -395,7 +406,17 @@ func (h *HTTPRedirectsServerTransport) dispatchPost303(req *http.Request) (*http
 	if h.srv.Post303 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post303 not implemented")}
 	}
-	respr, errRespr := h.srv.Post303(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPRedirectsClientPost303Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPRedirectsClientPost303Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post303(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -417,7 +438,17 @@ func (h *HTTPRedirectsServerTransport) dispatchPost307(req *http.Request) (*http
 	if h.srv.Post307 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post307 not implemented")}
 	}
-	respr, errRespr := h.srv.Post307(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPRedirectsClientPost307Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPRedirectsClientPost307Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post307(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpretry_server.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpretry_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"reflect"
 )
 
 // HTTPRetryServer is a fake server for instances of the httpinfrastructuregroup.HTTPRetryClient type.
@@ -116,7 +117,17 @@ func (h *HTTPRetryServerTransport) dispatchDelete503(req *http.Request) (*http.R
 	if h.srv.Delete503 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete503 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete503(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPRetryClientDelete503Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPRetryClientDelete503Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete503(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -230,7 +241,17 @@ func (h *HTTPRetryServerTransport) dispatchPost503(req *http.Request) (*http.Res
 	if h.srv.Post503 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post503 not implemented")}
 	}
-	respr, errRespr := h.srv.Post503(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPRetryClientPost503Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPRetryClientPost503Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post503(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpserverfailure_server.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpserverfailure_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"reflect"
 )
 
 // HTTPServerFailureServer is a fake server for instances of the httpinfrastructuregroup.HTTPServerFailureClient type.
@@ -86,7 +87,17 @@ func (h *HTTPServerFailureServerTransport) dispatchDelete505(req *http.Request) 
 	if h.srv.Delete505 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete505 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete505(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPServerFailureClientDelete505Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPServerFailureClientDelete505Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete505(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -143,7 +154,17 @@ func (h *HTTPServerFailureServerTransport) dispatchPost505(req *http.Request) (*
 	if h.srv.Post505 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post505 not implemented")}
 	}
-	respr, errRespr := h.srv.Post505(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPServerFailureClientPost505Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPServerFailureClientPost505Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post505(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpsuccess_server.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_httpsuccess_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
+	"reflect"
 )
 
 // HTTPSuccessServer is a fake server for instances of the httpinfrastructuregroup.HTTPSuccessClient type.
@@ -176,7 +177,17 @@ func (h *HTTPSuccessServerTransport) dispatchDelete200(req *http.Request) (*http
 	if h.srv.Delete200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete200 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete200(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientDelete200Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientDelete200Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete200(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -195,7 +206,17 @@ func (h *HTTPSuccessServerTransport) dispatchDelete202(req *http.Request) (*http
 	if h.srv.Delete202 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete202 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete202(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientDelete202Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientDelete202Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete202(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -214,7 +235,17 @@ func (h *HTTPSuccessServerTransport) dispatchDelete204(req *http.Request) (*http
 	if h.srv.Delete204 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete204 not implemented")}
 	}
-	respr, errRespr := h.srv.Delete204(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientDelete204Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientDelete204Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Delete204(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -385,7 +416,17 @@ func (h *HTTPSuccessServerTransport) dispatchPost200(req *http.Request) (*http.R
 	if h.srv.Post200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post200 not implemented")}
 	}
-	respr, errRespr := h.srv.Post200(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientPost200Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientPost200Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post200(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -404,7 +445,17 @@ func (h *HTTPSuccessServerTransport) dispatchPost201(req *http.Request) (*http.R
 	if h.srv.Post201 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post201 not implemented")}
 	}
-	respr, errRespr := h.srv.Post201(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientPost201Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientPost201Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post201(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -423,7 +474,17 @@ func (h *HTTPSuccessServerTransport) dispatchPost202(req *http.Request) (*http.R
 	if h.srv.Post202 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post202 not implemented")}
 	}
-	respr, errRespr := h.srv.Post202(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientPost202Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientPost202Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post202(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -442,7 +503,17 @@ func (h *HTTPSuccessServerTransport) dispatchPost204(req *http.Request) (*http.R
 	if h.srv.Post204 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Post204 not implemented")}
 	}
-	respr, errRespr := h.srv.Post204(req.Context(), nil)
+	body, err := server.UnmarshalRequestAsJSON[bool](req)
+	if err != nil {
+		return nil, err
+	}
+	var options *httpinfrastructuregroup.HTTPSuccessClientPost204Options
+	if !reflect.ValueOf(body).IsZero() {
+		options = &httpinfrastructuregroup.HTTPSuccessClientPost204Options{
+			BooleanValue: &body,
+		}
+	}
+	respr, errRespr := h.srv.Post204(req.Context(), options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpclientfailure_client.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpclientfailure_client.go
@@ -57,8 +57,11 @@ func (client *HTTPClientFailureClient) delete400CreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -98,8 +101,11 @@ func (client *HTTPClientFailureClient) delete407CreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -139,8 +145,11 @@ func (client *HTTPClientFailureClient) delete417CreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -793,8 +802,11 @@ func (client *HTTPClientFailureClient) post400CreateRequest(ctx context.Context,
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -834,8 +846,11 @@ func (client *HTTPClientFailureClient) post406CreateRequest(ctx context.Context,
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -875,8 +890,11 @@ func (client *HTTPClientFailureClient) post415CreateRequest(ctx context.Context,
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpredirects_client.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpredirects_client.go
@@ -56,8 +56,11 @@ func (client *HTTPRedirectsClient) delete307CreateRequest(ctx context.Context, o
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -543,8 +546,11 @@ func (client *HTTPRedirectsClient) post303CreateRequest(ctx context.Context, opt
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -592,8 +598,11 @@ func (client *HTTPRedirectsClient) post307CreateRequest(ctx context.Context, opt
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpretry_client.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpretry_client.go
@@ -56,8 +56,11 @@ func (client *HTTPRetryClient) delete503CreateRequest(ctx context.Context, optio
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -296,8 +299,11 @@ func (client *HTTPRetryClient) post503CreateRequest(ctx context.Context, options
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpserverfailure_client.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpserverfailure_client.go
@@ -57,8 +57,11 @@ func (client *HTTPServerFailureClient) delete505CreateRequest(ctx context.Contex
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -173,8 +176,11 @@ func (client *HTTPServerFailureClient) post505CreateRequest(ctx context.Context,
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpsuccess_client.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_httpsuccess_client.go
@@ -56,8 +56,11 @@ func (client *HTTPSuccessClient) delete200CreateRequest(ctx context.Context, opt
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -96,8 +99,11 @@ func (client *HTTPSuccessClient) delete202CreateRequest(ctx context.Context, opt
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -136,8 +142,11 @@ func (client *HTTPSuccessClient) delete204CreateRequest(ctx context.Context, opt
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -498,8 +507,11 @@ func (client *HTTPSuccessClient) post200CreateRequest(ctx context.Context, optio
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -538,8 +550,11 @@ func (client *HTTPSuccessClient) post201CreateRequest(ctx context.Context, optio
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -578,8 +593,11 @@ func (client *HTTPSuccessClient) post202CreateRequest(ctx context.Context, optio
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
@@ -618,8 +636,11 @@ func (client *HTTPSuccessClient) post204CreateRequest(ctx context.Context, optio
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, true); err != nil {
-		return nil, err
+	if options != nil && options.BooleanValue != nil {
+		if err := runtime.MarshalAsJSON(req, true); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_options.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/zz_options.go
@@ -10,17 +10,20 @@ package httpinfrastructuregroup
 
 // HTTPClientFailureClientDelete400Options contains the optional parameters for the HTTPClientFailureClient.Delete400 method.
 type HTTPClientFailureClientDelete400Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientDelete407Options contains the optional parameters for the HTTPClientFailureClient.Delete407 method.
 type HTTPClientFailureClientDelete407Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientDelete417Options contains the optional parameters for the HTTPClientFailureClient.Delete417 method.
 type HTTPClientFailureClientDelete417Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientGet400Options contains the optional parameters for the HTTPClientFailureClient.Get400 method.
@@ -105,17 +108,20 @@ type HTTPClientFailureClientPatch414Options struct {
 
 // HTTPClientFailureClientPost400Options contains the optional parameters for the HTTPClientFailureClient.Post400 method.
 type HTTPClientFailureClientPost400Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientPost406Options contains the optional parameters for the HTTPClientFailureClient.Post406 method.
 type HTTPClientFailureClientPost406Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientPost415Options contains the optional parameters for the HTTPClientFailureClient.Post415 method.
 type HTTPClientFailureClientPost415Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPClientFailureClientPut400Options contains the optional parameters for the HTTPClientFailureClient.Put400 method.
@@ -155,7 +161,8 @@ type HTTPFailureClientGetNoModelErrorOptions struct {
 
 // HTTPRedirectsClientDelete307Options contains the optional parameters for the HTTPRedirectsClient.Delete307 method.
 type HTTPRedirectsClientDelete307Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPRedirectsClientGet300Options contains the optional parameters for the HTTPRedirectsClient.Get300 method.
@@ -215,12 +222,14 @@ type HTTPRedirectsClientPatch307Options struct {
 
 // HTTPRedirectsClientPost303Options contains the optional parameters for the HTTPRedirectsClient.Post303 method.
 type HTTPRedirectsClientPost303Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPRedirectsClientPost307Options contains the optional parameters for the HTTPRedirectsClient.Post307 method.
 type HTTPRedirectsClientPost307Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPRedirectsClientPut301Options contains the optional parameters for the HTTPRedirectsClient.Put301 method.
@@ -235,7 +244,8 @@ type HTTPRedirectsClientPut307Options struct {
 
 // HTTPRetryClientDelete503Options contains the optional parameters for the HTTPRetryClient.Delete503 method.
 type HTTPRetryClientDelete503Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPRetryClientGet502Options contains the optional parameters for the HTTPRetryClient.Get502 method.
@@ -265,7 +275,8 @@ type HTTPRetryClientPatch504Options struct {
 
 // HTTPRetryClientPost503Options contains the optional parameters for the HTTPRetryClient.Post503 method.
 type HTTPRetryClientPost503Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPRetryClientPut500Options contains the optional parameters for the HTTPRetryClient.Put500 method.
@@ -280,7 +291,8 @@ type HTTPRetryClientPut504Options struct {
 
 // HTTPServerFailureClientDelete505Options contains the optional parameters for the HTTPServerFailureClient.Delete505 method.
 type HTTPServerFailureClientDelete505Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPServerFailureClientGet501Options contains the optional parameters for the HTTPServerFailureClient.Get501 method.
@@ -295,22 +307,26 @@ type HTTPServerFailureClientHead501Options struct {
 
 // HTTPServerFailureClientPost505Options contains the optional parameters for the HTTPServerFailureClient.Post505 method.
 type HTTPServerFailureClientPost505Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientDelete200Options contains the optional parameters for the HTTPSuccessClient.Delete200 method.
 type HTTPSuccessClientDelete200Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientDelete202Options contains the optional parameters for the HTTPSuccessClient.Delete202 method.
 type HTTPSuccessClientDelete202Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientDelete204Options contains the optional parameters for the HTTPSuccessClient.Delete204 method.
 type HTTPSuccessClientDelete204Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientGet200Options contains the optional parameters for the HTTPSuccessClient.Get200 method.
@@ -355,22 +371,26 @@ type HTTPSuccessClientPatch204Options struct {
 
 // HTTPSuccessClientPost200Options contains the optional parameters for the HTTPSuccessClient.Post200 method.
 type HTTPSuccessClientPost200Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientPost201Options contains the optional parameters for the HTTPSuccessClient.Post201 method.
 type HTTPSuccessClientPost201Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientPost202Options contains the optional parameters for the HTTPSuccessClient.Post202 method.
 type HTTPSuccessClientPost202Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientPost204Options contains the optional parameters for the HTTPSuccessClient.Post204 method.
 type HTTPSuccessClientPost204Options struct {
-	// placeholder for future optional parameters
+	// Simple boolean value true. Specifying any value will set the value to true.
+	BooleanValue *bool
 }
 
 // HTTPSuccessClientPut200Options contains the optional parameters for the HTTPSuccessClient.Put200 method.


### PR DESCRIPTION
This makes the behavior consistent with how optional, constant header and query parameters are handled.