### PR TITLE
Support concurrent usage of fake pager and poller APIs

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.52",
+  "version": "4.0.0-preview.53",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/fake/internal.ts
+++ b/packages/autorest.go/src/generator/fake/internal.ts
@@ -123,8 +123,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(\`/page_\\d+$\`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_lroretrys_server.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_lroretrys_server.go
@@ -55,20 +55,29 @@ type LRORetrysServer struct {
 // The returned LRORetrysServerTransport instance is connected to an instance of lrogroup.LRORetrysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLRORetrysServerTransport(srv *LRORetrysServer) *LRORetrysServerTransport {
-	return &LRORetrysServerTransport{srv: srv}
+	return &LRORetrysServerTransport{
+		srv:                                    srv,
+		beginDelete202Retry200:                 newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientDelete202Retry200Response]](),
+		beginDeleteAsyncRelativeRetrySucceeded: newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse]](),
+		beginDeleteProvisioning202Accepted200Succeeded: newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse]](),
+		beginPost202Retry200:                           newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientPost202Retry200Response]](),
+		beginPostAsyncRelativeRetrySucceeded:           newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientPostAsyncRelativeRetrySucceededResponse]](),
+		beginPut201CreatingSucceeded200:                newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientPut201CreatingSucceeded200Response]](),
+		beginPutAsyncRelativeRetrySucceeded:            newTracker[azfake.PollerResponder[lrogroup.LRORetrysClientPutAsyncRelativeRetrySucceededResponse]](),
+	}
 }
 
 // LRORetrysServerTransport connects instances of lrogroup.LRORetrysClient to instances of LRORetrysServer.
 // Don't use this type directly, use NewLRORetrysServerTransport instead.
 type LRORetrysServerTransport struct {
 	srv                                            *LRORetrysServer
-	beginDelete202Retry200                         *azfake.PollerResponder[lrogroup.LRORetrysClientDelete202Retry200Response]
-	beginDeleteAsyncRelativeRetrySucceeded         *azfake.PollerResponder[lrogroup.LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse]
-	beginDeleteProvisioning202Accepted200Succeeded *azfake.PollerResponder[lrogroup.LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse]
-	beginPost202Retry200                           *azfake.PollerResponder[lrogroup.LRORetrysClientPost202Retry200Response]
-	beginPostAsyncRelativeRetrySucceeded           *azfake.PollerResponder[lrogroup.LRORetrysClientPostAsyncRelativeRetrySucceededResponse]
-	beginPut201CreatingSucceeded200                *azfake.PollerResponder[lrogroup.LRORetrysClientPut201CreatingSucceeded200Response]
-	beginPutAsyncRelativeRetrySucceeded            *azfake.PollerResponder[lrogroup.LRORetrysClientPutAsyncRelativeRetrySucceededResponse]
+	beginDelete202Retry200                         *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientDelete202Retry200Response]]
+	beginDeleteAsyncRelativeRetrySucceeded         *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientDeleteAsyncRelativeRetrySucceededResponse]]
+	beginDeleteProvisioning202Accepted200Succeeded *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientDeleteProvisioning202Accepted200SucceededResponse]]
+	beginPost202Retry200                           *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientPost202Retry200Response]]
+	beginPostAsyncRelativeRetrySucceeded           *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientPostAsyncRelativeRetrySucceededResponse]]
+	beginPut201CreatingSucceeded200                *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientPut201CreatingSucceeded200Response]]
+	beginPutAsyncRelativeRetrySucceeded            *tracker[azfake.PollerResponder[lrogroup.LRORetrysClientPutAsyncRelativeRetrySucceededResponse]]
 }
 
 // Do implements the policy.Transporter interface for LRORetrysServerTransport.
@@ -112,24 +121,27 @@ func (l *LRORetrysServerTransport) dispatchBeginDelete202Retry200(req *http.Requ
 	if l.srv.BeginDelete202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete202Retry200 not implemented")}
 	}
-	if l.beginDelete202Retry200 == nil {
+	beginDelete202Retry200 := l.beginDelete202Retry200.get(req)
+	if beginDelete202Retry200 == nil {
 		respr, errRespr := l.srv.BeginDelete202Retry200(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete202Retry200 = &respr
+		beginDelete202Retry200 = &respr
+		l.beginDelete202Retry200.add(req, beginDelete202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete202Retry200, req)
+	resp, err := server.PollerResponderNext(beginDelete202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDelete202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete202Retry200) {
-		l.beginDelete202Retry200 = nil
+	if !server.PollerResponderMore(beginDelete202Retry200) {
+		l.beginDelete202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -139,24 +151,27 @@ func (l *LRORetrysServerTransport) dispatchBeginDeleteAsyncRelativeRetrySucceede
 	if l.srv.BeginDeleteAsyncRelativeRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRelativeRetrySucceeded not implemented")}
 	}
-	if l.beginDeleteAsyncRelativeRetrySucceeded == nil {
+	beginDeleteAsyncRelativeRetrySucceeded := l.beginDeleteAsyncRelativeRetrySucceeded.get(req)
+	if beginDeleteAsyncRelativeRetrySucceeded == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRelativeRetrySucceeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRelativeRetrySucceeded = &respr
+		beginDeleteAsyncRelativeRetrySucceeded = &respr
+		l.beginDeleteAsyncRelativeRetrySucceeded.add(req, beginDeleteAsyncRelativeRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRelativeRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRelativeRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRelativeRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRelativeRetrySucceeded) {
-		l.beginDeleteAsyncRelativeRetrySucceeded = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRelativeRetrySucceeded) {
+		l.beginDeleteAsyncRelativeRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -166,24 +181,27 @@ func (l *LRORetrysServerTransport) dispatchBeginDeleteProvisioning202Accepted200
 	if l.srv.BeginDeleteProvisioning202Accepted200Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteProvisioning202Accepted200Succeeded not implemented")}
 	}
-	if l.beginDeleteProvisioning202Accepted200Succeeded == nil {
+	beginDeleteProvisioning202Accepted200Succeeded := l.beginDeleteProvisioning202Accepted200Succeeded.get(req)
+	if beginDeleteProvisioning202Accepted200Succeeded == nil {
 		respr, errRespr := l.srv.BeginDeleteProvisioning202Accepted200Succeeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteProvisioning202Accepted200Succeeded = &respr
+		beginDeleteProvisioning202Accepted200Succeeded = &respr
+		l.beginDeleteProvisioning202Accepted200Succeeded.add(req, beginDeleteProvisioning202Accepted200Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteProvisioning202Accepted200Succeeded, req)
+	resp, err := server.PollerResponderNext(beginDeleteProvisioning202Accepted200Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteProvisioning202Accepted200Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteProvisioning202Accepted200Succeeded) {
-		l.beginDeleteProvisioning202Accepted200Succeeded = nil
+	if !server.PollerResponderMore(beginDeleteProvisioning202Accepted200Succeeded) {
+		l.beginDeleteProvisioning202Accepted200Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -193,7 +211,8 @@ func (l *LRORetrysServerTransport) dispatchBeginPost202Retry200(req *http.Reques
 	if l.srv.BeginPost202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202Retry200 not implemented")}
 	}
-	if l.beginPost202Retry200 == nil {
+	beginPost202Retry200 := l.beginPost202Retry200.get(req)
+	if beginPost202Retry200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -208,19 +227,21 @@ func (l *LRORetrysServerTransport) dispatchBeginPost202Retry200(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202Retry200 = &respr
+		beginPost202Retry200 = &respr
+		l.beginPost202Retry200.add(req, beginPost202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202Retry200, req)
+	resp, err := server.PollerResponderNext(beginPost202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202Retry200) {
-		l.beginPost202Retry200 = nil
+	if !server.PollerResponderMore(beginPost202Retry200) {
+		l.beginPost202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +251,8 @@ func (l *LRORetrysServerTransport) dispatchBeginPostAsyncRelativeRetrySucceeded(
 	if l.srv.BeginPostAsyncRelativeRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRelativeRetrySucceeded not implemented")}
 	}
-	if l.beginPostAsyncRelativeRetrySucceeded == nil {
+	beginPostAsyncRelativeRetrySucceeded := l.beginPostAsyncRelativeRetrySucceeded.get(req)
+	if beginPostAsyncRelativeRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -245,19 +267,21 @@ func (l *LRORetrysServerTransport) dispatchBeginPostAsyncRelativeRetrySucceeded(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRelativeRetrySucceeded = &respr
+		beginPostAsyncRelativeRetrySucceeded = &respr
+		l.beginPostAsyncRelativeRetrySucceeded.add(req, beginPostAsyncRelativeRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRelativeRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRelativeRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRelativeRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRelativeRetrySucceeded) {
-		l.beginPostAsyncRelativeRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPostAsyncRelativeRetrySucceeded) {
+		l.beginPostAsyncRelativeRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -267,7 +291,8 @@ func (l *LRORetrysServerTransport) dispatchBeginPut201CreatingSucceeded200(req *
 	if l.srv.BeginPut201CreatingSucceeded200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut201CreatingSucceeded200 not implemented")}
 	}
-	if l.beginPut201CreatingSucceeded200 == nil {
+	beginPut201CreatingSucceeded200 := l.beginPut201CreatingSucceeded200.get(req)
+	if beginPut201CreatingSucceeded200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -276,19 +301,21 @@ func (l *LRORetrysServerTransport) dispatchBeginPut201CreatingSucceeded200(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut201CreatingSucceeded200 = &respr
+		beginPut201CreatingSucceeded200 = &respr
+		l.beginPut201CreatingSucceeded200.add(req, beginPut201CreatingSucceeded200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut201CreatingSucceeded200, req)
+	resp, err := server.PollerResponderNext(beginPut201CreatingSucceeded200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut201CreatingSucceeded200) {
-		l.beginPut201CreatingSucceeded200 = nil
+	if !server.PollerResponderMore(beginPut201CreatingSucceeded200) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 	}
 
 	return resp, nil
@@ -298,7 +325,8 @@ func (l *LRORetrysServerTransport) dispatchBeginPutAsyncRelativeRetrySucceeded(r
 	if l.srv.BeginPutAsyncRelativeRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetrySucceeded not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetrySucceeded == nil {
+	beginPutAsyncRelativeRetrySucceeded := l.beginPutAsyncRelativeRetrySucceeded.get(req)
+	if beginPutAsyncRelativeRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -307,19 +335,21 @@ func (l *LRORetrysServerTransport) dispatchBeginPutAsyncRelativeRetrySucceeded(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetrySucceeded = &respr
+		beginPutAsyncRelativeRetrySucceeded = &respr
+		l.beginPutAsyncRelativeRetrySucceeded.add(req, beginPutAsyncRelativeRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetrySucceeded) {
-		l.beginPutAsyncRelativeRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetrySucceeded) {
+		l.beginPutAsyncRelativeRetrySucceeded.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_lros_server.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_lros_server.go
@@ -203,57 +203,103 @@ type LROsServer struct {
 // The returned LROsServerTransport instance is connected to an instance of lrogroup.LROsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLROsServerTransport(srv *LROsServer) *LROsServerTransport {
-	return &LROsServerTransport{srv: srv}
+	return &LROsServerTransport{
+		srv:                                              srv,
+		beginDelete202NoRetry204:                         newTracker[azfake.PollerResponder[lrogroup.LROsClientDelete202NoRetry204Response]](),
+		beginDelete202Retry200:                           newTracker[azfake.PollerResponder[lrogroup.LROsClientDelete202Retry200Response]](),
+		beginDelete204Succeeded:                          newTracker[azfake.PollerResponder[lrogroup.LROsClientDelete204SucceededResponse]](),
+		beginDeleteAsyncNoHeaderInRetry:                  newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoHeaderInRetryResponse]](),
+		beginDeleteAsyncNoRetrySucceeded:                 newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoRetrySucceededResponse]](),
+		beginDeleteAsyncRetryFailed:                      newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetryFailedResponse]](),
+		beginDeleteAsyncRetrySucceeded:                   newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrySucceededResponse]](),
+		beginDeleteAsyncRetrycanceled:                    newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrycanceledResponse]](),
+		beginDeleteNoHeaderInRetry:                       newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteNoHeaderInRetryResponse]](),
+		beginDeleteProvisioning202Accepted200Succeeded:   newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Accepted200SucceededResponse]](),
+		beginDeleteProvisioning202DeletingFailed200:      newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202DeletingFailed200Response]](),
+		beginDeleteProvisioning202Deletingcanceled200:    newTracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Deletingcanceled200Response]](),
+		beginPatch200SucceededIgnoreHeaders:              newTracker[azfake.PollerResponder[lrogroup.LROsClientPatch200SucceededIgnoreHeadersResponse]](),
+		beginPatch201RetryWithAsyncHeader:                newTracker[azfake.PollerResponder[lrogroup.LROsClientPatch201RetryWithAsyncHeaderResponse]](),
+		beginPatch202RetryWithAsyncAndLocationHeader:     newTracker[azfake.PollerResponder[lrogroup.LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse]](),
+		beginPost200WithPayload:                          newTracker[azfake.PollerResponder[lrogroup.LROsClientPost200WithPayloadResponse]](),
+		beginPost202List:                                 newTracker[azfake.PollerResponder[lrogroup.LROsClientPost202ListResponse]](),
+		beginPost202NoRetry204:                           newTracker[azfake.PollerResponder[lrogroup.LROsClientPost202NoRetry204Response]](),
+		beginPost202Retry200:                             newTracker[azfake.PollerResponder[lrogroup.LROsClientPost202Retry200Response]](),
+		beginPostAsyncNoRetrySucceeded:                   newTracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncNoRetrySucceededResponse]](),
+		beginPostAsyncRetryFailed:                        newTracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetryFailedResponse]](),
+		beginPostAsyncRetrySucceeded:                     newTracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrySucceededResponse]](),
+		beginPostAsyncRetrycanceled:                      newTracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrycanceledResponse]](),
+		beginPostDoubleHeadersFinalAzureHeaderGet:        newTracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse]](),
+		beginPostDoubleHeadersFinalAzureHeaderGetDefault: newTracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse]](),
+		beginPostDoubleHeadersFinalLocationGet:           newTracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalLocationGetResponse]](),
+		beginPut200Acceptedcanceled200:                   newTracker[azfake.PollerResponder[lrogroup.LROsClientPut200Acceptedcanceled200Response]](),
+		beginPut200Succeeded:                             newTracker[azfake.PollerResponder[lrogroup.LROsClientPut200SucceededResponse]](),
+		beginPut200SucceededNoState:                      newTracker[azfake.PollerResponder[lrogroup.LROsClientPut200SucceededNoStateResponse]](),
+		beginPut200UpdatingSucceeded204:                  newTracker[azfake.PollerResponder[lrogroup.LROsClientPut200UpdatingSucceeded204Response]](),
+		beginPut201CreatingFailed200:                     newTracker[azfake.PollerResponder[lrogroup.LROsClientPut201CreatingFailed200Response]](),
+		beginPut201CreatingSucceeded200:                  newTracker[azfake.PollerResponder[lrogroup.LROsClientPut201CreatingSucceeded200Response]](),
+		beginPut201Succeeded:                             newTracker[azfake.PollerResponder[lrogroup.LROsClientPut201SucceededResponse]](),
+		beginPut202Retry200:                              newTracker[azfake.PollerResponder[lrogroup.LROsClientPut202Retry200Response]](),
+		beginPutAsyncNoHeaderInRetry:                     newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoHeaderInRetryResponse]](),
+		beginPutAsyncNoRetrySucceeded:                    newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrySucceededResponse]](),
+		beginPutAsyncNoRetrycanceled:                     newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrycanceledResponse]](),
+		beginPutAsyncNonResource:                         newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNonResourceResponse]](),
+		beginPutAsyncRetryFailed:                         newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetryFailedResponse]](),
+		beginPutAsyncRetrySucceeded:                      newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetrySucceededResponse]](),
+		beginPutAsyncSubResource:                         newTracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncSubResourceResponse]](),
+		beginPutNoHeaderInRetry:                          newTracker[azfake.PollerResponder[lrogroup.LROsClientPutNoHeaderInRetryResponse]](),
+		beginPutNonResource:                              newTracker[azfake.PollerResponder[lrogroup.LROsClientPutNonResourceResponse]](),
+		beginPutSubResource:                              newTracker[azfake.PollerResponder[lrogroup.LROsClientPutSubResourceResponse]](),
+	}
 }
 
 // LROsServerTransport connects instances of lrogroup.LROsClient to instances of LROsServer.
 // Don't use this type directly, use NewLROsServerTransport instead.
 type LROsServerTransport struct {
 	srv                                              *LROsServer
-	beginDelete202NoRetry204                         *azfake.PollerResponder[lrogroup.LROsClientDelete202NoRetry204Response]
-	beginDelete202Retry200                           *azfake.PollerResponder[lrogroup.LROsClientDelete202Retry200Response]
-	beginDelete204Succeeded                          *azfake.PollerResponder[lrogroup.LROsClientDelete204SucceededResponse]
-	beginDeleteAsyncNoHeaderInRetry                  *azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoHeaderInRetryResponse]
-	beginDeleteAsyncNoRetrySucceeded                 *azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoRetrySucceededResponse]
-	beginDeleteAsyncRetryFailed                      *azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetryFailedResponse]
-	beginDeleteAsyncRetrySucceeded                   *azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrySucceededResponse]
-	beginDeleteAsyncRetrycanceled                    *azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrycanceledResponse]
-	beginDeleteNoHeaderInRetry                       *azfake.PollerResponder[lrogroup.LROsClientDeleteNoHeaderInRetryResponse]
-	beginDeleteProvisioning202Accepted200Succeeded   *azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Accepted200SucceededResponse]
-	beginDeleteProvisioning202DeletingFailed200      *azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202DeletingFailed200Response]
-	beginDeleteProvisioning202Deletingcanceled200    *azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Deletingcanceled200Response]
-	beginPatch200SucceededIgnoreHeaders              *azfake.PollerResponder[lrogroup.LROsClientPatch200SucceededIgnoreHeadersResponse]
-	beginPatch201RetryWithAsyncHeader                *azfake.PollerResponder[lrogroup.LROsClientPatch201RetryWithAsyncHeaderResponse]
-	beginPatch202RetryWithAsyncAndLocationHeader     *azfake.PollerResponder[lrogroup.LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse]
-	beginPost200WithPayload                          *azfake.PollerResponder[lrogroup.LROsClientPost200WithPayloadResponse]
-	beginPost202List                                 *azfake.PollerResponder[lrogroup.LROsClientPost202ListResponse]
-	beginPost202NoRetry204                           *azfake.PollerResponder[lrogroup.LROsClientPost202NoRetry204Response]
-	beginPost202Retry200                             *azfake.PollerResponder[lrogroup.LROsClientPost202Retry200Response]
-	beginPostAsyncNoRetrySucceeded                   *azfake.PollerResponder[lrogroup.LROsClientPostAsyncNoRetrySucceededResponse]
-	beginPostAsyncRetryFailed                        *azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetryFailedResponse]
-	beginPostAsyncRetrySucceeded                     *azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrySucceededResponse]
-	beginPostAsyncRetrycanceled                      *azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrycanceledResponse]
-	beginPostDoubleHeadersFinalAzureHeaderGet        *azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse]
-	beginPostDoubleHeadersFinalAzureHeaderGetDefault *azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse]
-	beginPostDoubleHeadersFinalLocationGet           *azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalLocationGetResponse]
-	beginPut200Acceptedcanceled200                   *azfake.PollerResponder[lrogroup.LROsClientPut200Acceptedcanceled200Response]
-	beginPut200Succeeded                             *azfake.PollerResponder[lrogroup.LROsClientPut200SucceededResponse]
-	beginPut200SucceededNoState                      *azfake.PollerResponder[lrogroup.LROsClientPut200SucceededNoStateResponse]
-	beginPut200UpdatingSucceeded204                  *azfake.PollerResponder[lrogroup.LROsClientPut200UpdatingSucceeded204Response]
-	beginPut201CreatingFailed200                     *azfake.PollerResponder[lrogroup.LROsClientPut201CreatingFailed200Response]
-	beginPut201CreatingSucceeded200                  *azfake.PollerResponder[lrogroup.LROsClientPut201CreatingSucceeded200Response]
-	beginPut201Succeeded                             *azfake.PollerResponder[lrogroup.LROsClientPut201SucceededResponse]
-	beginPut202Retry200                              *azfake.PollerResponder[lrogroup.LROsClientPut202Retry200Response]
-	beginPutAsyncNoHeaderInRetry                     *azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoHeaderInRetryResponse]
-	beginPutAsyncNoRetrySucceeded                    *azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrySucceededResponse]
-	beginPutAsyncNoRetrycanceled                     *azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrycanceledResponse]
-	beginPutAsyncNonResource                         *azfake.PollerResponder[lrogroup.LROsClientPutAsyncNonResourceResponse]
-	beginPutAsyncRetryFailed                         *azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetryFailedResponse]
-	beginPutAsyncRetrySucceeded                      *azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetrySucceededResponse]
-	beginPutAsyncSubResource                         *azfake.PollerResponder[lrogroup.LROsClientPutAsyncSubResourceResponse]
-	beginPutNoHeaderInRetry                          *azfake.PollerResponder[lrogroup.LROsClientPutNoHeaderInRetryResponse]
-	beginPutNonResource                              *azfake.PollerResponder[lrogroup.LROsClientPutNonResourceResponse]
-	beginPutSubResource                              *azfake.PollerResponder[lrogroup.LROsClientPutSubResourceResponse]
+	beginDelete202NoRetry204                         *tracker[azfake.PollerResponder[lrogroup.LROsClientDelete202NoRetry204Response]]
+	beginDelete202Retry200                           *tracker[azfake.PollerResponder[lrogroup.LROsClientDelete202Retry200Response]]
+	beginDelete204Succeeded                          *tracker[azfake.PollerResponder[lrogroup.LROsClientDelete204SucceededResponse]]
+	beginDeleteAsyncNoHeaderInRetry                  *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoHeaderInRetryResponse]]
+	beginDeleteAsyncNoRetrySucceeded                 *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncNoRetrySucceededResponse]]
+	beginDeleteAsyncRetryFailed                      *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetryFailedResponse]]
+	beginDeleteAsyncRetrySucceeded                   *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrySucceededResponse]]
+	beginDeleteAsyncRetrycanceled                    *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteAsyncRetrycanceledResponse]]
+	beginDeleteNoHeaderInRetry                       *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteNoHeaderInRetryResponse]]
+	beginDeleteProvisioning202Accepted200Succeeded   *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Accepted200SucceededResponse]]
+	beginDeleteProvisioning202DeletingFailed200      *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202DeletingFailed200Response]]
+	beginDeleteProvisioning202Deletingcanceled200    *tracker[azfake.PollerResponder[lrogroup.LROsClientDeleteProvisioning202Deletingcanceled200Response]]
+	beginPatch200SucceededIgnoreHeaders              *tracker[azfake.PollerResponder[lrogroup.LROsClientPatch200SucceededIgnoreHeadersResponse]]
+	beginPatch201RetryWithAsyncHeader                *tracker[azfake.PollerResponder[lrogroup.LROsClientPatch201RetryWithAsyncHeaderResponse]]
+	beginPatch202RetryWithAsyncAndLocationHeader     *tracker[azfake.PollerResponder[lrogroup.LROsClientPatch202RetryWithAsyncAndLocationHeaderResponse]]
+	beginPost200WithPayload                          *tracker[azfake.PollerResponder[lrogroup.LROsClientPost200WithPayloadResponse]]
+	beginPost202List                                 *tracker[azfake.PollerResponder[lrogroup.LROsClientPost202ListResponse]]
+	beginPost202NoRetry204                           *tracker[azfake.PollerResponder[lrogroup.LROsClientPost202NoRetry204Response]]
+	beginPost202Retry200                             *tracker[azfake.PollerResponder[lrogroup.LROsClientPost202Retry200Response]]
+	beginPostAsyncNoRetrySucceeded                   *tracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncNoRetrySucceededResponse]]
+	beginPostAsyncRetryFailed                        *tracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetryFailedResponse]]
+	beginPostAsyncRetrySucceeded                     *tracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrySucceededResponse]]
+	beginPostAsyncRetrycanceled                      *tracker[azfake.PollerResponder[lrogroup.LROsClientPostAsyncRetrycanceledResponse]]
+	beginPostDoubleHeadersFinalAzureHeaderGet        *tracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetResponse]]
+	beginPostDoubleHeadersFinalAzureHeaderGetDefault *tracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalAzureHeaderGetDefaultResponse]]
+	beginPostDoubleHeadersFinalLocationGet           *tracker[azfake.PollerResponder[lrogroup.LROsClientPostDoubleHeadersFinalLocationGetResponse]]
+	beginPut200Acceptedcanceled200                   *tracker[azfake.PollerResponder[lrogroup.LROsClientPut200Acceptedcanceled200Response]]
+	beginPut200Succeeded                             *tracker[azfake.PollerResponder[lrogroup.LROsClientPut200SucceededResponse]]
+	beginPut200SucceededNoState                      *tracker[azfake.PollerResponder[lrogroup.LROsClientPut200SucceededNoStateResponse]]
+	beginPut200UpdatingSucceeded204                  *tracker[azfake.PollerResponder[lrogroup.LROsClientPut200UpdatingSucceeded204Response]]
+	beginPut201CreatingFailed200                     *tracker[azfake.PollerResponder[lrogroup.LROsClientPut201CreatingFailed200Response]]
+	beginPut201CreatingSucceeded200                  *tracker[azfake.PollerResponder[lrogroup.LROsClientPut201CreatingSucceeded200Response]]
+	beginPut201Succeeded                             *tracker[azfake.PollerResponder[lrogroup.LROsClientPut201SucceededResponse]]
+	beginPut202Retry200                              *tracker[azfake.PollerResponder[lrogroup.LROsClientPut202Retry200Response]]
+	beginPutAsyncNoHeaderInRetry                     *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoHeaderInRetryResponse]]
+	beginPutAsyncNoRetrySucceeded                    *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrySucceededResponse]]
+	beginPutAsyncNoRetrycanceled                     *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNoRetrycanceledResponse]]
+	beginPutAsyncNonResource                         *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncNonResourceResponse]]
+	beginPutAsyncRetryFailed                         *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetryFailedResponse]]
+	beginPutAsyncRetrySucceeded                      *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncRetrySucceededResponse]]
+	beginPutAsyncSubResource                         *tracker[azfake.PollerResponder[lrogroup.LROsClientPutAsyncSubResourceResponse]]
+	beginPutNoHeaderInRetry                          *tracker[azfake.PollerResponder[lrogroup.LROsClientPutNoHeaderInRetryResponse]]
+	beginPutNonResource                              *tracker[azfake.PollerResponder[lrogroup.LROsClientPutNonResourceResponse]]
+	beginPutSubResource                              *tracker[azfake.PollerResponder[lrogroup.LROsClientPutSubResourceResponse]]
 }
 
 // Do implements the policy.Transporter interface for LROsServerTransport.
@@ -371,24 +417,27 @@ func (l *LROsServerTransport) dispatchBeginDelete202NoRetry204(req *http.Request
 	if l.srv.BeginDelete202NoRetry204 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete202NoRetry204 not implemented")}
 	}
-	if l.beginDelete202NoRetry204 == nil {
+	beginDelete202NoRetry204 := l.beginDelete202NoRetry204.get(req)
+	if beginDelete202NoRetry204 == nil {
 		respr, errRespr := l.srv.BeginDelete202NoRetry204(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete202NoRetry204 = &respr
+		beginDelete202NoRetry204 = &respr
+		l.beginDelete202NoRetry204.add(req, beginDelete202NoRetry204)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete202NoRetry204, req)
+	resp, err := server.PollerResponderNext(beginDelete202NoRetry204, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDelete202NoRetry204.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete202NoRetry204) {
-		l.beginDelete202NoRetry204 = nil
+	if !server.PollerResponderMore(beginDelete202NoRetry204) {
+		l.beginDelete202NoRetry204.remove(req)
 	}
 
 	return resp, nil
@@ -398,24 +447,27 @@ func (l *LROsServerTransport) dispatchBeginDelete202Retry200(req *http.Request) 
 	if l.srv.BeginDelete202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete202Retry200 not implemented")}
 	}
-	if l.beginDelete202Retry200 == nil {
+	beginDelete202Retry200 := l.beginDelete202Retry200.get(req)
+	if beginDelete202Retry200 == nil {
 		respr, errRespr := l.srv.BeginDelete202Retry200(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete202Retry200 = &respr
+		beginDelete202Retry200 = &respr
+		l.beginDelete202Retry200.add(req, beginDelete202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete202Retry200, req)
+	resp, err := server.PollerResponderNext(beginDelete202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDelete202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete202Retry200) {
-		l.beginDelete202Retry200 = nil
+	if !server.PollerResponderMore(beginDelete202Retry200) {
+		l.beginDelete202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -425,24 +477,27 @@ func (l *LROsServerTransport) dispatchBeginDelete204Succeeded(req *http.Request)
 	if l.srv.BeginDelete204Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete204Succeeded not implemented")}
 	}
-	if l.beginDelete204Succeeded == nil {
+	beginDelete204Succeeded := l.beginDelete204Succeeded.get(req)
+	if beginDelete204Succeeded == nil {
 		respr, errRespr := l.srv.BeginDelete204Succeeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete204Succeeded = &respr
+		beginDelete204Succeeded = &respr
+		l.beginDelete204Succeeded.add(req, beginDelete204Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete204Succeeded, req)
+	resp, err := server.PollerResponderNext(beginDelete204Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusNoContent}, resp.StatusCode) {
+		l.beginDelete204Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete204Succeeded) {
-		l.beginDelete204Succeeded = nil
+	if !server.PollerResponderMore(beginDelete204Succeeded) {
+		l.beginDelete204Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -452,24 +507,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteAsyncNoHeaderInRetry(req *http.
 	if l.srv.BeginDeleteAsyncNoHeaderInRetry == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncNoHeaderInRetry not implemented")}
 	}
-	if l.beginDeleteAsyncNoHeaderInRetry == nil {
+	beginDeleteAsyncNoHeaderInRetry := l.beginDeleteAsyncNoHeaderInRetry.get(req)
+	if beginDeleteAsyncNoHeaderInRetry == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncNoHeaderInRetry(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncNoHeaderInRetry = &respr
+		beginDeleteAsyncNoHeaderInRetry = &respr
+		l.beginDeleteAsyncNoHeaderInRetry.add(req, beginDeleteAsyncNoHeaderInRetry)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncNoHeaderInRetry, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncNoHeaderInRetry, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		l.beginDeleteAsyncNoHeaderInRetry.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncNoHeaderInRetry) {
-		l.beginDeleteAsyncNoHeaderInRetry = nil
+	if !server.PollerResponderMore(beginDeleteAsyncNoHeaderInRetry) {
+		l.beginDeleteAsyncNoHeaderInRetry.remove(req)
 	}
 
 	return resp, nil
@@ -479,24 +537,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteAsyncNoRetrySucceeded(req *http
 	if l.srv.BeginDeleteAsyncNoRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncNoRetrySucceeded not implemented")}
 	}
-	if l.beginDeleteAsyncNoRetrySucceeded == nil {
+	beginDeleteAsyncNoRetrySucceeded := l.beginDeleteAsyncNoRetrySucceeded.get(req)
+	if beginDeleteAsyncNoRetrySucceeded == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncNoRetrySucceeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncNoRetrySucceeded = &respr
+		beginDeleteAsyncNoRetrySucceeded = &respr
+		l.beginDeleteAsyncNoRetrySucceeded.add(req, beginDeleteAsyncNoRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncNoRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncNoRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncNoRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncNoRetrySucceeded) {
-		l.beginDeleteAsyncNoRetrySucceeded = nil
+	if !server.PollerResponderMore(beginDeleteAsyncNoRetrySucceeded) {
+		l.beginDeleteAsyncNoRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -506,24 +567,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteAsyncRetryFailed(req *http.Requ
 	if l.srv.BeginDeleteAsyncRetryFailed == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRetryFailed not implemented")}
 	}
-	if l.beginDeleteAsyncRetryFailed == nil {
+	beginDeleteAsyncRetryFailed := l.beginDeleteAsyncRetryFailed.get(req)
+	if beginDeleteAsyncRetryFailed == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRetryFailed(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRetryFailed = &respr
+		beginDeleteAsyncRetryFailed = &respr
+		l.beginDeleteAsyncRetryFailed.add(req, beginDeleteAsyncRetryFailed)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRetryFailed, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRetryFailed, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRetryFailed.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRetryFailed) {
-		l.beginDeleteAsyncRetryFailed = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRetryFailed) {
+		l.beginDeleteAsyncRetryFailed.remove(req)
 	}
 
 	return resp, nil
@@ -533,24 +597,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteAsyncRetrySucceeded(req *http.R
 	if l.srv.BeginDeleteAsyncRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRetrySucceeded not implemented")}
 	}
-	if l.beginDeleteAsyncRetrySucceeded == nil {
+	beginDeleteAsyncRetrySucceeded := l.beginDeleteAsyncRetrySucceeded.get(req)
+	if beginDeleteAsyncRetrySucceeded == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRetrySucceeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRetrySucceeded = &respr
+		beginDeleteAsyncRetrySucceeded = &respr
+		l.beginDeleteAsyncRetrySucceeded.add(req, beginDeleteAsyncRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRetrySucceeded) {
-		l.beginDeleteAsyncRetrySucceeded = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRetrySucceeded) {
+		l.beginDeleteAsyncRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -560,24 +627,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteAsyncRetrycanceled(req *http.Re
 	if l.srv.BeginDeleteAsyncRetrycanceled == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRetrycanceled not implemented")}
 	}
-	if l.beginDeleteAsyncRetrycanceled == nil {
+	beginDeleteAsyncRetrycanceled := l.beginDeleteAsyncRetrycanceled.get(req)
+	if beginDeleteAsyncRetrycanceled == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRetrycanceled(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRetrycanceled = &respr
+		beginDeleteAsyncRetrycanceled = &respr
+		l.beginDeleteAsyncRetrycanceled.add(req, beginDeleteAsyncRetrycanceled)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRetrycanceled, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRetrycanceled, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRetrycanceled.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRetrycanceled) {
-		l.beginDeleteAsyncRetrycanceled = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRetrycanceled) {
+		l.beginDeleteAsyncRetrycanceled.remove(req)
 	}
 
 	return resp, nil
@@ -587,24 +657,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteNoHeaderInRetry(req *http.Reque
 	if l.srv.BeginDeleteNoHeaderInRetry == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteNoHeaderInRetry not implemented")}
 	}
-	if l.beginDeleteNoHeaderInRetry == nil {
+	beginDeleteNoHeaderInRetry := l.beginDeleteNoHeaderInRetry.get(req)
+	if beginDeleteNoHeaderInRetry == nil {
 		respr, errRespr := l.srv.BeginDeleteNoHeaderInRetry(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteNoHeaderInRetry = &respr
+		beginDeleteNoHeaderInRetry = &respr
+		l.beginDeleteNoHeaderInRetry.add(req, beginDeleteNoHeaderInRetry)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteNoHeaderInRetry, req)
+	resp, err := server.PollerResponderNext(beginDeleteNoHeaderInRetry, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		l.beginDeleteNoHeaderInRetry.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteNoHeaderInRetry) {
-		l.beginDeleteNoHeaderInRetry = nil
+	if !server.PollerResponderMore(beginDeleteNoHeaderInRetry) {
+		l.beginDeleteNoHeaderInRetry.remove(req)
 	}
 
 	return resp, nil
@@ -614,24 +687,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteProvisioning202Accepted200Succe
 	if l.srv.BeginDeleteProvisioning202Accepted200Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteProvisioning202Accepted200Succeeded not implemented")}
 	}
-	if l.beginDeleteProvisioning202Accepted200Succeeded == nil {
+	beginDeleteProvisioning202Accepted200Succeeded := l.beginDeleteProvisioning202Accepted200Succeeded.get(req)
+	if beginDeleteProvisioning202Accepted200Succeeded == nil {
 		respr, errRespr := l.srv.BeginDeleteProvisioning202Accepted200Succeeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteProvisioning202Accepted200Succeeded = &respr
+		beginDeleteProvisioning202Accepted200Succeeded = &respr
+		l.beginDeleteProvisioning202Accepted200Succeeded.add(req, beginDeleteProvisioning202Accepted200Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteProvisioning202Accepted200Succeeded, req)
+	resp, err := server.PollerResponderNext(beginDeleteProvisioning202Accepted200Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteProvisioning202Accepted200Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteProvisioning202Accepted200Succeeded) {
-		l.beginDeleteProvisioning202Accepted200Succeeded = nil
+	if !server.PollerResponderMore(beginDeleteProvisioning202Accepted200Succeeded) {
+		l.beginDeleteProvisioning202Accepted200Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -641,24 +717,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteProvisioning202DeletingFailed20
 	if l.srv.BeginDeleteProvisioning202DeletingFailed200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteProvisioning202DeletingFailed200 not implemented")}
 	}
-	if l.beginDeleteProvisioning202DeletingFailed200 == nil {
+	beginDeleteProvisioning202DeletingFailed200 := l.beginDeleteProvisioning202DeletingFailed200.get(req)
+	if beginDeleteProvisioning202DeletingFailed200 == nil {
 		respr, errRespr := l.srv.BeginDeleteProvisioning202DeletingFailed200(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteProvisioning202DeletingFailed200 = &respr
+		beginDeleteProvisioning202DeletingFailed200 = &respr
+		l.beginDeleteProvisioning202DeletingFailed200.add(req, beginDeleteProvisioning202DeletingFailed200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteProvisioning202DeletingFailed200, req)
+	resp, err := server.PollerResponderNext(beginDeleteProvisioning202DeletingFailed200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteProvisioning202DeletingFailed200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteProvisioning202DeletingFailed200) {
-		l.beginDeleteProvisioning202DeletingFailed200 = nil
+	if !server.PollerResponderMore(beginDeleteProvisioning202DeletingFailed200) {
+		l.beginDeleteProvisioning202DeletingFailed200.remove(req)
 	}
 
 	return resp, nil
@@ -668,24 +747,27 @@ func (l *LROsServerTransport) dispatchBeginDeleteProvisioning202Deletingcanceled
 	if l.srv.BeginDeleteProvisioning202Deletingcanceled200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteProvisioning202Deletingcanceled200 not implemented")}
 	}
-	if l.beginDeleteProvisioning202Deletingcanceled200 == nil {
+	beginDeleteProvisioning202Deletingcanceled200 := l.beginDeleteProvisioning202Deletingcanceled200.get(req)
+	if beginDeleteProvisioning202Deletingcanceled200 == nil {
 		respr, errRespr := l.srv.BeginDeleteProvisioning202Deletingcanceled200(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteProvisioning202Deletingcanceled200 = &respr
+		beginDeleteProvisioning202Deletingcanceled200 = &respr
+		l.beginDeleteProvisioning202Deletingcanceled200.add(req, beginDeleteProvisioning202Deletingcanceled200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteProvisioning202Deletingcanceled200, req)
+	resp, err := server.PollerResponderNext(beginDeleteProvisioning202Deletingcanceled200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteProvisioning202Deletingcanceled200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteProvisioning202Deletingcanceled200) {
-		l.beginDeleteProvisioning202Deletingcanceled200 = nil
+	if !server.PollerResponderMore(beginDeleteProvisioning202Deletingcanceled200) {
+		l.beginDeleteProvisioning202Deletingcanceled200.remove(req)
 	}
 
 	return resp, nil
@@ -695,7 +777,8 @@ func (l *LROsServerTransport) dispatchBeginPatch200SucceededIgnoreHeaders(req *h
 	if l.srv.BeginPatch200SucceededIgnoreHeaders == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPatch200SucceededIgnoreHeaders not implemented")}
 	}
-	if l.beginPatch200SucceededIgnoreHeaders == nil {
+	beginPatch200SucceededIgnoreHeaders := l.beginPatch200SucceededIgnoreHeaders.get(req)
+	if beginPatch200SucceededIgnoreHeaders == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -704,19 +787,21 @@ func (l *LROsServerTransport) dispatchBeginPatch200SucceededIgnoreHeaders(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPatch200SucceededIgnoreHeaders = &respr
+		beginPatch200SucceededIgnoreHeaders = &respr
+		l.beginPatch200SucceededIgnoreHeaders.add(req, beginPatch200SucceededIgnoreHeaders)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPatch200SucceededIgnoreHeaders, req)
+	resp, err := server.PollerResponderNext(beginPatch200SucceededIgnoreHeaders, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPatch200SucceededIgnoreHeaders.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPatch200SucceededIgnoreHeaders) {
-		l.beginPatch200SucceededIgnoreHeaders = nil
+	if !server.PollerResponderMore(beginPatch200SucceededIgnoreHeaders) {
+		l.beginPatch200SucceededIgnoreHeaders.remove(req)
 	}
 
 	return resp, nil
@@ -726,7 +811,8 @@ func (l *LROsServerTransport) dispatchBeginPatch201RetryWithAsyncHeader(req *htt
 	if l.srv.BeginPatch201RetryWithAsyncHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPatch201RetryWithAsyncHeader not implemented")}
 	}
-	if l.beginPatch201RetryWithAsyncHeader == nil {
+	beginPatch201RetryWithAsyncHeader := l.beginPatch201RetryWithAsyncHeader.get(req)
+	if beginPatch201RetryWithAsyncHeader == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -735,19 +821,21 @@ func (l *LROsServerTransport) dispatchBeginPatch201RetryWithAsyncHeader(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPatch201RetryWithAsyncHeader = &respr
+		beginPatch201RetryWithAsyncHeader = &respr
+		l.beginPatch201RetryWithAsyncHeader.add(req, beginPatch201RetryWithAsyncHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPatch201RetryWithAsyncHeader, req)
+	resp, err := server.PollerResponderNext(beginPatch201RetryWithAsyncHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPatch201RetryWithAsyncHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPatch201RetryWithAsyncHeader) {
-		l.beginPatch201RetryWithAsyncHeader = nil
+	if !server.PollerResponderMore(beginPatch201RetryWithAsyncHeader) {
+		l.beginPatch201RetryWithAsyncHeader.remove(req)
 	}
 
 	return resp, nil
@@ -757,7 +845,8 @@ func (l *LROsServerTransport) dispatchBeginPatch202RetryWithAsyncAndLocationHead
 	if l.srv.BeginPatch202RetryWithAsyncAndLocationHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPatch202RetryWithAsyncAndLocationHeader not implemented")}
 	}
-	if l.beginPatch202RetryWithAsyncAndLocationHeader == nil {
+	beginPatch202RetryWithAsyncAndLocationHeader := l.beginPatch202RetryWithAsyncAndLocationHeader.get(req)
+	if beginPatch202RetryWithAsyncAndLocationHeader == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -766,19 +855,21 @@ func (l *LROsServerTransport) dispatchBeginPatch202RetryWithAsyncAndLocationHead
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPatch202RetryWithAsyncAndLocationHeader = &respr
+		beginPatch202RetryWithAsyncAndLocationHeader = &respr
+		l.beginPatch202RetryWithAsyncAndLocationHeader.add(req, beginPatch202RetryWithAsyncAndLocationHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPatch202RetryWithAsyncAndLocationHeader, req)
+	resp, err := server.PollerResponderNext(beginPatch202RetryWithAsyncAndLocationHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginPatch202RetryWithAsyncAndLocationHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPatch202RetryWithAsyncAndLocationHeader) {
-		l.beginPatch202RetryWithAsyncAndLocationHeader = nil
+	if !server.PollerResponderMore(beginPatch202RetryWithAsyncAndLocationHeader) {
+		l.beginPatch202RetryWithAsyncAndLocationHeader.remove(req)
 	}
 
 	return resp, nil
@@ -788,24 +879,27 @@ func (l *LROsServerTransport) dispatchBeginPost200WithPayload(req *http.Request)
 	if l.srv.BeginPost200WithPayload == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost200WithPayload not implemented")}
 	}
-	if l.beginPost200WithPayload == nil {
+	beginPost200WithPayload := l.beginPost200WithPayload.get(req)
+	if beginPost200WithPayload == nil {
 		respr, errRespr := l.srv.BeginPost200WithPayload(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost200WithPayload = &respr
+		beginPost200WithPayload = &respr
+		l.beginPost200WithPayload.add(req, beginPost200WithPayload)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost200WithPayload, req)
+	resp, err := server.PollerResponderNext(beginPost200WithPayload, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost200WithPayload.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost200WithPayload) {
-		l.beginPost200WithPayload = nil
+	if !server.PollerResponderMore(beginPost200WithPayload) {
+		l.beginPost200WithPayload.remove(req)
 	}
 
 	return resp, nil
@@ -815,24 +909,27 @@ func (l *LROsServerTransport) dispatchBeginPost202List(req *http.Request) (*http
 	if l.srv.BeginPost202List == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202List not implemented")}
 	}
-	if l.beginPost202List == nil {
+	beginPost202List := l.beginPost202List.get(req)
+	if beginPost202List == nil {
 		respr, errRespr := l.srv.BeginPost202List(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202List = &respr
+		beginPost202List = &respr
+		l.beginPost202List.add(req, beginPost202List)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202List, req)
+	resp, err := server.PollerResponderNext(beginPost202List, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202List.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202List) {
-		l.beginPost202List = nil
+	if !server.PollerResponderMore(beginPost202List) {
+		l.beginPost202List.remove(req)
 	}
 
 	return resp, nil
@@ -842,7 +939,8 @@ func (l *LROsServerTransport) dispatchBeginPost202NoRetry204(req *http.Request) 
 	if l.srv.BeginPost202NoRetry204 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202NoRetry204 not implemented")}
 	}
-	if l.beginPost202NoRetry204 == nil {
+	beginPost202NoRetry204 := l.beginPost202NoRetry204.get(req)
+	if beginPost202NoRetry204 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -857,19 +955,21 @@ func (l *LROsServerTransport) dispatchBeginPost202NoRetry204(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202NoRetry204 = &respr
+		beginPost202NoRetry204 = &respr
+		l.beginPost202NoRetry204.add(req, beginPost202NoRetry204)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202NoRetry204, req)
+	resp, err := server.PollerResponderNext(beginPost202NoRetry204, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202NoRetry204.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202NoRetry204) {
-		l.beginPost202NoRetry204 = nil
+	if !server.PollerResponderMore(beginPost202NoRetry204) {
+		l.beginPost202NoRetry204.remove(req)
 	}
 
 	return resp, nil
@@ -879,7 +979,8 @@ func (l *LROsServerTransport) dispatchBeginPost202Retry200(req *http.Request) (*
 	if l.srv.BeginPost202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202Retry200 not implemented")}
 	}
-	if l.beginPost202Retry200 == nil {
+	beginPost202Retry200 := l.beginPost202Retry200.get(req)
+	if beginPost202Retry200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -894,19 +995,21 @@ func (l *LROsServerTransport) dispatchBeginPost202Retry200(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202Retry200 = &respr
+		beginPost202Retry200 = &respr
+		l.beginPost202Retry200.add(req, beginPost202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202Retry200, req)
+	resp, err := server.PollerResponderNext(beginPost202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202Retry200) {
-		l.beginPost202Retry200 = nil
+	if !server.PollerResponderMore(beginPost202Retry200) {
+		l.beginPost202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -916,7 +1019,8 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncNoRetrySucceeded(req *http.R
 	if l.srv.BeginPostAsyncNoRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncNoRetrySucceeded not implemented")}
 	}
-	if l.beginPostAsyncNoRetrySucceeded == nil {
+	beginPostAsyncNoRetrySucceeded := l.beginPostAsyncNoRetrySucceeded.get(req)
+	if beginPostAsyncNoRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -931,19 +1035,21 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncNoRetrySucceeded(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncNoRetrySucceeded = &respr
+		beginPostAsyncNoRetrySucceeded = &respr
+		l.beginPostAsyncNoRetrySucceeded.add(req, beginPostAsyncNoRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncNoRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncNoRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncNoRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncNoRetrySucceeded) {
-		l.beginPostAsyncNoRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPostAsyncNoRetrySucceeded) {
+		l.beginPostAsyncNoRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -953,7 +1059,8 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetryFailed(req *http.Reques
 	if l.srv.BeginPostAsyncRetryFailed == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRetryFailed not implemented")}
 	}
-	if l.beginPostAsyncRetryFailed == nil {
+	beginPostAsyncRetryFailed := l.beginPostAsyncRetryFailed.get(req)
+	if beginPostAsyncRetryFailed == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -968,19 +1075,21 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetryFailed(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRetryFailed = &respr
+		beginPostAsyncRetryFailed = &respr
+		l.beginPostAsyncRetryFailed.add(req, beginPostAsyncRetryFailed)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRetryFailed, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRetryFailed, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRetryFailed.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRetryFailed) {
-		l.beginPostAsyncRetryFailed = nil
+	if !server.PollerResponderMore(beginPostAsyncRetryFailed) {
+		l.beginPostAsyncRetryFailed.remove(req)
 	}
 
 	return resp, nil
@@ -990,7 +1099,8 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetrySucceeded(req *http.Req
 	if l.srv.BeginPostAsyncRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRetrySucceeded not implemented")}
 	}
-	if l.beginPostAsyncRetrySucceeded == nil {
+	beginPostAsyncRetrySucceeded := l.beginPostAsyncRetrySucceeded.get(req)
+	if beginPostAsyncRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1005,19 +1115,21 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetrySucceeded(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRetrySucceeded = &respr
+		beginPostAsyncRetrySucceeded = &respr
+		l.beginPostAsyncRetrySucceeded.add(req, beginPostAsyncRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRetrySucceeded) {
-		l.beginPostAsyncRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPostAsyncRetrySucceeded) {
+		l.beginPostAsyncRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -1027,7 +1139,8 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetrycanceled(req *http.Requ
 	if l.srv.BeginPostAsyncRetrycanceled == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRetrycanceled not implemented")}
 	}
-	if l.beginPostAsyncRetrycanceled == nil {
+	beginPostAsyncRetrycanceled := l.beginPostAsyncRetrycanceled.get(req)
+	if beginPostAsyncRetrycanceled == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1042,19 +1155,21 @@ func (l *LROsServerTransport) dispatchBeginPostAsyncRetrycanceled(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRetrycanceled = &respr
+		beginPostAsyncRetrycanceled = &respr
+		l.beginPostAsyncRetrycanceled.add(req, beginPostAsyncRetrycanceled)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRetrycanceled, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRetrycanceled, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRetrycanceled.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRetrycanceled) {
-		l.beginPostAsyncRetrycanceled = nil
+	if !server.PollerResponderMore(beginPostAsyncRetrycanceled) {
+		l.beginPostAsyncRetrycanceled.remove(req)
 	}
 
 	return resp, nil
@@ -1064,24 +1179,27 @@ func (l *LROsServerTransport) dispatchBeginPostDoubleHeadersFinalAzureHeaderGet(
 	if l.srv.BeginPostDoubleHeadersFinalAzureHeaderGet == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostDoubleHeadersFinalAzureHeaderGet not implemented")}
 	}
-	if l.beginPostDoubleHeadersFinalAzureHeaderGet == nil {
+	beginPostDoubleHeadersFinalAzureHeaderGet := l.beginPostDoubleHeadersFinalAzureHeaderGet.get(req)
+	if beginPostDoubleHeadersFinalAzureHeaderGet == nil {
 		respr, errRespr := l.srv.BeginPostDoubleHeadersFinalAzureHeaderGet(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostDoubleHeadersFinalAzureHeaderGet = &respr
+		beginPostDoubleHeadersFinalAzureHeaderGet = &respr
+		l.beginPostDoubleHeadersFinalAzureHeaderGet.add(req, beginPostDoubleHeadersFinalAzureHeaderGet)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostDoubleHeadersFinalAzureHeaderGet, req)
+	resp, err := server.PollerResponderNext(beginPostDoubleHeadersFinalAzureHeaderGet, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostDoubleHeadersFinalAzureHeaderGet.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostDoubleHeadersFinalAzureHeaderGet) {
-		l.beginPostDoubleHeadersFinalAzureHeaderGet = nil
+	if !server.PollerResponderMore(beginPostDoubleHeadersFinalAzureHeaderGet) {
+		l.beginPostDoubleHeadersFinalAzureHeaderGet.remove(req)
 	}
 
 	return resp, nil
@@ -1091,24 +1209,27 @@ func (l *LROsServerTransport) dispatchBeginPostDoubleHeadersFinalAzureHeaderGetD
 	if l.srv.BeginPostDoubleHeadersFinalAzureHeaderGetDefault == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostDoubleHeadersFinalAzureHeaderGetDefault not implemented")}
 	}
-	if l.beginPostDoubleHeadersFinalAzureHeaderGetDefault == nil {
+	beginPostDoubleHeadersFinalAzureHeaderGetDefault := l.beginPostDoubleHeadersFinalAzureHeaderGetDefault.get(req)
+	if beginPostDoubleHeadersFinalAzureHeaderGetDefault == nil {
 		respr, errRespr := l.srv.BeginPostDoubleHeadersFinalAzureHeaderGetDefault(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostDoubleHeadersFinalAzureHeaderGetDefault = &respr
+		beginPostDoubleHeadersFinalAzureHeaderGetDefault = &respr
+		l.beginPostDoubleHeadersFinalAzureHeaderGetDefault.add(req, beginPostDoubleHeadersFinalAzureHeaderGetDefault)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostDoubleHeadersFinalAzureHeaderGetDefault, req)
+	resp, err := server.PollerResponderNext(beginPostDoubleHeadersFinalAzureHeaderGetDefault, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostDoubleHeadersFinalAzureHeaderGetDefault.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostDoubleHeadersFinalAzureHeaderGetDefault) {
-		l.beginPostDoubleHeadersFinalAzureHeaderGetDefault = nil
+	if !server.PollerResponderMore(beginPostDoubleHeadersFinalAzureHeaderGetDefault) {
+		l.beginPostDoubleHeadersFinalAzureHeaderGetDefault.remove(req)
 	}
 
 	return resp, nil
@@ -1118,24 +1239,27 @@ func (l *LROsServerTransport) dispatchBeginPostDoubleHeadersFinalLocationGet(req
 	if l.srv.BeginPostDoubleHeadersFinalLocationGet == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostDoubleHeadersFinalLocationGet not implemented")}
 	}
-	if l.beginPostDoubleHeadersFinalLocationGet == nil {
+	beginPostDoubleHeadersFinalLocationGet := l.beginPostDoubleHeadersFinalLocationGet.get(req)
+	if beginPostDoubleHeadersFinalLocationGet == nil {
 		respr, errRespr := l.srv.BeginPostDoubleHeadersFinalLocationGet(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostDoubleHeadersFinalLocationGet = &respr
+		beginPostDoubleHeadersFinalLocationGet = &respr
+		l.beginPostDoubleHeadersFinalLocationGet.add(req, beginPostDoubleHeadersFinalLocationGet)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostDoubleHeadersFinalLocationGet, req)
+	resp, err := server.PollerResponderNext(beginPostDoubleHeadersFinalLocationGet, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostDoubleHeadersFinalLocationGet.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostDoubleHeadersFinalLocationGet) {
-		l.beginPostDoubleHeadersFinalLocationGet = nil
+	if !server.PollerResponderMore(beginPostDoubleHeadersFinalLocationGet) {
+		l.beginPostDoubleHeadersFinalLocationGet.remove(req)
 	}
 
 	return resp, nil
@@ -1145,7 +1269,8 @@ func (l *LROsServerTransport) dispatchBeginPut200Acceptedcanceled200(req *http.R
 	if l.srv.BeginPut200Acceptedcanceled200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut200Acceptedcanceled200 not implemented")}
 	}
-	if l.beginPut200Acceptedcanceled200 == nil {
+	beginPut200Acceptedcanceled200 := l.beginPut200Acceptedcanceled200.get(req)
+	if beginPut200Acceptedcanceled200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1154,19 +1279,21 @@ func (l *LROsServerTransport) dispatchBeginPut200Acceptedcanceled200(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut200Acceptedcanceled200 = &respr
+		beginPut200Acceptedcanceled200 = &respr
+		l.beginPut200Acceptedcanceled200.add(req, beginPut200Acceptedcanceled200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut200Acceptedcanceled200, req)
+	resp, err := server.PollerResponderNext(beginPut200Acceptedcanceled200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPut200Acceptedcanceled200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut200Acceptedcanceled200) {
-		l.beginPut200Acceptedcanceled200 = nil
+	if !server.PollerResponderMore(beginPut200Acceptedcanceled200) {
+		l.beginPut200Acceptedcanceled200.remove(req)
 	}
 
 	return resp, nil
@@ -1176,7 +1303,8 @@ func (l *LROsServerTransport) dispatchBeginPut200Succeeded(req *http.Request) (*
 	if l.srv.BeginPut200Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut200Succeeded not implemented")}
 	}
-	if l.beginPut200Succeeded == nil {
+	beginPut200Succeeded := l.beginPut200Succeeded.get(req)
+	if beginPut200Succeeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1185,19 +1313,21 @@ func (l *LROsServerTransport) dispatchBeginPut200Succeeded(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut200Succeeded = &respr
+		beginPut200Succeeded = &respr
+		l.beginPut200Succeeded.add(req, beginPut200Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut200Succeeded, req)
+	resp, err := server.PollerResponderNext(beginPut200Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusNoContent}, resp.StatusCode) {
+		l.beginPut200Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut200Succeeded) {
-		l.beginPut200Succeeded = nil
+	if !server.PollerResponderMore(beginPut200Succeeded) {
+		l.beginPut200Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -1207,7 +1337,8 @@ func (l *LROsServerTransport) dispatchBeginPut200SucceededNoState(req *http.Requ
 	if l.srv.BeginPut200SucceededNoState == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut200SucceededNoState not implemented")}
 	}
-	if l.beginPut200SucceededNoState == nil {
+	beginPut200SucceededNoState := l.beginPut200SucceededNoState.get(req)
+	if beginPut200SucceededNoState == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1216,19 +1347,21 @@ func (l *LROsServerTransport) dispatchBeginPut200SucceededNoState(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut200SucceededNoState = &respr
+		beginPut200SucceededNoState = &respr
+		l.beginPut200SucceededNoState.add(req, beginPut200SucceededNoState)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut200SucceededNoState, req)
+	resp, err := server.PollerResponderNext(beginPut200SucceededNoState, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPut200SucceededNoState.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut200SucceededNoState) {
-		l.beginPut200SucceededNoState = nil
+	if !server.PollerResponderMore(beginPut200SucceededNoState) {
+		l.beginPut200SucceededNoState.remove(req)
 	}
 
 	return resp, nil
@@ -1238,7 +1371,8 @@ func (l *LROsServerTransport) dispatchBeginPut200UpdatingSucceeded204(req *http.
 	if l.srv.BeginPut200UpdatingSucceeded204 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut200UpdatingSucceeded204 not implemented")}
 	}
-	if l.beginPut200UpdatingSucceeded204 == nil {
+	beginPut200UpdatingSucceeded204 := l.beginPut200UpdatingSucceeded204.get(req)
+	if beginPut200UpdatingSucceeded204 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1247,19 +1381,21 @@ func (l *LROsServerTransport) dispatchBeginPut200UpdatingSucceeded204(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut200UpdatingSucceeded204 = &respr
+		beginPut200UpdatingSucceeded204 = &respr
+		l.beginPut200UpdatingSucceeded204.add(req, beginPut200UpdatingSucceeded204)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut200UpdatingSucceeded204, req)
+	resp, err := server.PollerResponderNext(beginPut200UpdatingSucceeded204, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPut200UpdatingSucceeded204.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut200UpdatingSucceeded204) {
-		l.beginPut200UpdatingSucceeded204 = nil
+	if !server.PollerResponderMore(beginPut200UpdatingSucceeded204) {
+		l.beginPut200UpdatingSucceeded204.remove(req)
 	}
 
 	return resp, nil
@@ -1269,7 +1405,8 @@ func (l *LROsServerTransport) dispatchBeginPut201CreatingFailed200(req *http.Req
 	if l.srv.BeginPut201CreatingFailed200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut201CreatingFailed200 not implemented")}
 	}
-	if l.beginPut201CreatingFailed200 == nil {
+	beginPut201CreatingFailed200 := l.beginPut201CreatingFailed200.get(req)
+	if beginPut201CreatingFailed200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1278,19 +1415,21 @@ func (l *LROsServerTransport) dispatchBeginPut201CreatingFailed200(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut201CreatingFailed200 = &respr
+		beginPut201CreatingFailed200 = &respr
+		l.beginPut201CreatingFailed200.add(req, beginPut201CreatingFailed200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut201CreatingFailed200, req)
+	resp, err := server.PollerResponderNext(beginPut201CreatingFailed200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPut201CreatingFailed200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut201CreatingFailed200) {
-		l.beginPut201CreatingFailed200 = nil
+	if !server.PollerResponderMore(beginPut201CreatingFailed200) {
+		l.beginPut201CreatingFailed200.remove(req)
 	}
 
 	return resp, nil
@@ -1300,7 +1439,8 @@ func (l *LROsServerTransport) dispatchBeginPut201CreatingSucceeded200(req *http.
 	if l.srv.BeginPut201CreatingSucceeded200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut201CreatingSucceeded200 not implemented")}
 	}
-	if l.beginPut201CreatingSucceeded200 == nil {
+	beginPut201CreatingSucceeded200 := l.beginPut201CreatingSucceeded200.get(req)
+	if beginPut201CreatingSucceeded200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1309,19 +1449,21 @@ func (l *LROsServerTransport) dispatchBeginPut201CreatingSucceeded200(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut201CreatingSucceeded200 = &respr
+		beginPut201CreatingSucceeded200 = &respr
+		l.beginPut201CreatingSucceeded200.add(req, beginPut201CreatingSucceeded200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut201CreatingSucceeded200, req)
+	resp, err := server.PollerResponderNext(beginPut201CreatingSucceeded200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut201CreatingSucceeded200) {
-		l.beginPut201CreatingSucceeded200 = nil
+	if !server.PollerResponderMore(beginPut201CreatingSucceeded200) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 	}
 
 	return resp, nil
@@ -1331,7 +1473,8 @@ func (l *LROsServerTransport) dispatchBeginPut201Succeeded(req *http.Request) (*
 	if l.srv.BeginPut201Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut201Succeeded not implemented")}
 	}
-	if l.beginPut201Succeeded == nil {
+	beginPut201Succeeded := l.beginPut201Succeeded.get(req)
+	if beginPut201Succeeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1340,19 +1483,21 @@ func (l *LROsServerTransport) dispatchBeginPut201Succeeded(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut201Succeeded = &respr
+		beginPut201Succeeded = &respr
+		l.beginPut201Succeeded.add(req, beginPut201Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut201Succeeded, req)
+	resp, err := server.PollerResponderNext(beginPut201Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusCreated}, resp.StatusCode) {
+		l.beginPut201Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut201Succeeded) {
-		l.beginPut201Succeeded = nil
+	if !server.PollerResponderMore(beginPut201Succeeded) {
+		l.beginPut201Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -1362,7 +1507,8 @@ func (l *LROsServerTransport) dispatchBeginPut202Retry200(req *http.Request) (*h
 	if l.srv.BeginPut202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut202Retry200 not implemented")}
 	}
-	if l.beginPut202Retry200 == nil {
+	beginPut202Retry200 := l.beginPut202Retry200.get(req)
+	if beginPut202Retry200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1371,19 +1517,21 @@ func (l *LROsServerTransport) dispatchBeginPut202Retry200(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut202Retry200 = &respr
+		beginPut202Retry200 = &respr
+		l.beginPut202Retry200.add(req, beginPut202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut202Retry200, req)
+	resp, err := server.PollerResponderNext(beginPut202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPut202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut202Retry200) {
-		l.beginPut202Retry200 = nil
+	if !server.PollerResponderMore(beginPut202Retry200) {
+		l.beginPut202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -1393,7 +1541,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoHeaderInRetry(req *http.Req
 	if l.srv.BeginPutAsyncNoHeaderInRetry == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncNoHeaderInRetry not implemented")}
 	}
-	if l.beginPutAsyncNoHeaderInRetry == nil {
+	beginPutAsyncNoHeaderInRetry := l.beginPutAsyncNoHeaderInRetry.get(req)
+	if beginPutAsyncNoHeaderInRetry == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1402,19 +1551,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoHeaderInRetry(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncNoHeaderInRetry = &respr
+		beginPutAsyncNoHeaderInRetry = &respr
+		l.beginPutAsyncNoHeaderInRetry.add(req, beginPutAsyncNoHeaderInRetry)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncNoHeaderInRetry, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncNoHeaderInRetry, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusCreated}, resp.StatusCode) {
+		l.beginPutAsyncNoHeaderInRetry.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncNoHeaderInRetry) {
-		l.beginPutAsyncNoHeaderInRetry = nil
+	if !server.PollerResponderMore(beginPutAsyncNoHeaderInRetry) {
+		l.beginPutAsyncNoHeaderInRetry.remove(req)
 	}
 
 	return resp, nil
@@ -1424,7 +1575,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoRetrySucceeded(req *http.Re
 	if l.srv.BeginPutAsyncNoRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncNoRetrySucceeded not implemented")}
 	}
-	if l.beginPutAsyncNoRetrySucceeded == nil {
+	beginPutAsyncNoRetrySucceeded := l.beginPutAsyncNoRetrySucceeded.get(req)
+	if beginPutAsyncNoRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1433,19 +1585,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoRetrySucceeded(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncNoRetrySucceeded = &respr
+		beginPutAsyncNoRetrySucceeded = &respr
+		l.beginPutAsyncNoRetrySucceeded.add(req, beginPutAsyncNoRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncNoRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncNoRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncNoRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncNoRetrySucceeded) {
-		l.beginPutAsyncNoRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPutAsyncNoRetrySucceeded) {
+		l.beginPutAsyncNoRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -1455,7 +1609,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoRetrycanceled(req *http.Req
 	if l.srv.BeginPutAsyncNoRetrycanceled == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncNoRetrycanceled not implemented")}
 	}
-	if l.beginPutAsyncNoRetrycanceled == nil {
+	beginPutAsyncNoRetrycanceled := l.beginPutAsyncNoRetrycanceled.get(req)
+	if beginPutAsyncNoRetrycanceled == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1464,19 +1619,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNoRetrycanceled(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncNoRetrycanceled = &respr
+		beginPutAsyncNoRetrycanceled = &respr
+		l.beginPutAsyncNoRetrycanceled.add(req, beginPutAsyncNoRetrycanceled)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncNoRetrycanceled, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncNoRetrycanceled, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncNoRetrycanceled.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncNoRetrycanceled) {
-		l.beginPutAsyncNoRetrycanceled = nil
+	if !server.PollerResponderMore(beginPutAsyncNoRetrycanceled) {
+		l.beginPutAsyncNoRetrycanceled.remove(req)
 	}
 
 	return resp, nil
@@ -1486,7 +1643,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNonResource(req *http.Request
 	if l.srv.BeginPutAsyncNonResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncNonResource not implemented")}
 	}
-	if l.beginPutAsyncNonResource == nil {
+	beginPutAsyncNonResource := l.beginPutAsyncNonResource.get(req)
+	if beginPutAsyncNonResource == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.SKU](req)
 		if err != nil {
 			return nil, err
@@ -1495,19 +1653,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncNonResource(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncNonResource = &respr
+		beginPutAsyncNonResource = &respr
+		l.beginPutAsyncNonResource.add(req, beginPutAsyncNonResource)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncNonResource, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncNonResource, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPutAsyncNonResource.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncNonResource) {
-		l.beginPutAsyncNonResource = nil
+	if !server.PollerResponderMore(beginPutAsyncNonResource) {
+		l.beginPutAsyncNonResource.remove(req)
 	}
 
 	return resp, nil
@@ -1517,7 +1677,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncRetryFailed(req *http.Request
 	if l.srv.BeginPutAsyncRetryFailed == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRetryFailed not implemented")}
 	}
-	if l.beginPutAsyncRetryFailed == nil {
+	beginPutAsyncRetryFailed := l.beginPutAsyncRetryFailed.get(req)
+	if beginPutAsyncRetryFailed == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1526,19 +1687,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncRetryFailed(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRetryFailed = &respr
+		beginPutAsyncRetryFailed = &respr
+		l.beginPutAsyncRetryFailed.add(req, beginPutAsyncRetryFailed)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRetryFailed, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRetryFailed, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRetryFailed.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRetryFailed) {
-		l.beginPutAsyncRetryFailed = nil
+	if !server.PollerResponderMore(beginPutAsyncRetryFailed) {
+		l.beginPutAsyncRetryFailed.remove(req)
 	}
 
 	return resp, nil
@@ -1548,7 +1711,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncRetrySucceeded(req *http.Requ
 	if l.srv.BeginPutAsyncRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRetrySucceeded not implemented")}
 	}
-	if l.beginPutAsyncRetrySucceeded == nil {
+	beginPutAsyncRetrySucceeded := l.beginPutAsyncRetrySucceeded.get(req)
+	if beginPutAsyncRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1557,19 +1721,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncRetrySucceeded(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRetrySucceeded = &respr
+		beginPutAsyncRetrySucceeded = &respr
+		l.beginPutAsyncRetrySucceeded.add(req, beginPutAsyncRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRetrySucceeded) {
-		l.beginPutAsyncRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPutAsyncRetrySucceeded) {
+		l.beginPutAsyncRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -1579,7 +1745,8 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncSubResource(req *http.Request
 	if l.srv.BeginPutAsyncSubResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncSubResource not implemented")}
 	}
-	if l.beginPutAsyncSubResource == nil {
+	beginPutAsyncSubResource := l.beginPutAsyncSubResource.get(req)
+	if beginPutAsyncSubResource == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.SubProduct](req)
 		if err != nil {
 			return nil, err
@@ -1588,19 +1755,21 @@ func (l *LROsServerTransport) dispatchBeginPutAsyncSubResource(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncSubResource = &respr
+		beginPutAsyncSubResource = &respr
+		l.beginPutAsyncSubResource.add(req, beginPutAsyncSubResource)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncSubResource, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncSubResource, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPutAsyncSubResource.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncSubResource) {
-		l.beginPutAsyncSubResource = nil
+	if !server.PollerResponderMore(beginPutAsyncSubResource) {
+		l.beginPutAsyncSubResource.remove(req)
 	}
 
 	return resp, nil
@@ -1610,7 +1779,8 @@ func (l *LROsServerTransport) dispatchBeginPutNoHeaderInRetry(req *http.Request)
 	if l.srv.BeginPutNoHeaderInRetry == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutNoHeaderInRetry not implemented")}
 	}
-	if l.beginPutNoHeaderInRetry == nil {
+	beginPutNoHeaderInRetry := l.beginPutNoHeaderInRetry.get(req)
+	if beginPutNoHeaderInRetry == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1619,19 +1789,21 @@ func (l *LROsServerTransport) dispatchBeginPutNoHeaderInRetry(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutNoHeaderInRetry = &respr
+		beginPutNoHeaderInRetry = &respr
+		l.beginPutNoHeaderInRetry.add(req, beginPutNoHeaderInRetry)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutNoHeaderInRetry, req)
+	resp, err := server.PollerResponderNext(beginPutNoHeaderInRetry, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPutNoHeaderInRetry.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutNoHeaderInRetry) {
-		l.beginPutNoHeaderInRetry = nil
+	if !server.PollerResponderMore(beginPutNoHeaderInRetry) {
+		l.beginPutNoHeaderInRetry.remove(req)
 	}
 
 	return resp, nil
@@ -1641,7 +1813,8 @@ func (l *LROsServerTransport) dispatchBeginPutNonResource(req *http.Request) (*h
 	if l.srv.BeginPutNonResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutNonResource not implemented")}
 	}
-	if l.beginPutNonResource == nil {
+	beginPutNonResource := l.beginPutNonResource.get(req)
+	if beginPutNonResource == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.SKU](req)
 		if err != nil {
 			return nil, err
@@ -1650,19 +1823,21 @@ func (l *LROsServerTransport) dispatchBeginPutNonResource(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutNonResource = &respr
+		beginPutNonResource = &respr
+		l.beginPutNonResource.add(req, beginPutNonResource)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutNonResource, req)
+	resp, err := server.PollerResponderNext(beginPutNonResource, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPutNonResource.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutNonResource) {
-		l.beginPutNonResource = nil
+	if !server.PollerResponderMore(beginPutNonResource) {
+		l.beginPutNonResource.remove(req)
 	}
 
 	return resp, nil
@@ -1672,7 +1847,8 @@ func (l *LROsServerTransport) dispatchBeginPutSubResource(req *http.Request) (*h
 	if l.srv.BeginPutSubResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutSubResource not implemented")}
 	}
-	if l.beginPutSubResource == nil {
+	beginPutSubResource := l.beginPutSubResource.get(req)
+	if beginPutSubResource == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.SubProduct](req)
 		if err != nil {
 			return nil, err
@@ -1681,19 +1857,21 @@ func (l *LROsServerTransport) dispatchBeginPutSubResource(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutSubResource = &respr
+		beginPutSubResource = &respr
+		l.beginPutSubResource.add(req, beginPutSubResource)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutSubResource, req)
+	resp, err := server.PollerResponderNext(beginPutSubResource, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPutSubResource.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutSubResource) {
-		l.beginPutSubResource = nil
+	if !server.PollerResponderMore(beginPutSubResource) {
+		l.beginPutSubResource.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_lrosads_server.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_lrosads_server.go
@@ -131,39 +131,67 @@ type LROSADsServer struct {
 // The returned LROSADsServerTransport instance is connected to an instance of lrogroup.LROSADsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLROSADsServerTransport(srv *LROSADsServer) *LROSADsServerTransport {
-	return &LROSADsServerTransport{srv: srv}
+	return &LROSADsServerTransport{
+		srv:                                             srv,
+		beginDelete202NonRetry400:                       newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete202NonRetry400Response]](),
+		beginDelete202RetryInvalidHeader:                newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete202RetryInvalidHeaderResponse]](),
+		beginDelete204Succeeded:                         newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete204SucceededResponse]](),
+		beginDeleteAsyncRelativeRetry400:                newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetry400Response]](),
+		beginDeleteAsyncRelativeRetryInvalidHeader:      newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse]](),
+		beginDeleteAsyncRelativeRetryInvalidJSONPolling: newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse]](),
+		beginDeleteAsyncRelativeRetryNoStatus:           newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse]](),
+		beginDeleteNonRetry400:                          newTracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteNonRetry400Response]](),
+		beginPost202NoLocation:                          newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202NoLocationResponse]](),
+		beginPost202NonRetry400:                         newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202NonRetry400Response]](),
+		beginPost202RetryInvalidHeader:                  newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202RetryInvalidHeaderResponse]](),
+		beginPostAsyncRelativeRetry400:                  newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetry400Response]](),
+		beginPostAsyncRelativeRetryInvalidHeader:        newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse]](),
+		beginPostAsyncRelativeRetryInvalidJSONPolling:   newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse]](),
+		beginPostAsyncRelativeRetryNoPayload:            newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryNoPayloadResponse]](),
+		beginPostNonRetry400:                            newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPostNonRetry400Response]](),
+		beginPut200InvalidJSON:                          newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPut200InvalidJSONResponse]](),
+		beginPutAsyncRelativeRetry400:                   newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetry400Response]](),
+		beginPutAsyncRelativeRetryInvalidHeader:         newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse]](),
+		beginPutAsyncRelativeRetryInvalidJSONPolling:    newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse]](),
+		beginPutAsyncRelativeRetryNoStatus:              newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusResponse]](),
+		beginPutAsyncRelativeRetryNoStatusPayload:       newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse]](),
+		beginPutError201NoProvisioningStatePayload:      newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutError201NoProvisioningStatePayloadResponse]](),
+		beginPutNonRetry201Creating400:                  newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400Response]](),
+		beginPutNonRetry201Creating400InvalidJSON:       newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400InvalidJSONResponse]](),
+		beginPutNonRetry400:                             newTracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry400Response]](),
+	}
 }
 
 // LROSADsServerTransport connects instances of lrogroup.LROSADsClient to instances of LROSADsServer.
 // Don't use this type directly, use NewLROSADsServerTransport instead.
 type LROSADsServerTransport struct {
 	srv                                             *LROSADsServer
-	beginDelete202NonRetry400                       *azfake.PollerResponder[lrogroup.LROSADsClientDelete202NonRetry400Response]
-	beginDelete202RetryInvalidHeader                *azfake.PollerResponder[lrogroup.LROSADsClientDelete202RetryInvalidHeaderResponse]
-	beginDelete204Succeeded                         *azfake.PollerResponder[lrogroup.LROSADsClientDelete204SucceededResponse]
-	beginDeleteAsyncRelativeRetry400                *azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetry400Response]
-	beginDeleteAsyncRelativeRetryInvalidHeader      *azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse]
-	beginDeleteAsyncRelativeRetryInvalidJSONPolling *azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse]
-	beginDeleteAsyncRelativeRetryNoStatus           *azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse]
-	beginDeleteNonRetry400                          *azfake.PollerResponder[lrogroup.LROSADsClientDeleteNonRetry400Response]
-	beginPost202NoLocation                          *azfake.PollerResponder[lrogroup.LROSADsClientPost202NoLocationResponse]
-	beginPost202NonRetry400                         *azfake.PollerResponder[lrogroup.LROSADsClientPost202NonRetry400Response]
-	beginPost202RetryInvalidHeader                  *azfake.PollerResponder[lrogroup.LROSADsClientPost202RetryInvalidHeaderResponse]
-	beginPostAsyncRelativeRetry400                  *azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetry400Response]
-	beginPostAsyncRelativeRetryInvalidHeader        *azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse]
-	beginPostAsyncRelativeRetryInvalidJSONPolling   *azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse]
-	beginPostAsyncRelativeRetryNoPayload            *azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryNoPayloadResponse]
-	beginPostNonRetry400                            *azfake.PollerResponder[lrogroup.LROSADsClientPostNonRetry400Response]
-	beginPut200InvalidJSON                          *azfake.PollerResponder[lrogroup.LROSADsClientPut200InvalidJSONResponse]
-	beginPutAsyncRelativeRetry400                   *azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetry400Response]
-	beginPutAsyncRelativeRetryInvalidHeader         *azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse]
-	beginPutAsyncRelativeRetryInvalidJSONPolling    *azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse]
-	beginPutAsyncRelativeRetryNoStatus              *azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusResponse]
-	beginPutAsyncRelativeRetryNoStatusPayload       *azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse]
-	beginPutError201NoProvisioningStatePayload      *azfake.PollerResponder[lrogroup.LROSADsClientPutError201NoProvisioningStatePayloadResponse]
-	beginPutNonRetry201Creating400                  *azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400Response]
-	beginPutNonRetry201Creating400InvalidJSON       *azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400InvalidJSONResponse]
-	beginPutNonRetry400                             *azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry400Response]
+	beginDelete202NonRetry400                       *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete202NonRetry400Response]]
+	beginDelete202RetryInvalidHeader                *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete202RetryInvalidHeaderResponse]]
+	beginDelete204Succeeded                         *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDelete204SucceededResponse]]
+	beginDeleteAsyncRelativeRetry400                *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetry400Response]]
+	beginDeleteAsyncRelativeRetryInvalidHeader      *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidHeaderResponse]]
+	beginDeleteAsyncRelativeRetryInvalidJSONPolling *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryInvalidJSONPollingResponse]]
+	beginDeleteAsyncRelativeRetryNoStatus           *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteAsyncRelativeRetryNoStatusResponse]]
+	beginDeleteNonRetry400                          *tracker[azfake.PollerResponder[lrogroup.LROSADsClientDeleteNonRetry400Response]]
+	beginPost202NoLocation                          *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202NoLocationResponse]]
+	beginPost202NonRetry400                         *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202NonRetry400Response]]
+	beginPost202RetryInvalidHeader                  *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPost202RetryInvalidHeaderResponse]]
+	beginPostAsyncRelativeRetry400                  *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetry400Response]]
+	beginPostAsyncRelativeRetryInvalidHeader        *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidHeaderResponse]]
+	beginPostAsyncRelativeRetryInvalidJSONPolling   *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryInvalidJSONPollingResponse]]
+	beginPostAsyncRelativeRetryNoPayload            *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPostAsyncRelativeRetryNoPayloadResponse]]
+	beginPostNonRetry400                            *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPostNonRetry400Response]]
+	beginPut200InvalidJSON                          *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPut200InvalidJSONResponse]]
+	beginPutAsyncRelativeRetry400                   *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetry400Response]]
+	beginPutAsyncRelativeRetryInvalidHeader         *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidHeaderResponse]]
+	beginPutAsyncRelativeRetryInvalidJSONPolling    *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryInvalidJSONPollingResponse]]
+	beginPutAsyncRelativeRetryNoStatus              *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusResponse]]
+	beginPutAsyncRelativeRetryNoStatusPayload       *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutAsyncRelativeRetryNoStatusPayloadResponse]]
+	beginPutError201NoProvisioningStatePayload      *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutError201NoProvisioningStatePayloadResponse]]
+	beginPutNonRetry201Creating400                  *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400Response]]
+	beginPutNonRetry201Creating400InvalidJSON       *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry201Creating400InvalidJSONResponse]]
+	beginPutNonRetry400                             *tracker[azfake.PollerResponder[lrogroup.LROSADsClientPutNonRetry400Response]]
 }
 
 // Do implements the policy.Transporter interface for LROSADsServerTransport.
@@ -245,24 +273,27 @@ func (l *LROSADsServerTransport) dispatchBeginDelete202NonRetry400(req *http.Req
 	if l.srv.BeginDelete202NonRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete202NonRetry400 not implemented")}
 	}
-	if l.beginDelete202NonRetry400 == nil {
+	beginDelete202NonRetry400 := l.beginDelete202NonRetry400.get(req)
+	if beginDelete202NonRetry400 == nil {
 		respr, errRespr := l.srv.BeginDelete202NonRetry400(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete202NonRetry400 = &respr
+		beginDelete202NonRetry400 = &respr
+		l.beginDelete202NonRetry400.add(req, beginDelete202NonRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete202NonRetry400, req)
+	resp, err := server.PollerResponderNext(beginDelete202NonRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDelete202NonRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete202NonRetry400) {
-		l.beginDelete202NonRetry400 = nil
+	if !server.PollerResponderMore(beginDelete202NonRetry400) {
+		l.beginDelete202NonRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -272,24 +303,27 @@ func (l *LROSADsServerTransport) dispatchBeginDelete202RetryInvalidHeader(req *h
 	if l.srv.BeginDelete202RetryInvalidHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete202RetryInvalidHeader not implemented")}
 	}
-	if l.beginDelete202RetryInvalidHeader == nil {
+	beginDelete202RetryInvalidHeader := l.beginDelete202RetryInvalidHeader.get(req)
+	if beginDelete202RetryInvalidHeader == nil {
 		respr, errRespr := l.srv.BeginDelete202RetryInvalidHeader(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete202RetryInvalidHeader = &respr
+		beginDelete202RetryInvalidHeader = &respr
+		l.beginDelete202RetryInvalidHeader.add(req, beginDelete202RetryInvalidHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete202RetryInvalidHeader, req)
+	resp, err := server.PollerResponderNext(beginDelete202RetryInvalidHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDelete202RetryInvalidHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete202RetryInvalidHeader) {
-		l.beginDelete202RetryInvalidHeader = nil
+	if !server.PollerResponderMore(beginDelete202RetryInvalidHeader) {
+		l.beginDelete202RetryInvalidHeader.remove(req)
 	}
 
 	return resp, nil
@@ -299,24 +333,27 @@ func (l *LROSADsServerTransport) dispatchBeginDelete204Succeeded(req *http.Reque
 	if l.srv.BeginDelete204Succeeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete204Succeeded not implemented")}
 	}
-	if l.beginDelete204Succeeded == nil {
+	beginDelete204Succeeded := l.beginDelete204Succeeded.get(req)
+	if beginDelete204Succeeded == nil {
 		respr, errRespr := l.srv.BeginDelete204Succeeded(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete204Succeeded = &respr
+		beginDelete204Succeeded = &respr
+		l.beginDelete204Succeeded.add(req, beginDelete204Succeeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete204Succeeded, req)
+	resp, err := server.PollerResponderNext(beginDelete204Succeeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusNoContent}, resp.StatusCode) {
+		l.beginDelete204Succeeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete204Succeeded) {
-		l.beginDelete204Succeeded = nil
+	if !server.PollerResponderMore(beginDelete204Succeeded) {
+		l.beginDelete204Succeeded.remove(req)
 	}
 
 	return resp, nil
@@ -326,24 +363,27 @@ func (l *LROSADsServerTransport) dispatchBeginDeleteAsyncRelativeRetry400(req *h
 	if l.srv.BeginDeleteAsyncRelativeRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRelativeRetry400 not implemented")}
 	}
-	if l.beginDeleteAsyncRelativeRetry400 == nil {
+	beginDeleteAsyncRelativeRetry400 := l.beginDeleteAsyncRelativeRetry400.get(req)
+	if beginDeleteAsyncRelativeRetry400 == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRelativeRetry400(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRelativeRetry400 = &respr
+		beginDeleteAsyncRelativeRetry400 = &respr
+		l.beginDeleteAsyncRelativeRetry400.add(req, beginDeleteAsyncRelativeRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRelativeRetry400, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRelativeRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRelativeRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRelativeRetry400) {
-		l.beginDeleteAsyncRelativeRetry400 = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRelativeRetry400) {
+		l.beginDeleteAsyncRelativeRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -353,24 +393,27 @@ func (l *LROSADsServerTransport) dispatchBeginDeleteAsyncRelativeRetryInvalidHea
 	if l.srv.BeginDeleteAsyncRelativeRetryInvalidHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRelativeRetryInvalidHeader not implemented")}
 	}
-	if l.beginDeleteAsyncRelativeRetryInvalidHeader == nil {
+	beginDeleteAsyncRelativeRetryInvalidHeader := l.beginDeleteAsyncRelativeRetryInvalidHeader.get(req)
+	if beginDeleteAsyncRelativeRetryInvalidHeader == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRelativeRetryInvalidHeader(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRelativeRetryInvalidHeader = &respr
+		beginDeleteAsyncRelativeRetryInvalidHeader = &respr
+		l.beginDeleteAsyncRelativeRetryInvalidHeader.add(req, beginDeleteAsyncRelativeRetryInvalidHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRelativeRetryInvalidHeader, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRelativeRetryInvalidHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRelativeRetryInvalidHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRelativeRetryInvalidHeader) {
-		l.beginDeleteAsyncRelativeRetryInvalidHeader = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRelativeRetryInvalidHeader) {
+		l.beginDeleteAsyncRelativeRetryInvalidHeader.remove(req)
 	}
 
 	return resp, nil
@@ -380,24 +423,27 @@ func (l *LROSADsServerTransport) dispatchBeginDeleteAsyncRelativeRetryInvalidJSO
 	if l.srv.BeginDeleteAsyncRelativeRetryInvalidJSONPolling == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRelativeRetryInvalidJSONPolling not implemented")}
 	}
-	if l.beginDeleteAsyncRelativeRetryInvalidJSONPolling == nil {
+	beginDeleteAsyncRelativeRetryInvalidJSONPolling := l.beginDeleteAsyncRelativeRetryInvalidJSONPolling.get(req)
+	if beginDeleteAsyncRelativeRetryInvalidJSONPolling == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRelativeRetryInvalidJSONPolling(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRelativeRetryInvalidJSONPolling = &respr
+		beginDeleteAsyncRelativeRetryInvalidJSONPolling = &respr
+		l.beginDeleteAsyncRelativeRetryInvalidJSONPolling.add(req, beginDeleteAsyncRelativeRetryInvalidJSONPolling)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRelativeRetryInvalidJSONPolling, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRelativeRetryInvalidJSONPolling, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRelativeRetryInvalidJSONPolling.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRelativeRetryInvalidJSONPolling) {
-		l.beginDeleteAsyncRelativeRetryInvalidJSONPolling = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRelativeRetryInvalidJSONPolling) {
+		l.beginDeleteAsyncRelativeRetryInvalidJSONPolling.remove(req)
 	}
 
 	return resp, nil
@@ -407,24 +453,27 @@ func (l *LROSADsServerTransport) dispatchBeginDeleteAsyncRelativeRetryNoStatus(r
 	if l.srv.BeginDeleteAsyncRelativeRetryNoStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAsyncRelativeRetryNoStatus not implemented")}
 	}
-	if l.beginDeleteAsyncRelativeRetryNoStatus == nil {
+	beginDeleteAsyncRelativeRetryNoStatus := l.beginDeleteAsyncRelativeRetryNoStatus.get(req)
+	if beginDeleteAsyncRelativeRetryNoStatus == nil {
 		respr, errRespr := l.srv.BeginDeleteAsyncRelativeRetryNoStatus(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteAsyncRelativeRetryNoStatus = &respr
+		beginDeleteAsyncRelativeRetryNoStatus = &respr
+		l.beginDeleteAsyncRelativeRetryNoStatus.add(req, beginDeleteAsyncRelativeRetryNoStatus)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteAsyncRelativeRetryNoStatus, req)
+	resp, err := server.PollerResponderNext(beginDeleteAsyncRelativeRetryNoStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteAsyncRelativeRetryNoStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteAsyncRelativeRetryNoStatus) {
-		l.beginDeleteAsyncRelativeRetryNoStatus = nil
+	if !server.PollerResponderMore(beginDeleteAsyncRelativeRetryNoStatus) {
+		l.beginDeleteAsyncRelativeRetryNoStatus.remove(req)
 	}
 
 	return resp, nil
@@ -434,24 +483,27 @@ func (l *LROSADsServerTransport) dispatchBeginDeleteNonRetry400(req *http.Reques
 	if l.srv.BeginDeleteNonRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteNonRetry400 not implemented")}
 	}
-	if l.beginDeleteNonRetry400 == nil {
+	beginDeleteNonRetry400 := l.beginDeleteNonRetry400.get(req)
+	if beginDeleteNonRetry400 == nil {
 		respr, errRespr := l.srv.BeginDeleteNonRetry400(req.Context(), nil)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDeleteNonRetry400 = &respr
+		beginDeleteNonRetry400 = &respr
+		l.beginDeleteNonRetry400.add(req, beginDeleteNonRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDeleteNonRetry400, req)
+	resp, err := server.PollerResponderNext(beginDeleteNonRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginDeleteNonRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDeleteNonRetry400) {
-		l.beginDeleteNonRetry400 = nil
+	if !server.PollerResponderMore(beginDeleteNonRetry400) {
+		l.beginDeleteNonRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -461,7 +513,8 @@ func (l *LROSADsServerTransport) dispatchBeginPost202NoLocation(req *http.Reques
 	if l.srv.BeginPost202NoLocation == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202NoLocation not implemented")}
 	}
-	if l.beginPost202NoLocation == nil {
+	beginPost202NoLocation := l.beginPost202NoLocation.get(req)
+	if beginPost202NoLocation == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -476,19 +529,21 @@ func (l *LROSADsServerTransport) dispatchBeginPost202NoLocation(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202NoLocation = &respr
+		beginPost202NoLocation = &respr
+		l.beginPost202NoLocation.add(req, beginPost202NoLocation)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202NoLocation, req)
+	resp, err := server.PollerResponderNext(beginPost202NoLocation, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202NoLocation.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202NoLocation) {
-		l.beginPost202NoLocation = nil
+	if !server.PollerResponderMore(beginPost202NoLocation) {
+		l.beginPost202NoLocation.remove(req)
 	}
 
 	return resp, nil
@@ -498,7 +553,8 @@ func (l *LROSADsServerTransport) dispatchBeginPost202NonRetry400(req *http.Reque
 	if l.srv.BeginPost202NonRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202NonRetry400 not implemented")}
 	}
-	if l.beginPost202NonRetry400 == nil {
+	beginPost202NonRetry400 := l.beginPost202NonRetry400.get(req)
+	if beginPost202NonRetry400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -513,19 +569,21 @@ func (l *LROSADsServerTransport) dispatchBeginPost202NonRetry400(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202NonRetry400 = &respr
+		beginPost202NonRetry400 = &respr
+		l.beginPost202NonRetry400.add(req, beginPost202NonRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202NonRetry400, req)
+	resp, err := server.PollerResponderNext(beginPost202NonRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202NonRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202NonRetry400) {
-		l.beginPost202NonRetry400 = nil
+	if !server.PollerResponderMore(beginPost202NonRetry400) {
+		l.beginPost202NonRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -535,7 +593,8 @@ func (l *LROSADsServerTransport) dispatchBeginPost202RetryInvalidHeader(req *htt
 	if l.srv.BeginPost202RetryInvalidHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202RetryInvalidHeader not implemented")}
 	}
-	if l.beginPost202RetryInvalidHeader == nil {
+	beginPost202RetryInvalidHeader := l.beginPost202RetryInvalidHeader.get(req)
+	if beginPost202RetryInvalidHeader == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -550,19 +609,21 @@ func (l *LROSADsServerTransport) dispatchBeginPost202RetryInvalidHeader(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202RetryInvalidHeader = &respr
+		beginPost202RetryInvalidHeader = &respr
+		l.beginPost202RetryInvalidHeader.add(req, beginPost202RetryInvalidHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202RetryInvalidHeader, req)
+	resp, err := server.PollerResponderNext(beginPost202RetryInvalidHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202RetryInvalidHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202RetryInvalidHeader) {
-		l.beginPost202RetryInvalidHeader = nil
+	if !server.PollerResponderMore(beginPost202RetryInvalidHeader) {
+		l.beginPost202RetryInvalidHeader.remove(req)
 	}
 
 	return resp, nil
@@ -572,7 +633,8 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetry400(req *htt
 	if l.srv.BeginPostAsyncRelativeRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRelativeRetry400 not implemented")}
 	}
-	if l.beginPostAsyncRelativeRetry400 == nil {
+	beginPostAsyncRelativeRetry400 := l.beginPostAsyncRelativeRetry400.get(req)
+	if beginPostAsyncRelativeRetry400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -587,19 +649,21 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetry400(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRelativeRetry400 = &respr
+		beginPostAsyncRelativeRetry400 = &respr
+		l.beginPostAsyncRelativeRetry400.add(req, beginPostAsyncRelativeRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRelativeRetry400, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRelativeRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRelativeRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRelativeRetry400) {
-		l.beginPostAsyncRelativeRetry400 = nil
+	if !server.PollerResponderMore(beginPostAsyncRelativeRetry400) {
+		l.beginPostAsyncRelativeRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -609,7 +673,8 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryInvalidHeade
 	if l.srv.BeginPostAsyncRelativeRetryInvalidHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRelativeRetryInvalidHeader not implemented")}
 	}
-	if l.beginPostAsyncRelativeRetryInvalidHeader == nil {
+	beginPostAsyncRelativeRetryInvalidHeader := l.beginPostAsyncRelativeRetryInvalidHeader.get(req)
+	if beginPostAsyncRelativeRetryInvalidHeader == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -624,19 +689,21 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryInvalidHeade
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRelativeRetryInvalidHeader = &respr
+		beginPostAsyncRelativeRetryInvalidHeader = &respr
+		l.beginPostAsyncRelativeRetryInvalidHeader.add(req, beginPostAsyncRelativeRetryInvalidHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRelativeRetryInvalidHeader, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRelativeRetryInvalidHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRelativeRetryInvalidHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRelativeRetryInvalidHeader) {
-		l.beginPostAsyncRelativeRetryInvalidHeader = nil
+	if !server.PollerResponderMore(beginPostAsyncRelativeRetryInvalidHeader) {
+		l.beginPostAsyncRelativeRetryInvalidHeader.remove(req)
 	}
 
 	return resp, nil
@@ -646,7 +713,8 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryInvalidJSONP
 	if l.srv.BeginPostAsyncRelativeRetryInvalidJSONPolling == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRelativeRetryInvalidJSONPolling not implemented")}
 	}
-	if l.beginPostAsyncRelativeRetryInvalidJSONPolling == nil {
+	beginPostAsyncRelativeRetryInvalidJSONPolling := l.beginPostAsyncRelativeRetryInvalidJSONPolling.get(req)
+	if beginPostAsyncRelativeRetryInvalidJSONPolling == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -661,19 +729,21 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryInvalidJSONP
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRelativeRetryInvalidJSONPolling = &respr
+		beginPostAsyncRelativeRetryInvalidJSONPolling = &respr
+		l.beginPostAsyncRelativeRetryInvalidJSONPolling.add(req, beginPostAsyncRelativeRetryInvalidJSONPolling)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRelativeRetryInvalidJSONPolling, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRelativeRetryInvalidJSONPolling, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRelativeRetryInvalidJSONPolling.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRelativeRetryInvalidJSONPolling) {
-		l.beginPostAsyncRelativeRetryInvalidJSONPolling = nil
+	if !server.PollerResponderMore(beginPostAsyncRelativeRetryInvalidJSONPolling) {
+		l.beginPostAsyncRelativeRetryInvalidJSONPolling.remove(req)
 	}
 
 	return resp, nil
@@ -683,7 +753,8 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryNoPayload(re
 	if l.srv.BeginPostAsyncRelativeRetryNoPayload == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRelativeRetryNoPayload not implemented")}
 	}
-	if l.beginPostAsyncRelativeRetryNoPayload == nil {
+	beginPostAsyncRelativeRetryNoPayload := l.beginPostAsyncRelativeRetryNoPayload.get(req)
+	if beginPostAsyncRelativeRetryNoPayload == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -698,19 +769,21 @@ func (l *LROSADsServerTransport) dispatchBeginPostAsyncRelativeRetryNoPayload(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRelativeRetryNoPayload = &respr
+		beginPostAsyncRelativeRetryNoPayload = &respr
+		l.beginPostAsyncRelativeRetryNoPayload.add(req, beginPostAsyncRelativeRetryNoPayload)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRelativeRetryNoPayload, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRelativeRetryNoPayload, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRelativeRetryNoPayload.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRelativeRetryNoPayload) {
-		l.beginPostAsyncRelativeRetryNoPayload = nil
+	if !server.PollerResponderMore(beginPostAsyncRelativeRetryNoPayload) {
+		l.beginPostAsyncRelativeRetryNoPayload.remove(req)
 	}
 
 	return resp, nil
@@ -720,7 +793,8 @@ func (l *LROSADsServerTransport) dispatchBeginPostNonRetry400(req *http.Request)
 	if l.srv.BeginPostNonRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostNonRetry400 not implemented")}
 	}
-	if l.beginPostNonRetry400 == nil {
+	beginPostNonRetry400 := l.beginPostNonRetry400.get(req)
+	if beginPostNonRetry400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -735,19 +809,21 @@ func (l *LROSADsServerTransport) dispatchBeginPostNonRetry400(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostNonRetry400 = &respr
+		beginPostNonRetry400 = &respr
+		l.beginPostNonRetry400.add(req, beginPostNonRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostNonRetry400, req)
+	resp, err := server.PollerResponderNext(beginPostNonRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostNonRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostNonRetry400) {
-		l.beginPostNonRetry400 = nil
+	if !server.PollerResponderMore(beginPostNonRetry400) {
+		l.beginPostNonRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -757,7 +833,8 @@ func (l *LROSADsServerTransport) dispatchBeginPut200InvalidJSON(req *http.Reques
 	if l.srv.BeginPut200InvalidJSON == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut200InvalidJSON not implemented")}
 	}
-	if l.beginPut200InvalidJSON == nil {
+	beginPut200InvalidJSON := l.beginPut200InvalidJSON.get(req)
+	if beginPut200InvalidJSON == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -766,19 +843,21 @@ func (l *LROSADsServerTransport) dispatchBeginPut200InvalidJSON(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut200InvalidJSON = &respr
+		beginPut200InvalidJSON = &respr
+		l.beginPut200InvalidJSON.add(req, beginPut200InvalidJSON)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut200InvalidJSON, req)
+	resp, err := server.PollerResponderNext(beginPut200InvalidJSON, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusNoContent}, resp.StatusCode) {
+		l.beginPut200InvalidJSON.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut200InvalidJSON) {
-		l.beginPut200InvalidJSON = nil
+	if !server.PollerResponderMore(beginPut200InvalidJSON) {
+		l.beginPut200InvalidJSON.remove(req)
 	}
 
 	return resp, nil
@@ -788,7 +867,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetry400(req *http
 	if l.srv.BeginPutAsyncRelativeRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetry400 not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetry400 == nil {
+	beginPutAsyncRelativeRetry400 := l.beginPutAsyncRelativeRetry400.get(req)
+	if beginPutAsyncRelativeRetry400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -797,19 +877,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetry400(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetry400 = &respr
+		beginPutAsyncRelativeRetry400 = &respr
+		l.beginPutAsyncRelativeRetry400.add(req, beginPutAsyncRelativeRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetry400, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetry400) {
-		l.beginPutAsyncRelativeRetry400 = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetry400) {
+		l.beginPutAsyncRelativeRetry400.remove(req)
 	}
 
 	return resp, nil
@@ -819,7 +901,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryInvalidHeader
 	if l.srv.BeginPutAsyncRelativeRetryInvalidHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetryInvalidHeader not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetryInvalidHeader == nil {
+	beginPutAsyncRelativeRetryInvalidHeader := l.beginPutAsyncRelativeRetryInvalidHeader.get(req)
+	if beginPutAsyncRelativeRetryInvalidHeader == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -828,19 +911,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryInvalidHeader
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetryInvalidHeader = &respr
+		beginPutAsyncRelativeRetryInvalidHeader = &respr
+		l.beginPutAsyncRelativeRetryInvalidHeader.add(req, beginPutAsyncRelativeRetryInvalidHeader)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetryInvalidHeader, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetryInvalidHeader, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetryInvalidHeader.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetryInvalidHeader) {
-		l.beginPutAsyncRelativeRetryInvalidHeader = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetryInvalidHeader) {
+		l.beginPutAsyncRelativeRetryInvalidHeader.remove(req)
 	}
 
 	return resp, nil
@@ -850,7 +935,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryInvalidJSONPo
 	if l.srv.BeginPutAsyncRelativeRetryInvalidJSONPolling == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetryInvalidJSONPolling not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetryInvalidJSONPolling == nil {
+	beginPutAsyncRelativeRetryInvalidJSONPolling := l.beginPutAsyncRelativeRetryInvalidJSONPolling.get(req)
+	if beginPutAsyncRelativeRetryInvalidJSONPolling == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -859,19 +945,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryInvalidJSONPo
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetryInvalidJSONPolling = &respr
+		beginPutAsyncRelativeRetryInvalidJSONPolling = &respr
+		l.beginPutAsyncRelativeRetryInvalidJSONPolling.add(req, beginPutAsyncRelativeRetryInvalidJSONPolling)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetryInvalidJSONPolling, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetryInvalidJSONPolling, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetryInvalidJSONPolling.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetryInvalidJSONPolling) {
-		l.beginPutAsyncRelativeRetryInvalidJSONPolling = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetryInvalidJSONPolling) {
+		l.beginPutAsyncRelativeRetryInvalidJSONPolling.remove(req)
 	}
 
 	return resp, nil
@@ -881,7 +969,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryNoStatus(req 
 	if l.srv.BeginPutAsyncRelativeRetryNoStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetryNoStatus not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetryNoStatus == nil {
+	beginPutAsyncRelativeRetryNoStatus := l.beginPutAsyncRelativeRetryNoStatus.get(req)
+	if beginPutAsyncRelativeRetryNoStatus == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -890,19 +979,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryNoStatus(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetryNoStatus = &respr
+		beginPutAsyncRelativeRetryNoStatus = &respr
+		l.beginPutAsyncRelativeRetryNoStatus.add(req, beginPutAsyncRelativeRetryNoStatus)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetryNoStatus, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetryNoStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetryNoStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetryNoStatus) {
-		l.beginPutAsyncRelativeRetryNoStatus = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetryNoStatus) {
+		l.beginPutAsyncRelativeRetryNoStatus.remove(req)
 	}
 
 	return resp, nil
@@ -912,7 +1003,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryNoStatusPaylo
 	if l.srv.BeginPutAsyncRelativeRetryNoStatusPayload == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRelativeRetryNoStatusPayload not implemented")}
 	}
-	if l.beginPutAsyncRelativeRetryNoStatusPayload == nil {
+	beginPutAsyncRelativeRetryNoStatusPayload := l.beginPutAsyncRelativeRetryNoStatusPayload.get(req)
+	if beginPutAsyncRelativeRetryNoStatusPayload == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -921,19 +1013,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutAsyncRelativeRetryNoStatusPaylo
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRelativeRetryNoStatusPayload = &respr
+		beginPutAsyncRelativeRetryNoStatusPayload = &respr
+		l.beginPutAsyncRelativeRetryNoStatusPayload.add(req, beginPutAsyncRelativeRetryNoStatusPayload)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRelativeRetryNoStatusPayload, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRelativeRetryNoStatusPayload, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRelativeRetryNoStatusPayload.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRelativeRetryNoStatusPayload) {
-		l.beginPutAsyncRelativeRetryNoStatusPayload = nil
+	if !server.PollerResponderMore(beginPutAsyncRelativeRetryNoStatusPayload) {
+		l.beginPutAsyncRelativeRetryNoStatusPayload.remove(req)
 	}
 
 	return resp, nil
@@ -943,7 +1037,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutError201NoProvisioningStatePayl
 	if l.srv.BeginPutError201NoProvisioningStatePayload == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutError201NoProvisioningStatePayload not implemented")}
 	}
-	if l.beginPutError201NoProvisioningStatePayload == nil {
+	beginPutError201NoProvisioningStatePayload := l.beginPutError201NoProvisioningStatePayload.get(req)
+	if beginPutError201NoProvisioningStatePayload == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -952,19 +1047,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutError201NoProvisioningStatePayl
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutError201NoProvisioningStatePayload = &respr
+		beginPutError201NoProvisioningStatePayload = &respr
+		l.beginPutError201NoProvisioningStatePayload.add(req, beginPutError201NoProvisioningStatePayload)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutError201NoProvisioningStatePayload, req)
+	resp, err := server.PollerResponderNext(beginPutError201NoProvisioningStatePayload, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPutError201NoProvisioningStatePayload.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutError201NoProvisioningStatePayload) {
-		l.beginPutError201NoProvisioningStatePayload = nil
+	if !server.PollerResponderMore(beginPutError201NoProvisioningStatePayload) {
+		l.beginPutError201NoProvisioningStatePayload.remove(req)
 	}
 
 	return resp, nil
@@ -974,7 +1071,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry201Creating400(req *htt
 	if l.srv.BeginPutNonRetry201Creating400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutNonRetry201Creating400 not implemented")}
 	}
-	if l.beginPutNonRetry201Creating400 == nil {
+	beginPutNonRetry201Creating400 := l.beginPutNonRetry201Creating400.get(req)
+	if beginPutNonRetry201Creating400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -983,19 +1081,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry201Creating400(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutNonRetry201Creating400 = &respr
+		beginPutNonRetry201Creating400 = &respr
+		l.beginPutNonRetry201Creating400.add(req, beginPutNonRetry201Creating400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutNonRetry201Creating400, req)
+	resp, err := server.PollerResponderNext(beginPutNonRetry201Creating400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPutNonRetry201Creating400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutNonRetry201Creating400) {
-		l.beginPutNonRetry201Creating400 = nil
+	if !server.PollerResponderMore(beginPutNonRetry201Creating400) {
+		l.beginPutNonRetry201Creating400.remove(req)
 	}
 
 	return resp, nil
@@ -1005,7 +1105,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry201Creating400InvalidJS
 	if l.srv.BeginPutNonRetry201Creating400InvalidJSON == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutNonRetry201Creating400InvalidJSON not implemented")}
 	}
-	if l.beginPutNonRetry201Creating400InvalidJSON == nil {
+	beginPutNonRetry201Creating400InvalidJSON := l.beginPutNonRetry201Creating400InvalidJSON.get(req)
+	if beginPutNonRetry201Creating400InvalidJSON == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1014,19 +1115,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry201Creating400InvalidJS
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutNonRetry201Creating400InvalidJSON = &respr
+		beginPutNonRetry201Creating400InvalidJSON = &respr
+		l.beginPutNonRetry201Creating400InvalidJSON.add(req, beginPutNonRetry201Creating400InvalidJSON)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutNonRetry201Creating400InvalidJSON, req)
+	resp, err := server.PollerResponderNext(beginPutNonRetry201Creating400InvalidJSON, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPutNonRetry201Creating400InvalidJSON.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutNonRetry201Creating400InvalidJSON) {
-		l.beginPutNonRetry201Creating400InvalidJSON = nil
+	if !server.PollerResponderMore(beginPutNonRetry201Creating400InvalidJSON) {
+		l.beginPutNonRetry201Creating400InvalidJSON.remove(req)
 	}
 
 	return resp, nil
@@ -1036,7 +1139,8 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry400(req *http.Request) 
 	if l.srv.BeginPutNonRetry400 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutNonRetry400 not implemented")}
 	}
-	if l.beginPutNonRetry400 == nil {
+	beginPutNonRetry400 := l.beginPutNonRetry400.get(req)
+	if beginPutNonRetry400 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -1045,19 +1149,21 @@ func (l *LROSADsServerTransport) dispatchBeginPutNonRetry400(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutNonRetry400 = &respr
+		beginPutNonRetry400 = &respr
+		l.beginPutNonRetry400.add(req, beginPutNonRetry400)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutNonRetry400, req)
+	resp, err := server.PollerResponderNext(beginPutNonRetry400, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPutNonRetry400.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutNonRetry400) {
-		l.beginPutNonRetry400 = nil
+	if !server.PollerResponderMore(beginPutNonRetry400) {
+		l.beginPutNonRetry400.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_lroscustomheader_server.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_lroscustomheader_server.go
@@ -43,17 +43,23 @@ type LROsCustomHeaderServer struct {
 // The returned LROsCustomHeaderServerTransport instance is connected to an instance of lrogroup.LROsCustomHeaderClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLROsCustomHeaderServerTransport(srv *LROsCustomHeaderServer) *LROsCustomHeaderServerTransport {
-	return &LROsCustomHeaderServerTransport{srv: srv}
+	return &LROsCustomHeaderServerTransport{
+		srv:                             srv,
+		beginPost202Retry200:            newTracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPost202Retry200Response]](),
+		beginPostAsyncRetrySucceeded:    newTracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPostAsyncRetrySucceededResponse]](),
+		beginPut201CreatingSucceeded200: newTracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPut201CreatingSucceeded200Response]](),
+		beginPutAsyncRetrySucceeded:     newTracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPutAsyncRetrySucceededResponse]](),
+	}
 }
 
 // LROsCustomHeaderServerTransport connects instances of lrogroup.LROsCustomHeaderClient to instances of LROsCustomHeaderServer.
 // Don't use this type directly, use NewLROsCustomHeaderServerTransport instead.
 type LROsCustomHeaderServerTransport struct {
 	srv                             *LROsCustomHeaderServer
-	beginPost202Retry200            *azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPost202Retry200Response]
-	beginPostAsyncRetrySucceeded    *azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPostAsyncRetrySucceededResponse]
-	beginPut201CreatingSucceeded200 *azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPut201CreatingSucceeded200Response]
-	beginPutAsyncRetrySucceeded     *azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPutAsyncRetrySucceededResponse]
+	beginPost202Retry200            *tracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPost202Retry200Response]]
+	beginPostAsyncRetrySucceeded    *tracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPostAsyncRetrySucceededResponse]]
+	beginPut201CreatingSucceeded200 *tracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPut201CreatingSucceeded200Response]]
+	beginPutAsyncRetrySucceeded     *tracker[azfake.PollerResponder[lrogroup.LROsCustomHeaderClientPutAsyncRetrySucceededResponse]]
 }
 
 // Do implements the policy.Transporter interface for LROsCustomHeaderServerTransport.
@@ -91,7 +97,8 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPost202Retry200(req *http
 	if l.srv.BeginPost202Retry200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost202Retry200 not implemented")}
 	}
-	if l.beginPost202Retry200 == nil {
+	beginPost202Retry200 := l.beginPost202Retry200.get(req)
+	if beginPost202Retry200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -106,19 +113,21 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPost202Retry200(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPost202Retry200 = &respr
+		beginPost202Retry200 = &respr
+		l.beginPost202Retry200.add(req, beginPost202Retry200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPost202Retry200, req)
+	resp, err := server.PollerResponderNext(beginPost202Retry200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPost202Retry200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPost202Retry200) {
-		l.beginPost202Retry200 = nil
+	if !server.PollerResponderMore(beginPost202Retry200) {
+		l.beginPost202Retry200.remove(req)
 	}
 
 	return resp, nil
@@ -128,7 +137,8 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPostAsyncRetrySucceeded(r
 	if l.srv.BeginPostAsyncRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPostAsyncRetrySucceeded not implemented")}
 	}
-	if l.beginPostAsyncRetrySucceeded == nil {
+	beginPostAsyncRetrySucceeded := l.beginPostAsyncRetrySucceeded.get(req)
+	if beginPostAsyncRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -143,19 +153,21 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPostAsyncRetrySucceeded(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPostAsyncRetrySucceeded = &respr
+		beginPostAsyncRetrySucceeded = &respr
+		l.beginPostAsyncRetrySucceeded.add(req, beginPostAsyncRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPostAsyncRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPostAsyncRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		l.beginPostAsyncRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPostAsyncRetrySucceeded) {
-		l.beginPostAsyncRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPostAsyncRetrySucceeded) {
+		l.beginPostAsyncRetrySucceeded.remove(req)
 	}
 
 	return resp, nil
@@ -165,7 +177,8 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPut201CreatingSucceeded20
 	if l.srv.BeginPut201CreatingSucceeded200 == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPut201CreatingSucceeded200 not implemented")}
 	}
-	if l.beginPut201CreatingSucceeded200 == nil {
+	beginPut201CreatingSucceeded200 := l.beginPut201CreatingSucceeded200.get(req)
+	if beginPut201CreatingSucceeded200 == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -174,19 +187,21 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPut201CreatingSucceeded20
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPut201CreatingSucceeded200 = &respr
+		beginPut201CreatingSucceeded200 = &respr
+		l.beginPut201CreatingSucceeded200.add(req, beginPut201CreatingSucceeded200)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPut201CreatingSucceeded200, req)
+	resp, err := server.PollerResponderNext(beginPut201CreatingSucceeded200, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPut201CreatingSucceeded200) {
-		l.beginPut201CreatingSucceeded200 = nil
+	if !server.PollerResponderMore(beginPut201CreatingSucceeded200) {
+		l.beginPut201CreatingSucceeded200.remove(req)
 	}
 
 	return resp, nil
@@ -196,7 +211,8 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPutAsyncRetrySucceeded(re
 	if l.srv.BeginPutAsyncRetrySucceeded == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutAsyncRetrySucceeded not implemented")}
 	}
-	if l.beginPutAsyncRetrySucceeded == nil {
+	beginPutAsyncRetrySucceeded := l.beginPutAsyncRetrySucceeded.get(req)
+	if beginPutAsyncRetrySucceeded == nil {
 		body, err := server.UnmarshalRequestAsJSON[lrogroup.Product](req)
 		if err != nil {
 			return nil, err
@@ -205,19 +221,21 @@ func (l *LROsCustomHeaderServerTransport) dispatchBeginPutAsyncRetrySucceeded(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginPutAsyncRetrySucceeded = &respr
+		beginPutAsyncRetrySucceeded = &respr
+		l.beginPutAsyncRetrySucceeded.add(req, beginPutAsyncRetrySucceeded)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginPutAsyncRetrySucceeded, req)
+	resp, err := server.PollerResponderNext(beginPutAsyncRetrySucceeded, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.beginPutAsyncRetrySucceeded.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginPutAsyncRetrySucceeded) {
-		l.beginPutAsyncRetrySucceeded = nil
+	if !server.PollerResponderMore(beginPutAsyncRetrySucceeded) {
+		l.beginPutAsyncRetrySucceeded.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/autorest/paginggroup/fake/zz_paging_server.go
+++ b/packages/autorest.go/test/autorest/paginggroup/fake/zz_paging_server.go
@@ -102,31 +102,51 @@ type PagingServer struct {
 // The returned PagingServerTransport instance is connected to an instance of paginggroup.PagingClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPagingServerTransport(srv *PagingServer) *PagingServerTransport {
-	return &PagingServerTransport{srv: srv}
+	return &PagingServerTransport{
+		srv:                                                  srv,
+		newDuplicateParamsPager:                              newTracker[azfake.PagerResponder[paginggroup.PagingClientDuplicateParamsResponse]](),
+		newFirstResponseEmptyPager:                           newTracker[azfake.PagerResponder[paginggroup.PagingClientFirstResponseEmptyResponse]](),
+		newGetMultiplePagesPager:                             newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesResponse]](),
+		newGetMultiplePagesFailurePager:                      newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureResponse]](),
+		newGetMultiplePagesFailureURIPager:                   newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureURIResponse]](),
+		newGetMultiplePagesFragmentNextLinkPager:             newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentNextLinkResponse]](),
+		newGetMultiplePagesFragmentWithGroupingNextLinkPager: newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse]](),
+		beginGetMultiplePagesLRO:                             newTracker[azfake.PollerResponder[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesLROResponse]]](),
+		newGetMultiplePagesRetryFirstPager:                   newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetryFirstResponse]](),
+		newGetMultiplePagesRetrySecondPager:                  newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetrySecondResponse]](),
+		newGetMultiplePagesWithOffsetPager:                   newTracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesWithOffsetResponse]](),
+		newGetNoItemNamePagesPager:                           newTracker[azfake.PagerResponder[paginggroup.PagingClientGetNoItemNamePagesResponse]](),
+		newGetNullNextLinkNamePagesPager:                     newTracker[azfake.PagerResponder[paginggroup.PagingClientGetNullNextLinkNamePagesResponse]](),
+		newGetODataMultiplePagesPager:                        newTracker[azfake.PagerResponder[paginggroup.PagingClientGetODataMultiplePagesResponse]](),
+		newGetPagingModelWithItemNameWithXMSClientNamePager:  newTracker[azfake.PagerResponder[paginggroup.PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse]](),
+		newGetSinglePagesPager:                               newTracker[azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesResponse]](),
+		newGetSinglePagesFailurePager:                        newTracker[azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesFailureResponse]](),
+		newGetWithQueryParamsPager:                           newTracker[azfake.PagerResponder[paginggroup.PagingClientGetWithQueryParamsResponse]](),
+	}
 }
 
 // PagingServerTransport connects instances of paginggroup.PagingClient to instances of PagingServer.
 // Don't use this type directly, use NewPagingServerTransport instead.
 type PagingServerTransport struct {
 	srv                                                  *PagingServer
-	newDuplicateParamsPager                              *azfake.PagerResponder[paginggroup.PagingClientDuplicateParamsResponse]
-	newFirstResponseEmptyPager                           *azfake.PagerResponder[paginggroup.PagingClientFirstResponseEmptyResponse]
-	newGetMultiplePagesPager                             *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesResponse]
-	newGetMultiplePagesFailurePager                      *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureResponse]
-	newGetMultiplePagesFailureURIPager                   *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureURIResponse]
-	newGetMultiplePagesFragmentNextLinkPager             *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentNextLinkResponse]
-	newGetMultiplePagesFragmentWithGroupingNextLinkPager *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse]
-	beginGetMultiplePagesLRO                             *azfake.PollerResponder[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesLROResponse]]
-	newGetMultiplePagesRetryFirstPager                   *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetryFirstResponse]
-	newGetMultiplePagesRetrySecondPager                  *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetrySecondResponse]
-	newGetMultiplePagesWithOffsetPager                   *azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesWithOffsetResponse]
-	newGetNoItemNamePagesPager                           *azfake.PagerResponder[paginggroup.PagingClientGetNoItemNamePagesResponse]
-	newGetNullNextLinkNamePagesPager                     *azfake.PagerResponder[paginggroup.PagingClientGetNullNextLinkNamePagesResponse]
-	newGetODataMultiplePagesPager                        *azfake.PagerResponder[paginggroup.PagingClientGetODataMultiplePagesResponse]
-	newGetPagingModelWithItemNameWithXMSClientNamePager  *azfake.PagerResponder[paginggroup.PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse]
-	newGetSinglePagesPager                               *azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesResponse]
-	newGetSinglePagesFailurePager                        *azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesFailureResponse]
-	newGetWithQueryParamsPager                           *azfake.PagerResponder[paginggroup.PagingClientGetWithQueryParamsResponse]
+	newDuplicateParamsPager                              *tracker[azfake.PagerResponder[paginggroup.PagingClientDuplicateParamsResponse]]
+	newFirstResponseEmptyPager                           *tracker[azfake.PagerResponder[paginggroup.PagingClientFirstResponseEmptyResponse]]
+	newGetMultiplePagesPager                             *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesResponse]]
+	newGetMultiplePagesFailurePager                      *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureResponse]]
+	newGetMultiplePagesFailureURIPager                   *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFailureURIResponse]]
+	newGetMultiplePagesFragmentNextLinkPager             *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentNextLinkResponse]]
+	newGetMultiplePagesFragmentWithGroupingNextLinkPager *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse]]
+	beginGetMultiplePagesLRO                             *tracker[azfake.PollerResponder[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesLROResponse]]]
+	newGetMultiplePagesRetryFirstPager                   *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetryFirstResponse]]
+	newGetMultiplePagesRetrySecondPager                  *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesRetrySecondResponse]]
+	newGetMultiplePagesWithOffsetPager                   *tracker[azfake.PagerResponder[paginggroup.PagingClientGetMultiplePagesWithOffsetResponse]]
+	newGetNoItemNamePagesPager                           *tracker[azfake.PagerResponder[paginggroup.PagingClientGetNoItemNamePagesResponse]]
+	newGetNullNextLinkNamePagesPager                     *tracker[azfake.PagerResponder[paginggroup.PagingClientGetNullNextLinkNamePagesResponse]]
+	newGetODataMultiplePagesPager                        *tracker[azfake.PagerResponder[paginggroup.PagingClientGetODataMultiplePagesResponse]]
+	newGetPagingModelWithItemNameWithXMSClientNamePager  *tracker[azfake.PagerResponder[paginggroup.PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse]]
+	newGetSinglePagesPager                               *tracker[azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesResponse]]
+	newGetSinglePagesFailurePager                        *tracker[azfake.PagerResponder[paginggroup.PagingClientGetSinglePagesFailureResponse]]
+	newGetWithQueryParamsPager                           *tracker[azfake.PagerResponder[paginggroup.PagingClientGetWithQueryParamsResponse]]
 }
 
 // Do implements the policy.Transporter interface for PagingServerTransport.
@@ -192,7 +212,8 @@ func (p *PagingServerTransport) dispatchNewDuplicateParamsPager(req *http.Reques
 	if p.srv.NewDuplicateParamsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewDuplicateParamsPager not implemented")}
 	}
-	if p.newDuplicateParamsPager == nil {
+	newDuplicateParamsPager := p.newDuplicateParamsPager.get(req)
+	if newDuplicateParamsPager == nil {
 		qp := req.URL.Query()
 		filterUnescaped, err := url.QueryUnescape(qp.Get("$filter"))
 		if err != nil {
@@ -206,20 +227,22 @@ func (p *PagingServerTransport) dispatchNewDuplicateParamsPager(req *http.Reques
 			}
 		}
 		resp := p.srv.NewDuplicateParamsPager(options)
-		p.newDuplicateParamsPager = &resp
-		server.PagerResponderInjectNextLinks(p.newDuplicateParamsPager, req, func(page *paginggroup.PagingClientDuplicateParamsResponse, createLink func() string) {
+		newDuplicateParamsPager = &resp
+		p.newDuplicateParamsPager.add(req, newDuplicateParamsPager)
+		server.PagerResponderInjectNextLinks(newDuplicateParamsPager, req, func(page *paginggroup.PagingClientDuplicateParamsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newDuplicateParamsPager, req)
+	resp, err := server.PagerResponderNext(newDuplicateParamsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newDuplicateParamsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newDuplicateParamsPager) {
-		p.newDuplicateParamsPager = nil
+	if !server.PagerResponderMore(newDuplicateParamsPager) {
+		p.newDuplicateParamsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -228,22 +251,25 @@ func (p *PagingServerTransport) dispatchNewFirstResponseEmptyPager(req *http.Req
 	if p.srv.NewFirstResponseEmptyPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewFirstResponseEmptyPager not implemented")}
 	}
-	if p.newFirstResponseEmptyPager == nil {
+	newFirstResponseEmptyPager := p.newFirstResponseEmptyPager.get(req)
+	if newFirstResponseEmptyPager == nil {
 		resp := p.srv.NewFirstResponseEmptyPager(nil)
-		p.newFirstResponseEmptyPager = &resp
-		server.PagerResponderInjectNextLinks(p.newFirstResponseEmptyPager, req, func(page *paginggroup.PagingClientFirstResponseEmptyResponse, createLink func() string) {
+		newFirstResponseEmptyPager = &resp
+		p.newFirstResponseEmptyPager.add(req, newFirstResponseEmptyPager)
+		server.PagerResponderInjectNextLinks(newFirstResponseEmptyPager, req, func(page *paginggroup.PagingClientFirstResponseEmptyResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newFirstResponseEmptyPager, req)
+	resp, err := server.PagerResponderNext(newFirstResponseEmptyPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newFirstResponseEmptyPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newFirstResponseEmptyPager) {
-		p.newFirstResponseEmptyPager = nil
+	if !server.PagerResponderMore(newFirstResponseEmptyPager) {
+		p.newFirstResponseEmptyPager.remove(req)
 	}
 	return resp, nil
 }
@@ -252,7 +278,8 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesPager(req *http.Reque
 	if p.srv.NewGetMultiplePagesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesPager not implemented")}
 	}
-	if p.newGetMultiplePagesPager == nil {
+	newGetMultiplePagesPager := p.newGetMultiplePagesPager.get(req)
+	if newGetMultiplePagesPager == nil {
 		clientRequestIDParam := getOptional(getHeaderValue(req.Header, "client-request-id"))
 		maxresultsParam, err := parseOptional(getHeaderValue(req.Header, "maxresults"), func(v string) (int32, error) {
 			p, parseErr := strconv.ParseInt(v, 10, 32)
@@ -283,20 +310,22 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesPager(req *http.Reque
 			}
 		}
 		resp := p.srv.NewGetMultiplePagesPager(options)
-		p.newGetMultiplePagesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesPager, req, func(page *paginggroup.PagingClientGetMultiplePagesResponse, createLink func() string) {
+		newGetMultiplePagesPager = &resp
+		p.newGetMultiplePagesPager.add(req, newGetMultiplePagesPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesPager, req, func(page *paginggroup.PagingClientGetMultiplePagesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesPager) {
-		p.newGetMultiplePagesPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesPager) {
+		p.newGetMultiplePagesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -305,22 +334,25 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFailurePager(req *htt
 	if p.srv.NewGetMultiplePagesFailurePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesFailurePager not implemented")}
 	}
-	if p.newGetMultiplePagesFailurePager == nil {
+	newGetMultiplePagesFailurePager := p.newGetMultiplePagesFailurePager.get(req)
+	if newGetMultiplePagesFailurePager == nil {
 		resp := p.srv.NewGetMultiplePagesFailurePager(nil)
-		p.newGetMultiplePagesFailurePager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesFailurePager, req, func(page *paginggroup.PagingClientGetMultiplePagesFailureResponse, createLink func() string) {
+		newGetMultiplePagesFailurePager = &resp
+		p.newGetMultiplePagesFailurePager.add(req, newGetMultiplePagesFailurePager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesFailurePager, req, func(page *paginggroup.PagingClientGetMultiplePagesFailureResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesFailurePager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesFailurePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesFailurePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesFailurePager) {
-		p.newGetMultiplePagesFailurePager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesFailurePager) {
+		p.newGetMultiplePagesFailurePager.remove(req)
 	}
 	return resp, nil
 }
@@ -329,22 +361,25 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFailureURIPager(req *
 	if p.srv.NewGetMultiplePagesFailureURIPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesFailureURIPager not implemented")}
 	}
-	if p.newGetMultiplePagesFailureURIPager == nil {
+	newGetMultiplePagesFailureURIPager := p.newGetMultiplePagesFailureURIPager.get(req)
+	if newGetMultiplePagesFailureURIPager == nil {
 		resp := p.srv.NewGetMultiplePagesFailureURIPager(nil)
-		p.newGetMultiplePagesFailureURIPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesFailureURIPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFailureURIResponse, createLink func() string) {
+		newGetMultiplePagesFailureURIPager = &resp
+		p.newGetMultiplePagesFailureURIPager.add(req, newGetMultiplePagesFailureURIPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesFailureURIPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFailureURIResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesFailureURIPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesFailureURIPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesFailureURIPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesFailureURIPager) {
-		p.newGetMultiplePagesFailureURIPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesFailureURIPager) {
+		p.newGetMultiplePagesFailureURIPager.remove(req)
 	}
 	return resp, nil
 }
@@ -353,7 +388,8 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFragmentNextLinkPager
 	if p.srv.NewGetMultiplePagesFragmentNextLinkPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesFragmentNextLinkPager not implemented")}
 	}
-	if p.newGetMultiplePagesFragmentNextLinkPager == nil {
+	newGetMultiplePagesFragmentNextLinkPager := p.newGetMultiplePagesFragmentNextLinkPager.get(req)
+	if newGetMultiplePagesFragmentNextLinkPager == nil {
 		const regexStr = `/paging/multiple/fragment/(?P<tenant>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -370,20 +406,22 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFragmentNextLinkPager
 			return nil, err
 		}
 		resp := p.srv.NewGetMultiplePagesFragmentNextLinkPager(apiVersionUnescaped, tenantUnescaped, nil)
-		p.newGetMultiplePagesFragmentNextLinkPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesFragmentNextLinkPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFragmentNextLinkResponse, createLink func() string) {
+		newGetMultiplePagesFragmentNextLinkPager = &resp
+		p.newGetMultiplePagesFragmentNextLinkPager.add(req, newGetMultiplePagesFragmentNextLinkPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesFragmentNextLinkPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFragmentNextLinkResponse, createLink func() string) {
 			page.ODataNextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesFragmentNextLinkPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesFragmentNextLinkPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesFragmentNextLinkPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesFragmentNextLinkPager) {
-		p.newGetMultiplePagesFragmentNextLinkPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesFragmentNextLinkPager) {
+		p.newGetMultiplePagesFragmentNextLinkPager.remove(req)
 	}
 	return resp, nil
 }
@@ -392,7 +430,8 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFragmentWithGroupingN
 	if p.srv.NewGetMultiplePagesFragmentWithGroupingNextLinkPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesFragmentWithGroupingNextLinkPager not implemented")}
 	}
-	if p.newGetMultiplePagesFragmentWithGroupingNextLinkPager == nil {
+	newGetMultiplePagesFragmentWithGroupingNextLinkPager := p.newGetMultiplePagesFragmentWithGroupingNextLinkPager.get(req)
+	if newGetMultiplePagesFragmentWithGroupingNextLinkPager == nil {
 		const regexStr = `/paging/multiple/fragmentwithgrouping/(?P<tenant>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -415,20 +454,22 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesFragmentWithGroupingN
 			Tenant:     tenantParam,
 		}
 		resp := p.srv.NewGetMultiplePagesFragmentWithGroupingNextLinkPager(customParameterGroup, nil)
-		p.newGetMultiplePagesFragmentWithGroupingNextLinkPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesFragmentWithGroupingNextLinkPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse, createLink func() string) {
+		newGetMultiplePagesFragmentWithGroupingNextLinkPager = &resp
+		p.newGetMultiplePagesFragmentWithGroupingNextLinkPager.add(req, newGetMultiplePagesFragmentWithGroupingNextLinkPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesFragmentWithGroupingNextLinkPager, req, func(page *paginggroup.PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse, createLink func() string) {
 			page.ODataNextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesFragmentWithGroupingNextLinkPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesFragmentWithGroupingNextLinkPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesFragmentWithGroupingNextLinkPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesFragmentWithGroupingNextLinkPager) {
-		p.newGetMultiplePagesFragmentWithGroupingNextLinkPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesFragmentWithGroupingNextLinkPager) {
+		p.newGetMultiplePagesFragmentWithGroupingNextLinkPager.remove(req)
 	}
 	return resp, nil
 }
@@ -437,7 +478,8 @@ func (p *PagingServerTransport) dispatchBeginGetMultiplePagesLRO(req *http.Reque
 	if p.srv.BeginGetMultiplePagesLRO == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetMultiplePagesLRO not implemented")}
 	}
-	if p.beginGetMultiplePagesLRO == nil {
+	beginGetMultiplePagesLRO := p.beginGetMultiplePagesLRO.get(req)
+	if beginGetMultiplePagesLRO == nil {
 		clientRequestIDParam := getOptional(getHeaderValue(req.Header, "client-request-id"))
 		maxresultsParam, err := parseOptional(getHeaderValue(req.Header, "maxresults"), func(v string) (int32, error) {
 			p, parseErr := strconv.ParseInt(v, 10, 32)
@@ -471,19 +513,21 @@ func (p *PagingServerTransport) dispatchBeginGetMultiplePagesLRO(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginGetMultiplePagesLRO = &respr
+		beginGetMultiplePagesLRO = &respr
+		p.beginGetMultiplePagesLRO.add(req, beginGetMultiplePagesLRO)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginGetMultiplePagesLRO, req)
+	resp, err := server.PollerResponderNext(beginGetMultiplePagesLRO, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		p.beginGetMultiplePagesLRO.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginGetMultiplePagesLRO) {
-		p.beginGetMultiplePagesLRO = nil
+	if !server.PollerResponderMore(beginGetMultiplePagesLRO) {
+		p.beginGetMultiplePagesLRO.remove(req)
 	}
 
 	return resp, nil
@@ -493,22 +537,25 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesRetryFirstPager(req *
 	if p.srv.NewGetMultiplePagesRetryFirstPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesRetryFirstPager not implemented")}
 	}
-	if p.newGetMultiplePagesRetryFirstPager == nil {
+	newGetMultiplePagesRetryFirstPager := p.newGetMultiplePagesRetryFirstPager.get(req)
+	if newGetMultiplePagesRetryFirstPager == nil {
 		resp := p.srv.NewGetMultiplePagesRetryFirstPager(nil)
-		p.newGetMultiplePagesRetryFirstPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesRetryFirstPager, req, func(page *paginggroup.PagingClientGetMultiplePagesRetryFirstResponse, createLink func() string) {
+		newGetMultiplePagesRetryFirstPager = &resp
+		p.newGetMultiplePagesRetryFirstPager.add(req, newGetMultiplePagesRetryFirstPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesRetryFirstPager, req, func(page *paginggroup.PagingClientGetMultiplePagesRetryFirstResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesRetryFirstPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesRetryFirstPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesRetryFirstPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesRetryFirstPager) {
-		p.newGetMultiplePagesRetryFirstPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesRetryFirstPager) {
+		p.newGetMultiplePagesRetryFirstPager.remove(req)
 	}
 	return resp, nil
 }
@@ -517,22 +564,25 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesRetrySecondPager(req 
 	if p.srv.NewGetMultiplePagesRetrySecondPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesRetrySecondPager not implemented")}
 	}
-	if p.newGetMultiplePagesRetrySecondPager == nil {
+	newGetMultiplePagesRetrySecondPager := p.newGetMultiplePagesRetrySecondPager.get(req)
+	if newGetMultiplePagesRetrySecondPager == nil {
 		resp := p.srv.NewGetMultiplePagesRetrySecondPager(nil)
-		p.newGetMultiplePagesRetrySecondPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesRetrySecondPager, req, func(page *paginggroup.PagingClientGetMultiplePagesRetrySecondResponse, createLink func() string) {
+		newGetMultiplePagesRetrySecondPager = &resp
+		p.newGetMultiplePagesRetrySecondPager.add(req, newGetMultiplePagesRetrySecondPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesRetrySecondPager, req, func(page *paginggroup.PagingClientGetMultiplePagesRetrySecondResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesRetrySecondPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesRetrySecondPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesRetrySecondPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesRetrySecondPager) {
-		p.newGetMultiplePagesRetrySecondPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesRetrySecondPager) {
+		p.newGetMultiplePagesRetrySecondPager.remove(req)
 	}
 	return resp, nil
 }
@@ -541,7 +591,8 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesWithOffsetPager(req *
 	if p.srv.NewGetMultiplePagesWithOffsetPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetMultiplePagesWithOffsetPager not implemented")}
 	}
-	if p.newGetMultiplePagesWithOffsetPager == nil {
+	newGetMultiplePagesWithOffsetPager := p.newGetMultiplePagesWithOffsetPager.get(req)
+	if newGetMultiplePagesWithOffsetPager == nil {
 		const regexStr = `/paging/multiple/withpath/(?P<offset>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -590,20 +641,22 @@ func (p *PagingServerTransport) dispatchNewGetMultiplePagesWithOffsetPager(req *
 			Timeout:         timeoutParam,
 		}
 		resp := p.srv.NewGetMultiplePagesWithOffsetPager(options)
-		p.newGetMultiplePagesWithOffsetPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetMultiplePagesWithOffsetPager, req, func(page *paginggroup.PagingClientGetMultiplePagesWithOffsetResponse, createLink func() string) {
+		newGetMultiplePagesWithOffsetPager = &resp
+		p.newGetMultiplePagesWithOffsetPager.add(req, newGetMultiplePagesWithOffsetPager)
+		server.PagerResponderInjectNextLinks(newGetMultiplePagesWithOffsetPager, req, func(page *paginggroup.PagingClientGetMultiplePagesWithOffsetResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetMultiplePagesWithOffsetPager, req)
+	resp, err := server.PagerResponderNext(newGetMultiplePagesWithOffsetPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetMultiplePagesWithOffsetPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetMultiplePagesWithOffsetPager) {
-		p.newGetMultiplePagesWithOffsetPager = nil
+	if !server.PagerResponderMore(newGetMultiplePagesWithOffsetPager) {
+		p.newGetMultiplePagesWithOffsetPager.remove(req)
 	}
 	return resp, nil
 }
@@ -612,22 +665,25 @@ func (p *PagingServerTransport) dispatchNewGetNoItemNamePagesPager(req *http.Req
 	if p.srv.NewGetNoItemNamePagesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetNoItemNamePagesPager not implemented")}
 	}
-	if p.newGetNoItemNamePagesPager == nil {
+	newGetNoItemNamePagesPager := p.newGetNoItemNamePagesPager.get(req)
+	if newGetNoItemNamePagesPager == nil {
 		resp := p.srv.NewGetNoItemNamePagesPager(nil)
-		p.newGetNoItemNamePagesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetNoItemNamePagesPager, req, func(page *paginggroup.PagingClientGetNoItemNamePagesResponse, createLink func() string) {
+		newGetNoItemNamePagesPager = &resp
+		p.newGetNoItemNamePagesPager.add(req, newGetNoItemNamePagesPager)
+		server.PagerResponderInjectNextLinks(newGetNoItemNamePagesPager, req, func(page *paginggroup.PagingClientGetNoItemNamePagesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetNoItemNamePagesPager, req)
+	resp, err := server.PagerResponderNext(newGetNoItemNamePagesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetNoItemNamePagesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetNoItemNamePagesPager) {
-		p.newGetNoItemNamePagesPager = nil
+	if !server.PagerResponderMore(newGetNoItemNamePagesPager) {
+		p.newGetNoItemNamePagesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -636,19 +692,22 @@ func (p *PagingServerTransport) dispatchNewGetNullNextLinkNamePagesPager(req *ht
 	if p.srv.NewGetNullNextLinkNamePagesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetNullNextLinkNamePagesPager not implemented")}
 	}
-	if p.newGetNullNextLinkNamePagesPager == nil {
+	newGetNullNextLinkNamePagesPager := p.newGetNullNextLinkNamePagesPager.get(req)
+	if newGetNullNextLinkNamePagesPager == nil {
 		resp := p.srv.NewGetNullNextLinkNamePagesPager(nil)
-		p.newGetNullNextLinkNamePagesPager = &resp
+		newGetNullNextLinkNamePagesPager = &resp
+		p.newGetNullNextLinkNamePagesPager.add(req, newGetNullNextLinkNamePagesPager)
 	}
-	resp, err := server.PagerResponderNext(p.newGetNullNextLinkNamePagesPager, req)
+	resp, err := server.PagerResponderNext(newGetNullNextLinkNamePagesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetNullNextLinkNamePagesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetNullNextLinkNamePagesPager) {
-		p.newGetNullNextLinkNamePagesPager = nil
+	if !server.PagerResponderMore(newGetNullNextLinkNamePagesPager) {
+		p.newGetNullNextLinkNamePagesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -657,7 +716,8 @@ func (p *PagingServerTransport) dispatchNewGetODataMultiplePagesPager(req *http.
 	if p.srv.NewGetODataMultiplePagesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetODataMultiplePagesPager not implemented")}
 	}
-	if p.newGetODataMultiplePagesPager == nil {
+	newGetODataMultiplePagesPager := p.newGetODataMultiplePagesPager.get(req)
+	if newGetODataMultiplePagesPager == nil {
 		clientRequestIDParam := getOptional(getHeaderValue(req.Header, "client-request-id"))
 		maxresultsParam, err := parseOptional(getHeaderValue(req.Header, "maxresults"), func(v string) (int32, error) {
 			p, parseErr := strconv.ParseInt(v, 10, 32)
@@ -688,20 +748,22 @@ func (p *PagingServerTransport) dispatchNewGetODataMultiplePagesPager(req *http.
 			}
 		}
 		resp := p.srv.NewGetODataMultiplePagesPager(options)
-		p.newGetODataMultiplePagesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetODataMultiplePagesPager, req, func(page *paginggroup.PagingClientGetODataMultiplePagesResponse, createLink func() string) {
+		newGetODataMultiplePagesPager = &resp
+		p.newGetODataMultiplePagesPager.add(req, newGetODataMultiplePagesPager)
+		server.PagerResponderInjectNextLinks(newGetODataMultiplePagesPager, req, func(page *paginggroup.PagingClientGetODataMultiplePagesResponse, createLink func() string) {
 			page.ODataNextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetODataMultiplePagesPager, req)
+	resp, err := server.PagerResponderNext(newGetODataMultiplePagesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetODataMultiplePagesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetODataMultiplePagesPager) {
-		p.newGetODataMultiplePagesPager = nil
+	if !server.PagerResponderMore(newGetODataMultiplePagesPager) {
+		p.newGetODataMultiplePagesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -710,22 +772,25 @@ func (p *PagingServerTransport) dispatchNewGetPagingModelWithItemNameWithXMSClie
 	if p.srv.NewGetPagingModelWithItemNameWithXMSClientNamePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetPagingModelWithItemNameWithXMSClientNamePager not implemented")}
 	}
-	if p.newGetPagingModelWithItemNameWithXMSClientNamePager == nil {
+	newGetPagingModelWithItemNameWithXMSClientNamePager := p.newGetPagingModelWithItemNameWithXMSClientNamePager.get(req)
+	if newGetPagingModelWithItemNameWithXMSClientNamePager == nil {
 		resp := p.srv.NewGetPagingModelWithItemNameWithXMSClientNamePager(nil)
-		p.newGetPagingModelWithItemNameWithXMSClientNamePager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetPagingModelWithItemNameWithXMSClientNamePager, req, func(page *paginggroup.PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse, createLink func() string) {
+		newGetPagingModelWithItemNameWithXMSClientNamePager = &resp
+		p.newGetPagingModelWithItemNameWithXMSClientNamePager.add(req, newGetPagingModelWithItemNameWithXMSClientNamePager)
+		server.PagerResponderInjectNextLinks(newGetPagingModelWithItemNameWithXMSClientNamePager, req, func(page *paginggroup.PagingClientGetPagingModelWithItemNameWithXMSClientNameResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetPagingModelWithItemNameWithXMSClientNamePager, req)
+	resp, err := server.PagerResponderNext(newGetPagingModelWithItemNameWithXMSClientNamePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetPagingModelWithItemNameWithXMSClientNamePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetPagingModelWithItemNameWithXMSClientNamePager) {
-		p.newGetPagingModelWithItemNameWithXMSClientNamePager = nil
+	if !server.PagerResponderMore(newGetPagingModelWithItemNameWithXMSClientNamePager) {
+		p.newGetPagingModelWithItemNameWithXMSClientNamePager.remove(req)
 	}
 	return resp, nil
 }
@@ -734,22 +799,25 @@ func (p *PagingServerTransport) dispatchNewGetSinglePagesPager(req *http.Request
 	if p.srv.NewGetSinglePagesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetSinglePagesPager not implemented")}
 	}
-	if p.newGetSinglePagesPager == nil {
+	newGetSinglePagesPager := p.newGetSinglePagesPager.get(req)
+	if newGetSinglePagesPager == nil {
 		resp := p.srv.NewGetSinglePagesPager(nil)
-		p.newGetSinglePagesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetSinglePagesPager, req, func(page *paginggroup.PagingClientGetSinglePagesResponse, createLink func() string) {
+		newGetSinglePagesPager = &resp
+		p.newGetSinglePagesPager.add(req, newGetSinglePagesPager)
+		server.PagerResponderInjectNextLinks(newGetSinglePagesPager, req, func(page *paginggroup.PagingClientGetSinglePagesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetSinglePagesPager, req)
+	resp, err := server.PagerResponderNext(newGetSinglePagesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetSinglePagesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetSinglePagesPager) {
-		p.newGetSinglePagesPager = nil
+	if !server.PagerResponderMore(newGetSinglePagesPager) {
+		p.newGetSinglePagesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -758,22 +826,25 @@ func (p *PagingServerTransport) dispatchNewGetSinglePagesFailurePager(req *http.
 	if p.srv.NewGetSinglePagesFailurePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetSinglePagesFailurePager not implemented")}
 	}
-	if p.newGetSinglePagesFailurePager == nil {
+	newGetSinglePagesFailurePager := p.newGetSinglePagesFailurePager.get(req)
+	if newGetSinglePagesFailurePager == nil {
 		resp := p.srv.NewGetSinglePagesFailurePager(nil)
-		p.newGetSinglePagesFailurePager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetSinglePagesFailurePager, req, func(page *paginggroup.PagingClientGetSinglePagesFailureResponse, createLink func() string) {
+		newGetSinglePagesFailurePager = &resp
+		p.newGetSinglePagesFailurePager.add(req, newGetSinglePagesFailurePager)
+		server.PagerResponderInjectNextLinks(newGetSinglePagesFailurePager, req, func(page *paginggroup.PagingClientGetSinglePagesFailureResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetSinglePagesFailurePager, req)
+	resp, err := server.PagerResponderNext(newGetSinglePagesFailurePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetSinglePagesFailurePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetSinglePagesFailurePager) {
-		p.newGetSinglePagesFailurePager = nil
+	if !server.PagerResponderMore(newGetSinglePagesFailurePager) {
+		p.newGetSinglePagesFailurePager.remove(req)
 	}
 	return resp, nil
 }
@@ -782,7 +853,8 @@ func (p *PagingServerTransport) dispatchNewGetWithQueryParamsPager(req *http.Req
 	if p.srv.NewGetWithQueryParamsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetWithQueryParamsPager not implemented")}
 	}
-	if p.newGetWithQueryParamsPager == nil {
+	newGetWithQueryParamsPager := p.newGetWithQueryParamsPager.get(req)
+	if newGetWithQueryParamsPager == nil {
 		qp := req.URL.Query()
 		requiredQueryParameterUnescaped, err := url.QueryUnescape(qp.Get("requiredQueryParameter"))
 		if err != nil {
@@ -799,20 +871,22 @@ func (p *PagingServerTransport) dispatchNewGetWithQueryParamsPager(req *http.Req
 			return nil, err
 		}
 		resp := p.srv.NewGetWithQueryParamsPager(int32(requiredQueryParameterParam), nil)
-		p.newGetWithQueryParamsPager = &resp
-		server.PagerResponderInjectNextLinks(p.newGetWithQueryParamsPager, req, func(page *paginggroup.PagingClientGetWithQueryParamsResponse, createLink func() string) {
+		newGetWithQueryParamsPager = &resp
+		p.newGetWithQueryParamsPager.add(req, newGetWithQueryParamsPager)
+		server.PagerResponderInjectNextLinks(newGetWithQueryParamsPager, req, func(page *paginggroup.PagingClientGetWithQueryParamsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newGetWithQueryParamsPager, req)
+	resp, err := server.PagerResponderNext(newGetWithQueryParamsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newGetWithQueryParamsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newGetWithQueryParamsPager) {
-		p.newGetWithQueryParamsPager = nil
+	if !server.PagerResponderMore(newGetWithQueryParamsPager) {
+		p.newGetWithQueryParamsPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_availabilitysets_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_availabilitysets_server.go
@@ -57,16 +57,21 @@ type AvailabilitySetsServer struct {
 // The returned AvailabilitySetsServerTransport instance is connected to an instance of armcompute.AvailabilitySetsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailabilitySetsServerTransport(srv *AvailabilitySetsServer) *AvailabilitySetsServerTransport {
-	return &AvailabilitySetsServerTransport{srv: srv}
+	return &AvailabilitySetsServerTransport{
+		srv:                        srv,
+		newListPager:               newTracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListResponse]](),
+		newListAvailableSizesPager: newTracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListAvailableSizesResponse]](),
+		newListBySubscriptionPager: newTracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListBySubscriptionResponse]](),
+	}
 }
 
 // AvailabilitySetsServerTransport connects instances of armcompute.AvailabilitySetsClient to instances of AvailabilitySetsServer.
 // Don't use this type directly, use NewAvailabilitySetsServerTransport instead.
 type AvailabilitySetsServerTransport struct {
 	srv                        *AvailabilitySetsServer
-	newListPager               *azfake.PagerResponder[armcompute.AvailabilitySetsClientListResponse]
-	newListAvailableSizesPager *azfake.PagerResponder[armcompute.AvailabilitySetsClientListAvailableSizesResponse]
-	newListBySubscriptionPager *azfake.PagerResponder[armcompute.AvailabilitySetsClientListBySubscriptionResponse]
+	newListPager               *tracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListResponse]]
+	newListAvailableSizesPager *tracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListAvailableSizesResponse]]
+	newListBySubscriptionPager *tracker[azfake.PagerResponder[armcompute.AvailabilitySetsClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailabilitySetsServerTransport.
@@ -213,7 +218,8 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListPager(req *http.Request
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/availabilitySets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -225,20 +231,22 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListPager(req *http.Request
 			return nil, err
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armcompute.AvailabilitySetsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.AvailabilitySetsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -247,7 +255,8 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListAvailableSizesPager(req
 	if a.srv.NewListAvailableSizesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAvailableSizesPager not implemented")}
 	}
-	if a.newListAvailableSizesPager == nil {
+	newListAvailableSizesPager := a.newListAvailableSizesPager.get(req)
+	if newListAvailableSizesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/availabilitySets/(?P<availabilitySetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vmSizes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -263,17 +272,19 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListAvailableSizesPager(req
 			return nil, err
 		}
 		resp := a.srv.NewListAvailableSizesPager(resourceGroupNameUnescaped, availabilitySetNameUnescaped, nil)
-		a.newListAvailableSizesPager = &resp
+		newListAvailableSizesPager = &resp
+		a.newListAvailableSizesPager.add(req, newListAvailableSizesPager)
 	}
-	resp, err := server.PagerResponderNext(a.newListAvailableSizesPager, req)
+	resp, err := server.PagerResponderNext(newListAvailableSizesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListAvailableSizesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListAvailableSizesPager) {
-		a.newListAvailableSizesPager = nil
+	if !server.PagerResponderMore(newListAvailableSizesPager) {
+		a.newListAvailableSizesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -282,7 +293,8 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListBySubscriptionPager(req
 	if a.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if a.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := a.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/availabilitySets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -302,20 +314,22 @@ func (a *AvailabilitySetsServerTransport) dispatchNewListBySubscriptionPager(req
 			}
 		}
 		resp := a.srv.NewListBySubscriptionPager(options)
-		a.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListBySubscriptionPager, req, func(page *armcompute.AvailabilitySetsClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		a.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armcompute.AvailabilitySetsClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListBySubscriptionPager) {
-		a.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		a.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_capacityreservationgroups_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_capacityreservationgroups_server.go
@@ -53,15 +53,19 @@ type CapacityReservationGroupsServer struct {
 // The returned CapacityReservationGroupsServerTransport instance is connected to an instance of armcompute.CapacityReservationGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCapacityReservationGroupsServerTransport(srv *CapacityReservationGroupsServer) *CapacityReservationGroupsServerTransport {
-	return &CapacityReservationGroupsServerTransport{srv: srv}
+	return &CapacityReservationGroupsServerTransport{
+		srv:                         srv,
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListByResourceGroupResponse]](),
+		newListBySubscriptionPager:  newTracker[azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListBySubscriptionResponse]](),
+	}
 }
 
 // CapacityReservationGroupsServerTransport connects instances of armcompute.CapacityReservationGroupsClient to instances of CapacityReservationGroupsServer.
 // Don't use this type directly, use NewCapacityReservationGroupsServerTransport instead.
 type CapacityReservationGroupsServerTransport struct {
 	srv                         *CapacityReservationGroupsServer
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListByResourceGroupResponse]
-	newListBySubscriptionPager  *azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListBySubscriptionResponse]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListByResourceGroupResponse]]
+	newListBySubscriptionPager  *tracker[azfake.PagerResponder[armcompute.CapacityReservationGroupsClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for CapacityReservationGroupsServerTransport.
@@ -218,7 +222,8 @@ func (c *CapacityReservationGroupsServerTransport) dispatchNewListByResourceGrou
 	if c.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if c.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := c.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -242,20 +247,22 @@ func (c *CapacityReservationGroupsServerTransport) dispatchNewListByResourceGrou
 			}
 		}
 		resp := c.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, options)
-		c.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListByResourceGroupPager, req, func(page *armcompute.CapacityReservationGroupsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		c.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.CapacityReservationGroupsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListByResourceGroupPager) {
-		c.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		c.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -264,7 +271,8 @@ func (c *CapacityReservationGroupsServerTransport) dispatchNewListBySubscription
 	if c.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if c.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := c.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -284,20 +292,22 @@ func (c *CapacityReservationGroupsServerTransport) dispatchNewListBySubscription
 			}
 		}
 		resp := c.srv.NewListBySubscriptionPager(options)
-		c.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListBySubscriptionPager, req, func(page *armcompute.CapacityReservationGroupsClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		c.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armcompute.CapacityReservationGroupsClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListBySubscriptionPager) {
-		c.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		c.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_capacityreservations_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_capacityreservations_server.go
@@ -49,17 +49,23 @@ type CapacityReservationsServer struct {
 // The returned CapacityReservationsServerTransport instance is connected to an instance of armcompute.CapacityReservationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCapacityReservationsServerTransport(srv *CapacityReservationsServer) *CapacityReservationsServerTransport {
-	return &CapacityReservationsServerTransport{srv: srv}
+	return &CapacityReservationsServerTransport{
+		srv:                                    srv,
+		beginCreateOrUpdate:                    newTracker[azfake.PollerResponder[armcompute.CapacityReservationsClientCreateOrUpdateResponse]](),
+		beginDelete:                            newTracker[azfake.PollerResponder[armcompute.CapacityReservationsClientDeleteResponse]](),
+		newListByCapacityReservationGroupPager: newTracker[azfake.PagerResponder[armcompute.CapacityReservationsClientListByCapacityReservationGroupResponse]](),
+		beginUpdate:                            newTracker[azfake.PollerResponder[armcompute.CapacityReservationsClientUpdateResponse]](),
+	}
 }
 
 // CapacityReservationsServerTransport connects instances of armcompute.CapacityReservationsClient to instances of CapacityReservationsServer.
 // Don't use this type directly, use NewCapacityReservationsServerTransport instead.
 type CapacityReservationsServerTransport struct {
 	srv                                    *CapacityReservationsServer
-	beginCreateOrUpdate                    *azfake.PollerResponder[armcompute.CapacityReservationsClientCreateOrUpdateResponse]
-	beginDelete                            *azfake.PollerResponder[armcompute.CapacityReservationsClientDeleteResponse]
-	newListByCapacityReservationGroupPager *azfake.PagerResponder[armcompute.CapacityReservationsClientListByCapacityReservationGroupResponse]
-	beginUpdate                            *azfake.PollerResponder[armcompute.CapacityReservationsClientUpdateResponse]
+	beginCreateOrUpdate                    *tracker[azfake.PollerResponder[armcompute.CapacityReservationsClientCreateOrUpdateResponse]]
+	beginDelete                            *tracker[azfake.PollerResponder[armcompute.CapacityReservationsClientDeleteResponse]]
+	newListByCapacityReservationGroupPager *tracker[azfake.PagerResponder[armcompute.CapacityReservationsClientListByCapacityReservationGroupResponse]]
+	beginUpdate                            *tracker[azfake.PollerResponder[armcompute.CapacityReservationsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for CapacityReservationsServerTransport.
@@ -99,7 +105,8 @@ func (c *CapacityReservationsServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if c.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if c.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := c.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups/(?P<capacityReservationGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/capacityReservations/(?P<capacityReservationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -126,19 +133,21 @@ func (c *CapacityReservationsServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		c.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		c.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginCreateOrUpdate) {
-		c.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		c.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -148,7 +157,8 @@ func (c *CapacityReservationsServerTransport) dispatchBeginDelete(req *http.Requ
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups/(?P<capacityReservationGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/capacityReservations/(?P<capacityReservationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +181,21 @@ func (c *CapacityReservationsServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -242,7 +254,8 @@ func (c *CapacityReservationsServerTransport) dispatchNewListByCapacityReservati
 	if c.srv.NewListByCapacityReservationGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByCapacityReservationGroupPager not implemented")}
 	}
-	if c.newListByCapacityReservationGroupPager == nil {
+	newListByCapacityReservationGroupPager := c.newListByCapacityReservationGroupPager.get(req)
+	if newListByCapacityReservationGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups/(?P<capacityReservationGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/capacityReservations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -258,20 +271,22 @@ func (c *CapacityReservationsServerTransport) dispatchNewListByCapacityReservati
 			return nil, err
 		}
 		resp := c.srv.NewListByCapacityReservationGroupPager(resourceGroupNameUnescaped, capacityReservationGroupNameUnescaped, nil)
-		c.newListByCapacityReservationGroupPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListByCapacityReservationGroupPager, req, func(page *armcompute.CapacityReservationsClientListByCapacityReservationGroupResponse, createLink func() string) {
+		newListByCapacityReservationGroupPager = &resp
+		c.newListByCapacityReservationGroupPager.add(req, newListByCapacityReservationGroupPager)
+		server.PagerResponderInjectNextLinks(newListByCapacityReservationGroupPager, req, func(page *armcompute.CapacityReservationsClientListByCapacityReservationGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListByCapacityReservationGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByCapacityReservationGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListByCapacityReservationGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListByCapacityReservationGroupPager) {
-		c.newListByCapacityReservationGroupPager = nil
+	if !server.PagerResponderMore(newListByCapacityReservationGroupPager) {
+		c.newListByCapacityReservationGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -280,7 +295,8 @@ func (c *CapacityReservationsServerTransport) dispatchBeginUpdate(req *http.Requ
 	if c.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if c.beginUpdate == nil {
+	beginUpdate := c.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/capacityReservationGroups/(?P<capacityReservationGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/capacityReservations/(?P<capacityReservationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -307,19 +323,21 @@ func (c *CapacityReservationsServerTransport) dispatchBeginUpdate(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginUpdate = &respr
+		beginUpdate = &respr
+		c.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginUpdate) {
-		c.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		c.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceoperatingsystems_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceoperatingsystems_server.go
@@ -45,15 +45,19 @@ type CloudServiceOperatingSystemsServer struct {
 // The returned CloudServiceOperatingSystemsServerTransport instance is connected to an instance of armcompute.CloudServiceOperatingSystemsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCloudServiceOperatingSystemsServerTransport(srv *CloudServiceOperatingSystemsServer) *CloudServiceOperatingSystemsServerTransport {
-	return &CloudServiceOperatingSystemsServerTransport{srv: srv}
+	return &CloudServiceOperatingSystemsServerTransport{
+		srv:                    srv,
+		newListOSFamiliesPager: newTracker[azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSFamiliesResponse]](),
+		newListOSVersionsPager: newTracker[azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSVersionsResponse]](),
+	}
 }
 
 // CloudServiceOperatingSystemsServerTransport connects instances of armcompute.CloudServiceOperatingSystemsClient to instances of CloudServiceOperatingSystemsServer.
 // Don't use this type directly, use NewCloudServiceOperatingSystemsServerTransport instead.
 type CloudServiceOperatingSystemsServerTransport struct {
 	srv                    *CloudServiceOperatingSystemsServer
-	newListOSFamiliesPager *azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSFamiliesResponse]
-	newListOSVersionsPager *azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSVersionsResponse]
+	newListOSFamiliesPager *tracker[azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSFamiliesResponse]]
+	newListOSVersionsPager *tracker[azfake.PagerResponder[armcompute.CloudServiceOperatingSystemsClientListOSVersionsResponse]]
 }
 
 // Do implements the policy.Transporter interface for CloudServiceOperatingSystemsServerTransport.
@@ -157,7 +161,8 @@ func (c *CloudServiceOperatingSystemsServerTransport) dispatchNewListOSFamiliesP
 	if c.srv.NewListOSFamiliesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListOSFamiliesPager not implemented")}
 	}
-	if c.newListOSFamiliesPager == nil {
+	newListOSFamiliesPager := c.newListOSFamiliesPager.get(req)
+	if newListOSFamiliesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/cloudServiceOsFamilies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,20 +174,22 @@ func (c *CloudServiceOperatingSystemsServerTransport) dispatchNewListOSFamiliesP
 			return nil, err
 		}
 		resp := c.srv.NewListOSFamiliesPager(locationUnescaped, nil)
-		c.newListOSFamiliesPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListOSFamiliesPager, req, func(page *armcompute.CloudServiceOperatingSystemsClientListOSFamiliesResponse, createLink func() string) {
+		newListOSFamiliesPager = &resp
+		c.newListOSFamiliesPager.add(req, newListOSFamiliesPager)
+		server.PagerResponderInjectNextLinks(newListOSFamiliesPager, req, func(page *armcompute.CloudServiceOperatingSystemsClientListOSFamiliesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListOSFamiliesPager, req)
+	resp, err := server.PagerResponderNext(newListOSFamiliesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListOSFamiliesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListOSFamiliesPager) {
-		c.newListOSFamiliesPager = nil
+	if !server.PagerResponderMore(newListOSFamiliesPager) {
+		c.newListOSFamiliesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -191,7 +198,8 @@ func (c *CloudServiceOperatingSystemsServerTransport) dispatchNewListOSVersionsP
 	if c.srv.NewListOSVersionsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListOSVersionsPager not implemented")}
 	}
-	if c.newListOSVersionsPager == nil {
+	newListOSVersionsPager := c.newListOSVersionsPager.get(req)
+	if newListOSVersionsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/cloudServiceOsVersions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -203,20 +211,22 @@ func (c *CloudServiceOperatingSystemsServerTransport) dispatchNewListOSVersionsP
 			return nil, err
 		}
 		resp := c.srv.NewListOSVersionsPager(locationUnescaped, nil)
-		c.newListOSVersionsPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListOSVersionsPager, req, func(page *armcompute.CloudServiceOperatingSystemsClientListOSVersionsResponse, createLink func() string) {
+		newListOSVersionsPager = &resp
+		c.newListOSVersionsPager.add(req, newListOSVersionsPager)
+		server.PagerResponderInjectNextLinks(newListOSVersionsPager, req, func(page *armcompute.CloudServiceOperatingSystemsClientListOSVersionsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListOSVersionsPager, req)
+	resp, err := server.PagerResponderNext(newListOSVersionsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListOSVersionsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListOSVersionsPager) {
-		c.newListOSVersionsPager = nil
+	if !server.PagerResponderMore(newListOSVersionsPager) {
+		c.newListOSVersionsPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroleinstances_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroleinstances_server.go
@@ -61,18 +61,25 @@ type CloudServiceRoleInstancesServer struct {
 // The returned CloudServiceRoleInstancesServerTransport instance is connected to an instance of armcompute.CloudServiceRoleInstancesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCloudServiceRoleInstancesServerTransport(srv *CloudServiceRoleInstancesServer) *CloudServiceRoleInstancesServerTransport {
-	return &CloudServiceRoleInstancesServerTransport{srv: srv}
+	return &CloudServiceRoleInstancesServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armcompute.CloudServiceRoleInstancesClientListResponse]](),
+		beginRebuild: newTracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRebuildResponse]](),
+		beginReimage: newTracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientReimageResponse]](),
+		beginRestart: newTracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRestartResponse]](),
+	}
 }
 
 // CloudServiceRoleInstancesServerTransport connects instances of armcompute.CloudServiceRoleInstancesClient to instances of CloudServiceRoleInstancesServer.
 // Don't use this type directly, use NewCloudServiceRoleInstancesServerTransport instead.
 type CloudServiceRoleInstancesServerTransport struct {
 	srv          *CloudServiceRoleInstancesServer
-	beginDelete  *azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armcompute.CloudServiceRoleInstancesClientListResponse]
-	beginRebuild *azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRebuildResponse]
-	beginReimage *azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientReimageResponse]
-	beginRestart *azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRestartResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armcompute.CloudServiceRoleInstancesClientListResponse]]
+	beginRebuild *tracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRebuildResponse]]
+	beginReimage *tracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientReimageResponse]]
+	beginRestart *tracker[azfake.PollerResponder[armcompute.CloudServiceRoleInstancesClientRestartResponse]]
 }
 
 // Do implements the policy.Transporter interface for CloudServiceRoleInstancesServerTransport.
@@ -118,7 +125,8 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginDelete(req *http
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -141,19 +149,21 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -289,7 +299,8 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchNewListPager(req *htt
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -317,20 +328,22 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchNewListPager(req *htt
 			}
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, options)
-		c.newListPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListPager, req, func(page *armcompute.CloudServiceRoleInstancesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.CloudServiceRoleInstancesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -339,7 +352,8 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginRebuild(req *htt
 	if c.srv.BeginRebuild == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRebuild not implemented")}
 	}
-	if c.beginRebuild == nil {
+	beginRebuild := c.beginRebuild.get(req)
+	if beginRebuild == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rebuild`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -362,19 +376,21 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginRebuild(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginRebuild = &respr
+		beginRebuild = &respr
+		c.beginRebuild.add(req, beginRebuild)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginRebuild, req)
+	resp, err := server.PollerResponderNext(beginRebuild, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginRebuild.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginRebuild) {
-		c.beginRebuild = nil
+	if !server.PollerResponderMore(beginRebuild) {
+		c.beginRebuild.remove(req)
 	}
 
 	return resp, nil
@@ -384,7 +400,8 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginReimage(req *htt
 	if c.srv.BeginReimage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimage not implemented")}
 	}
-	if c.beginReimage == nil {
+	beginReimage := c.beginReimage.get(req)
+	if beginReimage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -407,19 +424,21 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginReimage(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginReimage = &respr
+		beginReimage = &respr
+		c.beginReimage.add(req, beginReimage)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginReimage, req)
+	resp, err := server.PollerResponderNext(beginReimage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginReimage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginReimage) {
-		c.beginReimage = nil
+	if !server.PollerResponderMore(beginReimage) {
+		c.beginReimage.remove(req)
 	}
 
 	return resp, nil
@@ -429,7 +448,8 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginRestart(req *htt
 	if c.srv.BeginRestart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRestart not implemented")}
 	}
-	if c.beginRestart == nil {
+	beginRestart := c.beginRestart.get(req)
+	if beginRestart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restart`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -452,19 +472,21 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchBeginRestart(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginRestart = &respr
+		beginRestart = &respr
+		c.beginRestart.add(req, beginRestart)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginRestart, req)
+	resp, err := server.PollerResponderNext(beginRestart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginRestart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginRestart) {
-		c.beginRestart = nil
+	if !server.PollerResponderMore(beginRestart) {
+		c.beginRestart.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroles_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroles_server.go
@@ -37,14 +37,17 @@ type CloudServiceRolesServer struct {
 // The returned CloudServiceRolesServerTransport instance is connected to an instance of armcompute.CloudServiceRolesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCloudServiceRolesServerTransport(srv *CloudServiceRolesServer) *CloudServiceRolesServerTransport {
-	return &CloudServiceRolesServerTransport{srv: srv}
+	return &CloudServiceRolesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.CloudServiceRolesClientListResponse]](),
+	}
 }
 
 // CloudServiceRolesServerTransport connects instances of armcompute.CloudServiceRolesClient to instances of CloudServiceRolesServer.
 // Don't use this type directly, use NewCloudServiceRolesServerTransport instead.
 type CloudServiceRolesServerTransport struct {
 	srv          *CloudServiceRolesServer
-	newListPager *azfake.PagerResponder[armcompute.CloudServiceRolesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.CloudServiceRolesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for CloudServiceRolesServerTransport.
@@ -115,7 +118,8 @@ func (c *CloudServiceRolesServerTransport) dispatchNewListPager(req *http.Reques
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roles`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (c *CloudServiceRolesServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, err
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, nil)
-		c.newListPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListPager, req, func(page *armcompute.CloudServiceRolesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.CloudServiceRolesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudservices_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudservices_server.go
@@ -82,24 +82,37 @@ type CloudServicesServer struct {
 // The returned CloudServicesServerTransport instance is connected to an instance of armcompute.CloudServicesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCloudServicesServerTransport(srv *CloudServicesServer) *CloudServicesServerTransport {
-	return &CloudServicesServerTransport{srv: srv}
+	return &CloudServicesServerTransport{
+		srv:                  srv,
+		beginCreateOrUpdate:  newTracker[azfake.PollerResponder[armcompute.CloudServicesClientCreateOrUpdateResponse]](),
+		beginDelete:          newTracker[azfake.PollerResponder[armcompute.CloudServicesClientDeleteResponse]](),
+		beginDeleteInstances: newTracker[azfake.PollerResponder[armcompute.CloudServicesClientDeleteInstancesResponse]](),
+		newListPager:         newTracker[azfake.PagerResponder[armcompute.CloudServicesClientListResponse]](),
+		newListAllPager:      newTracker[azfake.PagerResponder[armcompute.CloudServicesClientListAllResponse]](),
+		beginPowerOff:        newTracker[azfake.PollerResponder[armcompute.CloudServicesClientPowerOffResponse]](),
+		beginRebuild:         newTracker[azfake.PollerResponder[armcompute.CloudServicesClientRebuildResponse]](),
+		beginReimage:         newTracker[azfake.PollerResponder[armcompute.CloudServicesClientReimageResponse]](),
+		beginRestart:         newTracker[azfake.PollerResponder[armcompute.CloudServicesClientRestartResponse]](),
+		beginStart:           newTracker[azfake.PollerResponder[armcompute.CloudServicesClientStartResponse]](),
+		beginUpdate:          newTracker[azfake.PollerResponder[armcompute.CloudServicesClientUpdateResponse]](),
+	}
 }
 
 // CloudServicesServerTransport connects instances of armcompute.CloudServicesClient to instances of CloudServicesServer.
 // Don't use this type directly, use NewCloudServicesServerTransport instead.
 type CloudServicesServerTransport struct {
 	srv                  *CloudServicesServer
-	beginCreateOrUpdate  *azfake.PollerResponder[armcompute.CloudServicesClientCreateOrUpdateResponse]
-	beginDelete          *azfake.PollerResponder[armcompute.CloudServicesClientDeleteResponse]
-	beginDeleteInstances *azfake.PollerResponder[armcompute.CloudServicesClientDeleteInstancesResponse]
-	newListPager         *azfake.PagerResponder[armcompute.CloudServicesClientListResponse]
-	newListAllPager      *azfake.PagerResponder[armcompute.CloudServicesClientListAllResponse]
-	beginPowerOff        *azfake.PollerResponder[armcompute.CloudServicesClientPowerOffResponse]
-	beginRebuild         *azfake.PollerResponder[armcompute.CloudServicesClientRebuildResponse]
-	beginReimage         *azfake.PollerResponder[armcompute.CloudServicesClientReimageResponse]
-	beginRestart         *azfake.PollerResponder[armcompute.CloudServicesClientRestartResponse]
-	beginStart           *azfake.PollerResponder[armcompute.CloudServicesClientStartResponse]
-	beginUpdate          *azfake.PollerResponder[armcompute.CloudServicesClientUpdateResponse]
+	beginCreateOrUpdate  *tracker[azfake.PollerResponder[armcompute.CloudServicesClientCreateOrUpdateResponse]]
+	beginDelete          *tracker[azfake.PollerResponder[armcompute.CloudServicesClientDeleteResponse]]
+	beginDeleteInstances *tracker[azfake.PollerResponder[armcompute.CloudServicesClientDeleteInstancesResponse]]
+	newListPager         *tracker[azfake.PagerResponder[armcompute.CloudServicesClientListResponse]]
+	newListAllPager      *tracker[azfake.PagerResponder[armcompute.CloudServicesClientListAllResponse]]
+	beginPowerOff        *tracker[azfake.PollerResponder[armcompute.CloudServicesClientPowerOffResponse]]
+	beginRebuild         *tracker[azfake.PollerResponder[armcompute.CloudServicesClientRebuildResponse]]
+	beginReimage         *tracker[azfake.PollerResponder[armcompute.CloudServicesClientReimageResponse]]
+	beginRestart         *tracker[azfake.PollerResponder[armcompute.CloudServicesClientRestartResponse]]
+	beginStart           *tracker[azfake.PollerResponder[armcompute.CloudServicesClientStartResponse]]
+	beginUpdate          *tracker[azfake.PollerResponder[armcompute.CloudServicesClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for CloudServicesServerTransport.
@@ -155,7 +168,8 @@ func (c *CloudServicesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if c.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if c.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := c.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -178,19 +192,21 @@ func (c *CloudServicesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		c.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		c.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginCreateOrUpdate) {
-		c.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		c.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -200,7 +216,8 @@ func (c *CloudServicesServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -219,19 +236,21 @@ func (c *CloudServicesServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -241,7 +260,8 @@ func (c *CloudServicesServerTransport) dispatchBeginDeleteInstances(req *http.Re
 	if c.srv.BeginDeleteInstances == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteInstances not implemented")}
 	}
-	if c.beginDeleteInstances == nil {
+	beginDeleteInstances := c.beginDeleteInstances.get(req)
+	if beginDeleteInstances == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/delete`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -270,19 +290,21 @@ func (c *CloudServicesServerTransport) dispatchBeginDeleteInstances(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDeleteInstances = &respr
+		beginDeleteInstances = &respr
+		c.beginDeleteInstances.add(req, beginDeleteInstances)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDeleteInstances, req)
+	resp, err := server.PollerResponderNext(beginDeleteInstances, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginDeleteInstances.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDeleteInstances) {
-		c.beginDeleteInstances = nil
+	if !server.PollerResponderMore(beginDeleteInstances) {
+		c.beginDeleteInstances.remove(req)
 	}
 
 	return resp, nil
@@ -358,7 +380,8 @@ func (c *CloudServicesServerTransport) dispatchNewListPager(req *http.Request) (
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -370,20 +393,22 @@ func (c *CloudServicesServerTransport) dispatchNewListPager(req *http.Request) (
 			return nil, err
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		c.newListPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListPager, req, func(page *armcompute.CloudServicesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.CloudServicesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -392,7 +417,8 @@ func (c *CloudServicesServerTransport) dispatchNewListAllPager(req *http.Request
 	if c.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if c.newListAllPager == nil {
+	newListAllPager := c.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -400,20 +426,22 @@ func (c *CloudServicesServerTransport) dispatchNewListAllPager(req *http.Request
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := c.srv.NewListAllPager(nil)
-		c.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListAllPager, req, func(page *armcompute.CloudServicesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		c.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armcompute.CloudServicesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListAllPager) {
-		c.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		c.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -422,7 +450,8 @@ func (c *CloudServicesServerTransport) dispatchBeginPowerOff(req *http.Request) 
 	if c.srv.BeginPowerOff == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPowerOff not implemented")}
 	}
-	if c.beginPowerOff == nil {
+	beginPowerOff := c.beginPowerOff.get(req)
+	if beginPowerOff == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/poweroff`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -441,19 +470,21 @@ func (c *CloudServicesServerTransport) dispatchBeginPowerOff(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginPowerOff = &respr
+		beginPowerOff = &respr
+		c.beginPowerOff.add(req, beginPowerOff)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginPowerOff, req)
+	resp, err := server.PollerResponderNext(beginPowerOff, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginPowerOff.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginPowerOff) {
-		c.beginPowerOff = nil
+	if !server.PollerResponderMore(beginPowerOff) {
+		c.beginPowerOff.remove(req)
 	}
 
 	return resp, nil
@@ -463,7 +494,8 @@ func (c *CloudServicesServerTransport) dispatchBeginRebuild(req *http.Request) (
 	if c.srv.BeginRebuild == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRebuild not implemented")}
 	}
-	if c.beginRebuild == nil {
+	beginRebuild := c.beginRebuild.get(req)
+	if beginRebuild == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rebuild`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -492,19 +524,21 @@ func (c *CloudServicesServerTransport) dispatchBeginRebuild(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginRebuild = &respr
+		beginRebuild = &respr
+		c.beginRebuild.add(req, beginRebuild)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginRebuild, req)
+	resp, err := server.PollerResponderNext(beginRebuild, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginRebuild.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginRebuild) {
-		c.beginRebuild = nil
+	if !server.PollerResponderMore(beginRebuild) {
+		c.beginRebuild.remove(req)
 	}
 
 	return resp, nil
@@ -514,7 +548,8 @@ func (c *CloudServicesServerTransport) dispatchBeginReimage(req *http.Request) (
 	if c.srv.BeginReimage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimage not implemented")}
 	}
-	if c.beginReimage == nil {
+	beginReimage := c.beginReimage.get(req)
+	if beginReimage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -543,19 +578,21 @@ func (c *CloudServicesServerTransport) dispatchBeginReimage(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginReimage = &respr
+		beginReimage = &respr
+		c.beginReimage.add(req, beginReimage)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginReimage, req)
+	resp, err := server.PollerResponderNext(beginReimage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginReimage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginReimage) {
-		c.beginReimage = nil
+	if !server.PollerResponderMore(beginReimage) {
+		c.beginReimage.remove(req)
 	}
 
 	return resp, nil
@@ -565,7 +602,8 @@ func (c *CloudServicesServerTransport) dispatchBeginRestart(req *http.Request) (
 	if c.srv.BeginRestart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRestart not implemented")}
 	}
-	if c.beginRestart == nil {
+	beginRestart := c.beginRestart.get(req)
+	if beginRestart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restart`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -594,19 +632,21 @@ func (c *CloudServicesServerTransport) dispatchBeginRestart(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginRestart = &respr
+		beginRestart = &respr
+		c.beginRestart.add(req, beginRestart)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginRestart, req)
+	resp, err := server.PollerResponderNext(beginRestart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginRestart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginRestart) {
-		c.beginRestart = nil
+	if !server.PollerResponderMore(beginRestart) {
+		c.beginRestart.remove(req)
 	}
 
 	return resp, nil
@@ -616,7 +656,8 @@ func (c *CloudServicesServerTransport) dispatchBeginStart(req *http.Request) (*h
 	if c.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if c.beginStart == nil {
+	beginStart := c.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -635,19 +676,21 @@ func (c *CloudServicesServerTransport) dispatchBeginStart(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginStart = &respr
+		beginStart = &respr
+		c.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginStart) {
-		c.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		c.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -657,7 +700,8 @@ func (c *CloudServicesServerTransport) dispatchBeginUpdate(req *http.Request) (*
 	if c.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if c.beginUpdate == nil {
+	beginUpdate := c.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -680,19 +724,21 @@ func (c *CloudServicesServerTransport) dispatchBeginUpdate(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginUpdate = &respr
+		beginUpdate = &respr
+		c.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginUpdate) {
-		c.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		c.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudservicesupdatedomain_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudservicesupdatedomain_server.go
@@ -42,15 +42,19 @@ type CloudServicesUpdateDomainServer struct {
 // The returned CloudServicesUpdateDomainServerTransport instance is connected to an instance of armcompute.CloudServicesUpdateDomainClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCloudServicesUpdateDomainServerTransport(srv *CloudServicesUpdateDomainServer) *CloudServicesUpdateDomainServerTransport {
-	return &CloudServicesUpdateDomainServerTransport{srv: srv}
+	return &CloudServicesUpdateDomainServerTransport{
+		srv:                       srv,
+		newListUpdateDomainsPager: newTracker[azfake.PagerResponder[armcompute.CloudServicesUpdateDomainClientListUpdateDomainsResponse]](),
+		beginWalkUpdateDomain:     newTracker[azfake.PollerResponder[armcompute.CloudServicesUpdateDomainClientWalkUpdateDomainResponse]](),
+	}
 }
 
 // CloudServicesUpdateDomainServerTransport connects instances of armcompute.CloudServicesUpdateDomainClient to instances of CloudServicesUpdateDomainServer.
 // Don't use this type directly, use NewCloudServicesUpdateDomainServerTransport instead.
 type CloudServicesUpdateDomainServerTransport struct {
 	srv                       *CloudServicesUpdateDomainServer
-	newListUpdateDomainsPager *azfake.PagerResponder[armcompute.CloudServicesUpdateDomainClientListUpdateDomainsResponse]
-	beginWalkUpdateDomain     *azfake.PollerResponder[armcompute.CloudServicesUpdateDomainClientWalkUpdateDomainResponse]
+	newListUpdateDomainsPager *tracker[azfake.PagerResponder[armcompute.CloudServicesUpdateDomainClientListUpdateDomainsResponse]]
+	beginWalkUpdateDomain     *tracker[azfake.PollerResponder[armcompute.CloudServicesUpdateDomainClientWalkUpdateDomainResponse]]
 }
 
 // Do implements the policy.Transporter interface for CloudServicesUpdateDomainServerTransport.
@@ -133,7 +137,8 @@ func (c *CloudServicesUpdateDomainServerTransport) dispatchNewListUpdateDomainsP
 	if c.srv.NewListUpdateDomainsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListUpdateDomainsPager not implemented")}
 	}
-	if c.newListUpdateDomainsPager == nil {
+	newListUpdateDomainsPager := c.newListUpdateDomainsPager.get(req)
+	if newListUpdateDomainsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/updateDomains`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -149,20 +154,22 @@ func (c *CloudServicesUpdateDomainServerTransport) dispatchNewListUpdateDomainsP
 			return nil, err
 		}
 		resp := c.srv.NewListUpdateDomainsPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, nil)
-		c.newListUpdateDomainsPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListUpdateDomainsPager, req, func(page *armcompute.CloudServicesUpdateDomainClientListUpdateDomainsResponse, createLink func() string) {
+		newListUpdateDomainsPager = &resp
+		c.newListUpdateDomainsPager.add(req, newListUpdateDomainsPager)
+		server.PagerResponderInjectNextLinks(newListUpdateDomainsPager, req, func(page *armcompute.CloudServicesUpdateDomainClientListUpdateDomainsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListUpdateDomainsPager, req)
+	resp, err := server.PagerResponderNext(newListUpdateDomainsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListUpdateDomainsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListUpdateDomainsPager) {
-		c.newListUpdateDomainsPager = nil
+	if !server.PagerResponderMore(newListUpdateDomainsPager) {
+		c.newListUpdateDomainsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -171,7 +178,8 @@ func (c *CloudServicesUpdateDomainServerTransport) dispatchBeginWalkUpdateDomain
 	if c.srv.BeginWalkUpdateDomain == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginWalkUpdateDomain not implemented")}
 	}
-	if c.beginWalkUpdateDomain == nil {
+	beginWalkUpdateDomain := c.beginWalkUpdateDomain.get(req)
+	if beginWalkUpdateDomain == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/updateDomains/(?P<updateDomain>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -208,19 +216,21 @@ func (c *CloudServicesUpdateDomainServerTransport) dispatchBeginWalkUpdateDomain
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginWalkUpdateDomain = &respr
+		beginWalkUpdateDomain = &respr
+		c.beginWalkUpdateDomain.add(req, beginWalkUpdateDomain)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginWalkUpdateDomain, req)
+	resp, err := server.PollerResponderNext(beginWalkUpdateDomain, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginWalkUpdateDomain.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginWalkUpdateDomain) {
-		c.beginWalkUpdateDomain = nil
+	if !server.PollerResponderMore(beginWalkUpdateDomain) {
+		c.beginWalkUpdateDomain.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_dedicatedhostgroups_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_dedicatedhostgroups_server.go
@@ -53,15 +53,19 @@ type DedicatedHostGroupsServer struct {
 // The returned DedicatedHostGroupsServerTransport instance is connected to an instance of armcompute.DedicatedHostGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDedicatedHostGroupsServerTransport(srv *DedicatedHostGroupsServer) *DedicatedHostGroupsServerTransport {
-	return &DedicatedHostGroupsServerTransport{srv: srv}
+	return &DedicatedHostGroupsServerTransport{
+		srv:                         srv,
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListByResourceGroupResponse]](),
+		newListBySubscriptionPager:  newTracker[azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListBySubscriptionResponse]](),
+	}
 }
 
 // DedicatedHostGroupsServerTransport connects instances of armcompute.DedicatedHostGroupsClient to instances of DedicatedHostGroupsServer.
 // Don't use this type directly, use NewDedicatedHostGroupsServerTransport instead.
 type DedicatedHostGroupsServerTransport struct {
 	srv                         *DedicatedHostGroupsServer
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListByResourceGroupResponse]
-	newListBySubscriptionPager  *azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListBySubscriptionResponse]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListByResourceGroupResponse]]
+	newListBySubscriptionPager  *tracker[azfake.PagerResponder[armcompute.DedicatedHostGroupsClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for DedicatedHostGroupsServerTransport.
@@ -218,7 +222,8 @@ func (d *DedicatedHostGroupsServerTransport) dispatchNewListByResourceGroupPager
 	if d.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if d.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := d.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/hostGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -230,20 +235,22 @@ func (d *DedicatedHostGroupsServerTransport) dispatchNewListByResourceGroupPager
 			return nil, err
 		}
 		resp := d.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		d.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByResourceGroupPager, req, func(page *armcompute.DedicatedHostGroupsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		d.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.DedicatedHostGroupsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByResourceGroupPager) {
-		d.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		d.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -252,7 +259,8 @@ func (d *DedicatedHostGroupsServerTransport) dispatchNewListBySubscriptionPager(
 	if d.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if d.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := d.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/hostGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -260,20 +268,22 @@ func (d *DedicatedHostGroupsServerTransport) dispatchNewListBySubscriptionPager(
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListBySubscriptionPager(nil)
-		d.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListBySubscriptionPager, req, func(page *armcompute.DedicatedHostGroupsClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		d.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armcompute.DedicatedHostGroupsClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListBySubscriptionPager) {
-		d.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		d.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_diskaccesses_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_diskaccesses_server.go
@@ -73,21 +73,31 @@ type DiskAccessesServer struct {
 // The returned DiskAccessesServerTransport instance is connected to an instance of armcompute.DiskAccessesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDiskAccessesServerTransport(srv *DiskAccessesServer) *DiskAccessesServerTransport {
-	return &DiskAccessesServerTransport{srv: srv}
+	return &DiskAccessesServerTransport{
+		srv:                                    srv,
+		beginCreateOrUpdate:                    newTracker[azfake.PollerResponder[armcompute.DiskAccessesClientCreateOrUpdateResponse]](),
+		beginDelete:                            newTracker[azfake.PollerResponder[armcompute.DiskAccessesClientDeleteResponse]](),
+		beginDeleteAPrivateEndpointConnection:  newTracker[azfake.PollerResponder[armcompute.DiskAccessesClientDeleteAPrivateEndpointConnectionResponse]](),
+		newListPager:                           newTracker[azfake.PagerResponder[armcompute.DiskAccessesClientListResponse]](),
+		newListByResourceGroupPager:            newTracker[azfake.PagerResponder[armcompute.DiskAccessesClientListByResourceGroupResponse]](),
+		newListPrivateEndpointConnectionsPager: newTracker[azfake.PagerResponder[armcompute.DiskAccessesClientListPrivateEndpointConnectionsResponse]](),
+		beginUpdate:                            newTracker[azfake.PollerResponder[armcompute.DiskAccessesClientUpdateResponse]](),
+		beginUpdateAPrivateEndpointConnection:  newTracker[azfake.PollerResponder[armcompute.DiskAccessesClientUpdateAPrivateEndpointConnectionResponse]](),
+	}
 }
 
 // DiskAccessesServerTransport connects instances of armcompute.DiskAccessesClient to instances of DiskAccessesServer.
 // Don't use this type directly, use NewDiskAccessesServerTransport instead.
 type DiskAccessesServerTransport struct {
 	srv                                    *DiskAccessesServer
-	beginCreateOrUpdate                    *azfake.PollerResponder[armcompute.DiskAccessesClientCreateOrUpdateResponse]
-	beginDelete                            *azfake.PollerResponder[armcompute.DiskAccessesClientDeleteResponse]
-	beginDeleteAPrivateEndpointConnection  *azfake.PollerResponder[armcompute.DiskAccessesClientDeleteAPrivateEndpointConnectionResponse]
-	newListPager                           *azfake.PagerResponder[armcompute.DiskAccessesClientListResponse]
-	newListByResourceGroupPager            *azfake.PagerResponder[armcompute.DiskAccessesClientListByResourceGroupResponse]
-	newListPrivateEndpointConnectionsPager *azfake.PagerResponder[armcompute.DiskAccessesClientListPrivateEndpointConnectionsResponse]
-	beginUpdate                            *azfake.PollerResponder[armcompute.DiskAccessesClientUpdateResponse]
-	beginUpdateAPrivateEndpointConnection  *azfake.PollerResponder[armcompute.DiskAccessesClientUpdateAPrivateEndpointConnectionResponse]
+	beginCreateOrUpdate                    *tracker[azfake.PollerResponder[armcompute.DiskAccessesClientCreateOrUpdateResponse]]
+	beginDelete                            *tracker[azfake.PollerResponder[armcompute.DiskAccessesClientDeleteResponse]]
+	beginDeleteAPrivateEndpointConnection  *tracker[azfake.PollerResponder[armcompute.DiskAccessesClientDeleteAPrivateEndpointConnectionResponse]]
+	newListPager                           *tracker[azfake.PagerResponder[armcompute.DiskAccessesClientListResponse]]
+	newListByResourceGroupPager            *tracker[azfake.PagerResponder[armcompute.DiskAccessesClientListByResourceGroupResponse]]
+	newListPrivateEndpointConnectionsPager *tracker[azfake.PagerResponder[armcompute.DiskAccessesClientListPrivateEndpointConnectionsResponse]]
+	beginUpdate                            *tracker[azfake.PollerResponder[armcompute.DiskAccessesClientUpdateResponse]]
+	beginUpdateAPrivateEndpointConnection  *tracker[azfake.PollerResponder[armcompute.DiskAccessesClientUpdateAPrivateEndpointConnectionResponse]]
 }
 
 // Do implements the policy.Transporter interface for DiskAccessesServerTransport.
@@ -139,7 +149,8 @@ func (d *DiskAccessesServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -162,19 +173,21 @@ func (d *DiskAccessesServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -184,7 +197,8 @@ func (d *DiskAccessesServerTransport) dispatchBeginDelete(req *http.Request) (*h
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -203,19 +217,21 @@ func (d *DiskAccessesServerTransport) dispatchBeginDelete(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -225,7 +241,8 @@ func (d *DiskAccessesServerTransport) dispatchBeginDeleteAPrivateEndpointConnect
 	if d.srv.BeginDeleteAPrivateEndpointConnection == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteAPrivateEndpointConnection not implemented")}
 	}
-	if d.beginDeleteAPrivateEndpointConnection == nil {
+	beginDeleteAPrivateEndpointConnection := d.beginDeleteAPrivateEndpointConnection.get(req)
+	if beginDeleteAPrivateEndpointConnection == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections/(?P<privateEndpointConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,19 +265,21 @@ func (d *DiskAccessesServerTransport) dispatchBeginDeleteAPrivateEndpointConnect
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDeleteAPrivateEndpointConnection = &respr
+		beginDeleteAPrivateEndpointConnection = &respr
+		d.beginDeleteAPrivateEndpointConnection.add(req, beginDeleteAPrivateEndpointConnection)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDeleteAPrivateEndpointConnection, req)
+	resp, err := server.PollerResponderNext(beginDeleteAPrivateEndpointConnection, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDeleteAPrivateEndpointConnection.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDeleteAPrivateEndpointConnection) {
-		d.beginDeleteAPrivateEndpointConnection = nil
+	if !server.PollerResponderMore(beginDeleteAPrivateEndpointConnection) {
+		d.beginDeleteAPrivateEndpointConnection.remove(req)
 	}
 
 	return resp, nil
@@ -373,7 +392,8 @@ func (d *DiskAccessesServerTransport) dispatchNewListPager(req *http.Request) (*
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -381,20 +401,22 @@ func (d *DiskAccessesServerTransport) dispatchNewListPager(req *http.Request) (*
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListPager(nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armcompute.DiskAccessesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.DiskAccessesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -403,7 +425,8 @@ func (d *DiskAccessesServerTransport) dispatchNewListByResourceGroupPager(req *h
 	if d.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if d.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := d.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -415,20 +438,22 @@ func (d *DiskAccessesServerTransport) dispatchNewListByResourceGroupPager(req *h
 			return nil, err
 		}
 		resp := d.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		d.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByResourceGroupPager, req, func(page *armcompute.DiskAccessesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		d.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.DiskAccessesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByResourceGroupPager) {
-		d.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		d.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -437,7 +462,8 @@ func (d *DiskAccessesServerTransport) dispatchNewListPrivateEndpointConnectionsP
 	if d.srv.NewListPrivateEndpointConnectionsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPrivateEndpointConnectionsPager not implemented")}
 	}
-	if d.newListPrivateEndpointConnectionsPager == nil {
+	newListPrivateEndpointConnectionsPager := d.newListPrivateEndpointConnectionsPager.get(req)
+	if newListPrivateEndpointConnectionsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -453,20 +479,22 @@ func (d *DiskAccessesServerTransport) dispatchNewListPrivateEndpointConnectionsP
 			return nil, err
 		}
 		resp := d.srv.NewListPrivateEndpointConnectionsPager(resourceGroupNameUnescaped, diskAccessNameUnescaped, nil)
-		d.newListPrivateEndpointConnectionsPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPrivateEndpointConnectionsPager, req, func(page *armcompute.DiskAccessesClientListPrivateEndpointConnectionsResponse, createLink func() string) {
+		newListPrivateEndpointConnectionsPager = &resp
+		d.newListPrivateEndpointConnectionsPager.add(req, newListPrivateEndpointConnectionsPager)
+		server.PagerResponderInjectNextLinks(newListPrivateEndpointConnectionsPager, req, func(page *armcompute.DiskAccessesClientListPrivateEndpointConnectionsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPrivateEndpointConnectionsPager, req)
+	resp, err := server.PagerResponderNext(newListPrivateEndpointConnectionsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPrivateEndpointConnectionsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPrivateEndpointConnectionsPager) {
-		d.newListPrivateEndpointConnectionsPager = nil
+	if !server.PagerResponderMore(newListPrivateEndpointConnectionsPager) {
+		d.newListPrivateEndpointConnectionsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -475,7 +503,8 @@ func (d *DiskAccessesServerTransport) dispatchBeginUpdate(req *http.Request) (*h
 	if d.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if d.beginUpdate == nil {
+	beginUpdate := d.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -498,19 +527,21 @@ func (d *DiskAccessesServerTransport) dispatchBeginUpdate(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginUpdate = &respr
+		beginUpdate = &respr
+		d.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginUpdate) {
-		d.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		d.beginUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -520,7 +551,8 @@ func (d *DiskAccessesServerTransport) dispatchBeginUpdateAPrivateEndpointConnect
 	if d.srv.BeginUpdateAPrivateEndpointConnection == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateAPrivateEndpointConnection not implemented")}
 	}
-	if d.beginUpdateAPrivateEndpointConnection == nil {
+	beginUpdateAPrivateEndpointConnection := d.beginUpdateAPrivateEndpointConnection.get(req)
+	if beginUpdateAPrivateEndpointConnection == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskAccesses/(?P<diskAccessName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections/(?P<privateEndpointConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -547,19 +579,21 @@ func (d *DiskAccessesServerTransport) dispatchBeginUpdateAPrivateEndpointConnect
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginUpdateAPrivateEndpointConnection = &respr
+		beginUpdateAPrivateEndpointConnection = &respr
+		d.beginUpdateAPrivateEndpointConnection.add(req, beginUpdateAPrivateEndpointConnection)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginUpdateAPrivateEndpointConnection, req)
+	resp, err := server.PollerResponderNext(beginUpdateAPrivateEndpointConnection, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginUpdateAPrivateEndpointConnection.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginUpdateAPrivateEndpointConnection) {
-		d.beginUpdateAPrivateEndpointConnection = nil
+	if !server.PollerResponderMore(beginUpdateAPrivateEndpointConnection) {
+		d.beginUpdateAPrivateEndpointConnection.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_diskencryptionsets_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_diskencryptionsets_server.go
@@ -57,19 +57,27 @@ type DiskEncryptionSetsServer struct {
 // The returned DiskEncryptionSetsServerTransport instance is connected to an instance of armcompute.DiskEncryptionSetsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDiskEncryptionSetsServerTransport(srv *DiskEncryptionSetsServer) *DiskEncryptionSetsServerTransport {
-	return &DiskEncryptionSetsServerTransport{srv: srv}
+	return &DiskEncryptionSetsServerTransport{
+		srv:                             srv,
+		beginCreateOrUpdate:             newTracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientCreateOrUpdateResponse]](),
+		beginDelete:                     newTracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientDeleteResponse]](),
+		newListPager:                    newTracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListResponse]](),
+		newListAssociatedResourcesPager: newTracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListAssociatedResourcesResponse]](),
+		newListByResourceGroupPager:     newTracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListByResourceGroupResponse]](),
+		beginUpdate:                     newTracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientUpdateResponse]](),
+	}
 }
 
 // DiskEncryptionSetsServerTransport connects instances of armcompute.DiskEncryptionSetsClient to instances of DiskEncryptionSetsServer.
 // Don't use this type directly, use NewDiskEncryptionSetsServerTransport instead.
 type DiskEncryptionSetsServerTransport struct {
 	srv                             *DiskEncryptionSetsServer
-	beginCreateOrUpdate             *azfake.PollerResponder[armcompute.DiskEncryptionSetsClientCreateOrUpdateResponse]
-	beginDelete                     *azfake.PollerResponder[armcompute.DiskEncryptionSetsClientDeleteResponse]
-	newListPager                    *azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListResponse]
-	newListAssociatedResourcesPager *azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListAssociatedResourcesResponse]
-	newListByResourceGroupPager     *azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListByResourceGroupResponse]
-	beginUpdate                     *azfake.PollerResponder[armcompute.DiskEncryptionSetsClientUpdateResponse]
+	beginCreateOrUpdate             *tracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientCreateOrUpdateResponse]]
+	beginDelete                     *tracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientDeleteResponse]]
+	newListPager                    *tracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListResponse]]
+	newListAssociatedResourcesPager *tracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListAssociatedResourcesResponse]]
+	newListByResourceGroupPager     *tracker[azfake.PagerResponder[armcompute.DiskEncryptionSetsClientListByResourceGroupResponse]]
+	beginUpdate                     *tracker[azfake.PollerResponder[armcompute.DiskEncryptionSetsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for DiskEncryptionSetsServerTransport.
@@ -113,7 +121,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets/(?P<diskEncryptionSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -136,19 +145,21 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -158,7 +169,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginDelete(req *http.Reques
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets/(?P<diskEncryptionSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -177,19 +189,21 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginDelete(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -232,7 +246,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListPager(req *http.Reque
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -240,20 +255,22 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListPager(req *http.Reque
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListPager(nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armcompute.DiskEncryptionSetsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.DiskEncryptionSetsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -262,7 +279,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListAssociatedResourcesPa
 	if d.srv.NewListAssociatedResourcesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAssociatedResourcesPager not implemented")}
 	}
-	if d.newListAssociatedResourcesPager == nil {
+	newListAssociatedResourcesPager := d.newListAssociatedResourcesPager.get(req)
+	if newListAssociatedResourcesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets/(?P<diskEncryptionSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/associatedResources`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +296,22 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListAssociatedResourcesPa
 			return nil, err
 		}
 		resp := d.srv.NewListAssociatedResourcesPager(resourceGroupNameUnescaped, diskEncryptionSetNameUnescaped, nil)
-		d.newListAssociatedResourcesPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListAssociatedResourcesPager, req, func(page *armcompute.DiskEncryptionSetsClientListAssociatedResourcesResponse, createLink func() string) {
+		newListAssociatedResourcesPager = &resp
+		d.newListAssociatedResourcesPager.add(req, newListAssociatedResourcesPager)
+		server.PagerResponderInjectNextLinks(newListAssociatedResourcesPager, req, func(page *armcompute.DiskEncryptionSetsClientListAssociatedResourcesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListAssociatedResourcesPager, req)
+	resp, err := server.PagerResponderNext(newListAssociatedResourcesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListAssociatedResourcesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListAssociatedResourcesPager) {
-		d.newListAssociatedResourcesPager = nil
+	if !server.PagerResponderMore(newListAssociatedResourcesPager) {
+		d.newListAssociatedResourcesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -300,7 +320,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListByResourceGroupPager(
 	if d.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if d.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := d.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -312,20 +333,22 @@ func (d *DiskEncryptionSetsServerTransport) dispatchNewListByResourceGroupPager(
 			return nil, err
 		}
 		resp := d.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		d.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByResourceGroupPager, req, func(page *armcompute.DiskEncryptionSetsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		d.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.DiskEncryptionSetsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByResourceGroupPager) {
-		d.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		d.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -334,7 +357,8 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginUpdate(req *http.Reques
 	if d.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if d.beginUpdate == nil {
+	beginUpdate := d.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/diskEncryptionSets/(?P<diskEncryptionSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -357,19 +381,21 @@ func (d *DiskEncryptionSetsServerTransport) dispatchBeginUpdate(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginUpdate = &respr
+		beginUpdate = &respr
+		d.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginUpdate) {
-		d.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		d.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_diskrestorepoint_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_diskrestorepoint_server.go
@@ -45,16 +45,21 @@ type DiskRestorePointServer struct {
 // The returned DiskRestorePointServerTransport instance is connected to an instance of armcompute.DiskRestorePointClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDiskRestorePointServerTransport(srv *DiskRestorePointServer) *DiskRestorePointServerTransport {
-	return &DiskRestorePointServerTransport{srv: srv}
+	return &DiskRestorePointServerTransport{
+		srv:                        srv,
+		beginGrantAccess:           newTracker[azfake.PollerResponder[armcompute.DiskRestorePointClientGrantAccessResponse]](),
+		newListByRestorePointPager: newTracker[azfake.PagerResponder[armcompute.DiskRestorePointClientListByRestorePointResponse]](),
+		beginRevokeAccess:          newTracker[azfake.PollerResponder[armcompute.DiskRestorePointClientRevokeAccessResponse]](),
+	}
 }
 
 // DiskRestorePointServerTransport connects instances of armcompute.DiskRestorePointClient to instances of DiskRestorePointServer.
 // Don't use this type directly, use NewDiskRestorePointServerTransport instead.
 type DiskRestorePointServerTransport struct {
 	srv                        *DiskRestorePointServer
-	beginGrantAccess           *azfake.PollerResponder[armcompute.DiskRestorePointClientGrantAccessResponse]
-	newListByRestorePointPager *azfake.PagerResponder[armcompute.DiskRestorePointClientListByRestorePointResponse]
-	beginRevokeAccess          *azfake.PollerResponder[armcompute.DiskRestorePointClientRevokeAccessResponse]
+	beginGrantAccess           *tracker[azfake.PollerResponder[armcompute.DiskRestorePointClientGrantAccessResponse]]
+	newListByRestorePointPager *tracker[azfake.PagerResponder[armcompute.DiskRestorePointClientListByRestorePointResponse]]
+	beginRevokeAccess          *tracker[azfake.PollerResponder[armcompute.DiskRestorePointClientRevokeAccessResponse]]
 }
 
 // Do implements the policy.Transporter interface for DiskRestorePointServerTransport.
@@ -133,7 +138,8 @@ func (d *DiskRestorePointServerTransport) dispatchBeginGrantAccess(req *http.Req
 	if d.srv.BeginGrantAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGrantAccess not implemented")}
 	}
-	if d.beginGrantAccess == nil {
+	beginGrantAccess := d.beginGrantAccess.get(req)
+	if beginGrantAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restorePoints/(?P<vmRestorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/diskRestorePoints/(?P<diskRestorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/beginGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +170,21 @@ func (d *DiskRestorePointServerTransport) dispatchBeginGrantAccess(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginGrantAccess = &respr
+		beginGrantAccess = &respr
+		d.beginGrantAccess.add(req, beginGrantAccess)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginGrantAccess, req)
+	resp, err := server.PollerResponderNext(beginGrantAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginGrantAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginGrantAccess) {
-		d.beginGrantAccess = nil
+	if !server.PollerResponderMore(beginGrantAccess) {
+		d.beginGrantAccess.remove(req)
 	}
 
 	return resp, nil
@@ -186,7 +194,8 @@ func (d *DiskRestorePointServerTransport) dispatchNewListByRestorePointPager(req
 	if d.srv.NewListByRestorePointPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByRestorePointPager not implemented")}
 	}
-	if d.newListByRestorePointPager == nil {
+	newListByRestorePointPager := d.newListByRestorePointPager.get(req)
+	if newListByRestorePointPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restorePoints/(?P<vmRestorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/diskRestorePoints`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -206,20 +215,22 @@ func (d *DiskRestorePointServerTransport) dispatchNewListByRestorePointPager(req
 			return nil, err
 		}
 		resp := d.srv.NewListByRestorePointPager(resourceGroupNameUnescaped, restorePointCollectionNameUnescaped, vmRestorePointNameUnescaped, nil)
-		d.newListByRestorePointPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByRestorePointPager, req, func(page *armcompute.DiskRestorePointClientListByRestorePointResponse, createLink func() string) {
+		newListByRestorePointPager = &resp
+		d.newListByRestorePointPager.add(req, newListByRestorePointPager)
+		server.PagerResponderInjectNextLinks(newListByRestorePointPager, req, func(page *armcompute.DiskRestorePointClientListByRestorePointResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByRestorePointPager, req)
+	resp, err := server.PagerResponderNext(newListByRestorePointPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByRestorePointPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByRestorePointPager) {
-		d.newListByRestorePointPager = nil
+	if !server.PagerResponderMore(newListByRestorePointPager) {
+		d.newListByRestorePointPager.remove(req)
 	}
 	return resp, nil
 }
@@ -228,7 +239,8 @@ func (d *DiskRestorePointServerTransport) dispatchBeginRevokeAccess(req *http.Re
 	if d.srv.BeginRevokeAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRevokeAccess not implemented")}
 	}
-	if d.beginRevokeAccess == nil {
+	beginRevokeAccess := d.beginRevokeAccess.get(req)
+	if beginRevokeAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restorePoints/(?P<vmRestorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/diskRestorePoints/(?P<diskRestorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/endGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -255,19 +267,21 @@ func (d *DiskRestorePointServerTransport) dispatchBeginRevokeAccess(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginRevokeAccess = &respr
+		beginRevokeAccess = &respr
+		d.beginRevokeAccess.add(req, beginRevokeAccess)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginRevokeAccess, req)
+	resp, err := server.PollerResponderNext(beginRevokeAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginRevokeAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginRevokeAccess) {
-		d.beginRevokeAccess = nil
+	if !server.PollerResponderMore(beginRevokeAccess) {
+		d.beginRevokeAccess.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_disks_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_disks_server.go
@@ -61,20 +61,29 @@ type DisksServer struct {
 // The returned DisksServerTransport instance is connected to an instance of armcompute.DisksClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDisksServerTransport(srv *DisksServer) *DisksServerTransport {
-	return &DisksServerTransport{srv: srv}
+	return &DisksServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armcompute.DisksClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armcompute.DisksClientDeleteResponse]](),
+		beginGrantAccess:            newTracker[azfake.PollerResponder[armcompute.DisksClientGrantAccessResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armcompute.DisksClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.DisksClientListByResourceGroupResponse]](),
+		beginRevokeAccess:           newTracker[azfake.PollerResponder[armcompute.DisksClientRevokeAccessResponse]](),
+		beginUpdate:                 newTracker[azfake.PollerResponder[armcompute.DisksClientUpdateResponse]](),
+	}
 }
 
 // DisksServerTransport connects instances of armcompute.DisksClient to instances of DisksServer.
 // Don't use this type directly, use NewDisksServerTransport instead.
 type DisksServerTransport struct {
 	srv                         *DisksServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armcompute.DisksClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armcompute.DisksClientDeleteResponse]
-	beginGrantAccess            *azfake.PollerResponder[armcompute.DisksClientGrantAccessResponse]
-	newListPager                *azfake.PagerResponder[armcompute.DisksClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.DisksClientListByResourceGroupResponse]
-	beginRevokeAccess           *azfake.PollerResponder[armcompute.DisksClientRevokeAccessResponse]
-	beginUpdate                 *azfake.PollerResponder[armcompute.DisksClientUpdateResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armcompute.DisksClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armcompute.DisksClientDeleteResponse]]
+	beginGrantAccess            *tracker[azfake.PollerResponder[armcompute.DisksClientGrantAccessResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armcompute.DisksClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.DisksClientListByResourceGroupResponse]]
+	beginRevokeAccess           *tracker[azfake.PollerResponder[armcompute.DisksClientRevokeAccessResponse]]
+	beginUpdate                 *tracker[azfake.PollerResponder[armcompute.DisksClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for DisksServerTransport.
@@ -120,7 +129,8 @@ func (d *DisksServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (*
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks/(?P<diskName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -143,19 +153,21 @@ func (d *DisksServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -165,7 +177,8 @@ func (d *DisksServerTransport) dispatchBeginDelete(req *http.Request) (*http.Res
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks/(?P<diskName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -184,19 +197,21 @@ func (d *DisksServerTransport) dispatchBeginDelete(req *http.Request) (*http.Res
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -239,7 +254,8 @@ func (d *DisksServerTransport) dispatchBeginGrantAccess(req *http.Request) (*htt
 	if d.srv.BeginGrantAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGrantAccess not implemented")}
 	}
-	if d.beginGrantAccess == nil {
+	beginGrantAccess := d.beginGrantAccess.get(req)
+	if beginGrantAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks/(?P<diskName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/beginGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -262,19 +278,21 @@ func (d *DisksServerTransport) dispatchBeginGrantAccess(req *http.Request) (*htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginGrantAccess = &respr
+		beginGrantAccess = &respr
+		d.beginGrantAccess.add(req, beginGrantAccess)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginGrantAccess, req)
+	resp, err := server.PollerResponderNext(beginGrantAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginGrantAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginGrantAccess) {
-		d.beginGrantAccess = nil
+	if !server.PollerResponderMore(beginGrantAccess) {
+		d.beginGrantAccess.remove(req)
 	}
 
 	return resp, nil
@@ -284,7 +302,8 @@ func (d *DisksServerTransport) dispatchNewListPager(req *http.Request) (*http.Re
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -292,20 +311,22 @@ func (d *DisksServerTransport) dispatchNewListPager(req *http.Request) (*http.Re
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListPager(nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armcompute.DisksClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.DisksClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -314,7 +335,8 @@ func (d *DisksServerTransport) dispatchNewListByResourceGroupPager(req *http.Req
 	if d.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if d.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := d.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -326,20 +348,22 @@ func (d *DisksServerTransport) dispatchNewListByResourceGroupPager(req *http.Req
 			return nil, err
 		}
 		resp := d.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		d.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByResourceGroupPager, req, func(page *armcompute.DisksClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		d.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.DisksClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByResourceGroupPager) {
-		d.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		d.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -348,7 +372,8 @@ func (d *DisksServerTransport) dispatchBeginRevokeAccess(req *http.Request) (*ht
 	if d.srv.BeginRevokeAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRevokeAccess not implemented")}
 	}
-	if d.beginRevokeAccess == nil {
+	beginRevokeAccess := d.beginRevokeAccess.get(req)
+	if beginRevokeAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks/(?P<diskName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/endGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -367,19 +392,21 @@ func (d *DisksServerTransport) dispatchBeginRevokeAccess(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginRevokeAccess = &respr
+		beginRevokeAccess = &respr
+		d.beginRevokeAccess.add(req, beginRevokeAccess)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginRevokeAccess, req)
+	resp, err := server.PollerResponderNext(beginRevokeAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginRevokeAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginRevokeAccess) {
-		d.beginRevokeAccess = nil
+	if !server.PollerResponderMore(beginRevokeAccess) {
+		d.beginRevokeAccess.remove(req)
 	}
 
 	return resp, nil
@@ -389,7 +416,8 @@ func (d *DisksServerTransport) dispatchBeginUpdate(req *http.Request) (*http.Res
 	if d.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if d.beginUpdate == nil {
+	beginUpdate := d.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/disks/(?P<diskName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -412,19 +440,21 @@ func (d *DisksServerTransport) dispatchBeginUpdate(req *http.Request) (*http.Res
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginUpdate = &respr
+		beginUpdate = &respr
+		d.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		d.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginUpdate) {
-		d.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		d.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_galleries_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_galleries_server.go
@@ -53,18 +53,25 @@ type GalleriesServer struct {
 // The returned GalleriesServerTransport instance is connected to an instance of armcompute.GalleriesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGalleriesServerTransport(srv *GalleriesServer) *GalleriesServerTransport {
-	return &GalleriesServerTransport{srv: srv}
+	return &GalleriesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armcompute.GalleriesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armcompute.GalleriesClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armcompute.GalleriesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.GalleriesClientListByResourceGroupResponse]](),
+		beginUpdate:                 newTracker[azfake.PollerResponder[armcompute.GalleriesClientUpdateResponse]](),
+	}
 }
 
 // GalleriesServerTransport connects instances of armcompute.GalleriesClient to instances of GalleriesServer.
 // Don't use this type directly, use NewGalleriesServerTransport instead.
 type GalleriesServerTransport struct {
 	srv                         *GalleriesServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armcompute.GalleriesClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armcompute.GalleriesClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armcompute.GalleriesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.GalleriesClientListByResourceGroupResponse]
-	beginUpdate                 *azfake.PollerResponder[armcompute.GalleriesClientUpdateResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armcompute.GalleriesClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armcompute.GalleriesClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armcompute.GalleriesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.GalleriesClientListByResourceGroupResponse]]
+	beginUpdate                 *tracker[azfake.PollerResponder[armcompute.GalleriesClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GalleriesServerTransport.
@@ -106,7 +113,8 @@ func (g *GalleriesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 	if g.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if g.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := g.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -129,19 +137,21 @@ func (g *GalleriesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		g.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		g.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginCreateOrUpdate) {
-		g.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		g.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -151,7 +161,8 @@ func (g *GalleriesServerTransport) dispatchBeginDelete(req *http.Request) (*http
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -170,19 +181,21 @@ func (g *GalleriesServerTransport) dispatchBeginDelete(req *http.Request) (*http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -243,7 +256,8 @@ func (g *GalleriesServerTransport) dispatchNewListPager(req *http.Request) (*htt
 	if g.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if g.newListPager == nil {
+	newListPager := g.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -251,20 +265,22 @@ func (g *GalleriesServerTransport) dispatchNewListPager(req *http.Request) (*htt
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := g.srv.NewListPager(nil)
-		g.newListPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListPager, req, func(page *armcompute.GalleriesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		g.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.GalleriesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListPager) {
-		g.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		g.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -273,7 +289,8 @@ func (g *GalleriesServerTransport) dispatchNewListByResourceGroupPager(req *http
 	if g.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if g.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := g.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -285,20 +302,22 @@ func (g *GalleriesServerTransport) dispatchNewListByResourceGroupPager(req *http
 			return nil, err
 		}
 		resp := g.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		g.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListByResourceGroupPager, req, func(page *armcompute.GalleriesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		g.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.GalleriesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListByResourceGroupPager) {
-		g.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		g.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -307,7 +326,8 @@ func (g *GalleriesServerTransport) dispatchBeginUpdate(req *http.Request) (*http
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -330,19 +350,21 @@ func (g *GalleriesServerTransport) dispatchBeginUpdate(req *http.Request) (*http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_galleryapplications_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_galleryapplications_server.go
@@ -49,17 +49,23 @@ type GalleryApplicationsServer struct {
 // The returned GalleryApplicationsServerTransport instance is connected to an instance of armcompute.GalleryApplicationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGalleryApplicationsServerTransport(srv *GalleryApplicationsServer) *GalleryApplicationsServerTransport {
-	return &GalleryApplicationsServerTransport{srv: srv}
+	return &GalleryApplicationsServerTransport{
+		srv:                   srv,
+		beginCreateOrUpdate:   newTracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientCreateOrUpdateResponse]](),
+		beginDelete:           newTracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientDeleteResponse]](),
+		newListByGalleryPager: newTracker[azfake.PagerResponder[armcompute.GalleryApplicationsClientListByGalleryResponse]](),
+		beginUpdate:           newTracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientUpdateResponse]](),
+	}
 }
 
 // GalleryApplicationsServerTransport connects instances of armcompute.GalleryApplicationsClient to instances of GalleryApplicationsServer.
 // Don't use this type directly, use NewGalleryApplicationsServerTransport instead.
 type GalleryApplicationsServerTransport struct {
 	srv                   *GalleryApplicationsServer
-	beginCreateOrUpdate   *azfake.PollerResponder[armcompute.GalleryApplicationsClientCreateOrUpdateResponse]
-	beginDelete           *azfake.PollerResponder[armcompute.GalleryApplicationsClientDeleteResponse]
-	newListByGalleryPager *azfake.PagerResponder[armcompute.GalleryApplicationsClientListByGalleryResponse]
-	beginUpdate           *azfake.PollerResponder[armcompute.GalleryApplicationsClientUpdateResponse]
+	beginCreateOrUpdate   *tracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientCreateOrUpdateResponse]]
+	beginDelete           *tracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientDeleteResponse]]
+	newListByGalleryPager *tracker[azfake.PagerResponder[armcompute.GalleryApplicationsClientListByGalleryResponse]]
+	beginUpdate           *tracker[azfake.PollerResponder[armcompute.GalleryApplicationsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GalleryApplicationsServerTransport.
@@ -99,7 +105,8 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginCreateOrUpdate(req *ht
 	if g.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if g.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := g.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -126,19 +133,21 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginCreateOrUpdate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		g.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		g.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginCreateOrUpdate) {
-		g.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		g.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -148,7 +157,8 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginDelete(req *http.Reque
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +181,21 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginDelete(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +242,8 @@ func (g *GalleryApplicationsServerTransport) dispatchNewListByGalleryPager(req *
 	if g.srv.NewListByGalleryPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByGalleryPager not implemented")}
 	}
-	if g.newListByGalleryPager == nil {
+	newListByGalleryPager := g.newListByGalleryPager.get(req)
+	if newListByGalleryPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -246,20 +259,22 @@ func (g *GalleryApplicationsServerTransport) dispatchNewListByGalleryPager(req *
 			return nil, err
 		}
 		resp := g.srv.NewListByGalleryPager(resourceGroupNameUnescaped, galleryNameUnescaped, nil)
-		g.newListByGalleryPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListByGalleryPager, req, func(page *armcompute.GalleryApplicationsClientListByGalleryResponse, createLink func() string) {
+		newListByGalleryPager = &resp
+		g.newListByGalleryPager.add(req, newListByGalleryPager)
+		server.PagerResponderInjectNextLinks(newListByGalleryPager, req, func(page *armcompute.GalleryApplicationsClientListByGalleryResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListByGalleryPager, req)
+	resp, err := server.PagerResponderNext(newListByGalleryPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListByGalleryPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListByGalleryPager) {
-		g.newListByGalleryPager = nil
+	if !server.PagerResponderMore(newListByGalleryPager) {
+		g.newListByGalleryPager.remove(req)
 	}
 	return resp, nil
 }
@@ -268,7 +283,8 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginUpdate(req *http.Reque
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -295,19 +311,21 @@ func (g *GalleryApplicationsServerTransport) dispatchBeginUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_galleryapplicationversions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_galleryapplicationversions_server.go
@@ -49,17 +49,23 @@ type GalleryApplicationVersionsServer struct {
 // The returned GalleryApplicationVersionsServerTransport instance is connected to an instance of armcompute.GalleryApplicationVersionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGalleryApplicationVersionsServerTransport(srv *GalleryApplicationVersionsServer) *GalleryApplicationVersionsServerTransport {
-	return &GalleryApplicationVersionsServerTransport{srv: srv}
+	return &GalleryApplicationVersionsServerTransport{
+		srv:                              srv,
+		beginCreateOrUpdate:              newTracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientCreateOrUpdateResponse]](),
+		beginDelete:                      newTracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientDeleteResponse]](),
+		newListByGalleryApplicationPager: newTracker[azfake.PagerResponder[armcompute.GalleryApplicationVersionsClientListByGalleryApplicationResponse]](),
+		beginUpdate:                      newTracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientUpdateResponse]](),
+	}
 }
 
 // GalleryApplicationVersionsServerTransport connects instances of armcompute.GalleryApplicationVersionsClient to instances of GalleryApplicationVersionsServer.
 // Don't use this type directly, use NewGalleryApplicationVersionsServerTransport instead.
 type GalleryApplicationVersionsServerTransport struct {
 	srv                              *GalleryApplicationVersionsServer
-	beginCreateOrUpdate              *azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientCreateOrUpdateResponse]
-	beginDelete                      *azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientDeleteResponse]
-	newListByGalleryApplicationPager *azfake.PagerResponder[armcompute.GalleryApplicationVersionsClientListByGalleryApplicationResponse]
-	beginUpdate                      *azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientUpdateResponse]
+	beginCreateOrUpdate              *tracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientCreateOrUpdateResponse]]
+	beginDelete                      *tracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientDeleteResponse]]
+	newListByGalleryApplicationPager *tracker[azfake.PagerResponder[armcompute.GalleryApplicationVersionsClientListByGalleryApplicationResponse]]
+	beginUpdate                      *tracker[azfake.PollerResponder[armcompute.GalleryApplicationVersionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GalleryApplicationVersionsServerTransport.
@@ -99,7 +105,8 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginCreateOrUpdate(
 	if g.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if g.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := g.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryApplicationVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -130,19 +137,21 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginCreateOrUpdate(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		g.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		g.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginCreateOrUpdate) {
-		g.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		g.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -152,7 +161,8 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginDelete(req *htt
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryApplicationVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -179,19 +189,21 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginDelete(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -254,7 +266,8 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchNewListByGalleryAppl
 	if g.srv.NewListByGalleryApplicationPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByGalleryApplicationPager not implemented")}
 	}
-	if g.newListByGalleryApplicationPager == nil {
+	newListByGalleryApplicationPager := g.newListByGalleryApplicationPager.get(req)
+	if newListByGalleryApplicationPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -274,20 +287,22 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchNewListByGalleryAppl
 			return nil, err
 		}
 		resp := g.srv.NewListByGalleryApplicationPager(resourceGroupNameUnescaped, galleryNameUnescaped, galleryApplicationNameUnescaped, nil)
-		g.newListByGalleryApplicationPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListByGalleryApplicationPager, req, func(page *armcompute.GalleryApplicationVersionsClientListByGalleryApplicationResponse, createLink func() string) {
+		newListByGalleryApplicationPager = &resp
+		g.newListByGalleryApplicationPager.add(req, newListByGalleryApplicationPager)
+		server.PagerResponderInjectNextLinks(newListByGalleryApplicationPager, req, func(page *armcompute.GalleryApplicationVersionsClientListByGalleryApplicationResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListByGalleryApplicationPager, req)
+	resp, err := server.PagerResponderNext(newListByGalleryApplicationPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListByGalleryApplicationPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListByGalleryApplicationPager) {
-		g.newListByGalleryApplicationPager = nil
+	if !server.PagerResponderMore(newListByGalleryApplicationPager) {
+		g.newListByGalleryApplicationPager.remove(req)
 	}
 	return resp, nil
 }
@@ -296,7 +311,8 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginUpdate(req *htt
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applications/(?P<galleryApplicationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryApplicationVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -327,19 +343,21 @@ func (g *GalleryApplicationVersionsServerTransport) dispatchBeginUpdate(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_galleryimages_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_galleryimages_server.go
@@ -49,17 +49,23 @@ type GalleryImagesServer struct {
 // The returned GalleryImagesServerTransport instance is connected to an instance of armcompute.GalleryImagesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGalleryImagesServerTransport(srv *GalleryImagesServer) *GalleryImagesServerTransport {
-	return &GalleryImagesServerTransport{srv: srv}
+	return &GalleryImagesServerTransport{
+		srv:                   srv,
+		beginCreateOrUpdate:   newTracker[azfake.PollerResponder[armcompute.GalleryImagesClientCreateOrUpdateResponse]](),
+		beginDelete:           newTracker[azfake.PollerResponder[armcompute.GalleryImagesClientDeleteResponse]](),
+		newListByGalleryPager: newTracker[azfake.PagerResponder[armcompute.GalleryImagesClientListByGalleryResponse]](),
+		beginUpdate:           newTracker[azfake.PollerResponder[armcompute.GalleryImagesClientUpdateResponse]](),
+	}
 }
 
 // GalleryImagesServerTransport connects instances of armcompute.GalleryImagesClient to instances of GalleryImagesServer.
 // Don't use this type directly, use NewGalleryImagesServerTransport instead.
 type GalleryImagesServerTransport struct {
 	srv                   *GalleryImagesServer
-	beginCreateOrUpdate   *azfake.PollerResponder[armcompute.GalleryImagesClientCreateOrUpdateResponse]
-	beginDelete           *azfake.PollerResponder[armcompute.GalleryImagesClientDeleteResponse]
-	newListByGalleryPager *azfake.PagerResponder[armcompute.GalleryImagesClientListByGalleryResponse]
-	beginUpdate           *azfake.PollerResponder[armcompute.GalleryImagesClientUpdateResponse]
+	beginCreateOrUpdate   *tracker[azfake.PollerResponder[armcompute.GalleryImagesClientCreateOrUpdateResponse]]
+	beginDelete           *tracker[azfake.PollerResponder[armcompute.GalleryImagesClientDeleteResponse]]
+	newListByGalleryPager *tracker[azfake.PagerResponder[armcompute.GalleryImagesClientListByGalleryResponse]]
+	beginUpdate           *tracker[azfake.PollerResponder[armcompute.GalleryImagesClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GalleryImagesServerTransport.
@@ -99,7 +105,8 @@ func (g *GalleryImagesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if g.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if g.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := g.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -126,19 +133,21 @@ func (g *GalleryImagesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		g.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		g.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginCreateOrUpdate) {
-		g.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		g.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -148,7 +157,8 @@ func (g *GalleryImagesServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +181,21 @@ func (g *GalleryImagesServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +242,8 @@ func (g *GalleryImagesServerTransport) dispatchNewListByGalleryPager(req *http.R
 	if g.srv.NewListByGalleryPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByGalleryPager not implemented")}
 	}
-	if g.newListByGalleryPager == nil {
+	newListByGalleryPager := g.newListByGalleryPager.get(req)
+	if newListByGalleryPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -246,20 +259,22 @@ func (g *GalleryImagesServerTransport) dispatchNewListByGalleryPager(req *http.R
 			return nil, err
 		}
 		resp := g.srv.NewListByGalleryPager(resourceGroupNameUnescaped, galleryNameUnescaped, nil)
-		g.newListByGalleryPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListByGalleryPager, req, func(page *armcompute.GalleryImagesClientListByGalleryResponse, createLink func() string) {
+		newListByGalleryPager = &resp
+		g.newListByGalleryPager.add(req, newListByGalleryPager)
+		server.PagerResponderInjectNextLinks(newListByGalleryPager, req, func(page *armcompute.GalleryImagesClientListByGalleryResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListByGalleryPager, req)
+	resp, err := server.PagerResponderNext(newListByGalleryPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListByGalleryPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListByGalleryPager) {
-		g.newListByGalleryPager = nil
+	if !server.PagerResponderMore(newListByGalleryPager) {
+		g.newListByGalleryPager.remove(req)
 	}
 	return resp, nil
 }
@@ -268,7 +283,8 @@ func (g *GalleryImagesServerTransport) dispatchBeginUpdate(req *http.Request) (*
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -295,19 +311,21 @@ func (g *GalleryImagesServerTransport) dispatchBeginUpdate(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_galleryimageversions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_galleryimageversions_server.go
@@ -49,17 +49,23 @@ type GalleryImageVersionsServer struct {
 // The returned GalleryImageVersionsServerTransport instance is connected to an instance of armcompute.GalleryImageVersionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGalleryImageVersionsServerTransport(srv *GalleryImageVersionsServer) *GalleryImageVersionsServerTransport {
-	return &GalleryImageVersionsServerTransport{srv: srv}
+	return &GalleryImageVersionsServerTransport{
+		srv:                        srv,
+		beginCreateOrUpdate:        newTracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientCreateOrUpdateResponse]](),
+		beginDelete:                newTracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientDeleteResponse]](),
+		newListByGalleryImagePager: newTracker[azfake.PagerResponder[armcompute.GalleryImageVersionsClientListByGalleryImageResponse]](),
+		beginUpdate:                newTracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientUpdateResponse]](),
+	}
 }
 
 // GalleryImageVersionsServerTransport connects instances of armcompute.GalleryImageVersionsClient to instances of GalleryImageVersionsServer.
 // Don't use this type directly, use NewGalleryImageVersionsServerTransport instead.
 type GalleryImageVersionsServerTransport struct {
 	srv                        *GalleryImageVersionsServer
-	beginCreateOrUpdate        *azfake.PollerResponder[armcompute.GalleryImageVersionsClientCreateOrUpdateResponse]
-	beginDelete                *azfake.PollerResponder[armcompute.GalleryImageVersionsClientDeleteResponse]
-	newListByGalleryImagePager *azfake.PagerResponder[armcompute.GalleryImageVersionsClientListByGalleryImageResponse]
-	beginUpdate                *azfake.PollerResponder[armcompute.GalleryImageVersionsClientUpdateResponse]
+	beginCreateOrUpdate        *tracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientCreateOrUpdateResponse]]
+	beginDelete                *tracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientDeleteResponse]]
+	newListByGalleryImagePager *tracker[azfake.PagerResponder[armcompute.GalleryImageVersionsClientListByGalleryImageResponse]]
+	beginUpdate                *tracker[azfake.PollerResponder[armcompute.GalleryImageVersionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GalleryImageVersionsServerTransport.
@@ -99,7 +105,8 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if g.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if g.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := g.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryImageVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -130,19 +137,21 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		g.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		g.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginCreateOrUpdate) {
-		g.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		g.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -152,7 +161,8 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginDelete(req *http.Requ
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryImageVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -179,19 +189,21 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -254,7 +266,8 @@ func (g *GalleryImageVersionsServerTransport) dispatchNewListByGalleryImagePager
 	if g.srv.NewListByGalleryImagePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByGalleryImagePager not implemented")}
 	}
-	if g.newListByGalleryImagePager == nil {
+	newListByGalleryImagePager := g.newListByGalleryImagePager.get(req)
+	if newListByGalleryImagePager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -274,20 +287,22 @@ func (g *GalleryImageVersionsServerTransport) dispatchNewListByGalleryImagePager
 			return nil, err
 		}
 		resp := g.srv.NewListByGalleryImagePager(resourceGroupNameUnescaped, galleryNameUnescaped, galleryImageNameUnescaped, nil)
-		g.newListByGalleryImagePager = &resp
-		server.PagerResponderInjectNextLinks(g.newListByGalleryImagePager, req, func(page *armcompute.GalleryImageVersionsClientListByGalleryImageResponse, createLink func() string) {
+		newListByGalleryImagePager = &resp
+		g.newListByGalleryImagePager.add(req, newListByGalleryImagePager)
+		server.PagerResponderInjectNextLinks(newListByGalleryImagePager, req, func(page *armcompute.GalleryImageVersionsClientListByGalleryImageResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListByGalleryImagePager, req)
+	resp, err := server.PagerResponderNext(newListByGalleryImagePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListByGalleryImagePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListByGalleryImagePager) {
-		g.newListByGalleryImagePager = nil
+	if !server.PagerResponderMore(newListByGalleryImagePager) {
+		g.newListByGalleryImagePager.remove(req)
 	}
 	return resp, nil
 }
@@ -296,7 +311,8 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginUpdate(req *http.Requ
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions/(?P<galleryImageVersionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -327,19 +343,21 @@ func (g *GalleryImageVersionsServerTransport) dispatchBeginUpdate(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_gallerysharingprofile_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_gallerysharingprofile_server.go
@@ -32,14 +32,17 @@ type GallerySharingProfileServer struct {
 // The returned GallerySharingProfileServerTransport instance is connected to an instance of armcompute.GallerySharingProfileClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGallerySharingProfileServerTransport(srv *GallerySharingProfileServer) *GallerySharingProfileServerTransport {
-	return &GallerySharingProfileServerTransport{srv: srv}
+	return &GallerySharingProfileServerTransport{
+		srv:         srv,
+		beginUpdate: newTracker[azfake.PollerResponder[armcompute.GallerySharingProfileClientUpdateResponse]](),
+	}
 }
 
 // GallerySharingProfileServerTransport connects instances of armcompute.GallerySharingProfileClient to instances of GallerySharingProfileServer.
 // Don't use this type directly, use NewGallerySharingProfileServerTransport instead.
 type GallerySharingProfileServerTransport struct {
 	srv         *GallerySharingProfileServer
-	beginUpdate *azfake.PollerResponder[armcompute.GallerySharingProfileClientUpdateResponse]
+	beginUpdate *tracker[azfake.PollerResponder[armcompute.GallerySharingProfileClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for GallerySharingProfileServerTransport.
@@ -71,7 +74,8 @@ func (g *GallerySharingProfileServerTransport) dispatchBeginUpdate(req *http.Req
 	if g.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if g.beginUpdate == nil {
+	beginUpdate := g.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/galleries/(?P<galleryName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/share`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -94,19 +98,21 @@ func (g *GallerySharingProfileServerTransport) dispatchBeginUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginUpdate = &respr
+		beginUpdate = &respr
+		g.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		g.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginUpdate) {
-		g.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		g.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_images_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_images_server.go
@@ -53,18 +53,25 @@ type ImagesServer struct {
 // The returned ImagesServerTransport instance is connected to an instance of armcompute.ImagesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewImagesServerTransport(srv *ImagesServer) *ImagesServerTransport {
-	return &ImagesServerTransport{srv: srv}
+	return &ImagesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armcompute.ImagesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armcompute.ImagesClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armcompute.ImagesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.ImagesClientListByResourceGroupResponse]](),
+		beginUpdate:                 newTracker[azfake.PollerResponder[armcompute.ImagesClientUpdateResponse]](),
+	}
 }
 
 // ImagesServerTransport connects instances of armcompute.ImagesClient to instances of ImagesServer.
 // Don't use this type directly, use NewImagesServerTransport instead.
 type ImagesServerTransport struct {
 	srv                         *ImagesServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armcompute.ImagesClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armcompute.ImagesClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armcompute.ImagesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.ImagesClientListByResourceGroupResponse]
-	beginUpdate                 *azfake.PollerResponder[armcompute.ImagesClientUpdateResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armcompute.ImagesClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armcompute.ImagesClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armcompute.ImagesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.ImagesClientListByResourceGroupResponse]]
+	beginUpdate                 *tracker[azfake.PollerResponder[armcompute.ImagesClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for ImagesServerTransport.
@@ -106,7 +113,8 @@ func (i *ImagesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/images/(?P<imageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -129,19 +137,21 @@ func (i *ImagesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -151,7 +161,8 @@ func (i *ImagesServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/images/(?P<imageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -170,19 +181,21 @@ func (i *ImagesServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -237,7 +250,8 @@ func (i *ImagesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/images`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -245,20 +259,22 @@ func (i *ImagesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := i.srv.NewListPager(nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armcompute.ImagesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.ImagesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -267,7 +283,8 @@ func (i *ImagesServerTransport) dispatchNewListByResourceGroupPager(req *http.Re
 	if i.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if i.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := i.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/images`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -279,20 +296,22 @@ func (i *ImagesServerTransport) dispatchNewListByResourceGroupPager(req *http.Re
 			return nil, err
 		}
 		resp := i.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		i.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListByResourceGroupPager, req, func(page *armcompute.ImagesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		i.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.ImagesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListByResourceGroupPager) {
-		i.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		i.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -301,7 +320,8 @@ func (i *ImagesServerTransport) dispatchBeginUpdate(req *http.Request) (*http.Re
 	if i.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if i.beginUpdate == nil {
+	beginUpdate := i.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/images/(?P<imageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -324,19 +344,21 @@ func (i *ImagesServerTransport) dispatchBeginUpdate(req *http.Request) (*http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginUpdate = &respr
+		beginUpdate = &respr
+		i.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginUpdate) {
-		i.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		i.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_loganalytics_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_loganalytics_server.go
@@ -36,15 +36,19 @@ type LogAnalyticsServer struct {
 // The returned LogAnalyticsServerTransport instance is connected to an instance of armcompute.LogAnalyticsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLogAnalyticsServerTransport(srv *LogAnalyticsServer) *LogAnalyticsServerTransport {
-	return &LogAnalyticsServerTransport{srv: srv}
+	return &LogAnalyticsServerTransport{
+		srv:                              srv,
+		beginExportRequestRateByInterval: newTracker[azfake.PollerResponder[armcompute.LogAnalyticsClientExportRequestRateByIntervalResponse]](),
+		beginExportThrottledRequests:     newTracker[azfake.PollerResponder[armcompute.LogAnalyticsClientExportThrottledRequestsResponse]](),
+	}
 }
 
 // LogAnalyticsServerTransport connects instances of armcompute.LogAnalyticsClient to instances of LogAnalyticsServer.
 // Don't use this type directly, use NewLogAnalyticsServerTransport instead.
 type LogAnalyticsServerTransport struct {
 	srv                              *LogAnalyticsServer
-	beginExportRequestRateByInterval *azfake.PollerResponder[armcompute.LogAnalyticsClientExportRequestRateByIntervalResponse]
-	beginExportThrottledRequests     *azfake.PollerResponder[armcompute.LogAnalyticsClientExportThrottledRequestsResponse]
+	beginExportRequestRateByInterval *tracker[azfake.PollerResponder[armcompute.LogAnalyticsClientExportRequestRateByIntervalResponse]]
+	beginExportThrottledRequests     *tracker[azfake.PollerResponder[armcompute.LogAnalyticsClientExportThrottledRequestsResponse]]
 }
 
 // Do implements the policy.Transporter interface for LogAnalyticsServerTransport.
@@ -78,7 +82,8 @@ func (l *LogAnalyticsServerTransport) dispatchBeginExportRequestRateByInterval(r
 	if l.srv.BeginExportRequestRateByInterval == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginExportRequestRateByInterval not implemented")}
 	}
-	if l.beginExportRequestRateByInterval == nil {
+	beginExportRequestRateByInterval := l.beginExportRequestRateByInterval.get(req)
+	if beginExportRequestRateByInterval == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/logAnalytics/apiAccess/getRequestRateByInterval`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -97,19 +102,21 @@ func (l *LogAnalyticsServerTransport) dispatchBeginExportRequestRateByInterval(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginExportRequestRateByInterval = &respr
+		beginExportRequestRateByInterval = &respr
+		l.beginExportRequestRateByInterval.add(req, beginExportRequestRateByInterval)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginExportRequestRateByInterval, req)
+	resp, err := server.PollerResponderNext(beginExportRequestRateByInterval, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginExportRequestRateByInterval.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginExportRequestRateByInterval) {
-		l.beginExportRequestRateByInterval = nil
+	if !server.PollerResponderMore(beginExportRequestRateByInterval) {
+		l.beginExportRequestRateByInterval.remove(req)
 	}
 
 	return resp, nil
@@ -119,7 +126,8 @@ func (l *LogAnalyticsServerTransport) dispatchBeginExportThrottledRequests(req *
 	if l.srv.BeginExportThrottledRequests == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginExportThrottledRequests not implemented")}
 	}
-	if l.beginExportThrottledRequests == nil {
+	beginExportThrottledRequests := l.beginExportThrottledRequests.get(req)
+	if beginExportThrottledRequests == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/logAnalytics/apiAccess/getThrottledRequests`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -138,19 +146,21 @@ func (l *LogAnalyticsServerTransport) dispatchBeginExportThrottledRequests(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginExportThrottledRequests = &respr
+		beginExportThrottledRequests = &respr
+		l.beginExportThrottledRequests.add(req, beginExportThrottledRequests)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginExportThrottledRequests, req)
+	resp, err := server.PollerResponderNext(beginExportThrottledRequests, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginExportThrottledRequests.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginExportThrottledRequests) {
-		l.beginExportThrottledRequests = nil
+	if !server.PollerResponderMore(beginExportThrottledRequests) {
+		l.beginExportThrottledRequests.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_operations_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_operations_server.go
@@ -29,14 +29,17 @@ type OperationsServer struct {
 // The returned OperationsServerTransport instance is connected to an instance of armcompute.OperationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewOperationsServerTransport(srv *OperationsServer) *OperationsServerTransport {
-	return &OperationsServerTransport{srv: srv}
+	return &OperationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.OperationsClientListResponse]](),
+	}
 }
 
 // OperationsServerTransport connects instances of armcompute.OperationsClient to instances of OperationsServer.
 // Don't use this type directly, use NewOperationsServerTransport instead.
 type OperationsServerTransport struct {
 	srv          *OperationsServer
-	newListPager *azfake.PagerResponder[armcompute.OperationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.OperationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for OperationsServerTransport.
@@ -68,19 +71,22 @@ func (o *OperationsServerTransport) dispatchNewListPager(req *http.Request) (*ht
 	if o.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if o.newListPager == nil {
+	newListPager := o.newListPager.get(req)
+	if newListPager == nil {
 		resp := o.srv.NewListPager(nil)
-		o.newListPager = &resp
+		newListPager = &resp
+		o.newListPager.add(req, newListPager)
 	}
-	resp, err := server.PagerResponderNext(o.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		o.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(o.newListPager) {
-		o.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		o.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_proximityplacementgroups_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_proximityplacementgroups_server.go
@@ -53,15 +53,19 @@ type ProximityPlacementGroupsServer struct {
 // The returned ProximityPlacementGroupsServerTransport instance is connected to an instance of armcompute.ProximityPlacementGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewProximityPlacementGroupsServerTransport(srv *ProximityPlacementGroupsServer) *ProximityPlacementGroupsServerTransport {
-	return &ProximityPlacementGroupsServerTransport{srv: srv}
+	return &ProximityPlacementGroupsServerTransport{
+		srv:                         srv,
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListByResourceGroupResponse]](),
+		newListBySubscriptionPager:  newTracker[azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListBySubscriptionResponse]](),
+	}
 }
 
 // ProximityPlacementGroupsServerTransport connects instances of armcompute.ProximityPlacementGroupsClient to instances of ProximityPlacementGroupsServer.
 // Don't use this type directly, use NewProximityPlacementGroupsServerTransport instead.
 type ProximityPlacementGroupsServerTransport struct {
 	srv                         *ProximityPlacementGroupsServer
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListByResourceGroupResponse]
-	newListBySubscriptionPager  *azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListBySubscriptionResponse]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListByResourceGroupResponse]]
+	newListBySubscriptionPager  *tracker[azfake.PagerResponder[armcompute.ProximityPlacementGroupsClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for ProximityPlacementGroupsServerTransport.
@@ -218,7 +222,8 @@ func (p *ProximityPlacementGroupsServerTransport) dispatchNewListByResourceGroup
 	if p.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if p.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := p.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/proximityPlacementGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -230,20 +235,22 @@ func (p *ProximityPlacementGroupsServerTransport) dispatchNewListByResourceGroup
 			return nil, err
 		}
 		resp := p.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		p.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListByResourceGroupPager, req, func(page *armcompute.ProximityPlacementGroupsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		p.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.ProximityPlacementGroupsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListByResourceGroupPager) {
-		p.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		p.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -252,7 +259,8 @@ func (p *ProximityPlacementGroupsServerTransport) dispatchNewListBySubscriptionP
 	if p.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if p.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := p.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/proximityPlacementGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -260,20 +268,22 @@ func (p *ProximityPlacementGroupsServerTransport) dispatchNewListBySubscriptionP
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListBySubscriptionPager(nil)
-		p.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListBySubscriptionPager, req, func(page *armcompute.ProximityPlacementGroupsClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		p.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armcompute.ProximityPlacementGroupsClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListBySubscriptionPager) {
-		p.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		p.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_resourceskus_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_resourceskus_server.go
@@ -32,14 +32,17 @@ type ResourceSKUsServer struct {
 // The returned ResourceSKUsServerTransport instance is connected to an instance of armcompute.ResourceSKUsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewResourceSKUsServerTransport(srv *ResourceSKUsServer) *ResourceSKUsServerTransport {
-	return &ResourceSKUsServerTransport{srv: srv}
+	return &ResourceSKUsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.ResourceSKUsClientListResponse]](),
+	}
 }
 
 // ResourceSKUsServerTransport connects instances of armcompute.ResourceSKUsClient to instances of ResourceSKUsServer.
 // Don't use this type directly, use NewResourceSKUsServerTransport instead.
 type ResourceSKUsServerTransport struct {
 	srv          *ResourceSKUsServer
-	newListPager *azfake.PagerResponder[armcompute.ResourceSKUsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.ResourceSKUsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ResourceSKUsServerTransport.
@@ -71,7 +74,8 @@ func (r *ResourceSKUsServerTransport) dispatchNewListPager(req *http.Request) (*
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/skus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -97,20 +101,22 @@ func (r *ResourceSKUsServerTransport) dispatchNewListPager(req *http.Request) (*
 			}
 		}
 		resp := r.srv.NewListPager(options)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armcompute.ResourceSKUsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.ResourceSKUsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_restorepointcollections_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_restorepointcollections_server.go
@@ -53,16 +53,21 @@ type RestorePointCollectionsServer struct {
 // The returned RestorePointCollectionsServerTransport instance is connected to an instance of armcompute.RestorePointCollectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRestorePointCollectionsServerTransport(srv *RestorePointCollectionsServer) *RestorePointCollectionsServerTransport {
-	return &RestorePointCollectionsServerTransport{srv: srv}
+	return &RestorePointCollectionsServerTransport{
+		srv:             srv,
+		beginDelete:     newTracker[azfake.PollerResponder[armcompute.RestorePointCollectionsClientDeleteResponse]](),
+		newListPager:    newTracker[azfake.PagerResponder[armcompute.RestorePointCollectionsClientListResponse]](),
+		newListAllPager: newTracker[azfake.PagerResponder[armcompute.RestorePointCollectionsClientListAllResponse]](),
+	}
 }
 
 // RestorePointCollectionsServerTransport connects instances of armcompute.RestorePointCollectionsClient to instances of RestorePointCollectionsServer.
 // Don't use this type directly, use NewRestorePointCollectionsServerTransport instead.
 type RestorePointCollectionsServerTransport struct {
 	srv             *RestorePointCollectionsServer
-	beginDelete     *azfake.PollerResponder[armcompute.RestorePointCollectionsClientDeleteResponse]
-	newListPager    *azfake.PagerResponder[armcompute.RestorePointCollectionsClientListResponse]
-	newListAllPager *azfake.PagerResponder[armcompute.RestorePointCollectionsClientListAllResponse]
+	beginDelete     *tracker[azfake.PollerResponder[armcompute.RestorePointCollectionsClientDeleteResponse]]
+	newListPager    *tracker[azfake.PagerResponder[armcompute.RestorePointCollectionsClientListResponse]]
+	newListAllPager *tracker[azfake.PagerResponder[armcompute.RestorePointCollectionsClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for RestorePointCollectionsServerTransport.
@@ -141,7 +146,8 @@ func (r *RestorePointCollectionsServerTransport) dispatchBeginDelete(req *http.R
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -160,19 +166,21 @@ func (r *RestorePointCollectionsServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -227,7 +235,8 @@ func (r *RestorePointCollectionsServerTransport) dispatchNewListPager(req *http.
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +248,22 @@ func (r *RestorePointCollectionsServerTransport) dispatchNewListPager(req *http.
 			return nil, err
 		}
 		resp := r.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armcompute.RestorePointCollectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.RestorePointCollectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -261,7 +272,8 @@ func (r *RestorePointCollectionsServerTransport) dispatchNewListAllPager(req *ht
 	if r.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if r.newListAllPager == nil {
+	newListAllPager := r.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -269,20 +281,22 @@ func (r *RestorePointCollectionsServerTransport) dispatchNewListAllPager(req *ht
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := r.srv.NewListAllPager(nil)
-		r.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListAllPager, req, func(page *armcompute.RestorePointCollectionsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		r.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armcompute.RestorePointCollectionsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListAllPager) {
-		r.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		r.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_restorepoints_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_restorepoints_server.go
@@ -40,15 +40,19 @@ type RestorePointsServer struct {
 // The returned RestorePointsServerTransport instance is connected to an instance of armcompute.RestorePointsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRestorePointsServerTransport(srv *RestorePointsServer) *RestorePointsServerTransport {
-	return &RestorePointsServerTransport{srv: srv}
+	return &RestorePointsServerTransport{
+		srv:         srv,
+		beginCreate: newTracker[azfake.PollerResponder[armcompute.RestorePointsClientCreateResponse]](),
+		beginDelete: newTracker[azfake.PollerResponder[armcompute.RestorePointsClientDeleteResponse]](),
+	}
 }
 
 // RestorePointsServerTransport connects instances of armcompute.RestorePointsClient to instances of RestorePointsServer.
 // Don't use this type directly, use NewRestorePointsServerTransport instead.
 type RestorePointsServerTransport struct {
 	srv         *RestorePointsServer
-	beginCreate *azfake.PollerResponder[armcompute.RestorePointsClientCreateResponse]
-	beginDelete *azfake.PollerResponder[armcompute.RestorePointsClientDeleteResponse]
+	beginCreate *tracker[azfake.PollerResponder[armcompute.RestorePointsClientCreateResponse]]
+	beginDelete *tracker[azfake.PollerResponder[armcompute.RestorePointsClientDeleteResponse]]
 }
 
 // Do implements the policy.Transporter interface for RestorePointsServerTransport.
@@ -84,7 +88,8 @@ func (r *RestorePointsServerTransport) dispatchBeginCreate(req *http.Request) (*
 	if r.srv.BeginCreate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreate not implemented")}
 	}
-	if r.beginCreate == nil {
+	beginCreate := r.beginCreate.get(req)
+	if beginCreate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restorePoints/(?P<restorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -111,19 +116,21 @@ func (r *RestorePointsServerTransport) dispatchBeginCreate(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreate = &respr
+		beginCreate = &respr
+		r.beginCreate.add(req, beginCreate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreate, req)
+	resp, err := server.PollerResponderNext(beginCreate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusCreated}, resp.StatusCode) {
+		r.beginCreate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreate) {
-		r.beginCreate = nil
+	if !server.PollerResponderMore(beginCreate) {
+		r.beginCreate.remove(req)
 	}
 
 	return resp, nil
@@ -133,7 +140,8 @@ func (r *RestorePointsServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/restorePointCollections/(?P<restorePointCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restorePoints/(?P<restorePointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -156,19 +164,21 @@ func (r *RestorePointsServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleries_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleries_server.go
@@ -37,14 +37,17 @@ type SharedGalleriesServer struct {
 // The returned SharedGalleriesServerTransport instance is connected to an instance of armcompute.SharedGalleriesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSharedGalleriesServerTransport(srv *SharedGalleriesServer) *SharedGalleriesServerTransport {
-	return &SharedGalleriesServerTransport{srv: srv}
+	return &SharedGalleriesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.SharedGalleriesClientListResponse]](),
+	}
 }
 
 // SharedGalleriesServerTransport connects instances of armcompute.SharedGalleriesClient to instances of SharedGalleriesServer.
 // Don't use this type directly, use NewSharedGalleriesServerTransport instead.
 type SharedGalleriesServerTransport struct {
 	srv          *SharedGalleriesServer
-	newListPager *azfake.PagerResponder[armcompute.SharedGalleriesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.SharedGalleriesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SharedGalleriesServerTransport.
@@ -111,7 +114,8 @@ func (s *SharedGalleriesServerTransport) dispatchNewListPager(req *http.Request)
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sharedGalleries`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -135,20 +139,22 @@ func (s *SharedGalleriesServerTransport) dispatchNewListPager(req *http.Request)
 			}
 		}
 		resp := s.srv.NewListPager(locationUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armcompute.SharedGalleriesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.SharedGalleriesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleryimages_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleryimages_server.go
@@ -37,14 +37,17 @@ type SharedGalleryImagesServer struct {
 // The returned SharedGalleryImagesServerTransport instance is connected to an instance of armcompute.SharedGalleryImagesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSharedGalleryImagesServerTransport(srv *SharedGalleryImagesServer) *SharedGalleryImagesServerTransport {
-	return &SharedGalleryImagesServerTransport{srv: srv}
+	return &SharedGalleryImagesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.SharedGalleryImagesClientListResponse]](),
+	}
 }
 
 // SharedGalleryImagesServerTransport connects instances of armcompute.SharedGalleryImagesClient to instances of SharedGalleryImagesServer.
 // Don't use this type directly, use NewSharedGalleryImagesServerTransport instead.
 type SharedGalleryImagesServerTransport struct {
 	srv          *SharedGalleryImagesServer
-	newListPager *azfake.PagerResponder[armcompute.SharedGalleryImagesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.SharedGalleryImagesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SharedGalleryImagesServerTransport.
@@ -115,7 +118,8 @@ func (s *SharedGalleryImagesServerTransport) dispatchNewListPager(req *http.Requ
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sharedGalleries/(?P<galleryUniqueName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -143,20 +147,22 @@ func (s *SharedGalleryImagesServerTransport) dispatchNewListPager(req *http.Requ
 			}
 		}
 		resp := s.srv.NewListPager(locationUnescaped, galleryUniqueNameUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armcompute.SharedGalleryImagesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.SharedGalleryImagesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleryimageversions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_sharedgalleryimageversions_server.go
@@ -37,14 +37,17 @@ type SharedGalleryImageVersionsServer struct {
 // The returned SharedGalleryImageVersionsServerTransport instance is connected to an instance of armcompute.SharedGalleryImageVersionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSharedGalleryImageVersionsServerTransport(srv *SharedGalleryImageVersionsServer) *SharedGalleryImageVersionsServerTransport {
-	return &SharedGalleryImageVersionsServerTransport{srv: srv}
+	return &SharedGalleryImageVersionsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.SharedGalleryImageVersionsClientListResponse]](),
+	}
 }
 
 // SharedGalleryImageVersionsServerTransport connects instances of armcompute.SharedGalleryImageVersionsClient to instances of SharedGalleryImageVersionsServer.
 // Don't use this type directly, use NewSharedGalleryImageVersionsServerTransport instead.
 type SharedGalleryImageVersionsServerTransport struct {
 	srv          *SharedGalleryImageVersionsServer
-	newListPager *azfake.PagerResponder[armcompute.SharedGalleryImageVersionsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.SharedGalleryImageVersionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SharedGalleryImageVersionsServerTransport.
@@ -119,7 +122,8 @@ func (s *SharedGalleryImageVersionsServerTransport) dispatchNewListPager(req *ht
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sharedGalleries/(?P<galleryUniqueName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/images/(?P<galleryImageName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/versions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -151,20 +155,22 @@ func (s *SharedGalleryImageVersionsServerTransport) dispatchNewListPager(req *ht
 			}
 		}
 		resp := s.srv.NewListPager(locationUnescaped, galleryUniqueNameUnescaped, galleryImageNameUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armcompute.SharedGalleryImageVersionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.SharedGalleryImageVersionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_snapshots_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_snapshots_server.go
@@ -61,20 +61,29 @@ type SnapshotsServer struct {
 // The returned SnapshotsServerTransport instance is connected to an instance of armcompute.SnapshotsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSnapshotsServerTransport(srv *SnapshotsServer) *SnapshotsServerTransport {
-	return &SnapshotsServerTransport{srv: srv}
+	return &SnapshotsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armcompute.SnapshotsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armcompute.SnapshotsClientDeleteResponse]](),
+		beginGrantAccess:            newTracker[azfake.PollerResponder[armcompute.SnapshotsClientGrantAccessResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armcompute.SnapshotsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.SnapshotsClientListByResourceGroupResponse]](),
+		beginRevokeAccess:           newTracker[azfake.PollerResponder[armcompute.SnapshotsClientRevokeAccessResponse]](),
+		beginUpdate:                 newTracker[azfake.PollerResponder[armcompute.SnapshotsClientUpdateResponse]](),
+	}
 }
 
 // SnapshotsServerTransport connects instances of armcompute.SnapshotsClient to instances of SnapshotsServer.
 // Don't use this type directly, use NewSnapshotsServerTransport instead.
 type SnapshotsServerTransport struct {
 	srv                         *SnapshotsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armcompute.SnapshotsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armcompute.SnapshotsClientDeleteResponse]
-	beginGrantAccess            *azfake.PollerResponder[armcompute.SnapshotsClientGrantAccessResponse]
-	newListPager                *azfake.PagerResponder[armcompute.SnapshotsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.SnapshotsClientListByResourceGroupResponse]
-	beginRevokeAccess           *azfake.PollerResponder[armcompute.SnapshotsClientRevokeAccessResponse]
-	beginUpdate                 *azfake.PollerResponder[armcompute.SnapshotsClientUpdateResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armcompute.SnapshotsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armcompute.SnapshotsClientDeleteResponse]]
+	beginGrantAccess            *tracker[azfake.PollerResponder[armcompute.SnapshotsClientGrantAccessResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armcompute.SnapshotsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.SnapshotsClientListByResourceGroupResponse]]
+	beginRevokeAccess           *tracker[azfake.PollerResponder[armcompute.SnapshotsClientRevokeAccessResponse]]
+	beginUpdate                 *tracker[azfake.PollerResponder[armcompute.SnapshotsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for SnapshotsServerTransport.
@@ -120,7 +129,8 @@ func (s *SnapshotsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots/(?P<snapshotName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -143,19 +153,21 @@ func (s *SnapshotsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -165,7 +177,8 @@ func (s *SnapshotsServerTransport) dispatchBeginDelete(req *http.Request) (*http
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots/(?P<snapshotName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -184,19 +197,21 @@ func (s *SnapshotsServerTransport) dispatchBeginDelete(req *http.Request) (*http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -239,7 +254,8 @@ func (s *SnapshotsServerTransport) dispatchBeginGrantAccess(req *http.Request) (
 	if s.srv.BeginGrantAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGrantAccess not implemented")}
 	}
-	if s.beginGrantAccess == nil {
+	beginGrantAccess := s.beginGrantAccess.get(req)
+	if beginGrantAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots/(?P<snapshotName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/beginGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -262,19 +278,21 @@ func (s *SnapshotsServerTransport) dispatchBeginGrantAccess(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginGrantAccess = &respr
+		beginGrantAccess = &respr
+		s.beginGrantAccess.add(req, beginGrantAccess)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginGrantAccess, req)
+	resp, err := server.PollerResponderNext(beginGrantAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginGrantAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginGrantAccess) {
-		s.beginGrantAccess = nil
+	if !server.PollerResponderMore(beginGrantAccess) {
+		s.beginGrantAccess.remove(req)
 	}
 
 	return resp, nil
@@ -284,7 +302,8 @@ func (s *SnapshotsServerTransport) dispatchNewListPager(req *http.Request) (*htt
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -292,20 +311,22 @@ func (s *SnapshotsServerTransport) dispatchNewListPager(req *http.Request) (*htt
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := s.srv.NewListPager(nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armcompute.SnapshotsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.SnapshotsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -314,7 +335,8 @@ func (s *SnapshotsServerTransport) dispatchNewListByResourceGroupPager(req *http
 	if s.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if s.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := s.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -326,20 +348,22 @@ func (s *SnapshotsServerTransport) dispatchNewListByResourceGroupPager(req *http
 			return nil, err
 		}
 		resp := s.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		s.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListByResourceGroupPager, req, func(page *armcompute.SnapshotsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		s.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.SnapshotsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListByResourceGroupPager) {
-		s.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		s.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -348,7 +372,8 @@ func (s *SnapshotsServerTransport) dispatchBeginRevokeAccess(req *http.Request) 
 	if s.srv.BeginRevokeAccess == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRevokeAccess not implemented")}
 	}
-	if s.beginRevokeAccess == nil {
+	beginRevokeAccess := s.beginRevokeAccess.get(req)
+	if beginRevokeAccess == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots/(?P<snapshotName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/endGetAccess`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -367,19 +392,21 @@ func (s *SnapshotsServerTransport) dispatchBeginRevokeAccess(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginRevokeAccess = &respr
+		beginRevokeAccess = &respr
+		s.beginRevokeAccess.add(req, beginRevokeAccess)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginRevokeAccess, req)
+	resp, err := server.PollerResponderNext(beginRevokeAccess, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginRevokeAccess.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginRevokeAccess) {
-		s.beginRevokeAccess = nil
+	if !server.PollerResponderMore(beginRevokeAccess) {
+		s.beginRevokeAccess.remove(req)
 	}
 
 	return resp, nil
@@ -389,7 +416,8 @@ func (s *SnapshotsServerTransport) dispatchBeginUpdate(req *http.Request) (*http
 	if s.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if s.beginUpdate == nil {
+	beginUpdate := s.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/snapshots/(?P<snapshotName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -412,19 +440,21 @@ func (s *SnapshotsServerTransport) dispatchBeginUpdate(req *http.Request) (*http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginUpdate = &respr
+		beginUpdate = &respr
+		s.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginUpdate) {
-		s.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		s.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_sshpublickeys_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_sshpublickeys_server.go
@@ -57,15 +57,19 @@ type SSHPublicKeysServer struct {
 // The returned SSHPublicKeysServerTransport instance is connected to an instance of armcompute.SSHPublicKeysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSSHPublicKeysServerTransport(srv *SSHPublicKeysServer) *SSHPublicKeysServerTransport {
-	return &SSHPublicKeysServerTransport{srv: srv}
+	return &SSHPublicKeysServerTransport{
+		srv:                         srv,
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armcompute.SSHPublicKeysClientListByResourceGroupResponse]](),
+		newListBySubscriptionPager:  newTracker[azfake.PagerResponder[armcompute.SSHPublicKeysClientListBySubscriptionResponse]](),
+	}
 }
 
 // SSHPublicKeysServerTransport connects instances of armcompute.SSHPublicKeysClient to instances of SSHPublicKeysServer.
 // Don't use this type directly, use NewSSHPublicKeysServerTransport instead.
 type SSHPublicKeysServerTransport struct {
 	srv                         *SSHPublicKeysServer
-	newListByResourceGroupPager *azfake.PagerResponder[armcompute.SSHPublicKeysClientListByResourceGroupResponse]
-	newListBySubscriptionPager  *azfake.PagerResponder[armcompute.SSHPublicKeysClientListBySubscriptionResponse]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armcompute.SSHPublicKeysClientListByResourceGroupResponse]]
+	newListBySubscriptionPager  *tracker[azfake.PagerResponder[armcompute.SSHPublicKeysClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for SSHPublicKeysServerTransport.
@@ -245,7 +249,8 @@ func (s *SSHPublicKeysServerTransport) dispatchNewListByResourceGroupPager(req *
 	if s.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if s.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := s.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/sshPublicKeys`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -257,20 +262,22 @@ func (s *SSHPublicKeysServerTransport) dispatchNewListByResourceGroupPager(req *
 			return nil, err
 		}
 		resp := s.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		s.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListByResourceGroupPager, req, func(page *armcompute.SSHPublicKeysClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		s.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armcompute.SSHPublicKeysClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListByResourceGroupPager) {
-		s.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		s.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -279,7 +286,8 @@ func (s *SSHPublicKeysServerTransport) dispatchNewListBySubscriptionPager(req *h
 	if s.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if s.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := s.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/sshPublicKeys`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -287,20 +295,22 @@ func (s *SSHPublicKeysServerTransport) dispatchNewListBySubscriptionPager(req *h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := s.srv.NewListBySubscriptionPager(nil)
-		s.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListBySubscriptionPager, req, func(page *armcompute.SSHPublicKeysClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		s.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armcompute.SSHPublicKeysClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListBySubscriptionPager) {
-		s.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		s.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_usage_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_usage_server.go
@@ -32,14 +32,17 @@ type UsageServer struct {
 // The returned UsageServerTransport instance is connected to an instance of armcompute.UsageClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewUsageServerTransport(srv *UsageServer) *UsageServerTransport {
-	return &UsageServerTransport{srv: srv}
+	return &UsageServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.UsageClientListResponse]](),
+	}
 }
 
 // UsageServerTransport connects instances of armcompute.UsageClient to instances of UsageServer.
 // Don't use this type directly, use NewUsageServerTransport instead.
 type UsageServerTransport struct {
 	srv          *UsageServer
-	newListPager *azfake.PagerResponder[armcompute.UsageClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.UsageClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for UsageServerTransport.
@@ -71,7 +74,8 @@ func (u *UsageServerTransport) dispatchNewListPager(req *http.Request) (*http.Re
 	if u.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if u.newListPager == nil {
+	newListPager := u.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/usages`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -83,20 +87,22 @@ func (u *UsageServerTransport) dispatchNewListPager(req *http.Request) (*http.Re
 			return nil, err
 		}
 		resp := u.srv.NewListPager(locationUnescaped, nil)
-		u.newListPager = &resp
-		server.PagerResponderInjectNextLinks(u.newListPager, req, func(page *armcompute.UsageClientListResponse, createLink func() string) {
+		newListPager = &resp
+		u.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.UsageClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(u.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		u.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(u.newListPager) {
-		u.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		u.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachineextensions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachineextensions_server.go
@@ -48,16 +48,21 @@ type VirtualMachineExtensionsServer struct {
 // The returned VirtualMachineExtensionsServerTransport instance is connected to an instance of armcompute.VirtualMachineExtensionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineExtensionsServerTransport(srv *VirtualMachineExtensionsServer) *VirtualMachineExtensionsServerTransport {
-	return &VirtualMachineExtensionsServerTransport{srv: srv}
+	return &VirtualMachineExtensionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientDeleteResponse]](),
+		beginUpdate:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineExtensionsServerTransport connects instances of armcompute.VirtualMachineExtensionsClient to instances of VirtualMachineExtensionsServer.
 // Don't use this type directly, use NewVirtualMachineExtensionsServerTransport instead.
 type VirtualMachineExtensionsServerTransport struct {
 	srv                 *VirtualMachineExtensionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientDeleteResponse]
-	beginUpdate         *azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientUpdateResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientDeleteResponse]]
+	beginUpdate         *tracker[azfake.PollerResponder[armcompute.VirtualMachineExtensionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineExtensionsServerTransport.
@@ -97,7 +102,8 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginCreateOrUpdate(re
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -124,19 +130,21 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginCreateOrUpdate(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -146,7 +154,8 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginDelete(req *http.
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +178,21 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginDelete(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -285,7 +296,8 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginUpdate(req *http.
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -312,19 +324,21 @@ func (v *VirtualMachineExtensionsServerTransport) dispatchBeginUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachineruncommands_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachineruncommands_server.go
@@ -57,18 +57,25 @@ type VirtualMachineRunCommandsServer struct {
 // The returned VirtualMachineRunCommandsServerTransport instance is connected to an instance of armcompute.VirtualMachineRunCommandsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineRunCommandsServerTransport(srv *VirtualMachineRunCommandsServer) *VirtualMachineRunCommandsServerTransport {
-	return &VirtualMachineRunCommandsServerTransport{srv: srv}
+	return &VirtualMachineRunCommandsServerTransport{
+		srv:                          srv,
+		beginCreateOrUpdate:          newTracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientCreateOrUpdateResponse]](),
+		beginDelete:                  newTracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientDeleteResponse]](),
+		newListPager:                 newTracker[azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListResponse]](),
+		newListByVirtualMachinePager: newTracker[azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListByVirtualMachineResponse]](),
+		beginUpdate:                  newTracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineRunCommandsServerTransport connects instances of armcompute.VirtualMachineRunCommandsClient to instances of VirtualMachineRunCommandsServer.
 // Don't use this type directly, use NewVirtualMachineRunCommandsServerTransport instead.
 type VirtualMachineRunCommandsServerTransport struct {
 	srv                          *VirtualMachineRunCommandsServer
-	beginCreateOrUpdate          *azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientCreateOrUpdateResponse]
-	beginDelete                  *azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientDeleteResponse]
-	newListPager                 *azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListResponse]
-	newListByVirtualMachinePager *azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListByVirtualMachineResponse]
-	beginUpdate                  *azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientUpdateResponse]
+	beginCreateOrUpdate          *tracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientCreateOrUpdateResponse]]
+	beginDelete                  *tracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientDeleteResponse]]
+	newListPager                 *tracker[azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListResponse]]
+	newListByVirtualMachinePager *tracker[azfake.PagerResponder[armcompute.VirtualMachineRunCommandsClientListByVirtualMachineResponse]]
+	beginUpdate                  *tracker[azfake.PollerResponder[armcompute.VirtualMachineRunCommandsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineRunCommandsServerTransport.
@@ -112,7 +119,8 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginCreateOrUpdate(r
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -139,19 +147,21 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginCreateOrUpdate(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -161,7 +171,8 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginDelete(req *http
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -184,19 +195,21 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -288,7 +301,8 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchNewListPager(req *htt
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -300,20 +314,22 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := v.srv.NewListPager(locationUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachineRunCommandsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachineRunCommandsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -322,7 +338,8 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchNewListByVirtualMachi
 	if v.srv.NewListByVirtualMachinePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVirtualMachinePager not implemented")}
 	}
-	if v.newListByVirtualMachinePager == nil {
+	newListByVirtualMachinePager := v.newListByVirtualMachinePager.get(req)
+	if newListByVirtualMachinePager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -350,20 +367,22 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchNewListByVirtualMachi
 			}
 		}
 		resp := v.srv.NewListByVirtualMachinePager(resourceGroupNameUnescaped, vmNameUnescaped, options)
-		v.newListByVirtualMachinePager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByVirtualMachinePager, req, func(page *armcompute.VirtualMachineRunCommandsClientListByVirtualMachineResponse, createLink func() string) {
+		newListByVirtualMachinePager = &resp
+		v.newListByVirtualMachinePager.add(req, newListByVirtualMachinePager)
+		server.PagerResponderInjectNextLinks(newListByVirtualMachinePager, req, func(page *armcompute.VirtualMachineRunCommandsClientListByVirtualMachineResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByVirtualMachinePager, req)
+	resp, err := server.PagerResponderNext(newListByVirtualMachinePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByVirtualMachinePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByVirtualMachinePager) {
-		v.newListByVirtualMachinePager = nil
+	if !server.PagerResponderMore(newListByVirtualMachinePager) {
+		v.newListByVirtualMachinePager.remove(req)
 	}
 	return resp, nil
 }
@@ -372,7 +391,8 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginUpdate(req *http
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -399,19 +419,21 @@ func (v *VirtualMachineRunCommandsServerTransport) dispatchBeginUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachines_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachines_server.go
@@ -131,33 +131,55 @@ type VirtualMachinesServer struct {
 // The returned VirtualMachinesServerTransport instance is connected to an instance of armcompute.VirtualMachinesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachinesServerTransport(srv *VirtualMachinesServer) *VirtualMachinesServerTransport {
-	return &VirtualMachinesServerTransport{srv: srv}
+	return &VirtualMachinesServerTransport{
+		srv:                        srv,
+		beginAssessPatches:         newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientAssessPatchesResponse]](),
+		beginCapture:               newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientCaptureResponse]](),
+		beginConvertToManagedDisks: newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientConvertToManagedDisksResponse]](),
+		beginCreateOrUpdate:        newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientCreateOrUpdateResponse]](),
+		beginDeallocate:            newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientDeallocateResponse]](),
+		beginDelete:                newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientDeleteResponse]](),
+		beginInstallPatches:        newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientInstallPatchesResponse]](),
+		newListPager:               newTracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListResponse]](),
+		newListAllPager:            newTracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]](),
+		newListAvailableSizesPager: newTracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListAvailableSizesResponse]](),
+		newListByLocationPager:     newTracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListByLocationResponse]](),
+		beginPerformMaintenance:    newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientPerformMaintenanceResponse]](),
+		beginPowerOff:              newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientPowerOffResponse]](),
+		beginReapply:               newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientReapplyResponse]](),
+		beginRedeploy:              newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRedeployResponse]](),
+		beginReimage:               newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientReimageResponse]](),
+		beginRestart:               newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRestartResponse]](),
+		beginRunCommand:            newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRunCommandResponse]](),
+		beginStart:                 newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientStartResponse]](),
+		beginUpdate:                newTracker[azfake.PollerResponder[armcompute.VirtualMachinesClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachinesServerTransport connects instances of armcompute.VirtualMachinesClient to instances of VirtualMachinesServer.
 // Don't use this type directly, use NewVirtualMachinesServerTransport instead.
 type VirtualMachinesServerTransport struct {
 	srv                        *VirtualMachinesServer
-	beginAssessPatches         *azfake.PollerResponder[armcompute.VirtualMachinesClientAssessPatchesResponse]
-	beginCapture               *azfake.PollerResponder[armcompute.VirtualMachinesClientCaptureResponse]
-	beginConvertToManagedDisks *azfake.PollerResponder[armcompute.VirtualMachinesClientConvertToManagedDisksResponse]
-	beginCreateOrUpdate        *azfake.PollerResponder[armcompute.VirtualMachinesClientCreateOrUpdateResponse]
-	beginDeallocate            *azfake.PollerResponder[armcompute.VirtualMachinesClientDeallocateResponse]
-	beginDelete                *azfake.PollerResponder[armcompute.VirtualMachinesClientDeleteResponse]
-	beginInstallPatches        *azfake.PollerResponder[armcompute.VirtualMachinesClientInstallPatchesResponse]
-	newListPager               *azfake.PagerResponder[armcompute.VirtualMachinesClientListResponse]
-	newListAllPager            *azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]
-	newListAvailableSizesPager *azfake.PagerResponder[armcompute.VirtualMachinesClientListAvailableSizesResponse]
-	newListByLocationPager     *azfake.PagerResponder[armcompute.VirtualMachinesClientListByLocationResponse]
-	beginPerformMaintenance    *azfake.PollerResponder[armcompute.VirtualMachinesClientPerformMaintenanceResponse]
-	beginPowerOff              *azfake.PollerResponder[armcompute.VirtualMachinesClientPowerOffResponse]
-	beginReapply               *azfake.PollerResponder[armcompute.VirtualMachinesClientReapplyResponse]
-	beginRedeploy              *azfake.PollerResponder[armcompute.VirtualMachinesClientRedeployResponse]
-	beginReimage               *azfake.PollerResponder[armcompute.VirtualMachinesClientReimageResponse]
-	beginRestart               *azfake.PollerResponder[armcompute.VirtualMachinesClientRestartResponse]
-	beginRunCommand            *azfake.PollerResponder[armcompute.VirtualMachinesClientRunCommandResponse]
-	beginStart                 *azfake.PollerResponder[armcompute.VirtualMachinesClientStartResponse]
-	beginUpdate                *azfake.PollerResponder[armcompute.VirtualMachinesClientUpdateResponse]
+	beginAssessPatches         *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientAssessPatchesResponse]]
+	beginCapture               *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientCaptureResponse]]
+	beginConvertToManagedDisks *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientConvertToManagedDisksResponse]]
+	beginCreateOrUpdate        *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientCreateOrUpdateResponse]]
+	beginDeallocate            *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientDeallocateResponse]]
+	beginDelete                *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientDeleteResponse]]
+	beginInstallPatches        *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientInstallPatchesResponse]]
+	newListPager               *tracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListResponse]]
+	newListAllPager            *tracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]]
+	newListAvailableSizesPager *tracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListAvailableSizesResponse]]
+	newListByLocationPager     *tracker[azfake.PagerResponder[armcompute.VirtualMachinesClientListByLocationResponse]]
+	beginPerformMaintenance    *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientPerformMaintenanceResponse]]
+	beginPowerOff              *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientPowerOffResponse]]
+	beginReapply               *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientReapplyResponse]]
+	beginRedeploy              *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRedeployResponse]]
+	beginReimage               *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientReimageResponse]]
+	beginRestart               *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRestartResponse]]
+	beginRunCommand            *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientRunCommandResponse]]
+	beginStart                 *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientStartResponse]]
+	beginUpdate                *tracker[azfake.PollerResponder[armcompute.VirtualMachinesClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachinesServerTransport.
@@ -237,7 +259,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginAssessPatches(req *http.Re
 	if v.srv.BeginAssessPatches == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginAssessPatches not implemented")}
 	}
-	if v.beginAssessPatches == nil {
+	beginAssessPatches := v.beginAssessPatches.get(req)
+	if beginAssessPatches == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/assessPatches`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -256,19 +279,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginAssessPatches(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginAssessPatches = &respr
+		beginAssessPatches = &respr
+		v.beginAssessPatches.add(req, beginAssessPatches)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginAssessPatches, req)
+	resp, err := server.PollerResponderNext(beginAssessPatches, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginAssessPatches.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginAssessPatches) {
-		v.beginAssessPatches = nil
+	if !server.PollerResponderMore(beginAssessPatches) {
+		v.beginAssessPatches.remove(req)
 	}
 
 	return resp, nil
@@ -278,7 +303,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginCapture(req *http.Request)
 	if v.srv.BeginCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCapture not implemented")}
 	}
-	if v.beginCapture == nil {
+	beginCapture := v.beginCapture.get(req)
+	if beginCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/capture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -301,19 +327,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginCapture(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCapture = &respr
+		beginCapture = &respr
+		v.beginCapture.add(req, beginCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCapture, req)
+	resp, err := server.PollerResponderNext(beginCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCapture) {
-		v.beginCapture = nil
+	if !server.PollerResponderMore(beginCapture) {
+		v.beginCapture.remove(req)
 	}
 
 	return resp, nil
@@ -323,7 +351,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginConvertToManagedDisks(req 
 	if v.srv.BeginConvertToManagedDisks == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginConvertToManagedDisks not implemented")}
 	}
-	if v.beginConvertToManagedDisks == nil {
+	beginConvertToManagedDisks := v.beginConvertToManagedDisks.get(req)
+	if beginConvertToManagedDisks == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/convertToManagedDisks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -342,19 +371,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginConvertToManagedDisks(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginConvertToManagedDisks = &respr
+		beginConvertToManagedDisks = &respr
+		v.beginConvertToManagedDisks.add(req, beginConvertToManagedDisks)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginConvertToManagedDisks, req)
+	resp, err := server.PollerResponderNext(beginConvertToManagedDisks, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginConvertToManagedDisks.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginConvertToManagedDisks) {
-		v.beginConvertToManagedDisks = nil
+	if !server.PollerResponderMore(beginConvertToManagedDisks) {
+		v.beginConvertToManagedDisks.remove(req)
 	}
 
 	return resp, nil
@@ -364,7 +395,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -387,19 +419,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -409,7 +443,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginDeallocate(req *http.Reque
 	if v.srv.BeginDeallocate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeallocate not implemented")}
 	}
-	if v.beginDeallocate == nil {
+	beginDeallocate := v.beginDeallocate.get(req)
+	if beginDeallocate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/deallocate`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -443,19 +478,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginDeallocate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDeallocate = &respr
+		beginDeallocate = &respr
+		v.beginDeallocate.add(req, beginDeallocate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDeallocate, req)
+	resp, err := server.PollerResponderNext(beginDeallocate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDeallocate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDeallocate) {
-		v.beginDeallocate = nil
+	if !server.PollerResponderMore(beginDeallocate) {
+		v.beginDeallocate.remove(req)
 	}
 
 	return resp, nil
@@ -465,7 +502,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginDelete(req *http.Request) 
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -499,19 +537,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginDelete(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -599,7 +639,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginInstallPatches(req *http.R
 	if v.srv.BeginInstallPatches == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginInstallPatches not implemented")}
 	}
-	if v.beginInstallPatches == nil {
+	beginInstallPatches := v.beginInstallPatches.get(req)
+	if beginInstallPatches == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/installPatches`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -622,19 +663,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginInstallPatches(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginInstallPatches = &respr
+		beginInstallPatches = &respr
+		v.beginInstallPatches.add(req, beginInstallPatches)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginInstallPatches, req)
+	resp, err := server.PollerResponderNext(beginInstallPatches, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginInstallPatches.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginInstallPatches) {
-		v.beginInstallPatches = nil
+	if !server.PollerResponderMore(beginInstallPatches) {
+		v.beginInstallPatches.remove(req)
 	}
 
 	return resp, nil
@@ -677,7 +720,8 @@ func (v *VirtualMachinesServerTransport) dispatchNewListPager(req *http.Request)
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -701,20 +745,22 @@ func (v *VirtualMachinesServerTransport) dispatchNewListPager(req *http.Request)
 			}
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, options)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachinesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachinesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -723,7 +769,8 @@ func (v *VirtualMachinesServerTransport) dispatchNewListAllPager(req *http.Reque
 	if v.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if v.newListAllPager == nil {
+	newListAllPager := v.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -749,20 +796,22 @@ func (v *VirtualMachinesServerTransport) dispatchNewListAllPager(req *http.Reque
 			}
 		}
 		resp := v.srv.NewListAllPager(options)
-		v.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListAllPager, req, func(page *armcompute.VirtualMachinesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		v.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armcompute.VirtualMachinesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListAllPager) {
-		v.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		v.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -771,7 +820,8 @@ func (v *VirtualMachinesServerTransport) dispatchNewListAvailableSizesPager(req 
 	if v.srv.NewListAvailableSizesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAvailableSizesPager not implemented")}
 	}
-	if v.newListAvailableSizesPager == nil {
+	newListAvailableSizesPager := v.newListAvailableSizesPager.get(req)
+	if newListAvailableSizesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vmSizes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -787,17 +837,19 @@ func (v *VirtualMachinesServerTransport) dispatchNewListAvailableSizesPager(req 
 			return nil, err
 		}
 		resp := v.srv.NewListAvailableSizesPager(resourceGroupNameUnescaped, vmNameUnescaped, nil)
-		v.newListAvailableSizesPager = &resp
+		newListAvailableSizesPager = &resp
+		v.newListAvailableSizesPager.add(req, newListAvailableSizesPager)
 	}
-	resp, err := server.PagerResponderNext(v.newListAvailableSizesPager, req)
+	resp, err := server.PagerResponderNext(newListAvailableSizesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListAvailableSizesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListAvailableSizesPager) {
-		v.newListAvailableSizesPager = nil
+	if !server.PagerResponderMore(newListAvailableSizesPager) {
+		v.newListAvailableSizesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -806,7 +858,8 @@ func (v *VirtualMachinesServerTransport) dispatchNewListByLocationPager(req *htt
 	if v.srv.NewListByLocationPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByLocationPager not implemented")}
 	}
-	if v.newListByLocationPager == nil {
+	newListByLocationPager := v.newListByLocationPager.get(req)
+	if newListByLocationPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -818,20 +871,22 @@ func (v *VirtualMachinesServerTransport) dispatchNewListByLocationPager(req *htt
 			return nil, err
 		}
 		resp := v.srv.NewListByLocationPager(locationUnescaped, nil)
-		v.newListByLocationPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByLocationPager, req, func(page *armcompute.VirtualMachinesClientListByLocationResponse, createLink func() string) {
+		newListByLocationPager = &resp
+		v.newListByLocationPager.add(req, newListByLocationPager)
+		server.PagerResponderInjectNextLinks(newListByLocationPager, req, func(page *armcompute.VirtualMachinesClientListByLocationResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByLocationPager, req)
+	resp, err := server.PagerResponderNext(newListByLocationPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByLocationPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByLocationPager) {
-		v.newListByLocationPager = nil
+	if !server.PagerResponderMore(newListByLocationPager) {
+		v.newListByLocationPager.remove(req)
 	}
 	return resp, nil
 }
@@ -840,7 +895,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginPerformMaintenance(req *ht
 	if v.srv.BeginPerformMaintenance == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPerformMaintenance not implemented")}
 	}
-	if v.beginPerformMaintenance == nil {
+	beginPerformMaintenance := v.beginPerformMaintenance.get(req)
+	if beginPerformMaintenance == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/performMaintenance`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -859,19 +915,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginPerformMaintenance(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPerformMaintenance = &respr
+		beginPerformMaintenance = &respr
+		v.beginPerformMaintenance.add(req, beginPerformMaintenance)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPerformMaintenance, req)
+	resp, err := server.PollerResponderNext(beginPerformMaintenance, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPerformMaintenance.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPerformMaintenance) {
-		v.beginPerformMaintenance = nil
+	if !server.PollerResponderMore(beginPerformMaintenance) {
+		v.beginPerformMaintenance.remove(req)
 	}
 
 	return resp, nil
@@ -881,7 +939,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginPowerOff(req *http.Request
 	if v.srv.BeginPowerOff == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPowerOff not implemented")}
 	}
-	if v.beginPowerOff == nil {
+	beginPowerOff := v.beginPowerOff.get(req)
+	if beginPowerOff == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/powerOff`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -915,19 +974,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginPowerOff(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPowerOff = &respr
+		beginPowerOff = &respr
+		v.beginPowerOff.add(req, beginPowerOff)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPowerOff, req)
+	resp, err := server.PollerResponderNext(beginPowerOff, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPowerOff.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPowerOff) {
-		v.beginPowerOff = nil
+	if !server.PollerResponderMore(beginPowerOff) {
+		v.beginPowerOff.remove(req)
 	}
 
 	return resp, nil
@@ -937,7 +998,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginReapply(req *http.Request)
 	if v.srv.BeginReapply == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReapply not implemented")}
 	}
-	if v.beginReapply == nil {
+	beginReapply := v.beginReapply.get(req)
+	if beginReapply == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reapply`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -956,19 +1018,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginReapply(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReapply = &respr
+		beginReapply = &respr
+		v.beginReapply.add(req, beginReapply)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReapply, req)
+	resp, err := server.PollerResponderNext(beginReapply, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReapply.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReapply) {
-		v.beginReapply = nil
+	if !server.PollerResponderMore(beginReapply) {
+		v.beginReapply.remove(req)
 	}
 
 	return resp, nil
@@ -978,7 +1042,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRedeploy(req *http.Request
 	if v.srv.BeginRedeploy == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRedeploy not implemented")}
 	}
-	if v.beginRedeploy == nil {
+	beginRedeploy := v.beginRedeploy.get(req)
+	if beginRedeploy == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/redeploy`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -997,19 +1062,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRedeploy(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRedeploy = &respr
+		beginRedeploy = &respr
+		v.beginRedeploy.add(req, beginRedeploy)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRedeploy, req)
+	resp, err := server.PollerResponderNext(beginRedeploy, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRedeploy.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRedeploy) {
-		v.beginRedeploy = nil
+	if !server.PollerResponderMore(beginRedeploy) {
+		v.beginRedeploy.remove(req)
 	}
 
 	return resp, nil
@@ -1019,7 +1086,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginReimage(req *http.Request)
 	if v.srv.BeginReimage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimage not implemented")}
 	}
-	if v.beginReimage == nil {
+	beginReimage := v.beginReimage.get(req)
+	if beginReimage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1048,19 +1116,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginReimage(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReimage = &respr
+		beginReimage = &respr
+		v.beginReimage.add(req, beginReimage)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReimage, req)
+	resp, err := server.PollerResponderNext(beginReimage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReimage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReimage) {
-		v.beginReimage = nil
+	if !server.PollerResponderMore(beginReimage) {
+		v.beginReimage.remove(req)
 	}
 
 	return resp, nil
@@ -1070,7 +1140,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRestart(req *http.Request)
 	if v.srv.BeginRestart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRestart not implemented")}
 	}
-	if v.beginRestart == nil {
+	beginRestart := v.beginRestart.get(req)
+	if beginRestart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restart`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1089,19 +1160,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRestart(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRestart = &respr
+		beginRestart = &respr
+		v.beginRestart.add(req, beginRestart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRestart, req)
+	resp, err := server.PollerResponderNext(beginRestart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRestart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRestart) {
-		v.beginRestart = nil
+	if !server.PollerResponderMore(beginRestart) {
+		v.beginRestart.remove(req)
 	}
 
 	return resp, nil
@@ -1165,7 +1238,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRunCommand(req *http.Reque
 	if v.srv.BeginRunCommand == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRunCommand not implemented")}
 	}
-	if v.beginRunCommand == nil {
+	beginRunCommand := v.beginRunCommand.get(req)
+	if beginRunCommand == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommand`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1188,19 +1262,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginRunCommand(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRunCommand = &respr
+		beginRunCommand = &respr
+		v.beginRunCommand.add(req, beginRunCommand)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRunCommand, req)
+	resp, err := server.PollerResponderNext(beginRunCommand, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRunCommand.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRunCommand) {
-		v.beginRunCommand = nil
+	if !server.PollerResponderMore(beginRunCommand) {
+		v.beginRunCommand.remove(req)
 	}
 
 	return resp, nil
@@ -1243,7 +1319,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginStart(req *http.Request) (
 	if v.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if v.beginStart == nil {
+	beginStart := v.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1262,19 +1339,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginStart(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStart = &respr
+		beginStart = &respr
+		v.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStart) {
-		v.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		v.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -1284,7 +1363,8 @@ func (v *VirtualMachinesServerTransport) dispatchBeginUpdate(req *http.Request) 
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachines/(?P<vmName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1307,19 +1387,21 @@ func (v *VirtualMachinesServerTransport) dispatchBeginUpdate(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetextensions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetextensions_server.go
@@ -49,17 +49,23 @@ type VirtualMachineScaleSetExtensionsServer struct {
 // The returned VirtualMachineScaleSetExtensionsServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetExtensionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetExtensionsServerTransport(srv *VirtualMachineScaleSetExtensionsServer) *VirtualMachineScaleSetExtensionsServerTransport {
-	return &VirtualMachineScaleSetExtensionsServerTransport{srv: srv}
+	return &VirtualMachineScaleSetExtensionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetExtensionsClientListResponse]](),
+		beginUpdate:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetExtensionsServerTransport connects instances of armcompute.VirtualMachineScaleSetExtensionsClient to instances of VirtualMachineScaleSetExtensionsServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetExtensionsServerTransport instead.
 type VirtualMachineScaleSetExtensionsServerTransport struct {
 	srv                 *VirtualMachineScaleSetExtensionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armcompute.VirtualMachineScaleSetExtensionsClientListResponse]
-	beginUpdate         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientUpdateResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetExtensionsClientListResponse]]
+	beginUpdate         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetExtensionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetExtensionsServerTransport.
@@ -99,7 +105,8 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginCreateOrU
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmssExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -126,19 +133,21 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginCreateOrU
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -148,7 +157,8 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginDelete(re
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmssExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +181,21 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginDelete(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -242,7 +254,8 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchNewListPager(r
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -258,20 +271,22 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchNewListPager(r
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, vmScaleSetNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachineScaleSetExtensionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachineScaleSetExtensionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -280,7 +295,8 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginUpdate(re
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmssExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -307,19 +323,21 @@ func (v *VirtualMachineScaleSetExtensionsServerTransport) dispatchBeginUpdate(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetrollingupgrades_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetrollingupgrades_server.go
@@ -44,16 +44,21 @@ type VirtualMachineScaleSetRollingUpgradesServer struct {
 // The returned VirtualMachineScaleSetRollingUpgradesServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetRollingUpgradesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetRollingUpgradesServerTransport(srv *VirtualMachineScaleSetRollingUpgradesServer) *VirtualMachineScaleSetRollingUpgradesServerTransport {
-	return &VirtualMachineScaleSetRollingUpgradesServerTransport{srv: srv}
+	return &VirtualMachineScaleSetRollingUpgradesServerTransport{
+		srv:                        srv,
+		beginCancel:                newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientCancelResponse]](),
+		beginStartExtensionUpgrade: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse]](),
+		beginStartOSUpgrade:        newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetRollingUpgradesServerTransport connects instances of armcompute.VirtualMachineScaleSetRollingUpgradesClient to instances of VirtualMachineScaleSetRollingUpgradesServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetRollingUpgradesServerTransport instead.
 type VirtualMachineScaleSetRollingUpgradesServerTransport struct {
 	srv                        *VirtualMachineScaleSetRollingUpgradesServer
-	beginCancel                *azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientCancelResponse]
-	beginStartExtensionUpgrade *azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse]
-	beginStartOSUpgrade        *azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse]
+	beginCancel                *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientCancelResponse]]
+	beginStartExtensionUpgrade *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartExtensionUpgradeResponse]]
+	beginStartOSUpgrade        *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetRollingUpgradesClientStartOSUpgradeResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetRollingUpgradesServerTransport.
@@ -91,7 +96,8 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginCanc
 	if v.srv.BeginCancel == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCancel not implemented")}
 	}
-	if v.beginCancel == nil {
+	beginCancel := v.beginCancel.get(req)
+	if beginCancel == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rollingUpgrades/cancel`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -110,19 +116,21 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginCanc
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCancel = &respr
+		beginCancel = &respr
+		v.beginCancel.add(req, beginCancel)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCancel, req)
+	resp, err := server.PollerResponderNext(beginCancel, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginCancel.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCancel) {
-		v.beginCancel = nil
+	if !server.PollerResponderMore(beginCancel) {
+		v.beginCancel.remove(req)
 	}
 
 	return resp, nil
@@ -165,7 +173,8 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginStar
 	if v.srv.BeginStartExtensionUpgrade == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartExtensionUpgrade not implemented")}
 	}
-	if v.beginStartExtensionUpgrade == nil {
+	beginStartExtensionUpgrade := v.beginStartExtensionUpgrade.get(req)
+	if beginStartExtensionUpgrade == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensionRollingUpgrade`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -184,19 +193,21 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginStar
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartExtensionUpgrade = &respr
+		beginStartExtensionUpgrade = &respr
+		v.beginStartExtensionUpgrade.add(req, beginStartExtensionUpgrade)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartExtensionUpgrade, req)
+	resp, err := server.PollerResponderNext(beginStartExtensionUpgrade, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartExtensionUpgrade.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartExtensionUpgrade) {
-		v.beginStartExtensionUpgrade = nil
+	if !server.PollerResponderMore(beginStartExtensionUpgrade) {
+		v.beginStartExtensionUpgrade.remove(req)
 	}
 
 	return resp, nil
@@ -206,7 +217,8 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginStar
 	if v.srv.BeginStartOSUpgrade == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartOSUpgrade not implemented")}
 	}
-	if v.beginStartOSUpgrade == nil {
+	beginStartOSUpgrade := v.beginStartOSUpgrade.get(req)
+	if beginStartOSUpgrade == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/osRollingUpgrade`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -225,19 +237,21 @@ func (v *VirtualMachineScaleSetRollingUpgradesServerTransport) dispatchBeginStar
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartOSUpgrade = &respr
+		beginStartOSUpgrade = &respr
+		v.beginStartOSUpgrade.add(req, beginStartOSUpgrade)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartOSUpgrade, req)
+	resp, err := server.PollerResponderNext(beginStartOSUpgrade, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartOSUpgrade.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartOSUpgrade) {
-		v.beginStartOSUpgrade = nil
+	if !server.PollerResponderMore(beginStartOSUpgrade) {
+		v.beginStartOSUpgrade.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesets_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesets_server.go
@@ -123,32 +123,53 @@ type VirtualMachineScaleSetsServer struct {
 // The returned VirtualMachineScaleSetsServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetsServerTransport(srv *VirtualMachineScaleSetsServer) *VirtualMachineScaleSetsServerTransport {
-	return &VirtualMachineScaleSetsServerTransport{srv: srv}
+	return &VirtualMachineScaleSetsServerTransport{
+		srv:                               srv,
+		beginCreateOrUpdate:               newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]](),
+		beginDeallocate:                   newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]](),
+		beginDelete:                       newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteResponse]](),
+		beginDeleteInstances:              newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]](),
+		newGetOSUpgradeHistoryPager:       newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse]](),
+		newListPager:                      newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListResponse]](),
+		newListAllPager:                   newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]](),
+		newListByLocationPager:            newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListByLocationResponse]](),
+		newListSKUsPager:                  newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListSKUsResponse]](),
+		beginPerformMaintenance:           newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPerformMaintenanceResponse]](),
+		beginPowerOff:                     newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPowerOffResponse]](),
+		beginRedeploy:                     newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRedeployResponse]](),
+		beginReimage:                      newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageResponse]](),
+		beginReimageAll:                   newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageAllResponse]](),
+		beginRestart:                      newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRestartResponse]](),
+		beginSetOrchestrationServiceState: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse]](),
+		beginStart:                        newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientStartResponse]](),
+		beginUpdate:                       newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateResponse]](),
+		beginUpdateInstances:              newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateInstancesResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetsServerTransport connects instances of armcompute.VirtualMachineScaleSetsClient to instances of VirtualMachineScaleSetsServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetsServerTransport instead.
 type VirtualMachineScaleSetsServerTransport struct {
 	srv                               *VirtualMachineScaleSetsServer
-	beginCreateOrUpdate               *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]
-	beginDeallocate                   *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]
-	beginDelete                       *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteResponse]
-	beginDeleteInstances              *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]
-	newGetOSUpgradeHistoryPager       *azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse]
-	newListPager                      *azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListResponse]
-	newListAllPager                   *azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]
-	newListByLocationPager            *azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListByLocationResponse]
-	newListSKUsPager                  *azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListSKUsResponse]
-	beginPerformMaintenance           *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPerformMaintenanceResponse]
-	beginPowerOff                     *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPowerOffResponse]
-	beginRedeploy                     *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRedeployResponse]
-	beginReimage                      *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageResponse]
-	beginReimageAll                   *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageAllResponse]
-	beginRestart                      *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRestartResponse]
-	beginSetOrchestrationServiceState *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse]
-	beginStart                        *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientStartResponse]
-	beginUpdate                       *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateResponse]
-	beginUpdateInstances              *azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateInstancesResponse]
+	beginCreateOrUpdate               *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientCreateOrUpdateResponse]]
+	beginDeallocate                   *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeallocateResponse]]
+	beginDelete                       *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteResponse]]
+	beginDeleteInstances              *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientDeleteInstancesResponse]]
+	newGetOSUpgradeHistoryPager       *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse]]
+	newListPager                      *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListResponse]]
+	newListAllPager                   *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]]
+	newListByLocationPager            *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListByLocationResponse]]
+	newListSKUsPager                  *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListSKUsResponse]]
+	beginPerformMaintenance           *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPerformMaintenanceResponse]]
+	beginPowerOff                     *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientPowerOffResponse]]
+	beginRedeploy                     *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRedeployResponse]]
+	beginReimage                      *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageResponse]]
+	beginReimageAll                   *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientReimageAllResponse]]
+	beginRestart                      *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientRestartResponse]]
+	beginSetOrchestrationServiceState *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientSetOrchestrationServiceStateResponse]]
+	beginStart                        *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientStartResponse]]
+	beginUpdate                       *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateResponse]]
+	beginUpdateInstances              *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetsClientUpdateInstancesResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetsServerTransport.
@@ -261,7 +282,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginCreateOrUpdate(req
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -284,19 +306,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -306,7 +330,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDeallocate(req *ht
 	if v.srv.BeginDeallocate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeallocate not implemented")}
 	}
-	if v.beginDeallocate == nil {
+	beginDeallocate := v.beginDeallocate.get(req)
+	if beginDeallocate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/deallocate`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -335,19 +360,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDeallocate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDeallocate = &respr
+		beginDeallocate = &respr
+		v.beginDeallocate.add(req, beginDeallocate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDeallocate, req)
+	resp, err := server.PollerResponderNext(beginDeallocate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDeallocate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDeallocate) {
-		v.beginDeallocate = nil
+	if !server.PollerResponderMore(beginDeallocate) {
+		v.beginDeallocate.remove(req)
 	}
 
 	return resp, nil
@@ -357,7 +384,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDelete(req *http.R
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -391,19 +419,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -413,7 +443,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDeleteInstances(re
 	if v.srv.BeginDeleteInstances == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteInstances not implemented")}
 	}
-	if v.beginDeleteInstances == nil {
+	beginDeleteInstances := v.beginDeleteInstances.get(req)
+	if beginDeleteInstances == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/delete`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -451,19 +482,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginDeleteInstances(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDeleteInstances = &respr
+		beginDeleteInstances = &respr
+		v.beginDeleteInstances.add(req, beginDeleteInstances)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDeleteInstances, req)
+	resp, err := server.PollerResponderNext(beginDeleteInstances, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDeleteInstances.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDeleteInstances) {
-		v.beginDeleteInstances = nil
+	if !server.PollerResponderMore(beginDeleteInstances) {
+		v.beginDeleteInstances.remove(req)
 	}
 
 	return resp, nil
@@ -616,7 +649,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewGetOSUpgradeHistoryP
 	if v.srv.NewGetOSUpgradeHistoryPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetOSUpgradeHistoryPager not implemented")}
 	}
-	if v.newGetOSUpgradeHistoryPager == nil {
+	newGetOSUpgradeHistoryPager := v.newGetOSUpgradeHistoryPager.get(req)
+	if newGetOSUpgradeHistoryPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/osUpgradeHistory`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -632,20 +666,22 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewGetOSUpgradeHistoryP
 			return nil, err
 		}
 		resp := v.srv.NewGetOSUpgradeHistoryPager(resourceGroupNameUnescaped, vmScaleSetNameUnescaped, nil)
-		v.newGetOSUpgradeHistoryPager = &resp
-		server.PagerResponderInjectNextLinks(v.newGetOSUpgradeHistoryPager, req, func(page *armcompute.VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse, createLink func() string) {
+		newGetOSUpgradeHistoryPager = &resp
+		v.newGetOSUpgradeHistoryPager.add(req, newGetOSUpgradeHistoryPager)
+		server.PagerResponderInjectNextLinks(newGetOSUpgradeHistoryPager, req, func(page *armcompute.VirtualMachineScaleSetsClientGetOSUpgradeHistoryResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newGetOSUpgradeHistoryPager, req)
+	resp, err := server.PagerResponderNext(newGetOSUpgradeHistoryPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newGetOSUpgradeHistoryPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newGetOSUpgradeHistoryPager) {
-		v.newGetOSUpgradeHistoryPager = nil
+	if !server.PagerResponderMore(newGetOSUpgradeHistoryPager) {
+		v.newGetOSUpgradeHistoryPager.remove(req)
 	}
 	return resp, nil
 }
@@ -654,7 +690,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListPager(req *http.
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -666,20 +703,22 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListPager(req *http.
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -688,7 +727,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListAllPager(req *ht
 	if v.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if v.newListAllPager == nil {
+	newListAllPager := v.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -696,20 +736,22 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListAllPager(req *ht
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListAllPager(nil)
-		v.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListAllPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		v.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListAllPager) {
-		v.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		v.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -718,7 +760,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListByLocationPager(
 	if v.srv.NewListByLocationPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByLocationPager not implemented")}
 	}
-	if v.newListByLocationPager == nil {
+	newListByLocationPager := v.newListByLocationPager.get(req)
+	if newListByLocationPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachineScaleSets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -730,20 +773,22 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListByLocationPager(
 			return nil, err
 		}
 		resp := v.srv.NewListByLocationPager(locationUnescaped, nil)
-		v.newListByLocationPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByLocationPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListByLocationResponse, createLink func() string) {
+		newListByLocationPager = &resp
+		v.newListByLocationPager.add(req, newListByLocationPager)
+		server.PagerResponderInjectNextLinks(newListByLocationPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListByLocationResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByLocationPager, req)
+	resp, err := server.PagerResponderNext(newListByLocationPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByLocationPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByLocationPager) {
-		v.newListByLocationPager = nil
+	if !server.PagerResponderMore(newListByLocationPager) {
+		v.newListByLocationPager.remove(req)
 	}
 	return resp, nil
 }
@@ -752,7 +797,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListSKUsPager(req *h
 	if v.srv.NewListSKUsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListSKUsPager not implemented")}
 	}
-	if v.newListSKUsPager == nil {
+	newListSKUsPager := v.newListSKUsPager.get(req)
+	if newListSKUsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/skus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -768,20 +814,22 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchNewListSKUsPager(req *h
 			return nil, err
 		}
 		resp := v.srv.NewListSKUsPager(resourceGroupNameUnescaped, vmScaleSetNameUnescaped, nil)
-		v.newListSKUsPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListSKUsPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListSKUsResponse, createLink func() string) {
+		newListSKUsPager = &resp
+		v.newListSKUsPager.add(req, newListSKUsPager)
+		server.PagerResponderInjectNextLinks(newListSKUsPager, req, func(page *armcompute.VirtualMachineScaleSetsClientListSKUsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListSKUsPager, req)
+	resp, err := server.PagerResponderNext(newListSKUsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListSKUsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListSKUsPager) {
-		v.newListSKUsPager = nil
+	if !server.PagerResponderMore(newListSKUsPager) {
+		v.newListSKUsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -790,7 +838,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginPerformMaintenance
 	if v.srv.BeginPerformMaintenance == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPerformMaintenance not implemented")}
 	}
-	if v.beginPerformMaintenance == nil {
+	beginPerformMaintenance := v.beginPerformMaintenance.get(req)
+	if beginPerformMaintenance == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/performMaintenance`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -819,19 +868,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginPerformMaintenance
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPerformMaintenance = &respr
+		beginPerformMaintenance = &respr
+		v.beginPerformMaintenance.add(req, beginPerformMaintenance)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPerformMaintenance, req)
+	resp, err := server.PollerResponderNext(beginPerformMaintenance, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPerformMaintenance.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPerformMaintenance) {
-		v.beginPerformMaintenance = nil
+	if !server.PollerResponderMore(beginPerformMaintenance) {
+		v.beginPerformMaintenance.remove(req)
 	}
 
 	return resp, nil
@@ -841,7 +892,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginPowerOff(req *http
 	if v.srv.BeginPowerOff == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPowerOff not implemented")}
 	}
-	if v.beginPowerOff == nil {
+	beginPowerOff := v.beginPowerOff.get(req)
+	if beginPowerOff == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/poweroff`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -880,19 +932,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginPowerOff(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPowerOff = &respr
+		beginPowerOff = &respr
+		v.beginPowerOff.add(req, beginPowerOff)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPowerOff, req)
+	resp, err := server.PollerResponderNext(beginPowerOff, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPowerOff.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPowerOff) {
-		v.beginPowerOff = nil
+	if !server.PollerResponderMore(beginPowerOff) {
+		v.beginPowerOff.remove(req)
 	}
 
 	return resp, nil
@@ -902,7 +956,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginRedeploy(req *http
 	if v.srv.BeginRedeploy == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRedeploy not implemented")}
 	}
-	if v.beginRedeploy == nil {
+	beginRedeploy := v.beginRedeploy.get(req)
+	if beginRedeploy == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/redeploy`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -931,19 +986,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginRedeploy(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRedeploy = &respr
+		beginRedeploy = &respr
+		v.beginRedeploy.add(req, beginRedeploy)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRedeploy, req)
+	resp, err := server.PollerResponderNext(beginRedeploy, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRedeploy.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRedeploy) {
-		v.beginRedeploy = nil
+	if !server.PollerResponderMore(beginRedeploy) {
+		v.beginRedeploy.remove(req)
 	}
 
 	return resp, nil
@@ -953,7 +1010,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginReimage(req *http.
 	if v.srv.BeginReimage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimage not implemented")}
 	}
-	if v.beginReimage == nil {
+	beginReimage := v.beginReimage.get(req)
+	if beginReimage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -982,19 +1040,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginReimage(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReimage = &respr
+		beginReimage = &respr
+		v.beginReimage.add(req, beginReimage)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReimage, req)
+	resp, err := server.PollerResponderNext(beginReimage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReimage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReimage) {
-		v.beginReimage = nil
+	if !server.PollerResponderMore(beginReimage) {
+		v.beginReimage.remove(req)
 	}
 
 	return resp, nil
@@ -1004,7 +1064,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginReimageAll(req *ht
 	if v.srv.BeginReimageAll == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimageAll not implemented")}
 	}
-	if v.beginReimageAll == nil {
+	beginReimageAll := v.beginReimageAll.get(req)
+	if beginReimageAll == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimageall`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1033,19 +1094,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginReimageAll(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReimageAll = &respr
+		beginReimageAll = &respr
+		v.beginReimageAll.add(req, beginReimageAll)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReimageAll, req)
+	resp, err := server.PollerResponderNext(beginReimageAll, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReimageAll.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReimageAll) {
-		v.beginReimageAll = nil
+	if !server.PollerResponderMore(beginReimageAll) {
+		v.beginReimageAll.remove(req)
 	}
 
 	return resp, nil
@@ -1055,7 +1118,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginRestart(req *http.
 	if v.srv.BeginRestart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRestart not implemented")}
 	}
-	if v.beginRestart == nil {
+	beginRestart := v.beginRestart.get(req)
+	if beginRestart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restart`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1084,19 +1148,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginRestart(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRestart = &respr
+		beginRestart = &respr
+		v.beginRestart.add(req, beginRestart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRestart, req)
+	resp, err := server.PollerResponderNext(beginRestart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRestart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRestart) {
-		v.beginRestart = nil
+	if !server.PollerResponderMore(beginRestart) {
+		v.beginRestart.remove(req)
 	}
 
 	return resp, nil
@@ -1106,7 +1172,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginSetOrchestrationSe
 	if v.srv.BeginSetOrchestrationServiceState == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginSetOrchestrationServiceState not implemented")}
 	}
-	if v.beginSetOrchestrationServiceState == nil {
+	beginSetOrchestrationServiceState := v.beginSetOrchestrationServiceState.get(req)
+	if beginSetOrchestrationServiceState == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/setOrchestrationServiceState`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1129,19 +1196,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginSetOrchestrationSe
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginSetOrchestrationServiceState = &respr
+		beginSetOrchestrationServiceState = &respr
+		v.beginSetOrchestrationServiceState.add(req, beginSetOrchestrationServiceState)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginSetOrchestrationServiceState, req)
+	resp, err := server.PollerResponderNext(beginSetOrchestrationServiceState, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginSetOrchestrationServiceState.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginSetOrchestrationServiceState) {
-		v.beginSetOrchestrationServiceState = nil
+	if !server.PollerResponderMore(beginSetOrchestrationServiceState) {
+		v.beginSetOrchestrationServiceState.remove(req)
 	}
 
 	return resp, nil
@@ -1151,7 +1220,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginStart(req *http.Re
 	if v.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if v.beginStart == nil {
+	beginStart := v.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1180,19 +1250,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginStart(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStart = &respr
+		beginStart = &respr
+		v.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStart) {
-		v.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		v.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -1202,7 +1274,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginUpdate(req *http.R
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1225,19 +1298,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginUpdate(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -1247,7 +1322,8 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginUpdateInstances(re
 	if v.srv.BeginUpdateInstances == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateInstances not implemented")}
 	}
-	if v.beginUpdateInstances == nil {
+	beginUpdateInstances := v.beginUpdateInstances.get(req)
+	if beginUpdateInstances == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/manualupgrade`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1270,19 +1346,21 @@ func (v *VirtualMachineScaleSetsServerTransport) dispatchBeginUpdateInstances(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdateInstances = &respr
+		beginUpdateInstances = &respr
+		v.beginUpdateInstances.add(req, beginUpdateInstances)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdateInstances, req)
+	resp, err := server.PollerResponderNext(beginUpdateInstances, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginUpdateInstances.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdateInstances) {
-		v.beginUpdateInstances = nil
+	if !server.PollerResponderMore(beginUpdateInstances) {
+		v.beginUpdateInstances.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvmextensions_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvmextensions_server.go
@@ -48,16 +48,21 @@ type VirtualMachineScaleSetVMExtensionsServer struct {
 // The returned VirtualMachineScaleSetVMExtensionsServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetVMExtensionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetVMExtensionsServerTransport(srv *VirtualMachineScaleSetVMExtensionsServer) *VirtualMachineScaleSetVMExtensionsServerTransport {
-	return &VirtualMachineScaleSetVMExtensionsServerTransport{srv: srv}
+	return &VirtualMachineScaleSetVMExtensionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientDeleteResponse]](),
+		beginUpdate:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetVMExtensionsServerTransport connects instances of armcompute.VirtualMachineScaleSetVMExtensionsClient to instances of VirtualMachineScaleSetVMExtensionsServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetVMExtensionsServerTransport instead.
 type VirtualMachineScaleSetVMExtensionsServerTransport struct {
 	srv                 *VirtualMachineScaleSetVMExtensionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientDeleteResponse]
-	beginUpdate         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientUpdateResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientDeleteResponse]]
+	beginUpdate         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMExtensionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetVMExtensionsServerTransport.
@@ -97,7 +102,8 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginCreateO
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +134,21 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginCreateO
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +158,8 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginDelete(
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -177,19 +186,21 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginDelete(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -301,7 +312,8 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginUpdate(
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/extensions/(?P<vmExtensionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -332,19 +344,21 @@ func (v *VirtualMachineScaleSetVMExtensionsServerTransport) dispatchBeginUpdate(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvmruncommands_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvmruncommands_server.go
@@ -49,17 +49,23 @@ type VirtualMachineScaleSetVMRunCommandsServer struct {
 // The returned VirtualMachineScaleSetVMRunCommandsServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetVMRunCommandsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetVMRunCommandsServerTransport(srv *VirtualMachineScaleSetVMRunCommandsServer) *VirtualMachineScaleSetVMRunCommandsServerTransport {
-	return &VirtualMachineScaleSetVMRunCommandsServerTransport{srv: srv}
+	return &VirtualMachineScaleSetVMRunCommandsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientListResponse]](),
+		beginUpdate:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetVMRunCommandsServerTransport connects instances of armcompute.VirtualMachineScaleSetVMRunCommandsClient to instances of VirtualMachineScaleSetVMRunCommandsServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetVMRunCommandsServerTransport instead.
 type VirtualMachineScaleSetVMRunCommandsServerTransport struct {
 	srv                 *VirtualMachineScaleSetVMRunCommandsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientListResponse]
-	beginUpdate         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientUpdateResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientListResponse]]
+	beginUpdate         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMRunCommandsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetVMRunCommandsServerTransport.
@@ -99,7 +105,8 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginCreate
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -130,19 +137,21 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginCreate
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -152,7 +161,8 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginDelete
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -179,19 +189,21 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginDelete
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -254,7 +266,8 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchNewListPage
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -286,20 +299,22 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchNewListPage
 			}
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, vmScaleSetNameUnescaped, instanceIDUnescaped, options)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachineScaleSetVMRunCommandsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachineScaleSetVMRunCommandsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -308,7 +323,8 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginUpdate
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommands/(?P<runCommandName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -339,19 +355,21 @@ func (v *VirtualMachineScaleSetVMRunCommandsServerTransport) dispatchBeginUpdate
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvms_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinescalesetvms_server.go
@@ -95,25 +95,39 @@ type VirtualMachineScaleSetVMsServer struct {
 // The returned VirtualMachineScaleSetVMsServerTransport instance is connected to an instance of armcompute.VirtualMachineScaleSetVMsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineScaleSetVMsServerTransport(srv *VirtualMachineScaleSetVMsServer) *VirtualMachineScaleSetVMsServerTransport {
-	return &VirtualMachineScaleSetVMsServerTransport{srv: srv}
+	return &VirtualMachineScaleSetVMsServerTransport{
+		srv:                     srv,
+		beginDeallocate:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeallocateResponse]](),
+		beginDelete:             newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse]](),
+		newListPager:            newTracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMsClientListResponse]](),
+		beginPerformMaintenance: newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPerformMaintenanceResponse]](),
+		beginPowerOff:           newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPowerOffResponse]](),
+		beginRedeploy:           newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRedeployResponse]](),
+		beginReimage:            newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageResponse]](),
+		beginReimageAll:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageAllResponse]](),
+		beginRestart:            newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRestartResponse]](),
+		beginRunCommand:         newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRunCommandResponse]](),
+		beginStart:              newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientStartResponse]](),
+		beginUpdate:             newTracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]](),
+	}
 }
 
 // VirtualMachineScaleSetVMsServerTransport connects instances of armcompute.VirtualMachineScaleSetVMsClient to instances of VirtualMachineScaleSetVMsServer.
 // Don't use this type directly, use NewVirtualMachineScaleSetVMsServerTransport instead.
 type VirtualMachineScaleSetVMsServerTransport struct {
 	srv                     *VirtualMachineScaleSetVMsServer
-	beginDeallocate         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeallocateResponse]
-	beginDelete             *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse]
-	newListPager            *azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMsClientListResponse]
-	beginPerformMaintenance *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPerformMaintenanceResponse]
-	beginPowerOff           *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPowerOffResponse]
-	beginRedeploy           *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRedeployResponse]
-	beginReimage            *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageResponse]
-	beginReimageAll         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageAllResponse]
-	beginRestart            *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRestartResponse]
-	beginRunCommand         *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRunCommandResponse]
-	beginStart              *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientStartResponse]
-	beginUpdate             *azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]
+	beginDeallocate         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeallocateResponse]]
+	beginDelete             *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientDeleteResponse]]
+	newListPager            *tracker[azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMsClientListResponse]]
+	beginPerformMaintenance *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPerformMaintenanceResponse]]
+	beginPowerOff           *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientPowerOffResponse]]
+	beginRedeploy           *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRedeployResponse]]
+	beginReimage            *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageResponse]]
+	beginReimageAll         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientReimageAllResponse]]
+	beginRestart            *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRestartResponse]]
+	beginRunCommand         *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientRunCommandResponse]]
+	beginStart              *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientStartResponse]]
+	beginUpdate             *tracker[azfake.PollerResponder[armcompute.VirtualMachineScaleSetVMsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineScaleSetVMsServerTransport.
@@ -175,7 +189,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginDeallocate(req *
 	if v.srv.BeginDeallocate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeallocate not implemented")}
 	}
-	if v.beginDeallocate == nil {
+	beginDeallocate := v.beginDeallocate.get(req)
+	if beginDeallocate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/deallocate`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -198,19 +213,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginDeallocate(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDeallocate = &respr
+		beginDeallocate = &respr
+		v.beginDeallocate.add(req, beginDeallocate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDeallocate, req)
+	resp, err := server.PollerResponderNext(beginDeallocate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDeallocate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDeallocate) {
-		v.beginDeallocate = nil
+	if !server.PollerResponderMore(beginDeallocate) {
+		v.beginDeallocate.remove(req)
 	}
 
 	return resp, nil
@@ -220,7 +237,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginDelete(req *http
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -258,19 +276,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -366,7 +386,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchNewListPager(req *htt
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -406,20 +427,22 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchNewListPager(req *htt
 			}
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, options)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armcompute.VirtualMachineScaleSetVMsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armcompute.VirtualMachineScaleSetVMsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -428,7 +451,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginPerformMaintenan
 	if v.srv.BeginPerformMaintenance == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPerformMaintenance not implemented")}
 	}
-	if v.beginPerformMaintenance == nil {
+	beginPerformMaintenance := v.beginPerformMaintenance.get(req)
+	if beginPerformMaintenance == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/performMaintenance`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -451,19 +475,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginPerformMaintenan
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPerformMaintenance = &respr
+		beginPerformMaintenance = &respr
+		v.beginPerformMaintenance.add(req, beginPerformMaintenance)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPerformMaintenance, req)
+	resp, err := server.PollerResponderNext(beginPerformMaintenance, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPerformMaintenance.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPerformMaintenance) {
-		v.beginPerformMaintenance = nil
+	if !server.PollerResponderMore(beginPerformMaintenance) {
+		v.beginPerformMaintenance.remove(req)
 	}
 
 	return resp, nil
@@ -473,7 +499,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginPowerOff(req *ht
 	if v.srv.BeginPowerOff == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPowerOff not implemented")}
 	}
-	if v.beginPowerOff == nil {
+	beginPowerOff := v.beginPowerOff.get(req)
+	if beginPowerOff == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/poweroff`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -511,19 +538,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginPowerOff(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginPowerOff = &respr
+		beginPowerOff = &respr
+		v.beginPowerOff.add(req, beginPowerOff)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginPowerOff, req)
+	resp, err := server.PollerResponderNext(beginPowerOff, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginPowerOff.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginPowerOff) {
-		v.beginPowerOff = nil
+	if !server.PollerResponderMore(beginPowerOff) {
+		v.beginPowerOff.remove(req)
 	}
 
 	return resp, nil
@@ -533,7 +562,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRedeploy(req *ht
 	if v.srv.BeginRedeploy == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRedeploy not implemented")}
 	}
-	if v.beginRedeploy == nil {
+	beginRedeploy := v.beginRedeploy.get(req)
+	if beginRedeploy == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/redeploy`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -556,19 +586,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRedeploy(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRedeploy = &respr
+		beginRedeploy = &respr
+		v.beginRedeploy.add(req, beginRedeploy)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRedeploy, req)
+	resp, err := server.PollerResponderNext(beginRedeploy, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRedeploy.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRedeploy) {
-		v.beginRedeploy = nil
+	if !server.PollerResponderMore(beginRedeploy) {
+		v.beginRedeploy.remove(req)
 	}
 
 	return resp, nil
@@ -578,7 +610,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginReimage(req *htt
 	if v.srv.BeginReimage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimage not implemented")}
 	}
-	if v.beginReimage == nil {
+	beginReimage := v.beginReimage.get(req)
+	if beginReimage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -611,19 +644,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginReimage(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReimage = &respr
+		beginReimage = &respr
+		v.beginReimage.add(req, beginReimage)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReimage, req)
+	resp, err := server.PollerResponderNext(beginReimage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReimage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReimage) {
-		v.beginReimage = nil
+	if !server.PollerResponderMore(beginReimage) {
+		v.beginReimage.remove(req)
 	}
 
 	return resp, nil
@@ -633,7 +668,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginReimageAll(req *
 	if v.srv.BeginReimageAll == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReimageAll not implemented")}
 	}
-	if v.beginReimageAll == nil {
+	beginReimageAll := v.beginReimageAll.get(req)
+	if beginReimageAll == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reimageall`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -656,19 +692,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginReimageAll(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReimageAll = &respr
+		beginReimageAll = &respr
+		v.beginReimageAll.add(req, beginReimageAll)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReimageAll, req)
+	resp, err := server.PollerResponderNext(beginReimageAll, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReimageAll.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReimageAll) {
-		v.beginReimageAll = nil
+	if !server.PollerResponderMore(beginReimageAll) {
+		v.beginReimageAll.remove(req)
 	}
 
 	return resp, nil
@@ -678,7 +716,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRestart(req *htt
 	if v.srv.BeginRestart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRestart not implemented")}
 	}
-	if v.beginRestart == nil {
+	beginRestart := v.beginRestart.get(req)
+	if beginRestart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/restart`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -701,19 +740,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRestart(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRestart = &respr
+		beginRestart = &respr
+		v.beginRestart.add(req, beginRestart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRestart, req)
+	resp, err := server.PollerResponderNext(beginRestart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRestart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRestart) {
-		v.beginRestart = nil
+	if !server.PollerResponderMore(beginRestart) {
+		v.beginRestart.remove(req)
 	}
 
 	return resp, nil
@@ -781,7 +822,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRunCommand(req *
 	if v.srv.BeginRunCommand == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginRunCommand not implemented")}
 	}
-	if v.beginRunCommand == nil {
+	beginRunCommand := v.beginRunCommand.get(req)
+	if beginRunCommand == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/runCommand`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -808,19 +850,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginRunCommand(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginRunCommand = &respr
+		beginRunCommand = &respr
+		v.beginRunCommand.add(req, beginRunCommand)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginRunCommand, req)
+	resp, err := server.PollerResponderNext(beginRunCommand, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginRunCommand.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginRunCommand) {
-		v.beginRunCommand = nil
+	if !server.PollerResponderMore(beginRunCommand) {
+		v.beginRunCommand.remove(req)
 	}
 
 	return resp, nil
@@ -867,7 +911,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginStart(req *http.
 	if v.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if v.beginStart == nil {
+	beginStart := v.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualmachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -890,19 +935,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginStart(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStart = &respr
+		beginStart = &respr
+		v.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStart) {
-		v.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		v.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -912,7 +959,8 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginUpdate(req *http
 	if v.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if v.beginUpdate == nil {
+	beginUpdate := v.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<vmScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<instanceId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -939,19 +987,21 @@ func (v *VirtualMachineScaleSetVMsServerTransport) dispatchBeginUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdate = &respr
+		beginUpdate = &respr
+		v.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdate) {
-		v.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		v.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinesizes_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_virtualmachinesizes_server.go
@@ -31,14 +31,17 @@ type VirtualMachineSizesServer struct {
 // The returned VirtualMachineSizesServerTransport instance is connected to an instance of armcompute.VirtualMachineSizesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualMachineSizesServerTransport(srv *VirtualMachineSizesServer) *VirtualMachineSizesServerTransport {
-	return &VirtualMachineSizesServerTransport{srv: srv}
+	return &VirtualMachineSizesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armcompute.VirtualMachineSizesClientListResponse]](),
+	}
 }
 
 // VirtualMachineSizesServerTransport connects instances of armcompute.VirtualMachineSizesClient to instances of VirtualMachineSizesServer.
 // Don't use this type directly, use NewVirtualMachineSizesServerTransport instead.
 type VirtualMachineSizesServerTransport struct {
 	srv          *VirtualMachineSizesServer
-	newListPager *azfake.PagerResponder[armcompute.VirtualMachineSizesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armcompute.VirtualMachineSizesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualMachineSizesServerTransport.
@@ -70,7 +73,8 @@ func (v *VirtualMachineSizesServerTransport) dispatchNewListPager(req *http.Requ
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vmSizes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -82,17 +86,19 @@ func (v *VirtualMachineSizesServerTransport) dispatchNewListPager(req *http.Requ
 			return nil, err
 		}
 		resp := v.srv.NewListPager(locationUnescaped, nil)
-		v.newListPager = &resp
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/compute/armcompute/fakes_test.go
+++ b/packages/autorest.go/test/compute/armcompute/fakes_test.go
@@ -1,0 +1,111 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package armcompute_test
+
+import (
+	"armcompute"
+	"armcompute/fake"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeDisksClientBeginDeleteConcurrent(t *testing.T) {
+	server := fake.DisksServer{
+		BeginDelete: func(ctx context.Context, resourceGroupName, diskName string, options *armcompute.DisksClientBeginDeleteOptions) (resp azfake.PollerResponder[armcompute.DisksClientDeleteResponse], errResp azfake.ErrorResponder) {
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.AddNonTerminalResponse(http.StatusOK, nil)
+			resp.SetTerminalResponse(http.StatusOK, armcompute.DisksClientDeleteResponse{}, nil)
+			return
+		},
+	}
+	client, err := armcompute.NewDisksClient("fake-subscription-id", azfake.NewTokenCredential(), &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: fake.NewDisksServerTransport(&server),
+		},
+	})
+	require.NoError(t, err)
+	poller1, err := client.BeginDelete(context.Background(), "fake-rg", "disk-1", nil)
+	require.NoError(t, err)
+	poller2, err := client.BeginDelete(context.Background(), "fake-rg", "disk-2", nil)
+	require.NoError(t, err)
+
+	poller1Done := make(chan error)
+	go func() {
+		_, err := poller1.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{
+			Frequency: time.Second,
+		})
+		poller1Done <- err
+	}()
+
+	poller2Done := make(chan error)
+	go func() {
+		_, err := poller2.PollUntilDone(context.Background(), &runtime.PollUntilDoneOptions{
+			Frequency: time.Second,
+		})
+		poller2Done <- err
+	}()
+
+	require.NoError(t, <-poller1Done)
+	require.NoError(t, <-poller2Done)
+}
+
+func TestFakeDisksClientNewListByResourceGroupPagerConcurrent(t *testing.T) {
+	server := fake.DisksServer{
+		NewListByResourceGroupPager: func(resourceGroupName string, options *armcompute.DisksClientListByResourceGroupOptions) (resp azfake.PagerResponder[armcompute.DisksClientListByResourceGroupResponse]) {
+			for pageCount := 0; pageCount < 10; pageCount++ {
+				resp.AddPage(http.StatusOK, armcompute.DisksClientListByResourceGroupResponse{}, nil)
+			}
+			return
+		},
+	}
+	client, err := armcompute.NewDisksClient("fake-subscription-id", azfake.NewTokenCredential(), &arm.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: fake.NewDisksServerTransport(&server),
+		},
+	})
+	require.NoError(t, err)
+	pager1 := client.NewListByResourceGroupPager("fake-rg-1", nil)
+	pager2 := client.NewListByResourceGroupPager("fake-rg-2", nil)
+
+	pager1Done := make(chan error)
+	go func() {
+		var err error
+		for pager1.More() {
+			_, err = pager1.NextPage(context.Background())
+			if err != nil {
+				break
+			}
+		}
+		pager1Done <- err
+	}()
+
+	pager2Done := make(chan error)
+	go func() {
+		var err error
+		for pager2.More() {
+			_, err = pager2.NextPage(context.Background())
+			if err != nil {
+				break
+			}
+		}
+		pager2Done <- err
+	}()
+
+	require.NoError(t, <-pager1Done)
+	require.NoError(t, <-pager2Done)
+}

--- a/packages/autorest.go/test/compute/armcompute/go.mod
+++ b/packages/autorest.go/test/compute/armcompute/go.mod
@@ -2,10 +2,16 @@ module armcompute
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0-beta.2
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0-beta.2
+	github.com/stretchr/testify v1.7.0
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.8.0 // indirect
 	golang.org/x/text v0.8.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/packages/autorest.go/test/compute/armcompute/go.sum
+++ b/packages/autorest.go/test/compute/armcompute/go.sum
@@ -3,10 +3,17 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.0-beta.2/go.mod h1:bjGvMhVMb+E
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/text v0.8.0 h1:57P1ETyNKtuIjB4SRd15iJxuhj8Gc416Y78H3qgMh68=
 golang.org/x/text v0.8.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_adminrulecollections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_adminrulecollections_server.go
@@ -46,15 +46,19 @@ type AdminRuleCollectionsServer struct {
 // The returned AdminRuleCollectionsServerTransport instance is connected to an instance of armnetwork.AdminRuleCollectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAdminRuleCollectionsServerTransport(srv *AdminRuleCollectionsServer) *AdminRuleCollectionsServerTransport {
-	return &AdminRuleCollectionsServerTransport{srv: srv}
+	return &AdminRuleCollectionsServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.AdminRuleCollectionsClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.AdminRuleCollectionsClientListResponse]](),
+	}
 }
 
 // AdminRuleCollectionsServerTransport connects instances of armnetwork.AdminRuleCollectionsClient to instances of AdminRuleCollectionsServer.
 // Don't use this type directly, use NewAdminRuleCollectionsServerTransport instead.
 type AdminRuleCollectionsServerTransport struct {
 	srv          *AdminRuleCollectionsServer
-	beginDelete  *azfake.PollerResponder[armnetwork.AdminRuleCollectionsClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.AdminRuleCollectionsClientListResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.AdminRuleCollectionsClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.AdminRuleCollectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for AdminRuleCollectionsServerTransport.
@@ -137,7 +141,8 @@ func (a *AdminRuleCollectionsServerTransport) dispatchBeginDelete(req *http.Requ
 	if a.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if a.beginDelete == nil {
+	beginDelete := a.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollections/(?P<ruleCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -179,19 +184,21 @@ func (a *AdminRuleCollectionsServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginDelete = &respr
+		beginDelete = &respr
+		a.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		a.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginDelete) {
-		a.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		a.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -242,7 +249,8 @@ func (a *AdminRuleCollectionsServerTransport) dispatchNewListPager(req *http.Req
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -289,20 +297,22 @@ func (a *AdminRuleCollectionsServerTransport) dispatchNewListPager(req *http.Req
 			}
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, configurationNameUnescaped, options)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AdminRuleCollectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AdminRuleCollectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_adminrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_adminrules_server.go
@@ -46,15 +46,19 @@ type AdminRulesServer struct {
 // The returned AdminRulesServerTransport instance is connected to an instance of armnetwork.AdminRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAdminRulesServerTransport(srv *AdminRulesServer) *AdminRulesServerTransport {
-	return &AdminRulesServerTransport{srv: srv}
+	return &AdminRulesServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.AdminRulesClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.AdminRulesClientListResponse]](),
+	}
 }
 
 // AdminRulesServerTransport connects instances of armnetwork.AdminRulesClient to instances of AdminRulesServer.
 // Don't use this type directly, use NewAdminRulesServerTransport instead.
 type AdminRulesServerTransport struct {
 	srv          *AdminRulesServer
-	beginDelete  *azfake.PollerResponder[armnetwork.AdminRulesClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.AdminRulesClientListResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.AdminRulesClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.AdminRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for AdminRulesServerTransport.
@@ -145,7 +149,8 @@ func (a *AdminRulesServerTransport) dispatchBeginDelete(req *http.Request) (*htt
 	if a.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if a.beginDelete == nil {
+	beginDelete := a.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollections/(?P<ruleCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rules/(?P<ruleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -191,19 +196,21 @@ func (a *AdminRulesServerTransport) dispatchBeginDelete(req *http.Request) (*htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginDelete = &respr
+		beginDelete = &respr
+		a.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		a.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginDelete) {
-		a.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		a.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -258,7 +265,8 @@ func (a *AdminRulesServerTransport) dispatchNewListPager(req *http.Request) (*ht
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollections/(?P<ruleCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/rules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -309,20 +317,22 @@ func (a *AdminRulesServerTransport) dispatchNewListPager(req *http.Request) (*ht
 			}
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, configurationNameUnescaped, ruleCollectionNameUnescaped, options)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AdminRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AdminRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewayprivateendpointconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewayprivateendpointconnections_server.go
@@ -45,16 +45,21 @@ type ApplicationGatewayPrivateEndpointConnectionsServer struct {
 // The returned ApplicationGatewayPrivateEndpointConnectionsServerTransport instance is connected to an instance of armnetwork.ApplicationGatewayPrivateEndpointConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewApplicationGatewayPrivateEndpointConnectionsServerTransport(srv *ApplicationGatewayPrivateEndpointConnectionsServer) *ApplicationGatewayPrivateEndpointConnectionsServerTransport {
-	return &ApplicationGatewayPrivateEndpointConnectionsServerTransport{srv: srv}
+	return &ApplicationGatewayPrivateEndpointConnectionsServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientListResponse]](),
+		beginUpdate:  newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientUpdateResponse]](),
+	}
 }
 
 // ApplicationGatewayPrivateEndpointConnectionsServerTransport connects instances of armnetwork.ApplicationGatewayPrivateEndpointConnectionsClient to instances of ApplicationGatewayPrivateEndpointConnectionsServer.
 // Don't use this type directly, use NewApplicationGatewayPrivateEndpointConnectionsServerTransport instead.
 type ApplicationGatewayPrivateEndpointConnectionsServerTransport struct {
 	srv          *ApplicationGatewayPrivateEndpointConnectionsServer
-	beginDelete  *azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientListResponse]
-	beginUpdate  *azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientUpdateResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientListResponse]]
+	beginUpdate  *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for ApplicationGatewayPrivateEndpointConnectionsServerTransport.
@@ -92,7 +97,8 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchBe
 	if a.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if a.beginDelete == nil {
+	beginDelete := a.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -115,19 +121,21 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchBe
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginDelete = &respr
+		beginDelete = &respr
+		a.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		a.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginDelete) {
-		a.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		a.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -174,7 +182,8 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchNe
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -190,20 +199,22 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchNe
 			return nil, err
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, applicationGatewayNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ApplicationGatewayPrivateEndpointConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -212,7 +223,8 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchBe
 	if a.srv.BeginUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdate not implemented")}
 	}
-	if a.beginUpdate == nil {
+	beginUpdate := a.beginUpdate.get(req)
+	if beginUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,19 +251,21 @@ func (a *ApplicationGatewayPrivateEndpointConnectionsServerTransport) dispatchBe
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginUpdate = &respr
+		beginUpdate = &respr
+		a.beginUpdate.add(req, beginUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginUpdate, req)
+	resp, err := server.PollerResponderNext(beginUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		a.beginUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginUpdate) {
-		a.beginUpdate = nil
+	if !server.PollerResponderMore(beginUpdate) {
+		a.beginUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewayprivatelinkresources_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewayprivatelinkresources_server.go
@@ -32,14 +32,17 @@ type ApplicationGatewayPrivateLinkResourcesServer struct {
 // The returned ApplicationGatewayPrivateLinkResourcesServerTransport instance is connected to an instance of armnetwork.ApplicationGatewayPrivateLinkResourcesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewApplicationGatewayPrivateLinkResourcesServerTransport(srv *ApplicationGatewayPrivateLinkResourcesServer) *ApplicationGatewayPrivateLinkResourcesServerTransport {
-	return &ApplicationGatewayPrivateLinkResourcesServerTransport{srv: srv}
+	return &ApplicationGatewayPrivateLinkResourcesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateLinkResourcesClientListResponse]](),
+	}
 }
 
 // ApplicationGatewayPrivateLinkResourcesServerTransport connects instances of armnetwork.ApplicationGatewayPrivateLinkResourcesClient to instances of ApplicationGatewayPrivateLinkResourcesServer.
 // Don't use this type directly, use NewApplicationGatewayPrivateLinkResourcesServerTransport instead.
 type ApplicationGatewayPrivateLinkResourcesServerTransport struct {
 	srv          *ApplicationGatewayPrivateLinkResourcesServer
-	newListPager *azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateLinkResourcesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewayPrivateLinkResourcesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ApplicationGatewayPrivateLinkResourcesServerTransport.
@@ -71,7 +74,8 @@ func (a *ApplicationGatewayPrivateLinkResourcesServerTransport) dispatchNewListP
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateLinkResources`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -87,20 +91,22 @@ func (a *ApplicationGatewayPrivateLinkResourcesServerTransport) dispatchNewListP
 			return nil, err
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, applicationGatewayNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.ApplicationGatewayPrivateLinkResourcesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ApplicationGatewayPrivateLinkResourcesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgateways_server.go
@@ -97,22 +97,33 @@ type ApplicationGatewaysServer struct {
 // The returned ApplicationGatewaysServerTransport instance is connected to an instance of armnetwork.ApplicationGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewApplicationGatewaysServerTransport(srv *ApplicationGatewaysServer) *ApplicationGatewaysServerTransport {
-	return &ApplicationGatewaysServerTransport{srv: srv}
+	return &ApplicationGatewaysServerTransport{
+		srv:                        srv,
+		beginBackendHealth:         newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthResponse]](),
+		beginBackendHealthOnDemand: newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthOnDemandResponse]](),
+		beginCreateOrUpdate:        newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:                newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientDeleteResponse]](),
+		newListPager:               newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListResponse]](),
+		newListAllPager:            newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAllResponse]](),
+		newListAvailableSSLPredefinedPoliciesPager: newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse]](),
+		beginStart: newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStartResponse]](),
+		beginStop:  newTracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStopResponse]](),
+	}
 }
 
 // ApplicationGatewaysServerTransport connects instances of armnetwork.ApplicationGatewaysClient to instances of ApplicationGatewaysServer.
 // Don't use this type directly, use NewApplicationGatewaysServerTransport instead.
 type ApplicationGatewaysServerTransport struct {
 	srv                                        *ApplicationGatewaysServer
-	beginBackendHealth                         *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthResponse]
-	beginBackendHealthOnDemand                 *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthOnDemandResponse]
-	beginCreateOrUpdate                        *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientCreateOrUpdateResponse]
-	beginDelete                                *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientDeleteResponse]
-	newListPager                               *azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListResponse]
-	newListAllPager                            *azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAllResponse]
-	newListAvailableSSLPredefinedPoliciesPager *azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse]
-	beginStart                                 *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStartResponse]
-	beginStop                                  *azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStopResponse]
+	beginBackendHealth                         *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthResponse]]
+	beginBackendHealthOnDemand                 *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientBackendHealthOnDemandResponse]]
+	beginCreateOrUpdate                        *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientCreateOrUpdateResponse]]
+	beginDelete                                *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientDeleteResponse]]
+	newListPager                               *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListResponse]]
+	newListAllPager                            *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAllResponse]]
+	newListAvailableSSLPredefinedPoliciesPager *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse]]
+	beginStart                                 *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStartResponse]]
+	beginStop                                  *tracker[azfake.PollerResponder[armnetwork.ApplicationGatewaysClientStopResponse]]
 }
 
 // Do implements the policy.Transporter interface for ApplicationGatewaysServerTransport.
@@ -176,7 +187,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginBackendHealth(req *htt
 	if a.srv.BeginBackendHealth == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginBackendHealth not implemented")}
 	}
-	if a.beginBackendHealth == nil {
+	beginBackendHealth := a.beginBackendHealth.get(req)
+	if beginBackendHealth == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backendhealth`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -207,19 +219,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginBackendHealth(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginBackendHealth = &respr
+		beginBackendHealth = &respr
+		a.beginBackendHealth.add(req, beginBackendHealth)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginBackendHealth, req)
+	resp, err := server.PollerResponderNext(beginBackendHealth, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		a.beginBackendHealth.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginBackendHealth) {
-		a.beginBackendHealth = nil
+	if !server.PollerResponderMore(beginBackendHealth) {
+		a.beginBackendHealth.remove(req)
 	}
 
 	return resp, nil
@@ -229,7 +243,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginBackendHealthOnDemand(
 	if a.srv.BeginBackendHealthOnDemand == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginBackendHealthOnDemand not implemented")}
 	}
-	if a.beginBackendHealthOnDemand == nil {
+	beginBackendHealthOnDemand := a.beginBackendHealthOnDemand.get(req)
+	if beginBackendHealthOnDemand == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getBackendHealthOnDemand`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -264,19 +279,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginBackendHealthOnDemand(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginBackendHealthOnDemand = &respr
+		beginBackendHealthOnDemand = &respr
+		a.beginBackendHealthOnDemand.add(req, beginBackendHealthOnDemand)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginBackendHealthOnDemand, req)
+	resp, err := server.PollerResponderNext(beginBackendHealthOnDemand, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		a.beginBackendHealthOnDemand.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginBackendHealthOnDemand) {
-		a.beginBackendHealthOnDemand = nil
+	if !server.PollerResponderMore(beginBackendHealthOnDemand) {
+		a.beginBackendHealthOnDemand.remove(req)
 	}
 
 	return resp, nil
@@ -286,7 +303,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *ht
 	if a.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if a.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := a.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -309,19 +327,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		a.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		a.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginCreateOrUpdate) {
-		a.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		a.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -331,7 +351,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginDelete(req *http.Reque
 	if a.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if a.beginDelete == nil {
+	beginDelete := a.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -350,19 +371,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginDelete(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginDelete = &respr
+		beginDelete = &respr
+		a.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		a.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginDelete) {
-		a.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		a.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -434,7 +457,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListPager(req *http.Requ
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -446,20 +470,22 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListPager(req *http.Requ
 			return nil, err
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.ApplicationGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ApplicationGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -468,7 +494,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListAllPager(req *http.R
 	if a.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if a.newListAllPager == nil {
+	newListAllPager := a.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -476,20 +503,22 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListAllPager(req *http.R
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := a.srv.NewListAllPager(nil)
-		a.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListAllPager, req, func(page *armnetwork.ApplicationGatewaysClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		a.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.ApplicationGatewaysClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListAllPager) {
-		a.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		a.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -573,7 +602,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListAvailableSSLPredefin
 	if a.srv.NewListAvailableSSLPredefinedPoliciesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAvailableSSLPredefinedPoliciesPager not implemented")}
 	}
-	if a.newListAvailableSSLPredefinedPoliciesPager == nil {
+	newListAvailableSSLPredefinedPoliciesPager := a.newListAvailableSSLPredefinedPoliciesPager.get(req)
+	if newListAvailableSSLPredefinedPoliciesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -581,20 +611,22 @@ func (a *ApplicationGatewaysServerTransport) dispatchNewListAvailableSSLPredefin
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := a.srv.NewListAvailableSSLPredefinedPoliciesPager(nil)
-		a.newListAvailableSSLPredefinedPoliciesPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListAvailableSSLPredefinedPoliciesPager, req, func(page *armnetwork.ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse, createLink func() string) {
+		newListAvailableSSLPredefinedPoliciesPager = &resp
+		a.newListAvailableSSLPredefinedPoliciesPager.add(req, newListAvailableSSLPredefinedPoliciesPager)
+		server.PagerResponderInjectNextLinks(newListAvailableSSLPredefinedPoliciesPager, req, func(page *armnetwork.ApplicationGatewaysClientListAvailableSSLPredefinedPoliciesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListAvailableSSLPredefinedPoliciesPager, req)
+	resp, err := server.PagerResponderNext(newListAvailableSSLPredefinedPoliciesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListAvailableSSLPredefinedPoliciesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListAvailableSSLPredefinedPoliciesPager) {
-		a.newListAvailableSSLPredefinedPoliciesPager = nil
+	if !server.PagerResponderMore(newListAvailableSSLPredefinedPoliciesPager) {
+		a.newListAvailableSSLPredefinedPoliciesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -653,7 +685,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginStart(req *http.Reques
 	if a.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if a.beginStart == nil {
+	beginStart := a.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -672,19 +705,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginStart(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginStart = &respr
+		beginStart = &respr
+		a.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		a.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginStart) {
-		a.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		a.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -694,7 +729,8 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginStop(req *http.Request
 	if a.srv.BeginStop == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStop not implemented")}
 	}
-	if a.beginStop == nil {
+	beginStop := a.beginStop.get(req)
+	if beginStop == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationGateways/(?P<applicationGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stop`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -713,19 +749,21 @@ func (a *ApplicationGatewaysServerTransport) dispatchBeginStop(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginStop = &respr
+		beginStop = &respr
+		a.beginStop.add(req, beginStop)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginStop, req)
+	resp, err := server.PollerResponderNext(beginStop, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		a.beginStop.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginStop) {
-		a.beginStop = nil
+	if !server.PollerResponderMore(beginStop) {
+		a.beginStop.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewaywafdynamicmanifests_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_applicationgatewaywafdynamicmanifests_server.go
@@ -32,14 +32,17 @@ type ApplicationGatewayWafDynamicManifestsServer struct {
 // The returned ApplicationGatewayWafDynamicManifestsServerTransport instance is connected to an instance of armnetwork.ApplicationGatewayWafDynamicManifestsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewApplicationGatewayWafDynamicManifestsServerTransport(srv *ApplicationGatewayWafDynamicManifestsServer) *ApplicationGatewayWafDynamicManifestsServerTransport {
-	return &ApplicationGatewayWafDynamicManifestsServerTransport{srv: srv}
+	return &ApplicationGatewayWafDynamicManifestsServerTransport{
+		srv:         srv,
+		newGetPager: newTracker[azfake.PagerResponder[armnetwork.ApplicationGatewayWafDynamicManifestsClientGetResponse]](),
+	}
 }
 
 // ApplicationGatewayWafDynamicManifestsServerTransport connects instances of armnetwork.ApplicationGatewayWafDynamicManifestsClient to instances of ApplicationGatewayWafDynamicManifestsServer.
 // Don't use this type directly, use NewApplicationGatewayWafDynamicManifestsServerTransport instead.
 type ApplicationGatewayWafDynamicManifestsServerTransport struct {
 	srv         *ApplicationGatewayWafDynamicManifestsServer
-	newGetPager *azfake.PagerResponder[armnetwork.ApplicationGatewayWafDynamicManifestsClientGetResponse]
+	newGetPager *tracker[azfake.PagerResponder[armnetwork.ApplicationGatewayWafDynamicManifestsClientGetResponse]]
 }
 
 // Do implements the policy.Transporter interface for ApplicationGatewayWafDynamicManifestsServerTransport.
@@ -71,7 +74,8 @@ func (a *ApplicationGatewayWafDynamicManifestsServerTransport) dispatchNewGetPag
 	if a.srv.NewGetPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetPager not implemented")}
 	}
-	if a.newGetPager == nil {
+	newGetPager := a.newGetPager.get(req)
+	if newGetPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/applicationGatewayWafDynamicManifests`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -83,20 +87,22 @@ func (a *ApplicationGatewayWafDynamicManifestsServerTransport) dispatchNewGetPag
 			return nil, err
 		}
 		resp := a.srv.NewGetPager(locationUnescaped, nil)
-		a.newGetPager = &resp
-		server.PagerResponderInjectNextLinks(a.newGetPager, req, func(page *armnetwork.ApplicationGatewayWafDynamicManifestsClientGetResponse, createLink func() string) {
+		newGetPager = &resp
+		a.newGetPager.add(req, newGetPager)
+		server.PagerResponderInjectNextLinks(newGetPager, req, func(page *armnetwork.ApplicationGatewayWafDynamicManifestsClientGetResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newGetPager, req)
+	resp, err := server.PagerResponderNext(newGetPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newGetPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newGetPager) {
-		a.newGetPager = nil
+	if !server.PagerResponderMore(newGetPager) {
+		a.newGetPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_applicationsecuritygroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_applicationsecuritygroups_server.go
@@ -53,17 +53,23 @@ type ApplicationSecurityGroupsServer struct {
 // The returned ApplicationSecurityGroupsServerTransport instance is connected to an instance of armnetwork.ApplicationSecurityGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewApplicationSecurityGroupsServerTransport(srv *ApplicationSecurityGroupsServer) *ApplicationSecurityGroupsServerTransport {
-	return &ApplicationSecurityGroupsServerTransport{srv: srv}
+	return &ApplicationSecurityGroupsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListAllResponse]](),
+	}
 }
 
 // ApplicationSecurityGroupsServerTransport connects instances of armnetwork.ApplicationSecurityGroupsClient to instances of ApplicationSecurityGroupsServer.
 // Don't use this type directly, use NewApplicationSecurityGroupsServerTransport instead.
 type ApplicationSecurityGroupsServerTransport struct {
 	srv                 *ApplicationSecurityGroupsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ApplicationSecurityGroupsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.ApplicationSecurityGroupsClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for ApplicationSecurityGroupsServerTransport.
@@ -105,7 +111,8 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchBeginCreateOrUpdate(r
 	if a.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if a.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := a.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationSecurityGroups/(?P<applicationSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchBeginCreateOrUpdate(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		a.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		a.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginCreateOrUpdate) {
-		a.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		a.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchBeginDelete(req *http
 	if a.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if a.beginDelete == nil {
+	beginDelete := a.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationSecurityGroups/(?P<applicationSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		a.beginDelete = &respr
+		beginDelete = &respr
+		a.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(a.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		a.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(a.beginDelete) {
-		a.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		a.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchNewListPager(req *htt
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationSecurityGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -236,20 +249,22 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := a.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.ApplicationSecurityGroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ApplicationSecurityGroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -258,7 +273,8 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchNewListAllPager(req *
 	if a.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if a.newListAllPager == nil {
+	newListAllPager := a.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/applicationSecurityGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (a *ApplicationSecurityGroupsServerTransport) dispatchNewListAllPager(req *
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := a.srv.NewListAllPager(nil)
-		a.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListAllPager, req, func(page *armnetwork.ApplicationSecurityGroupsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		a.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.ApplicationSecurityGroupsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListAllPager) {
-		a.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		a.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_availabledelegations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_availabledelegations_server.go
@@ -32,14 +32,17 @@ type AvailableDelegationsServer struct {
 // The returned AvailableDelegationsServerTransport instance is connected to an instance of armnetwork.AvailableDelegationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailableDelegationsServerTransport(srv *AvailableDelegationsServer) *AvailableDelegationsServerTransport {
-	return &AvailableDelegationsServerTransport{srv: srv}
+	return &AvailableDelegationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.AvailableDelegationsClientListResponse]](),
+	}
 }
 
 // AvailableDelegationsServerTransport connects instances of armnetwork.AvailableDelegationsClient to instances of AvailableDelegationsServer.
 // Don't use this type directly, use NewAvailableDelegationsServerTransport instead.
 type AvailableDelegationsServerTransport struct {
 	srv          *AvailableDelegationsServer
-	newListPager *azfake.PagerResponder[armnetwork.AvailableDelegationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.AvailableDelegationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailableDelegationsServerTransport.
@@ -71,7 +74,8 @@ func (a *AvailableDelegationsServerTransport) dispatchNewListPager(req *http.Req
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availableDelegations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -83,20 +87,22 @@ func (a *AvailableDelegationsServerTransport) dispatchNewListPager(req *http.Req
 			return nil, err
 		}
 		resp := a.srv.NewListPager(locationUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AvailableDelegationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AvailableDelegationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_availableendpointservices_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_availableendpointservices_server.go
@@ -32,14 +32,17 @@ type AvailableEndpointServicesServer struct {
 // The returned AvailableEndpointServicesServerTransport instance is connected to an instance of armnetwork.AvailableEndpointServicesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailableEndpointServicesServerTransport(srv *AvailableEndpointServicesServer) *AvailableEndpointServicesServerTransport {
-	return &AvailableEndpointServicesServerTransport{srv: srv}
+	return &AvailableEndpointServicesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.AvailableEndpointServicesClientListResponse]](),
+	}
 }
 
 // AvailableEndpointServicesServerTransport connects instances of armnetwork.AvailableEndpointServicesClient to instances of AvailableEndpointServicesServer.
 // Don't use this type directly, use NewAvailableEndpointServicesServerTransport instead.
 type AvailableEndpointServicesServerTransport struct {
 	srv          *AvailableEndpointServicesServer
-	newListPager *azfake.PagerResponder[armnetwork.AvailableEndpointServicesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.AvailableEndpointServicesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailableEndpointServicesServerTransport.
@@ -71,7 +74,8 @@ func (a *AvailableEndpointServicesServerTransport) dispatchNewListPager(req *htt
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualNetworkAvailableEndpointServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -83,20 +87,22 @@ func (a *AvailableEndpointServicesServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := a.srv.NewListPager(locationUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AvailableEndpointServicesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AvailableEndpointServicesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_availableprivateendpointtypes_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_availableprivateendpointtypes_server.go
@@ -36,15 +36,19 @@ type AvailablePrivateEndpointTypesServer struct {
 // The returned AvailablePrivateEndpointTypesServerTransport instance is connected to an instance of armnetwork.AvailablePrivateEndpointTypesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailablePrivateEndpointTypesServerTransport(srv *AvailablePrivateEndpointTypesServer) *AvailablePrivateEndpointTypesServerTransport {
-	return &AvailablePrivateEndpointTypesServerTransport{srv: srv}
+	return &AvailablePrivateEndpointTypesServerTransport{
+		srv:                         srv,
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListByResourceGroupResponse]](),
+	}
 }
 
 // AvailablePrivateEndpointTypesServerTransport connects instances of armnetwork.AvailablePrivateEndpointTypesClient to instances of AvailablePrivateEndpointTypesServer.
 // Don't use this type directly, use NewAvailablePrivateEndpointTypesServerTransport instead.
 type AvailablePrivateEndpointTypesServerTransport struct {
 	srv                         *AvailablePrivateEndpointTypesServer
-	newListPager                *azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListByResourceGroupResponse]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.AvailablePrivateEndpointTypesClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailablePrivateEndpointTypesServerTransport.
@@ -78,7 +82,8 @@ func (a *AvailablePrivateEndpointTypesServerTransport) dispatchNewListPager(req 
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availablePrivateEndpointTypes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -90,20 +95,22 @@ func (a *AvailablePrivateEndpointTypesServerTransport) dispatchNewListPager(req 
 			return nil, err
 		}
 		resp := a.srv.NewListPager(locationUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AvailablePrivateEndpointTypesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AvailablePrivateEndpointTypesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -112,7 +119,8 @@ func (a *AvailablePrivateEndpointTypesServerTransport) dispatchNewListByResource
 	if a.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if a.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := a.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availablePrivateEndpointTypes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,20 +136,22 @@ func (a *AvailablePrivateEndpointTypesServerTransport) dispatchNewListByResource
 			return nil, err
 		}
 		resp := a.srv.NewListByResourceGroupPager(locationUnescaped, resourceGroupNameUnescaped, nil)
-		a.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListByResourceGroupPager, req, func(page *armnetwork.AvailablePrivateEndpointTypesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		a.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.AvailablePrivateEndpointTypesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListByResourceGroupPager) {
-		a.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		a.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_availableresourcegroupdelegations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_availableresourcegroupdelegations_server.go
@@ -32,14 +32,17 @@ type AvailableResourceGroupDelegationsServer struct {
 // The returned AvailableResourceGroupDelegationsServerTransport instance is connected to an instance of armnetwork.AvailableResourceGroupDelegationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailableResourceGroupDelegationsServerTransport(srv *AvailableResourceGroupDelegationsServer) *AvailableResourceGroupDelegationsServerTransport {
-	return &AvailableResourceGroupDelegationsServerTransport{srv: srv}
+	return &AvailableResourceGroupDelegationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.AvailableResourceGroupDelegationsClientListResponse]](),
+	}
 }
 
 // AvailableResourceGroupDelegationsServerTransport connects instances of armnetwork.AvailableResourceGroupDelegationsClient to instances of AvailableResourceGroupDelegationsServer.
 // Don't use this type directly, use NewAvailableResourceGroupDelegationsServerTransport instead.
 type AvailableResourceGroupDelegationsServerTransport struct {
 	srv          *AvailableResourceGroupDelegationsServer
-	newListPager *azfake.PagerResponder[armnetwork.AvailableResourceGroupDelegationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.AvailableResourceGroupDelegationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailableResourceGroupDelegationsServerTransport.
@@ -71,7 +74,8 @@ func (a *AvailableResourceGroupDelegationsServerTransport) dispatchNewListPager(
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availableDelegations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -87,20 +91,22 @@ func (a *AvailableResourceGroupDelegationsServerTransport) dispatchNewListPager(
 			return nil, err
 		}
 		resp := a.srv.NewListPager(locationUnescaped, resourceGroupNameUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AvailableResourceGroupDelegationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AvailableResourceGroupDelegationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_availableservicealiases_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_availableservicealiases_server.go
@@ -36,15 +36,19 @@ type AvailableServiceAliasesServer struct {
 // The returned AvailableServiceAliasesServerTransport instance is connected to an instance of armnetwork.AvailableServiceAliasesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAvailableServiceAliasesServerTransport(srv *AvailableServiceAliasesServer) *AvailableServiceAliasesServerTransport {
-	return &AvailableServiceAliasesServerTransport{srv: srv}
+	return &AvailableServiceAliasesServerTransport{
+		srv:                         srv,
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListByResourceGroupResponse]](),
+	}
 }
 
 // AvailableServiceAliasesServerTransport connects instances of armnetwork.AvailableServiceAliasesClient to instances of AvailableServiceAliasesServer.
 // Don't use this type directly, use NewAvailableServiceAliasesServerTransport instead.
 type AvailableServiceAliasesServerTransport struct {
 	srv                         *AvailableServiceAliasesServer
-	newListPager                *azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListByResourceGroupResponse]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.AvailableServiceAliasesClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for AvailableServiceAliasesServerTransport.
@@ -78,7 +82,8 @@ func (a *AvailableServiceAliasesServerTransport) dispatchNewListPager(req *http.
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if a.newListPager == nil {
+	newListPager := a.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availableServiceAliases`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -90,20 +95,22 @@ func (a *AvailableServiceAliasesServerTransport) dispatchNewListPager(req *http.
 			return nil, err
 		}
 		resp := a.srv.NewListPager(locationUnescaped, nil)
-		a.newListPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListPager, req, func(page *armnetwork.AvailableServiceAliasesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		a.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.AvailableServiceAliasesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListPager) {
-		a.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		a.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -112,7 +119,8 @@ func (a *AvailableServiceAliasesServerTransport) dispatchNewListByResourceGroupP
 	if a.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if a.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := a.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availableServiceAliases`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,20 +136,22 @@ func (a *AvailableServiceAliasesServerTransport) dispatchNewListByResourceGroupP
 			return nil, err
 		}
 		resp := a.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, locationUnescaped, nil)
-		a.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListByResourceGroupPager, req, func(page *armnetwork.AvailableServiceAliasesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		a.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.AvailableServiceAliasesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListByResourceGroupPager) {
-		a.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		a.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_azurefirewallfqdntags_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_azurefirewallfqdntags_server.go
@@ -31,14 +31,17 @@ type AzureFirewallFqdnTagsServer struct {
 // The returned AzureFirewallFqdnTagsServerTransport instance is connected to an instance of armnetwork.AzureFirewallFqdnTagsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewAzureFirewallFqdnTagsServerTransport(srv *AzureFirewallFqdnTagsServer) *AzureFirewallFqdnTagsServerTransport {
-	return &AzureFirewallFqdnTagsServerTransport{srv: srv}
+	return &AzureFirewallFqdnTagsServerTransport{
+		srv:             srv,
+		newListAllPager: newTracker[azfake.PagerResponder[armnetwork.AzureFirewallFqdnTagsClientListAllResponse]](),
+	}
 }
 
 // AzureFirewallFqdnTagsServerTransport connects instances of armnetwork.AzureFirewallFqdnTagsClient to instances of AzureFirewallFqdnTagsServer.
 // Don't use this type directly, use NewAzureFirewallFqdnTagsServerTransport instead.
 type AzureFirewallFqdnTagsServerTransport struct {
 	srv             *AzureFirewallFqdnTagsServer
-	newListAllPager *azfake.PagerResponder[armnetwork.AzureFirewallFqdnTagsClientListAllResponse]
+	newListAllPager *tracker[azfake.PagerResponder[armnetwork.AzureFirewallFqdnTagsClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for AzureFirewallFqdnTagsServerTransport.
@@ -70,7 +73,8 @@ func (a *AzureFirewallFqdnTagsServerTransport) dispatchNewListAllPager(req *http
 	if a.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if a.newListAllPager == nil {
+	newListAllPager := a.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/azureFirewallFqdnTags`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -78,20 +82,22 @@ func (a *AzureFirewallFqdnTagsServerTransport) dispatchNewListAllPager(req *http
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := a.srv.NewListAllPager(nil)
-		a.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(a.newListAllPager, req, func(page *armnetwork.AzureFirewallFqdnTagsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		a.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.AzureFirewallFqdnTagsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(a.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		a.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(a.newListAllPager) {
-		a.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		a.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_bastionhosts_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_bastionhosts_server.go
@@ -53,18 +53,25 @@ type BastionHostsServer struct {
 // The returned BastionHostsServerTransport instance is connected to an instance of armnetwork.BastionHostsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewBastionHostsServerTransport(srv *BastionHostsServer) *BastionHostsServerTransport {
-	return &BastionHostsServerTransport{srv: srv}
+	return &BastionHostsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.BastionHostsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.BastionHostsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.BastionHostsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.BastionHostsClientListByResourceGroupResponse]](),
+		beginUpdateTags:             newTracker[azfake.PollerResponder[armnetwork.BastionHostsClientUpdateTagsResponse]](),
+	}
 }
 
 // BastionHostsServerTransport connects instances of armnetwork.BastionHostsClient to instances of BastionHostsServer.
 // Don't use this type directly, use NewBastionHostsServerTransport instead.
 type BastionHostsServerTransport struct {
 	srv                         *BastionHostsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.BastionHostsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.BastionHostsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.BastionHostsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.BastionHostsClientListByResourceGroupResponse]
-	beginUpdateTags             *azfake.PollerResponder[armnetwork.BastionHostsClientUpdateTagsResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.BastionHostsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.BastionHostsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.BastionHostsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.BastionHostsClientListByResourceGroupResponse]]
+	beginUpdateTags             *tracker[azfake.PollerResponder[armnetwork.BastionHostsClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for BastionHostsServerTransport.
@@ -106,7 +113,8 @@ func (b *BastionHostsServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 	if b.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if b.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := b.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -129,19 +137,21 @@ func (b *BastionHostsServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		b.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		b.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(b.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		b.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(b.beginCreateOrUpdate) {
-		b.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		b.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -151,7 +161,8 @@ func (b *BastionHostsServerTransport) dispatchBeginDelete(req *http.Request) (*h
 	if b.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if b.beginDelete == nil {
+	beginDelete := b.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -170,19 +181,21 @@ func (b *BastionHostsServerTransport) dispatchBeginDelete(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		b.beginDelete = &respr
+		beginDelete = &respr
+		b.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(b.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		b.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(b.beginDelete) {
-		b.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		b.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -225,7 +238,8 @@ func (b *BastionHostsServerTransport) dispatchNewListPager(req *http.Request) (*
 	if b.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if b.newListPager == nil {
+	newListPager := b.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -233,20 +247,22 @@ func (b *BastionHostsServerTransport) dispatchNewListPager(req *http.Request) (*
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := b.srv.NewListPager(nil)
-		b.newListPager = &resp
-		server.PagerResponderInjectNextLinks(b.newListPager, req, func(page *armnetwork.BastionHostsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		b.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.BastionHostsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(b.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		b.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(b.newListPager) {
-		b.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		b.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -255,7 +271,8 @@ func (b *BastionHostsServerTransport) dispatchNewListByResourceGroupPager(req *h
 	if b.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if b.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := b.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -267,20 +284,22 @@ func (b *BastionHostsServerTransport) dispatchNewListByResourceGroupPager(req *h
 			return nil, err
 		}
 		resp := b.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		b.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(b.newListByResourceGroupPager, req, func(page *armnetwork.BastionHostsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		b.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.BastionHostsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(b.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		b.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(b.newListByResourceGroupPager) {
-		b.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		b.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -289,7 +308,8 @@ func (b *BastionHostsServerTransport) dispatchBeginUpdateTags(req *http.Request)
 	if b.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if b.beginUpdateTags == nil {
+	beginUpdateTags := b.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -312,19 +332,21 @@ func (b *BastionHostsServerTransport) dispatchBeginUpdateTags(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		b.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		b.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(b.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		b.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(b.beginUpdateTags) {
-		b.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		b.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_bgpservicecommunities_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_bgpservicecommunities_server.go
@@ -31,14 +31,17 @@ type BgpServiceCommunitiesServer struct {
 // The returned BgpServiceCommunitiesServerTransport instance is connected to an instance of armnetwork.BgpServiceCommunitiesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewBgpServiceCommunitiesServerTransport(srv *BgpServiceCommunitiesServer) *BgpServiceCommunitiesServerTransport {
-	return &BgpServiceCommunitiesServerTransport{srv: srv}
+	return &BgpServiceCommunitiesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.BgpServiceCommunitiesClientListResponse]](),
+	}
 }
 
 // BgpServiceCommunitiesServerTransport connects instances of armnetwork.BgpServiceCommunitiesClient to instances of BgpServiceCommunitiesServer.
 // Don't use this type directly, use NewBgpServiceCommunitiesServerTransport instead.
 type BgpServiceCommunitiesServerTransport struct {
 	srv          *BgpServiceCommunitiesServer
-	newListPager *azfake.PagerResponder[armnetwork.BgpServiceCommunitiesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.BgpServiceCommunitiesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for BgpServiceCommunitiesServerTransport.
@@ -70,7 +73,8 @@ func (b *BgpServiceCommunitiesServerTransport) dispatchNewListPager(req *http.Re
 	if b.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if b.newListPager == nil {
+	newListPager := b.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bgpServiceCommunities`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -78,20 +82,22 @@ func (b *BgpServiceCommunitiesServerTransport) dispatchNewListPager(req *http.Re
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := b.srv.NewListPager(nil)
-		b.newListPager = &resp
-		server.PagerResponderInjectNextLinks(b.newListPager, req, func(page *armnetwork.BgpServiceCommunitiesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		b.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.BgpServiceCommunitiesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(b.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		b.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(b.newListPager) {
-		b.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		b.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_configurationpolicygroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_configurationpolicygroups_server.go
@@ -45,16 +45,21 @@ type ConfigurationPolicyGroupsServer struct {
 // The returned ConfigurationPolicyGroupsServerTransport instance is connected to an instance of armnetwork.ConfigurationPolicyGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewConfigurationPolicyGroupsServerTransport(srv *ConfigurationPolicyGroupsServer) *ConfigurationPolicyGroupsServerTransport {
-	return &ConfigurationPolicyGroupsServerTransport{srv: srv}
+	return &ConfigurationPolicyGroupsServerTransport{
+		srv:                                  srv,
+		beginCreateOrUpdate:                  newTracker[azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:                          newTracker[azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientDeleteResponse]](),
+		newListByVPNServerConfigurationPager: newTracker[azfake.PagerResponder[armnetwork.ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse]](),
+	}
 }
 
 // ConfigurationPolicyGroupsServerTransport connects instances of armnetwork.ConfigurationPolicyGroupsClient to instances of ConfigurationPolicyGroupsServer.
 // Don't use this type directly, use NewConfigurationPolicyGroupsServerTransport instead.
 type ConfigurationPolicyGroupsServerTransport struct {
 	srv                                  *ConfigurationPolicyGroupsServer
-	beginCreateOrUpdate                  *azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientCreateOrUpdateResponse]
-	beginDelete                          *azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientDeleteResponse]
-	newListByVPNServerConfigurationPager *azfake.PagerResponder[armnetwork.ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse]
+	beginCreateOrUpdate                  *tracker[azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientCreateOrUpdateResponse]]
+	beginDelete                          *tracker[azfake.PollerResponder[armnetwork.ConfigurationPolicyGroupsClientDeleteResponse]]
+	newListByVPNServerConfigurationPager *tracker[azfake.PagerResponder[armnetwork.ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse]]
 }
 
 // Do implements the policy.Transporter interface for ConfigurationPolicyGroupsServerTransport.
@@ -92,7 +97,8 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchBeginCreateOrUpdate(r
 	if c.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if c.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := c.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations/(?P<vpnServerConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/configurationPolicyGroups/(?P<configurationPolicyGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchBeginCreateOrUpdate(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		c.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		c.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginCreateOrUpdate) {
-		c.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		c.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchBeginDelete(req *http
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations/(?P<vpnServerConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/configurationPolicyGroups/(?P<configurationPolicyGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchNewListByVPNServerCon
 	if c.srv.NewListByVPNServerConfigurationPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVPNServerConfigurationPager not implemented")}
 	}
-	if c.newListByVPNServerConfigurationPager == nil {
+	newListByVPNServerConfigurationPager := c.newListByVPNServerConfigurationPager.get(req)
+	if newListByVPNServerConfigurationPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations/(?P<vpnServerConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/configurationPolicyGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (c *ConfigurationPolicyGroupsServerTransport) dispatchNewListByVPNServerCon
 			return nil, err
 		}
 		resp := c.srv.NewListByVPNServerConfigurationPager(resourceGroupNameUnescaped, vpnServerConfigurationNameUnescaped, nil)
-		c.newListByVPNServerConfigurationPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListByVPNServerConfigurationPager, req, func(page *armnetwork.ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse, createLink func() string) {
+		newListByVPNServerConfigurationPager = &resp
+		c.newListByVPNServerConfigurationPager.add(req, newListByVPNServerConfigurationPager)
+		server.PagerResponderInjectNextLinks(newListByVPNServerConfigurationPager, req, func(page *armnetwork.ConfigurationPolicyGroupsClientListByVPNServerConfigurationResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListByVPNServerConfigurationPager, req)
+	resp, err := server.PagerResponderNext(newListByVPNServerConfigurationPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListByVPNServerConfigurationPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListByVPNServerConfigurationPager) {
-		c.newListByVPNServerConfigurationPager = nil
+	if !server.PagerResponderMore(newListByVPNServerConfigurationPager) {
+		c.newListByVPNServerConfigurationPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_connectionmonitors_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_connectionmonitors_server.go
@@ -60,19 +60,27 @@ type ConnectionMonitorsServer struct {
 // The returned ConnectionMonitorsServerTransport instance is connected to an instance of armnetwork.ConnectionMonitorsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewConnectionMonitorsServerTransport(srv *ConnectionMonitorsServer) *ConnectionMonitorsServerTransport {
-	return &ConnectionMonitorsServerTransport{srv: srv}
+	return &ConnectionMonitorsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ConnectionMonitorsClientListResponse]](),
+		beginQuery:          newTracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientQueryResponse]](),
+		beginStart:          newTracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStartResponse]](),
+		beginStop:           newTracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStopResponse]](),
+	}
 }
 
 // ConnectionMonitorsServerTransport connects instances of armnetwork.ConnectionMonitorsClient to instances of ConnectionMonitorsServer.
 // Don't use this type directly, use NewConnectionMonitorsServerTransport instead.
 type ConnectionMonitorsServerTransport struct {
 	srv                 *ConnectionMonitorsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ConnectionMonitorsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ConnectionMonitorsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ConnectionMonitorsClientListResponse]
-	beginQuery          *azfake.PollerResponder[armnetwork.ConnectionMonitorsClientQueryResponse]
-	beginStart          *azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStartResponse]
-	beginStop           *azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStopResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ConnectionMonitorsClientListResponse]]
+	beginQuery          *tracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientQueryResponse]]
+	beginStart          *tracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStartResponse]]
+	beginStop           *tracker[azfake.PollerResponder[armnetwork.ConnectionMonitorsClientStopResponse]]
 }
 
 // Do implements the policy.Transporter interface for ConnectionMonitorsServerTransport.
@@ -118,7 +126,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 	if c.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if c.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := c.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors/(?P<connectionMonitorName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -157,19 +166,21 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		c.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		c.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginCreateOrUpdate) {
-		c.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		c.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -179,7 +190,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginDelete(req *http.Reques
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors/(?P<connectionMonitorName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -202,19 +214,21 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginDelete(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -261,7 +275,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchNewListPager(req *http.Reque
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -277,17 +292,19 @@ func (c *ConnectionMonitorsServerTransport) dispatchNewListPager(req *http.Reque
 			return nil, err
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, networkWatcherNameUnescaped, nil)
-		c.newListPager = &resp
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -296,7 +313,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginQuery(req *http.Request
 	if c.srv.BeginQuery == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginQuery not implemented")}
 	}
-	if c.beginQuery == nil {
+	beginQuery := c.beginQuery.get(req)
+	if beginQuery == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors/(?P<connectionMonitorName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/query`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -319,19 +337,21 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginQuery(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginQuery = &respr
+		beginQuery = &respr
+		c.beginQuery.add(req, beginQuery)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginQuery, req)
+	resp, err := server.PollerResponderNext(beginQuery, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginQuery.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginQuery) {
-		c.beginQuery = nil
+	if !server.PollerResponderMore(beginQuery) {
+		c.beginQuery.remove(req)
 	}
 
 	return resp, nil
@@ -341,7 +361,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginStart(req *http.Request
 	if c.srv.BeginStart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStart not implemented")}
 	}
-	if c.beginStart == nil {
+	beginStart := c.beginStart.get(req)
+	if beginStart == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors/(?P<connectionMonitorName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/start`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -364,19 +385,21 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginStart(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginStart = &respr
+		beginStart = &respr
+		c.beginStart.add(req, beginStart)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginStart, req)
+	resp, err := server.PollerResponderNext(beginStart, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginStart.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginStart) {
-		c.beginStart = nil
+	if !server.PollerResponderMore(beginStart) {
+		c.beginStart.remove(req)
 	}
 
 	return resp, nil
@@ -386,7 +409,8 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginStop(req *http.Request)
 	if c.srv.BeginStop == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStop not implemented")}
 	}
-	if c.beginStop == nil {
+	beginStop := c.beginStop.get(req)
+	if beginStop == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectionMonitors/(?P<connectionMonitorName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stop`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -409,19 +433,21 @@ func (c *ConnectionMonitorsServerTransport) dispatchBeginStop(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginStop = &respr
+		beginStop = &respr
+		c.beginStop.add(req, beginStop)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginStop, req)
+	resp, err := server.PollerResponderNext(beginStop, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		c.beginStop.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginStop) {
-		c.beginStop = nil
+	if !server.PollerResponderMore(beginStop) {
+		c.beginStop.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_connectivityconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_connectivityconfigurations_server.go
@@ -46,15 +46,19 @@ type ConnectivityConfigurationsServer struct {
 // The returned ConnectivityConfigurationsServerTransport instance is connected to an instance of armnetwork.ConnectivityConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewConnectivityConfigurationsServerTransport(srv *ConnectivityConfigurationsServer) *ConnectivityConfigurationsServerTransport {
-	return &ConnectivityConfigurationsServerTransport{srv: srv}
+	return &ConnectivityConfigurationsServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.ConnectivityConfigurationsClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ConnectivityConfigurationsClientListResponse]](),
+	}
 }
 
 // ConnectivityConfigurationsServerTransport connects instances of armnetwork.ConnectivityConfigurationsClient to instances of ConnectivityConfigurationsServer.
 // Don't use this type directly, use NewConnectivityConfigurationsServerTransport instead.
 type ConnectivityConfigurationsServerTransport struct {
 	srv          *ConnectivityConfigurationsServer
-	beginDelete  *azfake.PollerResponder[armnetwork.ConnectivityConfigurationsClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.ConnectivityConfigurationsClientListResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.ConnectivityConfigurationsClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ConnectivityConfigurationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ConnectivityConfigurationsServerTransport.
@@ -133,7 +137,8 @@ func (c *ConnectivityConfigurationsServerTransport) dispatchBeginDelete(req *htt
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectivityConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +176,21 @@ func (c *ConnectivityConfigurationsServerTransport) dispatchBeginDelete(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +237,8 @@ func (c *ConnectivityConfigurationsServerTransport) dispatchNewListPager(req *ht
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectivityConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -273,20 +281,22 @@ func (c *ConnectivityConfigurationsServerTransport) dispatchNewListPager(req *ht
 			}
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, options)
-		c.newListPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListPager, req, func(page *armnetwork.ConnectivityConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ConnectivityConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_customipprefixes_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_customipprefixes_server.go
@@ -53,17 +53,23 @@ type CustomIPPrefixesServer struct {
 // The returned CustomIPPrefixesServerTransport instance is connected to an instance of armnetwork.CustomIPPrefixesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewCustomIPPrefixesServerTransport(srv *CustomIPPrefixesServer) *CustomIPPrefixesServerTransport {
-	return &CustomIPPrefixesServerTransport{srv: srv}
+	return &CustomIPPrefixesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.CustomIPPrefixesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.CustomIPPrefixesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListAllResponse]](),
+	}
 }
 
 // CustomIPPrefixesServerTransport connects instances of armnetwork.CustomIPPrefixesClient to instances of CustomIPPrefixesServer.
 // Don't use this type directly, use NewCustomIPPrefixesServerTransport instead.
 type CustomIPPrefixesServerTransport struct {
 	srv                 *CustomIPPrefixesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.CustomIPPrefixesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.CustomIPPrefixesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.CustomIPPrefixesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.CustomIPPrefixesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.CustomIPPrefixesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for CustomIPPrefixesServerTransport.
@@ -105,7 +111,8 @@ func (c *CustomIPPrefixesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 	if c.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if c.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := c.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/customIpPrefixes/(?P<customIpPrefixName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (c *CustomIPPrefixesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		c.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		c.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginCreateOrUpdate) {
-		c.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		c.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (c *CustomIPPrefixesServerTransport) dispatchBeginDelete(req *http.Request)
 	if c.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if c.beginDelete == nil {
+	beginDelete := c.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/customIpPrefixes/(?P<customIpPrefixName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (c *CustomIPPrefixesServerTransport) dispatchBeginDelete(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		c.beginDelete = &respr
+		beginDelete = &respr
+		c.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(c.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		c.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(c.beginDelete) {
-		c.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		c.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (c *CustomIPPrefixesServerTransport) dispatchNewListPager(req *http.Request
 	if c.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if c.newListPager == nil {
+	newListPager := c.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/customIpPrefixes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (c *CustomIPPrefixesServerTransport) dispatchNewListPager(req *http.Request
 			return nil, err
 		}
 		resp := c.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		c.newListPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListPager, req, func(page *armnetwork.CustomIPPrefixesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		c.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.CustomIPPrefixesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListPager) {
-		c.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		c.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (c *CustomIPPrefixesServerTransport) dispatchNewListAllPager(req *http.Requ
 	if c.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if c.newListAllPager == nil {
+	newListAllPager := c.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/customIpPrefixes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (c *CustomIPPrefixesServerTransport) dispatchNewListAllPager(req *http.Requ
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := c.srv.NewListAllPager(nil)
-		c.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(c.newListAllPager, req, func(page *armnetwork.CustomIPPrefixesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		c.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.CustomIPPrefixesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(c.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		c.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(c.newListAllPager) {
-		c.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		c.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_ddoscustompolicies_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_ddoscustompolicies_server.go
@@ -44,15 +44,19 @@ type DdosCustomPoliciesServer struct {
 // The returned DdosCustomPoliciesServerTransport instance is connected to an instance of armnetwork.DdosCustomPoliciesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDdosCustomPoliciesServerTransport(srv *DdosCustomPoliciesServer) *DdosCustomPoliciesServerTransport {
-	return &DdosCustomPoliciesServerTransport{srv: srv}
+	return &DdosCustomPoliciesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientDeleteResponse]](),
+	}
 }
 
 // DdosCustomPoliciesServerTransport connects instances of armnetwork.DdosCustomPoliciesClient to instances of DdosCustomPoliciesServer.
 // Don't use this type directly, use NewDdosCustomPoliciesServerTransport instead.
 type DdosCustomPoliciesServerTransport struct {
 	srv                 *DdosCustomPoliciesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientDeleteResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.DdosCustomPoliciesClientDeleteResponse]]
 }
 
 // Do implements the policy.Transporter interface for DdosCustomPoliciesServerTransport.
@@ -90,7 +94,8 @@ func (d *DdosCustomPoliciesServerTransport) dispatchBeginCreateOrUpdate(req *htt
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosCustomPolicies/(?P<ddosCustomPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -113,19 +118,21 @@ func (d *DdosCustomPoliciesServerTransport) dispatchBeginCreateOrUpdate(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -135,7 +142,8 @@ func (d *DdosCustomPoliciesServerTransport) dispatchBeginDelete(req *http.Reques
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosCustomPolicies/(?P<ddosCustomPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -154,19 +162,21 @@ func (d *DdosCustomPoliciesServerTransport) dispatchBeginDelete(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_ddosprotectionplans_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_ddosprotectionplans_server.go
@@ -53,17 +53,23 @@ type DdosProtectionPlansServer struct {
 // The returned DdosProtectionPlansServerTransport instance is connected to an instance of armnetwork.DdosProtectionPlansClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDdosProtectionPlansServerTransport(srv *DdosProtectionPlansServer) *DdosProtectionPlansServerTransport {
-	return &DdosProtectionPlansServerTransport{srv: srv}
+	return &DdosProtectionPlansServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.DdosProtectionPlansClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.DdosProtectionPlansClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListByResourceGroupResponse]](),
+	}
 }
 
 // DdosProtectionPlansServerTransport connects instances of armnetwork.DdosProtectionPlansClient to instances of DdosProtectionPlansServer.
 // Don't use this type directly, use NewDdosProtectionPlansServerTransport instead.
 type DdosProtectionPlansServerTransport struct {
 	srv                         *DdosProtectionPlansServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.DdosProtectionPlansClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.DdosProtectionPlansClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.DdosProtectionPlansClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.DdosProtectionPlansClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.DdosProtectionPlansClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for DdosProtectionPlansServerTransport.
@@ -105,7 +111,8 @@ func (d *DdosProtectionPlansServerTransport) dispatchBeginCreateOrUpdate(req *ht
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosProtectionPlans/(?P<ddosProtectionPlanName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (d *DdosProtectionPlansServerTransport) dispatchBeginCreateOrUpdate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (d *DdosProtectionPlansServerTransport) dispatchBeginDelete(req *http.Reque
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosProtectionPlans/(?P<ddosProtectionPlanName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (d *DdosProtectionPlansServerTransport) dispatchBeginDelete(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (d *DdosProtectionPlansServerTransport) dispatchNewListPager(req *http.Requ
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosProtectionPlans`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (d *DdosProtectionPlansServerTransport) dispatchNewListPager(req *http.Requ
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListPager(nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armnetwork.DdosProtectionPlansClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.DdosProtectionPlansClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (d *DdosProtectionPlansServerTransport) dispatchNewListByResourceGroupPager
 	if d.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if d.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := d.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ddosProtectionPlans`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (d *DdosProtectionPlansServerTransport) dispatchNewListByResourceGroupPager
 			return nil, err
 		}
 		resp := d.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		d.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListByResourceGroupPager, req, func(page *armnetwork.DdosProtectionPlansClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		d.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.DdosProtectionPlansClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListByResourceGroupPager) {
-		d.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		d.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_defaultsecurityrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_defaultsecurityrules_server.go
@@ -37,14 +37,17 @@ type DefaultSecurityRulesServer struct {
 // The returned DefaultSecurityRulesServerTransport instance is connected to an instance of armnetwork.DefaultSecurityRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDefaultSecurityRulesServerTransport(srv *DefaultSecurityRulesServer) *DefaultSecurityRulesServerTransport {
-	return &DefaultSecurityRulesServerTransport{srv: srv}
+	return &DefaultSecurityRulesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.DefaultSecurityRulesClientListResponse]](),
+	}
 }
 
 // DefaultSecurityRulesServerTransport connects instances of armnetwork.DefaultSecurityRulesClient to instances of DefaultSecurityRulesServer.
 // Don't use this type directly, use NewDefaultSecurityRulesServerTransport instead.
 type DefaultSecurityRulesServerTransport struct {
 	srv          *DefaultSecurityRulesServer
-	newListPager *azfake.PagerResponder[armnetwork.DefaultSecurityRulesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.DefaultSecurityRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for DefaultSecurityRulesServerTransport.
@@ -115,7 +118,8 @@ func (d *DefaultSecurityRulesServerTransport) dispatchNewListPager(req *http.Req
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/defaultSecurityRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (d *DefaultSecurityRulesServerTransport) dispatchNewListPager(req *http.Req
 			return nil, err
 		}
 		resp := d.srv.NewListPager(resourceGroupNameUnescaped, networkSecurityGroupNameUnescaped, nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armnetwork.DefaultSecurityRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.DefaultSecurityRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_dscpconfiguration_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_dscpconfiguration_server.go
@@ -49,17 +49,23 @@ type DscpConfigurationServer struct {
 // The returned DscpConfigurationServerTransport instance is connected to an instance of armnetwork.DscpConfigurationClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewDscpConfigurationServerTransport(srv *DscpConfigurationServer) *DscpConfigurationServerTransport {
-	return &DscpConfigurationServerTransport{srv: srv}
+	return &DscpConfigurationServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.DscpConfigurationClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.DscpConfigurationClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.DscpConfigurationClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.DscpConfigurationClientListAllResponse]](),
+	}
 }
 
 // DscpConfigurationServerTransport connects instances of armnetwork.DscpConfigurationClient to instances of DscpConfigurationServer.
 // Don't use this type directly, use NewDscpConfigurationServerTransport instead.
 type DscpConfigurationServerTransport struct {
 	srv                 *DscpConfigurationServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.DscpConfigurationClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.DscpConfigurationClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.DscpConfigurationClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.DscpConfigurationClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.DscpConfigurationClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.DscpConfigurationClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.DscpConfigurationClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.DscpConfigurationClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for DscpConfigurationServerTransport.
@@ -99,7 +105,8 @@ func (d *DscpConfigurationServerTransport) dispatchBeginCreateOrUpdate(req *http
 	if d.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if d.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := d.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/dscpConfigurations/(?P<dscpConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -122,19 +129,21 @@ func (d *DscpConfigurationServerTransport) dispatchBeginCreateOrUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		d.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		d.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginCreateOrUpdate) {
-		d.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		d.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -144,7 +153,8 @@ func (d *DscpConfigurationServerTransport) dispatchBeginDelete(req *http.Request
 	if d.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if d.beginDelete == nil {
+	beginDelete := d.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/dscpConfigurations/(?P<dscpConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -163,19 +173,21 @@ func (d *DscpConfigurationServerTransport) dispatchBeginDelete(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		d.beginDelete = &respr
+		beginDelete = &respr
+		d.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(d.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		d.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(d.beginDelete) {
-		d.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		d.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -218,7 +230,8 @@ func (d *DscpConfigurationServerTransport) dispatchNewListPager(req *http.Reques
 	if d.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if d.newListPager == nil {
+	newListPager := d.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/dscpConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -230,20 +243,22 @@ func (d *DscpConfigurationServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, err
 		}
 		resp := d.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		d.newListPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListPager, req, func(page *armnetwork.DscpConfigurationClientListResponse, createLink func() string) {
+		newListPager = &resp
+		d.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.DscpConfigurationClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListPager) {
-		d.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		d.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -252,7 +267,8 @@ func (d *DscpConfigurationServerTransport) dispatchNewListAllPager(req *http.Req
 	if d.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if d.newListAllPager == nil {
+	newListAllPager := d.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/dscpConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -260,20 +276,22 @@ func (d *DscpConfigurationServerTransport) dispatchNewListAllPager(req *http.Req
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := d.srv.NewListAllPager(nil)
-		d.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(d.newListAllPager, req, func(page *armnetwork.DscpConfigurationClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		d.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.DscpConfigurationClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(d.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		d.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(d.newListAllPager) {
-		d.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		d.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitauthorizations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitauthorizations_server.go
@@ -45,16 +45,21 @@ type ExpressRouteCircuitAuthorizationsServer struct {
 // The returned ExpressRouteCircuitAuthorizationsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCircuitAuthorizationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCircuitAuthorizationsServerTransport(srv *ExpressRouteCircuitAuthorizationsServer) *ExpressRouteCircuitAuthorizationsServerTransport {
-	return &ExpressRouteCircuitAuthorizationsServerTransport{srv: srv}
+	return &ExpressRouteCircuitAuthorizationsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientListResponse]](),
+	}
 }
 
 // ExpressRouteCircuitAuthorizationsServerTransport connects instances of armnetwork.ExpressRouteCircuitAuthorizationsClient to instances of ExpressRouteCircuitAuthorizationsServer.
 // Don't use this type directly, use NewExpressRouteCircuitAuthorizationsServerTransport instead.
 type ExpressRouteCircuitAuthorizationsServerTransport struct {
 	srv                 *ExpressRouteCircuitAuthorizationsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitAuthorizationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCircuitAuthorizationsServerTransport.
@@ -92,7 +97,8 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchBeginCreateOr
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations/(?P<authorizationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchBeginCreateOr
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchBeginDelete(r
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations/(?P<authorizationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchBeginDelete(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchNewListPager(
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (e *ExpressRouteCircuitAuthorizationsServerTransport) dispatchNewListPager(
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, circuitNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCircuitAuthorizationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCircuitAuthorizationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitconnections_server.go
@@ -45,16 +45,21 @@ type ExpressRouteCircuitConnectionsServer struct {
 // The returned ExpressRouteCircuitConnectionsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCircuitConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCircuitConnectionsServerTransport(srv *ExpressRouteCircuitConnectionsServer) *ExpressRouteCircuitConnectionsServerTransport {
-	return &ExpressRouteCircuitConnectionsServerTransport{srv: srv}
+	return &ExpressRouteCircuitConnectionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitConnectionsClientListResponse]](),
+	}
 }
 
 // ExpressRouteCircuitConnectionsServerTransport connects instances of armnetwork.ExpressRouteCircuitConnectionsClient to instances of ExpressRouteCircuitConnectionsServer.
 // Don't use this type directly, use NewExpressRouteCircuitConnectionsServerTransport instead.
 type ExpressRouteCircuitConnectionsServerTransport struct {
 	srv                 *ExpressRouteCircuitConnectionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ExpressRouteCircuitConnectionsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitConnectionsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCircuitConnectionsServerTransport.
@@ -92,7 +97,8 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchBeginCreateOrUpd
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -123,19 +129,21 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchBeginCreateOrUpd
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -145,7 +153,8 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchBeginDelete(req 
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -172,19 +181,21 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchBeginDelete(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -235,7 +246,8 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchNewListPager(req
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -255,20 +267,22 @@ func (e *ExpressRouteCircuitConnectionsServerTransport) dispatchNewListPager(req
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, circuitNameUnescaped, peeringNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCircuitConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCircuitConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitpeerings_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuitpeerings_server.go
@@ -45,16 +45,21 @@ type ExpressRouteCircuitPeeringsServer struct {
 // The returned ExpressRouteCircuitPeeringsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCircuitPeeringsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCircuitPeeringsServerTransport(srv *ExpressRouteCircuitPeeringsServer) *ExpressRouteCircuitPeeringsServerTransport {
-	return &ExpressRouteCircuitPeeringsServerTransport{srv: srv}
+	return &ExpressRouteCircuitPeeringsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitPeeringsClientListResponse]](),
+	}
 }
 
 // ExpressRouteCircuitPeeringsServerTransport connects instances of armnetwork.ExpressRouteCircuitPeeringsClient to instances of ExpressRouteCircuitPeeringsServer.
 // Don't use this type directly, use NewExpressRouteCircuitPeeringsServerTransport instead.
 type ExpressRouteCircuitPeeringsServerTransport struct {
 	srv                 *ExpressRouteCircuitPeeringsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ExpressRouteCircuitPeeringsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitPeeringsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitPeeringsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCircuitPeeringsServerTransport.
@@ -92,7 +97,8 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchBeginCreateOrUpdate
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchBeginCreateOrUpdate
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchBeginDelete(req *ht
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchBeginDelete(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchNewListPager(req *h
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (e *ExpressRouteCircuitPeeringsServerTransport) dispatchNewListPager(req *h
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, circuitNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCircuitPeeringsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCircuitPeeringsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuits_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecircuits_server.go
@@ -73,20 +73,29 @@ type ExpressRouteCircuitsServer struct {
 // The returned ExpressRouteCircuitsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCircuitsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCircuitsServerTransport(srv *ExpressRouteCircuitsServer) *ExpressRouteCircuitsServerTransport {
-	return &ExpressRouteCircuitsServerTransport{srv: srv}
+	return &ExpressRouteCircuitsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListResponse]](),
+		newListAllPager:             newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListAllResponse]](),
+		beginListArpTable:           newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListArpTableResponse]](),
+		beginListRoutesTable:        newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableResponse]](),
+		beginListRoutesTableSummary: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableSummaryResponse]](),
+	}
 }
 
 // ExpressRouteCircuitsServerTransport connects instances of armnetwork.ExpressRouteCircuitsClient to instances of ExpressRouteCircuitsServer.
 // Don't use this type directly, use NewExpressRouteCircuitsServerTransport instead.
 type ExpressRouteCircuitsServerTransport struct {
 	srv                         *ExpressRouteCircuitsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListResponse]
-	newListAllPager             *azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListAllResponse]
-	beginListArpTable           *azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListArpTableResponse]
-	beginListRoutesTable        *azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableResponse]
-	beginListRoutesTableSummary *azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableSummaryResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListResponse]]
+	newListAllPager             *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCircuitsClientListAllResponse]]
+	beginListArpTable           *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListArpTableResponse]]
+	beginListRoutesTable        *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableResponse]]
+	beginListRoutesTableSummary *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCircuitsClientListRoutesTableSummaryResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCircuitsServerTransport.
@@ -138,7 +147,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -161,19 +171,21 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -183,7 +195,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginDelete(req *http.Requ
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -202,19 +215,21 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -327,7 +342,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchNewListPager(req *http.Req
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -339,20 +355,22 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchNewListPager(req *http.Req
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCircuitsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCircuitsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -361,7 +379,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchNewListAllPager(req *http.
 	if e.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if e.newListAllPager == nil {
+	newListAllPager := e.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -369,20 +388,22 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchNewListAllPager(req *http.
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := e.srv.NewListAllPager(nil)
-		e.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListAllPager, req, func(page *armnetwork.ExpressRouteCircuitsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		e.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.ExpressRouteCircuitsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListAllPager) {
-		e.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		e.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -391,7 +412,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListArpTable(req *htt
 	if e.srv.BeginListArpTable == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListArpTable not implemented")}
 	}
-	if e.beginListArpTable == nil {
+	beginListArpTable := e.beginListArpTable.get(req)
+	if beginListArpTable == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/arpTables/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -418,19 +440,21 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListArpTable(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListArpTable = &respr
+		beginListArpTable = &respr
+		e.beginListArpTable.add(req, beginListArpTable)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListArpTable, req)
+	resp, err := server.PollerResponderNext(beginListArpTable, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListArpTable.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListArpTable) {
-		e.beginListArpTable = nil
+	if !server.PollerResponderMore(beginListArpTable) {
+		e.beginListArpTable.remove(req)
 	}
 
 	return resp, nil
@@ -440,7 +464,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListRoutesTable(req *
 	if e.srv.BeginListRoutesTable == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListRoutesTable not implemented")}
 	}
-	if e.beginListRoutesTable == nil {
+	beginListRoutesTable := e.beginListRoutesTable.get(req)
+	if beginListRoutesTable == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTables/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -467,19 +492,21 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListRoutesTable(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListRoutesTable = &respr
+		beginListRoutesTable = &respr
+		e.beginListRoutesTable.add(req, beginListRoutesTable)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListRoutesTable, req)
+	resp, err := server.PollerResponderNext(beginListRoutesTable, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListRoutesTable.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListRoutesTable) {
-		e.beginListRoutesTable = nil
+	if !server.PollerResponderMore(beginListRoutesTable) {
+		e.beginListRoutesTable.remove(req)
 	}
 
 	return resp, nil
@@ -489,7 +516,8 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListRoutesTableSummar
 	if e.srv.BeginListRoutesTableSummary == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListRoutesTableSummary not implemented")}
 	}
-	if e.beginListRoutesTableSummary == nil {
+	beginListRoutesTableSummary := e.beginListRoutesTableSummary.get(req)
+	if beginListRoutesTableSummary == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTablesSummary/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -516,19 +544,21 @@ func (e *ExpressRouteCircuitsServerTransport) dispatchBeginListRoutesTableSummar
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListRoutesTableSummary = &respr
+		beginListRoutesTableSummary = &respr
+		e.beginListRoutesTableSummary.add(req, beginListRoutesTableSummary)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListRoutesTableSummary, req)
+	resp, err := server.PollerResponderNext(beginListRoutesTableSummary, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListRoutesTableSummary.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListRoutesTableSummary) {
-		e.beginListRoutesTableSummary = nil
+	if !server.PollerResponderMore(beginListRoutesTableSummary) {
+		e.beginListRoutesTableSummary.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteconnections_server.go
@@ -44,15 +44,19 @@ type ExpressRouteConnectionsServer struct {
 // The returned ExpressRouteConnectionsServerTransport instance is connected to an instance of armnetwork.ExpressRouteConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteConnectionsServerTransport(srv *ExpressRouteConnectionsServer) *ExpressRouteConnectionsServerTransport {
-	return &ExpressRouteConnectionsServerTransport{srv: srv}
+	return &ExpressRouteConnectionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientDeleteResponse]](),
+	}
 }
 
 // ExpressRouteConnectionsServerTransport connects instances of armnetwork.ExpressRouteConnectionsClient to instances of ExpressRouteConnectionsServer.
 // Don't use this type directly, use NewExpressRouteConnectionsServerTransport instead.
 type ExpressRouteConnectionsServerTransport struct {
 	srv                 *ExpressRouteConnectionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientDeleteResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteConnectionsClientDeleteResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteConnectionsServerTransport.
@@ -90,7 +94,8 @@ func (e *ExpressRouteConnectionsServerTransport) dispatchBeginCreateOrUpdate(req
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteGateways/(?P<expressRouteGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/expressRouteConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -117,19 +122,21 @@ func (e *ExpressRouteConnectionsServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -139,7 +146,8 @@ func (e *ExpressRouteConnectionsServerTransport) dispatchBeginDelete(req *http.R
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteGateways/(?P<expressRouteGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/expressRouteConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -162,19 +170,21 @@ func (e *ExpressRouteConnectionsServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecrossconnectionpeerings_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecrossconnectionpeerings_server.go
@@ -45,16 +45,21 @@ type ExpressRouteCrossConnectionPeeringsServer struct {
 // The returned ExpressRouteCrossConnectionPeeringsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCrossConnectionPeeringsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCrossConnectionPeeringsServerTransport(srv *ExpressRouteCrossConnectionPeeringsServer) *ExpressRouteCrossConnectionPeeringsServerTransport {
-	return &ExpressRouteCrossConnectionPeeringsServerTransport{srv: srv}
+	return &ExpressRouteCrossConnectionPeeringsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientListResponse]](),
+	}
 }
 
 // ExpressRouteCrossConnectionPeeringsServerTransport connects instances of armnetwork.ExpressRouteCrossConnectionPeeringsClient to instances of ExpressRouteCrossConnectionPeeringsServer.
 // Don't use this type directly, use NewExpressRouteCrossConnectionPeeringsServerTransport instead.
 type ExpressRouteCrossConnectionPeeringsServerTransport struct {
 	srv                 *ExpressRouteCrossConnectionPeeringsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionPeeringsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCrossConnectionPeeringsServerTransport.
@@ -92,7 +97,8 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchBeginCreate
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchBeginCreate
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchBeginDelete
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchBeginDelete
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchNewListPage
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (e *ExpressRouteCrossConnectionPeeringsServerTransport) dispatchNewListPage
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, crossConnectionNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCrossConnectionPeeringsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCrossConnectionPeeringsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecrossconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutecrossconnections_server.go
@@ -61,19 +61,27 @@ type ExpressRouteCrossConnectionsServer struct {
 // The returned ExpressRouteCrossConnectionsServerTransport instance is connected to an instance of armnetwork.ExpressRouteCrossConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteCrossConnectionsServerTransport(srv *ExpressRouteCrossConnectionsServer) *ExpressRouteCrossConnectionsServerTransport {
-	return &ExpressRouteCrossConnectionsServerTransport{srv: srv}
+	return &ExpressRouteCrossConnectionsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientCreateOrUpdateResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListResponse]](),
+		beginListArpTable:           newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListArpTableResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListByResourceGroupResponse]](),
+		beginListRoutesTable:        newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableResponse]](),
+		beginListRoutesTableSummary: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse]](),
+	}
 }
 
 // ExpressRouteCrossConnectionsServerTransport connects instances of armnetwork.ExpressRouteCrossConnectionsClient to instances of ExpressRouteCrossConnectionsServer.
 // Don't use this type directly, use NewExpressRouteCrossConnectionsServerTransport instead.
 type ExpressRouteCrossConnectionsServerTransport struct {
 	srv                         *ExpressRouteCrossConnectionsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientCreateOrUpdateResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListResponse]
-	beginListArpTable           *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListArpTableResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListByResourceGroupResponse]
-	beginListRoutesTable        *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableResponse]
-	beginListRoutesTableSummary *azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientCreateOrUpdateResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListResponse]]
+	beginListArpTable           *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListArpTableResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.ExpressRouteCrossConnectionsClientListByResourceGroupResponse]]
+	beginListRoutesTable        *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableResponse]]
+	beginListRoutesTableSummary *tracker[azfake.PollerResponder[armnetwork.ExpressRouteCrossConnectionsClientListRoutesTableSummaryResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteCrossConnectionsServerTransport.
@@ -119,7 +127,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginCreateOrUpdat
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -142,19 +151,21 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginCreateOrUpdat
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -197,7 +208,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchNewListPager(req *
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -205,20 +217,22 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchNewListPager(req *
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := e.srv.NewListPager(nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteCrossConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteCrossConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -227,7 +241,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListArpTable(
 	if e.srv.BeginListArpTable == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListArpTable not implemented")}
 	}
-	if e.beginListArpTable == nil {
+	beginListArpTable := e.beginListArpTable.get(req)
+	if beginListArpTable == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/arpTables/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -254,19 +269,21 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListArpTable(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListArpTable = &respr
+		beginListArpTable = &respr
+		e.beginListArpTable.add(req, beginListArpTable)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListArpTable, req)
+	resp, err := server.PollerResponderNext(beginListArpTable, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListArpTable.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListArpTable) {
-		e.beginListArpTable = nil
+	if !server.PollerResponderMore(beginListArpTable) {
+		e.beginListArpTable.remove(req)
 	}
 
 	return resp, nil
@@ -276,7 +293,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchNewListByResourceG
 	if e.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if e.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := e.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -288,20 +306,22 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchNewListByResourceG
 			return nil, err
 		}
 		resp := e.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		e.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListByResourceGroupPager, req, func(page *armnetwork.ExpressRouteCrossConnectionsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		e.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.ExpressRouteCrossConnectionsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListByResourceGroupPager) {
-		e.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		e.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -310,7 +330,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListRoutesTab
 	if e.srv.BeginListRoutesTable == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListRoutesTable not implemented")}
 	}
-	if e.beginListRoutesTable == nil {
+	beginListRoutesTable := e.beginListRoutesTable.get(req)
+	if beginListRoutesTable == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTables/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -337,19 +358,21 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListRoutesTab
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListRoutesTable = &respr
+		beginListRoutesTable = &respr
+		e.beginListRoutesTable.add(req, beginListRoutesTable)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListRoutesTable, req)
+	resp, err := server.PollerResponderNext(beginListRoutesTable, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListRoutesTable.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListRoutesTable) {
-		e.beginListRoutesTable = nil
+	if !server.PollerResponderMore(beginListRoutesTable) {
+		e.beginListRoutesTable.remove(req)
 	}
 
 	return resp, nil
@@ -359,7 +382,8 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListRoutesTab
 	if e.srv.BeginListRoutesTableSummary == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListRoutesTableSummary not implemented")}
 	}
-	if e.beginListRoutesTableSummary == nil {
+	beginListRoutesTableSummary := e.beginListRoutesTableSummary.get(req)
+	if beginListRoutesTableSummary == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCrossConnections/(?P<crossConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTablesSummary/(?P<devicePath>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -386,19 +410,21 @@ func (e *ExpressRouteCrossConnectionsServerTransport) dispatchBeginListRoutesTab
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginListRoutesTableSummary = &respr
+		beginListRoutesTableSummary = &respr
+		e.beginListRoutesTableSummary.add(req, beginListRoutesTableSummary)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginListRoutesTableSummary, req)
+	resp, err := server.PollerResponderNext(beginListRoutesTableSummary, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginListRoutesTableSummary.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginListRoutesTableSummary) {
-		e.beginListRoutesTableSummary = nil
+	if !server.PollerResponderMore(beginListRoutesTableSummary) {
+		e.beginListRoutesTableSummary.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutegateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutegateways_server.go
@@ -52,16 +52,21 @@ type ExpressRouteGatewaysServer struct {
 // The returned ExpressRouteGatewaysServerTransport instance is connected to an instance of armnetwork.ExpressRouteGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteGatewaysServerTransport(srv *ExpressRouteGatewaysServer) *ExpressRouteGatewaysServerTransport {
-	return &ExpressRouteGatewaysServerTransport{srv: srv}
+	return &ExpressRouteGatewaysServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientDeleteResponse]](),
+		beginUpdateTags:     newTracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientUpdateTagsResponse]](),
+	}
 }
 
 // ExpressRouteGatewaysServerTransport connects instances of armnetwork.ExpressRouteGatewaysClient to instances of ExpressRouteGatewaysServer.
 // Don't use this type directly, use NewExpressRouteGatewaysServerTransport instead.
 type ExpressRouteGatewaysServerTransport struct {
 	srv                 *ExpressRouteGatewaysServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientDeleteResponse]
-	beginUpdateTags     *azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientUpdateTagsResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientDeleteResponse]]
+	beginUpdateTags     *tracker[azfake.PollerResponder[armnetwork.ExpressRouteGatewaysClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteGatewaysServerTransport.
@@ -103,7 +108,8 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteGateways/(?P<expressRouteGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -126,19 +132,21 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -148,7 +156,8 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginDelete(req *http.Requ
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteGateways/(?P<expressRouteGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -167,19 +176,21 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -276,7 +287,8 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginUpdateTags(req *http.
 	if e.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if e.beginUpdateTags == nil {
+	beginUpdateTags := e.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteGateways/(?P<expressRouteGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -299,19 +311,21 @@ func (e *ExpressRouteGatewaysServerTransport) dispatchBeginUpdateTags(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		e.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		e.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginUpdateTags) {
-		e.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		e.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutelinks_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressroutelinks_server.go
@@ -37,14 +37,17 @@ type ExpressRouteLinksServer struct {
 // The returned ExpressRouteLinksServerTransport instance is connected to an instance of armnetwork.ExpressRouteLinksClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteLinksServerTransport(srv *ExpressRouteLinksServer) *ExpressRouteLinksServerTransport {
-	return &ExpressRouteLinksServerTransport{srv: srv}
+	return &ExpressRouteLinksServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ExpressRouteLinksClientListResponse]](),
+	}
 }
 
 // ExpressRouteLinksServerTransport connects instances of armnetwork.ExpressRouteLinksClient to instances of ExpressRouteLinksServer.
 // Don't use this type directly, use NewExpressRouteLinksServerTransport instead.
 type ExpressRouteLinksServerTransport struct {
 	srv          *ExpressRouteLinksServer
-	newListPager *azfake.PagerResponder[armnetwork.ExpressRouteLinksClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ExpressRouteLinksClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteLinksServerTransport.
@@ -115,7 +118,8 @@ func (e *ExpressRouteLinksServerTransport) dispatchNewListPager(req *http.Reques
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/links`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (e *ExpressRouteLinksServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, expressRoutePortNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteLinksClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteLinksClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteportauthorizations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteportauthorizations_server.go
@@ -45,16 +45,21 @@ type ExpressRoutePortAuthorizationsServer struct {
 // The returned ExpressRoutePortAuthorizationsServerTransport instance is connected to an instance of armnetwork.ExpressRoutePortAuthorizationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRoutePortAuthorizationsServerTransport(srv *ExpressRoutePortAuthorizationsServer) *ExpressRoutePortAuthorizationsServerTransport {
-	return &ExpressRoutePortAuthorizationsServerTransport{srv: srv}
+	return &ExpressRoutePortAuthorizationsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.ExpressRoutePortAuthorizationsClientListResponse]](),
+	}
 }
 
 // ExpressRoutePortAuthorizationsServerTransport connects instances of armnetwork.ExpressRoutePortAuthorizationsClient to instances of ExpressRoutePortAuthorizationsServer.
 // Don't use this type directly, use NewExpressRoutePortAuthorizationsServerTransport instead.
 type ExpressRoutePortAuthorizationsServerTransport struct {
 	srv                 *ExpressRoutePortAuthorizationsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.ExpressRoutePortAuthorizationsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.ExpressRoutePortAuthorizationsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.ExpressRoutePortAuthorizationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRoutePortAuthorizationsServerTransport.
@@ -92,7 +97,8 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchBeginCreateOrUpd
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations/(?P<authorizationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchBeginCreateOrUpd
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchBeginDelete(req 
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations/(?P<authorizationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchBeginDelete(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchNewListPager(req
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/authorizations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (e *ExpressRoutePortAuthorizationsServerTransport) dispatchNewListPager(req
 			return nil, err
 		}
 		resp := e.srv.NewListPager(resourceGroupNameUnescaped, expressRoutePortNameUnescaped, nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRoutePortAuthorizationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRoutePortAuthorizationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteports_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteports_server.go
@@ -57,17 +57,23 @@ type ExpressRoutePortsServer struct {
 // The returned ExpressRoutePortsServerTransport instance is connected to an instance of armnetwork.ExpressRoutePortsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRoutePortsServerTransport(srv *ExpressRoutePortsServer) *ExpressRoutePortsServerTransport {
-	return &ExpressRoutePortsServerTransport{srv: srv}
+	return &ExpressRoutePortsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.ExpressRoutePortsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.ExpressRoutePortsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListByResourceGroupResponse]](),
+	}
 }
 
 // ExpressRoutePortsServerTransport connects instances of armnetwork.ExpressRoutePortsClient to instances of ExpressRoutePortsServer.
 // Don't use this type directly, use NewExpressRoutePortsServerTransport instead.
 type ExpressRoutePortsServerTransport struct {
 	srv                         *ExpressRoutePortsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.ExpressRoutePortsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.ExpressRoutePortsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.ExpressRoutePortsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.ExpressRoutePortsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRoutePortsServerTransport.
@@ -111,7 +117,8 @@ func (e *ExpressRoutePortsServerTransport) dispatchBeginCreateOrUpdate(req *http
 	if e.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if e.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := e.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -134,19 +141,21 @@ func (e *ExpressRoutePortsServerTransport) dispatchBeginCreateOrUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		e.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		e.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginCreateOrUpdate) {
-		e.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		e.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -156,7 +165,8 @@ func (e *ExpressRoutePortsServerTransport) dispatchBeginDelete(req *http.Request
 	if e.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if e.beginDelete == nil {
+	beginDelete := e.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePorts/(?P<expressRoutePortName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -175,19 +185,21 @@ func (e *ExpressRoutePortsServerTransport) dispatchBeginDelete(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		e.beginDelete = &respr
+		beginDelete = &respr
+		e.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(e.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		e.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(e.beginDelete) {
-		e.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		e.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -267,7 +279,8 @@ func (e *ExpressRoutePortsServerTransport) dispatchNewListPager(req *http.Reques
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePorts`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -275,20 +288,22 @@ func (e *ExpressRoutePortsServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := e.srv.NewListPager(nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRoutePortsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRoutePortsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -297,7 +312,8 @@ func (e *ExpressRoutePortsServerTransport) dispatchNewListByResourceGroupPager(r
 	if e.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if e.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := e.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePorts`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -309,20 +325,22 @@ func (e *ExpressRoutePortsServerTransport) dispatchNewListByResourceGroupPager(r
 			return nil, err
 		}
 		resp := e.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		e.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListByResourceGroupPager, req, func(page *armnetwork.ExpressRoutePortsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		e.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.ExpressRoutePortsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListByResourceGroupPager) {
-		e.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		e.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteportslocations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteportslocations_server.go
@@ -37,14 +37,17 @@ type ExpressRoutePortsLocationsServer struct {
 // The returned ExpressRoutePortsLocationsServerTransport instance is connected to an instance of armnetwork.ExpressRoutePortsLocationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRoutePortsLocationsServerTransport(srv *ExpressRoutePortsLocationsServer) *ExpressRoutePortsLocationsServerTransport {
-	return &ExpressRoutePortsLocationsServerTransport{srv: srv}
+	return &ExpressRoutePortsLocationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsLocationsClientListResponse]](),
+	}
 }
 
 // ExpressRoutePortsLocationsServerTransport connects instances of armnetwork.ExpressRoutePortsLocationsClient to instances of ExpressRoutePortsLocationsServer.
 // Don't use this type directly, use NewExpressRoutePortsLocationsServerTransport instead.
 type ExpressRoutePortsLocationsServerTransport struct {
 	srv          *ExpressRoutePortsLocationsServer
-	newListPager *azfake.PagerResponder[armnetwork.ExpressRoutePortsLocationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ExpressRoutePortsLocationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRoutePortsLocationsServerTransport.
@@ -107,7 +110,8 @@ func (e *ExpressRoutePortsLocationsServerTransport) dispatchNewListPager(req *ht
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ExpressRoutePortsLocations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -115,20 +119,22 @@ func (e *ExpressRoutePortsLocationsServerTransport) dispatchNewListPager(req *ht
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := e.srv.NewListPager(nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRoutePortsLocationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRoutePortsLocationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteserviceproviders_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_expressrouteserviceproviders_server.go
@@ -31,14 +31,17 @@ type ExpressRouteServiceProvidersServer struct {
 // The returned ExpressRouteServiceProvidersServerTransport instance is connected to an instance of armnetwork.ExpressRouteServiceProvidersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewExpressRouteServiceProvidersServerTransport(srv *ExpressRouteServiceProvidersServer) *ExpressRouteServiceProvidersServerTransport {
-	return &ExpressRouteServiceProvidersServerTransport{srv: srv}
+	return &ExpressRouteServiceProvidersServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ExpressRouteServiceProvidersClientListResponse]](),
+	}
 }
 
 // ExpressRouteServiceProvidersServerTransport connects instances of armnetwork.ExpressRouteServiceProvidersClient to instances of ExpressRouteServiceProvidersServer.
 // Don't use this type directly, use NewExpressRouteServiceProvidersServerTransport instead.
 type ExpressRouteServiceProvidersServerTransport struct {
 	srv          *ExpressRouteServiceProvidersServer
-	newListPager *azfake.PagerResponder[armnetwork.ExpressRouteServiceProvidersClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ExpressRouteServiceProvidersClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ExpressRouteServiceProvidersServerTransport.
@@ -70,7 +73,8 @@ func (e *ExpressRouteServiceProvidersServerTransport) dispatchNewListPager(req *
 	if e.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if e.newListPager == nil {
+	newListPager := e.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteServiceProviders`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -78,20 +82,22 @@ func (e *ExpressRouteServiceProvidersServerTransport) dispatchNewListPager(req *
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := e.srv.NewListPager(nil)
-		e.newListPager = &resp
-		server.PagerResponderInjectNextLinks(e.newListPager, req, func(page *armnetwork.ExpressRouteServiceProvidersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		e.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ExpressRouteServiceProvidersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(e.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		e.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(e.newListPager) {
-		e.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		e.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_firewallpolicies_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_firewallpolicies_server.go
@@ -53,17 +53,23 @@ type FirewallPoliciesServer struct {
 // The returned FirewallPoliciesServerTransport instance is connected to an instance of armnetwork.FirewallPoliciesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewFirewallPoliciesServerTransport(srv *FirewallPoliciesServer) *FirewallPoliciesServerTransport {
-	return &FirewallPoliciesServerTransport{srv: srv}
+	return &FirewallPoliciesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.FirewallPoliciesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.FirewallPoliciesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.FirewallPoliciesClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.FirewallPoliciesClientListAllResponse]](),
+	}
 }
 
 // FirewallPoliciesServerTransport connects instances of armnetwork.FirewallPoliciesClient to instances of FirewallPoliciesServer.
 // Don't use this type directly, use NewFirewallPoliciesServerTransport instead.
 type FirewallPoliciesServerTransport struct {
 	srv                 *FirewallPoliciesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.FirewallPoliciesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.FirewallPoliciesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.FirewallPoliciesClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.FirewallPoliciesClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.FirewallPoliciesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.FirewallPoliciesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.FirewallPoliciesClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.FirewallPoliciesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for FirewallPoliciesServerTransport.
@@ -105,7 +111,8 @@ func (f *FirewallPoliciesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 	if f.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if f.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := f.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies/(?P<firewallPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (f *FirewallPoliciesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		f.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		f.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginCreateOrUpdate) {
-		f.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		f.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (f *FirewallPoliciesServerTransport) dispatchBeginDelete(req *http.Request)
 	if f.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if f.beginDelete == nil {
+	beginDelete := f.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies/(?P<firewallPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (f *FirewallPoliciesServerTransport) dispatchBeginDelete(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginDelete = &respr
+		beginDelete = &respr
+		f.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		f.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginDelete) {
-		f.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		f.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (f *FirewallPoliciesServerTransport) dispatchNewListPager(req *http.Request
 	if f.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if f.newListPager == nil {
+	newListPager := f.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (f *FirewallPoliciesServerTransport) dispatchNewListPager(req *http.Request
 			return nil, err
 		}
 		resp := f.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		f.newListPager = &resp
-		server.PagerResponderInjectNextLinks(f.newListPager, req, func(page *armnetwork.FirewallPoliciesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		f.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.FirewallPoliciesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(f.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		f.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(f.newListPager) {
-		f.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		f.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (f *FirewallPoliciesServerTransport) dispatchNewListAllPager(req *http.Requ
 	if f.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if f.newListAllPager == nil {
+	newListAllPager := f.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (f *FirewallPoliciesServerTransport) dispatchNewListAllPager(req *http.Requ
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := f.srv.NewListAllPager(nil)
-		f.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(f.newListAllPager, req, func(page *armnetwork.FirewallPoliciesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		f.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.FirewallPoliciesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(f.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		f.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(f.newListAllPager) {
-		f.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		f.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_firewallpolicyrulecollectiongroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_firewallpolicyrulecollectiongroups_server.go
@@ -45,16 +45,21 @@ type FirewallPolicyRuleCollectionGroupsServer struct {
 // The returned FirewallPolicyRuleCollectionGroupsServerTransport instance is connected to an instance of armnetwork.FirewallPolicyRuleCollectionGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewFirewallPolicyRuleCollectionGroupsServerTransport(srv *FirewallPolicyRuleCollectionGroupsServer) *FirewallPolicyRuleCollectionGroupsServerTransport {
-	return &FirewallPolicyRuleCollectionGroupsServerTransport{srv: srv}
+	return &FirewallPolicyRuleCollectionGroupsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientListResponse]](),
+	}
 }
 
 // FirewallPolicyRuleCollectionGroupsServerTransport connects instances of armnetwork.FirewallPolicyRuleCollectionGroupsClient to instances of FirewallPolicyRuleCollectionGroupsServer.
 // Don't use this type directly, use NewFirewallPolicyRuleCollectionGroupsServerTransport instead.
 type FirewallPolicyRuleCollectionGroupsServerTransport struct {
 	srv                 *FirewallPolicyRuleCollectionGroupsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.FirewallPolicyRuleCollectionGroupsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for FirewallPolicyRuleCollectionGroupsServerTransport.
@@ -92,7 +97,8 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchBeginCreateO
 	if f.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if f.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := f.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies/(?P<firewallPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollectionGroups/(?P<ruleCollectionGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchBeginCreateO
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		f.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		f.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginCreateOrUpdate) {
-		f.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		f.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchBeginDelete(
 	if f.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if f.beginDelete == nil {
+	beginDelete := f.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies/(?P<firewallPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollectionGroups/(?P<ruleCollectionGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchBeginDelete(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginDelete = &respr
+		beginDelete = &respr
+		f.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		f.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginDelete) {
-		f.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		f.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchNewListPager
 	if f.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if f.newListPager == nil {
+	newListPager := f.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/firewallPolicies/(?P<firewallPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ruleCollectionGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (f *FirewallPolicyRuleCollectionGroupsServerTransport) dispatchNewListPager
 			return nil, err
 		}
 		resp := f.srv.NewListPager(resourceGroupNameUnescaped, firewallPolicyNameUnescaped, nil)
-		f.newListPager = &resp
-		server.PagerResponderInjectNextLinks(f.newListPager, req, func(page *armnetwork.FirewallPolicyRuleCollectionGroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		f.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.FirewallPolicyRuleCollectionGroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(f.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		f.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(f.newListPager) {
-		f.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		f.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_flowlogs_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_flowlogs_server.go
@@ -49,16 +49,21 @@ type FlowLogsServer struct {
 // The returned FlowLogsServerTransport instance is connected to an instance of armnetwork.FlowLogsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewFlowLogsServerTransport(srv *FlowLogsServer) *FlowLogsServerTransport {
-	return &FlowLogsServerTransport{srv: srv}
+	return &FlowLogsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.FlowLogsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.FlowLogsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.FlowLogsClientListResponse]](),
+	}
 }
 
 // FlowLogsServerTransport connects instances of armnetwork.FlowLogsClient to instances of FlowLogsServer.
 // Don't use this type directly, use NewFlowLogsServerTransport instead.
 type FlowLogsServerTransport struct {
 	srv                 *FlowLogsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.FlowLogsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.FlowLogsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.FlowLogsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.FlowLogsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.FlowLogsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.FlowLogsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for FlowLogsServerTransport.
@@ -98,7 +103,8 @@ func (f *FlowLogsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 	if f.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if f.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := f.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/flowLogs/(?P<flowLogName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -125,19 +131,21 @@ func (f *FlowLogsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		f.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		f.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginCreateOrUpdate) {
-		f.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		f.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -147,7 +155,8 @@ func (f *FlowLogsServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if f.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if f.beginDelete == nil {
+	beginDelete := f.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/flowLogs/(?P<flowLogName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -170,19 +179,21 @@ func (f *FlowLogsServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		f.beginDelete = &respr
+		beginDelete = &respr
+		f.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(f.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		f.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(f.beginDelete) {
-		f.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		f.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -229,7 +240,8 @@ func (f *FlowLogsServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if f.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if f.newListPager == nil {
+	newListPager := f.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/flowLogs`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -245,20 +257,22 @@ func (f *FlowLogsServerTransport) dispatchNewListPager(req *http.Request) (*http
 			return nil, err
 		}
 		resp := f.srv.NewListPager(resourceGroupNameUnescaped, networkWatcherNameUnescaped, nil)
-		f.newListPager = &resp
-		server.PagerResponderInjectNextLinks(f.newListPager, req, func(page *armnetwork.FlowLogsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		f.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.FlowLogsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(f.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		f.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(f.newListPager) {
-		f.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		f.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_groups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_groups_server.go
@@ -46,15 +46,19 @@ type GroupsServer struct {
 // The returned GroupsServerTransport instance is connected to an instance of armnetwork.GroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewGroupsServerTransport(srv *GroupsServer) *GroupsServerTransport {
-	return &GroupsServerTransport{srv: srv}
+	return &GroupsServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.GroupsClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.GroupsClientListResponse]](),
+	}
 }
 
 // GroupsServerTransport connects instances of armnetwork.GroupsClient to instances of GroupsServer.
 // Don't use this type directly, use NewGroupsServerTransport instead.
 type GroupsServerTransport struct {
 	srv          *GroupsServer
-	beginDelete  *azfake.PollerResponder[armnetwork.GroupsClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.GroupsClientListResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.GroupsClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.GroupsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for GroupsServerTransport.
@@ -143,7 +147,8 @@ func (g *GroupsServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 	if g.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if g.beginDelete == nil {
+	beginDelete := g.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkGroups/(?P<networkGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -181,19 +186,21 @@ func (g *GroupsServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		g.beginDelete = &respr
+		beginDelete = &respr
+		g.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(g.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		g.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(g.beginDelete) {
-		g.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		g.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -240,7 +247,8 @@ func (g *GroupsServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 	if g.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if g.newListPager == nil {
+	newListPager := g.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -283,20 +291,22 @@ func (g *GroupsServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 			}
 		}
 		resp := g.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, options)
-		g.newListPager = &resp
-		server.PagerResponderInjectNextLinks(g.newListPager, req, func(page *armnetwork.GroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		g.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.GroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(g.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		g.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(g.newListPager) {
-		g.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		g.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_hubroutetables_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_hubroutetables_server.go
@@ -45,16 +45,21 @@ type HubRouteTablesServer struct {
 // The returned HubRouteTablesServerTransport instance is connected to an instance of armnetwork.HubRouteTablesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewHubRouteTablesServerTransport(srv *HubRouteTablesServer) *HubRouteTablesServerTransport {
-	return &HubRouteTablesServerTransport{srv: srv}
+	return &HubRouteTablesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.HubRouteTablesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.HubRouteTablesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.HubRouteTablesClientListResponse]](),
+	}
 }
 
 // HubRouteTablesServerTransport connects instances of armnetwork.HubRouteTablesClient to instances of HubRouteTablesServer.
 // Don't use this type directly, use NewHubRouteTablesServerTransport instead.
 type HubRouteTablesServerTransport struct {
 	srv                 *HubRouteTablesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.HubRouteTablesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.HubRouteTablesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.HubRouteTablesClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.HubRouteTablesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.HubRouteTablesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.HubRouteTablesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for HubRouteTablesServerTransport.
@@ -92,7 +97,8 @@ func (h *HubRouteTablesServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 	if h.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if h.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := h.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubRouteTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (h *HubRouteTablesServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		h.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		h.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(h.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		h.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(h.beginCreateOrUpdate) {
-		h.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		h.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (h *HubRouteTablesServerTransport) dispatchBeginDelete(req *http.Request) (
 	if h.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if h.beginDelete == nil {
+	beginDelete := h.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubRouteTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (h *HubRouteTablesServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		h.beginDelete = &respr
+		beginDelete = &respr
+		h.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(h.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		h.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(h.beginDelete) {
-		h.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		h.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (h *HubRouteTablesServerTransport) dispatchNewListPager(req *http.Request) 
 	if h.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if h.newListPager == nil {
+	newListPager := h.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubRouteTables`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (h *HubRouteTablesServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, err
 		}
 		resp := h.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		h.newListPager = &resp
-		server.PagerResponderInjectNextLinks(h.newListPager, req, func(page *armnetwork.HubRouteTablesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		h.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.HubRouteTablesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(h.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		h.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(h.newListPager) {
-		h.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		h.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_hubvirtualnetworkconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_hubvirtualnetworkconnections_server.go
@@ -45,16 +45,21 @@ type HubVirtualNetworkConnectionsServer struct {
 // The returned HubVirtualNetworkConnectionsServerTransport instance is connected to an instance of armnetwork.HubVirtualNetworkConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewHubVirtualNetworkConnectionsServerTransport(srv *HubVirtualNetworkConnectionsServer) *HubVirtualNetworkConnectionsServerTransport {
-	return &HubVirtualNetworkConnectionsServerTransport{srv: srv}
+	return &HubVirtualNetworkConnectionsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.HubVirtualNetworkConnectionsClientListResponse]](),
+	}
 }
 
 // HubVirtualNetworkConnectionsServerTransport connects instances of armnetwork.HubVirtualNetworkConnectionsClient to instances of HubVirtualNetworkConnectionsServer.
 // Don't use this type directly, use NewHubVirtualNetworkConnectionsServerTransport instead.
 type HubVirtualNetworkConnectionsServerTransport struct {
 	srv                 *HubVirtualNetworkConnectionsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.HubVirtualNetworkConnectionsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.HubVirtualNetworkConnectionsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.HubVirtualNetworkConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for HubVirtualNetworkConnectionsServerTransport.
@@ -92,7 +97,8 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchBeginCreateOrUpdat
 	if h.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if h.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := h.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubVirtualNetworkConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchBeginCreateOrUpdat
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		h.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		h.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(h.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		h.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(h.beginCreateOrUpdate) {
-		h.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		h.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchBeginDelete(req *h
 	if h.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if h.beginDelete == nil {
+	beginDelete := h.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubVirtualNetworkConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchBeginDelete(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		h.beginDelete = &respr
+		beginDelete = &respr
+		h.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(h.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		h.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(h.beginDelete) {
-		h.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		h.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchNewListPager(req *
 	if h.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if h.newListPager == nil {
+	newListPager := h.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/hubVirtualNetworkConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (h *HubVirtualNetworkConnectionsServerTransport) dispatchNewListPager(req *
 			return nil, err
 		}
 		resp := h.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		h.newListPager = &resp
-		server.PagerResponderInjectNextLinks(h.newListPager, req, func(page *armnetwork.HubVirtualNetworkConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		h.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.HubVirtualNetworkConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(h.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		h.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(h.newListPager) {
-		h.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		h.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_inboundnatrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_inboundnatrules_server.go
@@ -45,16 +45,21 @@ type InboundNatRulesServer struct {
 // The returned InboundNatRulesServerTransport instance is connected to an instance of armnetwork.InboundNatRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInboundNatRulesServerTransport(srv *InboundNatRulesServer) *InboundNatRulesServerTransport {
-	return &InboundNatRulesServerTransport{srv: srv}
+	return &InboundNatRulesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.InboundNatRulesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.InboundNatRulesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.InboundNatRulesClientListResponse]](),
+	}
 }
 
 // InboundNatRulesServerTransport connects instances of armnetwork.InboundNatRulesClient to instances of InboundNatRulesServer.
 // Don't use this type directly, use NewInboundNatRulesServerTransport instead.
 type InboundNatRulesServerTransport struct {
 	srv                 *InboundNatRulesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.InboundNatRulesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.InboundNatRulesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.InboundNatRulesClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.InboundNatRulesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.InboundNatRulesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.InboundNatRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for InboundNatRulesServerTransport.
@@ -92,7 +97,8 @@ func (i *InboundNatRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/inboundNatRules/(?P<inboundNatRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (i *InboundNatRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (i *InboundNatRulesServerTransport) dispatchBeginDelete(req *http.Request) 
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/inboundNatRules/(?P<inboundNatRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (i *InboundNatRulesServerTransport) dispatchBeginDelete(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -235,7 +246,8 @@ func (i *InboundNatRulesServerTransport) dispatchNewListPager(req *http.Request)
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/inboundNatRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -251,20 +263,22 @@ func (i *InboundNatRulesServerTransport) dispatchNewListPager(req *http.Request)
 			return nil, err
 		}
 		resp := i.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.InboundNatRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.InboundNatRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_inboundsecurityrule_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_inboundsecurityrule_server.go
@@ -32,14 +32,17 @@ type InboundSecurityRuleServer struct {
 // The returned InboundSecurityRuleServerTransport instance is connected to an instance of armnetwork.InboundSecurityRuleClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInboundSecurityRuleServerTransport(srv *InboundSecurityRuleServer) *InboundSecurityRuleServerTransport {
-	return &InboundSecurityRuleServerTransport{srv: srv}
+	return &InboundSecurityRuleServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.InboundSecurityRuleClientCreateOrUpdateResponse]](),
+	}
 }
 
 // InboundSecurityRuleServerTransport connects instances of armnetwork.InboundSecurityRuleClient to instances of InboundSecurityRuleServer.
 // Don't use this type directly, use NewInboundSecurityRuleServerTransport instead.
 type InboundSecurityRuleServerTransport struct {
 	srv                 *InboundSecurityRuleServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.InboundSecurityRuleClientCreateOrUpdateResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.InboundSecurityRuleClientCreateOrUpdateResponse]]
 }
 
 // Do implements the policy.Transporter interface for InboundSecurityRuleServerTransport.
@@ -71,7 +74,8 @@ func (i *InboundSecurityRuleServerTransport) dispatchBeginCreateOrUpdate(req *ht
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/inboundSecurityRules/(?P<ruleCollectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -98,19 +102,21 @@ func (i *InboundSecurityRuleServerTransport) dispatchBeginCreateOrUpdate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_interfaceipconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_interfaceipconfigurations_server.go
@@ -37,14 +37,17 @@ type InterfaceIPConfigurationsServer struct {
 // The returned InterfaceIPConfigurationsServerTransport instance is connected to an instance of armnetwork.InterfaceIPConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInterfaceIPConfigurationsServerTransport(srv *InterfaceIPConfigurationsServer) *InterfaceIPConfigurationsServerTransport {
-	return &InterfaceIPConfigurationsServerTransport{srv: srv}
+	return &InterfaceIPConfigurationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.InterfaceIPConfigurationsClientListResponse]](),
+	}
 }
 
 // InterfaceIPConfigurationsServerTransport connects instances of armnetwork.InterfaceIPConfigurationsClient to instances of InterfaceIPConfigurationsServer.
 // Don't use this type directly, use NewInterfaceIPConfigurationsServerTransport instead.
 type InterfaceIPConfigurationsServerTransport struct {
 	srv          *InterfaceIPConfigurationsServer
-	newListPager *azfake.PagerResponder[armnetwork.InterfaceIPConfigurationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.InterfaceIPConfigurationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for InterfaceIPConfigurationsServerTransport.
@@ -115,7 +118,8 @@ func (i *InterfaceIPConfigurationsServerTransport) dispatchNewListPager(req *htt
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (i *InterfaceIPConfigurationsServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := i.srv.NewListPager(resourceGroupNameUnescaped, networkInterfaceNameUnescaped, nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.InterfaceIPConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.InterfaceIPConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_interfaceloadbalancers_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_interfaceloadbalancers_server.go
@@ -32,14 +32,17 @@ type InterfaceLoadBalancersServer struct {
 // The returned InterfaceLoadBalancersServerTransport instance is connected to an instance of armnetwork.InterfaceLoadBalancersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInterfaceLoadBalancersServerTransport(srv *InterfaceLoadBalancersServer) *InterfaceLoadBalancersServerTransport {
-	return &InterfaceLoadBalancersServerTransport{srv: srv}
+	return &InterfaceLoadBalancersServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.InterfaceLoadBalancersClientListResponse]](),
+	}
 }
 
 // InterfaceLoadBalancersServerTransport connects instances of armnetwork.InterfaceLoadBalancersClient to instances of InterfaceLoadBalancersServer.
 // Don't use this type directly, use NewInterfaceLoadBalancersServerTransport instead.
 type InterfaceLoadBalancersServerTransport struct {
 	srv          *InterfaceLoadBalancersServer
-	newListPager *azfake.PagerResponder[armnetwork.InterfaceLoadBalancersClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.InterfaceLoadBalancersClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for InterfaceLoadBalancersServerTransport.
@@ -71,7 +74,8 @@ func (i *InterfaceLoadBalancersServerTransport) dispatchNewListPager(req *http.R
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/loadBalancers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -87,20 +91,22 @@ func (i *InterfaceLoadBalancersServerTransport) dispatchNewListPager(req *http.R
 			return nil, err
 		}
 		resp := i.srv.NewListPager(resourceGroupNameUnescaped, networkInterfaceNameUnescaped, nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.InterfaceLoadBalancersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.InterfaceLoadBalancersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_interfaces_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_interfaces_server.go
@@ -93,24 +93,37 @@ type InterfacesServer struct {
 // The returned InterfacesServerTransport instance is connected to an instance of armnetwork.InterfacesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInterfacesServerTransport(srv *InterfacesServer) *InterfacesServerTransport {
-	return &InterfacesServerTransport{srv: srv}
+	return &InterfacesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.InterfacesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.InterfacesClientDeleteResponse]](),
+		beginGetEffectiveRouteTable: newTracker[azfake.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListResponse]](),
+		newListAllPager:             newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListAllResponse]](),
+		newListCloudServiceNetworkInterfacesPager:             newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceNetworkInterfacesResponse]](),
+		newListCloudServiceRoleInstanceNetworkInterfacesPager: newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse]](),
+		beginListEffectiveNetworkSecurityGroups:               newTracker[azfake.PollerResponder[armnetwork.InterfacesClientListEffectiveNetworkSecurityGroupsResponse]](),
+		newListVirtualMachineScaleSetIPConfigurationsPager:    newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse]](),
+		newListVirtualMachineScaleSetNetworkInterfacesPager:   newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse]](),
+		newListVirtualMachineScaleSetVMNetworkInterfacesPager: newTracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse]](),
+	}
 }
 
 // InterfacesServerTransport connects instances of armnetwork.InterfacesClient to instances of InterfacesServer.
 // Don't use this type directly, use NewInterfacesServerTransport instead.
 type InterfacesServerTransport struct {
 	srv                                                   *InterfacesServer
-	beginCreateOrUpdate                                   *azfake.PollerResponder[armnetwork.InterfacesClientCreateOrUpdateResponse]
-	beginDelete                                           *azfake.PollerResponder[armnetwork.InterfacesClientDeleteResponse]
-	beginGetEffectiveRouteTable                           *azfake.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse]
-	newListPager                                          *azfake.PagerResponder[armnetwork.InterfacesClientListResponse]
-	newListAllPager                                       *azfake.PagerResponder[armnetwork.InterfacesClientListAllResponse]
-	newListCloudServiceNetworkInterfacesPager             *azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceNetworkInterfacesResponse]
-	newListCloudServiceRoleInstanceNetworkInterfacesPager *azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse]
-	beginListEffectiveNetworkSecurityGroups               *azfake.PollerResponder[armnetwork.InterfacesClientListEffectiveNetworkSecurityGroupsResponse]
-	newListVirtualMachineScaleSetIPConfigurationsPager    *azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse]
-	newListVirtualMachineScaleSetNetworkInterfacesPager   *azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse]
-	newListVirtualMachineScaleSetVMNetworkInterfacesPager *azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse]
+	beginCreateOrUpdate                                   *tracker[azfake.PollerResponder[armnetwork.InterfacesClientCreateOrUpdateResponse]]
+	beginDelete                                           *tracker[azfake.PollerResponder[armnetwork.InterfacesClientDeleteResponse]]
+	beginGetEffectiveRouteTable                           *tracker[azfake.PollerResponder[armnetwork.InterfacesClientGetEffectiveRouteTableResponse]]
+	newListPager                                          *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListResponse]]
+	newListAllPager                                       *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListAllResponse]]
+	newListCloudServiceNetworkInterfacesPager             *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceNetworkInterfacesResponse]]
+	newListCloudServiceRoleInstanceNetworkInterfacesPager *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse]]
+	beginListEffectiveNetworkSecurityGroups               *tracker[azfake.PollerResponder[armnetwork.InterfacesClientListEffectiveNetworkSecurityGroupsResponse]]
+	newListVirtualMachineScaleSetIPConfigurationsPager    *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse]]
+	newListVirtualMachineScaleSetNetworkInterfacesPager   *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse]]
+	newListVirtualMachineScaleSetVMNetworkInterfacesPager *tracker[azfake.PagerResponder[armnetwork.InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse]]
 }
 
 // Do implements the policy.Transporter interface for InterfacesServerTransport.
@@ -172,7 +185,8 @@ func (i *InterfacesServerTransport) dispatchBeginCreateOrUpdate(req *http.Reques
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -195,19 +209,21 @@ func (i *InterfacesServerTransport) dispatchBeginCreateOrUpdate(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -217,7 +233,8 @@ func (i *InterfacesServerTransport) dispatchBeginDelete(req *http.Request) (*htt
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -236,19 +253,21 @@ func (i *InterfacesServerTransport) dispatchBeginDelete(req *http.Request) (*htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -356,7 +375,8 @@ func (i *InterfacesServerTransport) dispatchBeginGetEffectiveRouteTable(req *htt
 	if i.srv.BeginGetEffectiveRouteTable == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetEffectiveRouteTable not implemented")}
 	}
-	if i.beginGetEffectiveRouteTable == nil {
+	beginGetEffectiveRouteTable := i.beginGetEffectiveRouteTable.get(req)
+	if beginGetEffectiveRouteTable == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/effectiveRouteTable`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -375,19 +395,21 @@ func (i *InterfacesServerTransport) dispatchBeginGetEffectiveRouteTable(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginGetEffectiveRouteTable = &respr
+		beginGetEffectiveRouteTable = &respr
+		i.beginGetEffectiveRouteTable.add(req, beginGetEffectiveRouteTable)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginGetEffectiveRouteTable, req)
+	resp, err := server.PollerResponderNext(beginGetEffectiveRouteTable, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		i.beginGetEffectiveRouteTable.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginGetEffectiveRouteTable) {
-		i.beginGetEffectiveRouteTable = nil
+	if !server.PollerResponderMore(beginGetEffectiveRouteTable) {
+		i.beginGetEffectiveRouteTable.remove(req)
 	}
 
 	return resp, nil
@@ -507,7 +529,8 @@ func (i *InterfacesServerTransport) dispatchNewListPager(req *http.Request) (*ht
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -519,20 +542,22 @@ func (i *InterfacesServerTransport) dispatchNewListPager(req *http.Request) (*ht
 			return nil, err
 		}
 		resp := i.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.InterfacesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.InterfacesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -541,7 +566,8 @@ func (i *InterfacesServerTransport) dispatchNewListAllPager(req *http.Request) (
 	if i.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if i.newListAllPager == nil {
+	newListAllPager := i.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -549,20 +575,22 @@ func (i *InterfacesServerTransport) dispatchNewListAllPager(req *http.Request) (
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := i.srv.NewListAllPager(nil)
-		i.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListAllPager, req, func(page *armnetwork.InterfacesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		i.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.InterfacesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListAllPager) {
-		i.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		i.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -571,7 +599,8 @@ func (i *InterfacesServerTransport) dispatchNewListCloudServiceNetworkInterfaces
 	if i.srv.NewListCloudServiceNetworkInterfacesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListCloudServiceNetworkInterfacesPager not implemented")}
 	}
-	if i.newListCloudServiceNetworkInterfacesPager == nil {
+	newListCloudServiceNetworkInterfacesPager := i.newListCloudServiceNetworkInterfacesPager.get(req)
+	if newListCloudServiceNetworkInterfacesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -587,20 +616,22 @@ func (i *InterfacesServerTransport) dispatchNewListCloudServiceNetworkInterfaces
 			return nil, err
 		}
 		resp := i.srv.NewListCloudServiceNetworkInterfacesPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, nil)
-		i.newListCloudServiceNetworkInterfacesPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListCloudServiceNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListCloudServiceNetworkInterfacesResponse, createLink func() string) {
+		newListCloudServiceNetworkInterfacesPager = &resp
+		i.newListCloudServiceNetworkInterfacesPager.add(req, newListCloudServiceNetworkInterfacesPager)
+		server.PagerResponderInjectNextLinks(newListCloudServiceNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListCloudServiceNetworkInterfacesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListCloudServiceNetworkInterfacesPager, req)
+	resp, err := server.PagerResponderNext(newListCloudServiceNetworkInterfacesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListCloudServiceNetworkInterfacesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListCloudServiceNetworkInterfacesPager) {
-		i.newListCloudServiceNetworkInterfacesPager = nil
+	if !server.PagerResponderMore(newListCloudServiceNetworkInterfacesPager) {
+		i.newListCloudServiceNetworkInterfacesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -609,7 +640,8 @@ func (i *InterfacesServerTransport) dispatchNewListCloudServiceRoleInstanceNetwo
 	if i.srv.NewListCloudServiceRoleInstanceNetworkInterfacesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListCloudServiceRoleInstanceNetworkInterfacesPager not implemented")}
 	}
-	if i.newListCloudServiceRoleInstanceNetworkInterfacesPager == nil {
+	newListCloudServiceRoleInstanceNetworkInterfacesPager := i.newListCloudServiceRoleInstanceNetworkInterfacesPager.get(req)
+	if newListCloudServiceRoleInstanceNetworkInterfacesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -629,20 +661,22 @@ func (i *InterfacesServerTransport) dispatchNewListCloudServiceRoleInstanceNetwo
 			return nil, err
 		}
 		resp := i.srv.NewListCloudServiceRoleInstanceNetworkInterfacesPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, roleInstanceNameUnescaped, nil)
-		i.newListCloudServiceRoleInstanceNetworkInterfacesPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListCloudServiceRoleInstanceNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse, createLink func() string) {
+		newListCloudServiceRoleInstanceNetworkInterfacesPager = &resp
+		i.newListCloudServiceRoleInstanceNetworkInterfacesPager.add(req, newListCloudServiceRoleInstanceNetworkInterfacesPager)
+		server.PagerResponderInjectNextLinks(newListCloudServiceRoleInstanceNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListCloudServiceRoleInstanceNetworkInterfacesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListCloudServiceRoleInstanceNetworkInterfacesPager, req)
+	resp, err := server.PagerResponderNext(newListCloudServiceRoleInstanceNetworkInterfacesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListCloudServiceRoleInstanceNetworkInterfacesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListCloudServiceRoleInstanceNetworkInterfacesPager) {
-		i.newListCloudServiceRoleInstanceNetworkInterfacesPager = nil
+	if !server.PagerResponderMore(newListCloudServiceRoleInstanceNetworkInterfacesPager) {
+		i.newListCloudServiceRoleInstanceNetworkInterfacesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -651,7 +685,8 @@ func (i *InterfacesServerTransport) dispatchBeginListEffectiveNetworkSecurityGro
 	if i.srv.BeginListEffectiveNetworkSecurityGroups == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListEffectiveNetworkSecurityGroups not implemented")}
 	}
-	if i.beginListEffectiveNetworkSecurityGroups == nil {
+	beginListEffectiveNetworkSecurityGroups := i.beginListEffectiveNetworkSecurityGroups.get(req)
+	if beginListEffectiveNetworkSecurityGroups == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/effectiveNetworkSecurityGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -670,19 +705,21 @@ func (i *InterfacesServerTransport) dispatchBeginListEffectiveNetworkSecurityGro
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginListEffectiveNetworkSecurityGroups = &respr
+		beginListEffectiveNetworkSecurityGroups = &respr
+		i.beginListEffectiveNetworkSecurityGroups.add(req, beginListEffectiveNetworkSecurityGroups)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginListEffectiveNetworkSecurityGroups, req)
+	resp, err := server.PollerResponderNext(beginListEffectiveNetworkSecurityGroups, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		i.beginListEffectiveNetworkSecurityGroups.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginListEffectiveNetworkSecurityGroups) {
-		i.beginListEffectiveNetworkSecurityGroups = nil
+	if !server.PollerResponderMore(beginListEffectiveNetworkSecurityGroups) {
+		i.beginListEffectiveNetworkSecurityGroups.remove(req)
 	}
 
 	return resp, nil
@@ -692,7 +729,8 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetIPConfi
 	if i.srv.NewListVirtualMachineScaleSetIPConfigurationsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListVirtualMachineScaleSetIPConfigurationsPager not implemented")}
 	}
-	if i.newListVirtualMachineScaleSetIPConfigurationsPager == nil {
+	newListVirtualMachineScaleSetIPConfigurationsPager := i.newListVirtualMachineScaleSetIPConfigurationsPager.get(req)
+	if newListVirtualMachineScaleSetIPConfigurationsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<virtualmachineIndex>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -728,20 +766,22 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetIPConfi
 			}
 		}
 		resp := i.srv.NewListVirtualMachineScaleSetIPConfigurationsPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, virtualmachineIndexUnescaped, networkInterfaceNameUnescaped, options)
-		i.newListVirtualMachineScaleSetIPConfigurationsPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListVirtualMachineScaleSetIPConfigurationsPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse, createLink func() string) {
+		newListVirtualMachineScaleSetIPConfigurationsPager = &resp
+		i.newListVirtualMachineScaleSetIPConfigurationsPager.add(req, newListVirtualMachineScaleSetIPConfigurationsPager)
+		server.PagerResponderInjectNextLinks(newListVirtualMachineScaleSetIPConfigurationsPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetIPConfigurationsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListVirtualMachineScaleSetIPConfigurationsPager, req)
+	resp, err := server.PagerResponderNext(newListVirtualMachineScaleSetIPConfigurationsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListVirtualMachineScaleSetIPConfigurationsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListVirtualMachineScaleSetIPConfigurationsPager) {
-		i.newListVirtualMachineScaleSetIPConfigurationsPager = nil
+	if !server.PagerResponderMore(newListVirtualMachineScaleSetIPConfigurationsPager) {
+		i.newListVirtualMachineScaleSetIPConfigurationsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -750,7 +790,8 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetNetwork
 	if i.srv.NewListVirtualMachineScaleSetNetworkInterfacesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListVirtualMachineScaleSetNetworkInterfacesPager not implemented")}
 	}
-	if i.newListVirtualMachineScaleSetNetworkInterfacesPager == nil {
+	newListVirtualMachineScaleSetNetworkInterfacesPager := i.newListVirtualMachineScaleSetNetworkInterfacesPager.get(req)
+	if newListVirtualMachineScaleSetNetworkInterfacesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -766,20 +807,22 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetNetwork
 			return nil, err
 		}
 		resp := i.srv.NewListVirtualMachineScaleSetNetworkInterfacesPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, nil)
-		i.newListVirtualMachineScaleSetNetworkInterfacesPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListVirtualMachineScaleSetNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse, createLink func() string) {
+		newListVirtualMachineScaleSetNetworkInterfacesPager = &resp
+		i.newListVirtualMachineScaleSetNetworkInterfacesPager.add(req, newListVirtualMachineScaleSetNetworkInterfacesPager)
+		server.PagerResponderInjectNextLinks(newListVirtualMachineScaleSetNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetNetworkInterfacesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListVirtualMachineScaleSetNetworkInterfacesPager, req)
+	resp, err := server.PagerResponderNext(newListVirtualMachineScaleSetNetworkInterfacesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListVirtualMachineScaleSetNetworkInterfacesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListVirtualMachineScaleSetNetworkInterfacesPager) {
-		i.newListVirtualMachineScaleSetNetworkInterfacesPager = nil
+	if !server.PagerResponderMore(newListVirtualMachineScaleSetNetworkInterfacesPager) {
+		i.newListVirtualMachineScaleSetNetworkInterfacesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -788,7 +831,8 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetVMNetwo
 	if i.srv.NewListVirtualMachineScaleSetVMNetworkInterfacesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListVirtualMachineScaleSetVMNetworkInterfacesPager not implemented")}
 	}
-	if i.newListVirtualMachineScaleSetVMNetworkInterfacesPager == nil {
+	newListVirtualMachineScaleSetVMNetworkInterfacesPager := i.newListVirtualMachineScaleSetVMNetworkInterfacesPager.get(req)
+	if newListVirtualMachineScaleSetVMNetworkInterfacesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<virtualmachineIndex>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -808,20 +852,22 @@ func (i *InterfacesServerTransport) dispatchNewListVirtualMachineScaleSetVMNetwo
 			return nil, err
 		}
 		resp := i.srv.NewListVirtualMachineScaleSetVMNetworkInterfacesPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, virtualmachineIndexUnescaped, nil)
-		i.newListVirtualMachineScaleSetVMNetworkInterfacesPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListVirtualMachineScaleSetVMNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse, createLink func() string) {
+		newListVirtualMachineScaleSetVMNetworkInterfacesPager = &resp
+		i.newListVirtualMachineScaleSetVMNetworkInterfacesPager.add(req, newListVirtualMachineScaleSetVMNetworkInterfacesPager)
+		server.PagerResponderInjectNextLinks(newListVirtualMachineScaleSetVMNetworkInterfacesPager, req, func(page *armnetwork.InterfacesClientListVirtualMachineScaleSetVMNetworkInterfacesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListVirtualMachineScaleSetVMNetworkInterfacesPager, req)
+	resp, err := server.PagerResponderNext(newListVirtualMachineScaleSetVMNetworkInterfacesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListVirtualMachineScaleSetVMNetworkInterfacesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListVirtualMachineScaleSetVMNetworkInterfacesPager) {
-		i.newListVirtualMachineScaleSetVMNetworkInterfacesPager = nil
+	if !server.PagerResponderMore(newListVirtualMachineScaleSetVMNetworkInterfacesPager) {
+		i.newListVirtualMachineScaleSetVMNetworkInterfacesPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_interfacetapconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_interfacetapconfigurations_server.go
@@ -45,16 +45,21 @@ type InterfaceTapConfigurationsServer struct {
 // The returned InterfaceTapConfigurationsServerTransport instance is connected to an instance of armnetwork.InterfaceTapConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewInterfaceTapConfigurationsServerTransport(srv *InterfaceTapConfigurationsServer) *InterfaceTapConfigurationsServerTransport {
-	return &InterfaceTapConfigurationsServerTransport{srv: srv}
+	return &InterfaceTapConfigurationsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.InterfaceTapConfigurationsClientListResponse]](),
+	}
 }
 
 // InterfaceTapConfigurationsServerTransport connects instances of armnetwork.InterfaceTapConfigurationsClient to instances of InterfaceTapConfigurationsServer.
 // Don't use this type directly, use NewInterfaceTapConfigurationsServerTransport instead.
 type InterfaceTapConfigurationsServerTransport struct {
 	srv                 *InterfaceTapConfigurationsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.InterfaceTapConfigurationsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.InterfaceTapConfigurationsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.InterfaceTapConfigurationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for InterfaceTapConfigurationsServerTransport.
@@ -92,7 +97,8 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchBeginCreateOrUpdate(
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/tapConfigurations/(?P<tapConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchBeginCreateOrUpdate(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchBeginDelete(req *htt
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/tapConfigurations/(?P<tapConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchBeginDelete(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchNewListPager(req *ht
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/tapConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (i *InterfaceTapConfigurationsServerTransport) dispatchNewListPager(req *ht
 			return nil, err
 		}
 		resp := i.srv.NewListPager(resourceGroupNameUnescaped, networkInterfaceNameUnescaped, nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.InterfaceTapConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.InterfaceTapConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
@@ -12,6 +12,9 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"regexp"
+	"strings"
+	"sync"
 )
 
 type nonRetriableError struct {
@@ -75,4 +78,44 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func newTracker[T any]() *tracker[T] {
+	return &tracker[T]{
+		items: map[string]*T{},
+	}
+}
+
+type tracker[T any] struct {
+	items map[string]*T
+	mu    sync.Mutex
+}
+
+func (p *tracker[T]) key(req *http.Request) string {
+	path := req.URL.Path
+	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
+		path = path[:strings.LastIndex(path, "/")]
+	}
+	return req.Method + path
+}
+
+func (p *tracker[T]) get(req *http.Request) *T {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if item, ok := p.items[p.key(req)]; ok {
+		return item
+	}
+	return nil
+}
+
+func (p *tracker[T]) add(req *http.Request, item *T) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.items[p.key(req)] = item
+}
+
+func (p *tracker[T]) remove(req *http.Request) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.items, p.key(req))
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
@@ -95,8 +95,10 @@ func (p *tracker[T]) key(req *http.Request) string {
 	path := req.URL.Path
 	if match, _ := regexp.Match(`/page_\d+$`, []byte(path)); match {
 		path = path[:strings.LastIndex(path, "/")]
+	} else if strings.HasSuffix(path, "/get/fake/status") {
+		path = path[:len(path)-16]
 	}
-	return req.Method + path
+	return path
 }
 
 func (p *tracker[T]) get(req *http.Request) *T {

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_ipallocations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_ipallocations_server.go
@@ -53,17 +53,23 @@ type IPAllocationsServer struct {
 // The returned IPAllocationsServerTransport instance is connected to an instance of armnetwork.IPAllocationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewIPAllocationsServerTransport(srv *IPAllocationsServer) *IPAllocationsServerTransport {
-	return &IPAllocationsServerTransport{srv: srv}
+	return &IPAllocationsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.IPAllocationsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.IPAllocationsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.IPAllocationsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.IPAllocationsClientListByResourceGroupResponse]](),
+	}
 }
 
 // IPAllocationsServerTransport connects instances of armnetwork.IPAllocationsClient to instances of IPAllocationsServer.
 // Don't use this type directly, use NewIPAllocationsServerTransport instead.
 type IPAllocationsServerTransport struct {
 	srv                         *IPAllocationsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.IPAllocationsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.IPAllocationsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.IPAllocationsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.IPAllocationsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.IPAllocationsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.IPAllocationsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.IPAllocationsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.IPAllocationsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for IPAllocationsServerTransport.
@@ -105,7 +111,8 @@ func (i *IPAllocationsServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/IpAllocations/(?P<ipAllocationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (i *IPAllocationsServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (i *IPAllocationsServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/IpAllocations/(?P<ipAllocationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (i *IPAllocationsServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (i *IPAllocationsServerTransport) dispatchNewListPager(req *http.Request) (
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/IpAllocations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -244,20 +257,22 @@ func (i *IPAllocationsServerTransport) dispatchNewListPager(req *http.Request) (
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := i.srv.NewListPager(nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.IPAllocationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.IPAllocationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -266,7 +281,8 @@ func (i *IPAllocationsServerTransport) dispatchNewListByResourceGroupPager(req *
 	if i.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if i.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := i.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/IpAllocations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (i *IPAllocationsServerTransport) dispatchNewListByResourceGroupPager(req *
 			return nil, err
 		}
 		resp := i.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		i.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListByResourceGroupPager, req, func(page *armnetwork.IPAllocationsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		i.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.IPAllocationsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListByResourceGroupPager) {
-		i.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		i.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_ipgroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_ipgroups_server.go
@@ -53,17 +53,23 @@ type IPGroupsServer struct {
 // The returned IPGroupsServerTransport instance is connected to an instance of armnetwork.IPGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewIPGroupsServerTransport(srv *IPGroupsServer) *IPGroupsServerTransport {
-	return &IPGroupsServerTransport{srv: srv}
+	return &IPGroupsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.IPGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.IPGroupsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.IPGroupsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.IPGroupsClientListByResourceGroupResponse]](),
+	}
 }
 
 // IPGroupsServerTransport connects instances of armnetwork.IPGroupsClient to instances of IPGroupsServer.
 // Don't use this type directly, use NewIPGroupsServerTransport instead.
 type IPGroupsServerTransport struct {
 	srv                         *IPGroupsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.IPGroupsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.IPGroupsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.IPGroupsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.IPGroupsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.IPGroupsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.IPGroupsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.IPGroupsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.IPGroupsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for IPGroupsServerTransport.
@@ -105,7 +111,8 @@ func (i *IPGroupsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 	if i.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if i.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := i.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ipGroups/(?P<ipGroupsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (i *IPGroupsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		i.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		i.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginCreateOrUpdate) {
-		i.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		i.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (i *IPGroupsServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if i.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if i.beginDelete == nil {
+	beginDelete := i.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ipGroups/(?P<ipGroupsName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (i *IPGroupsServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		i.beginDelete = &respr
+		beginDelete = &respr
+		i.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(i.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		i.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(i.beginDelete) {
-		i.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		i.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (i *IPGroupsServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if i.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if i.newListPager == nil {
+	newListPager := i.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ipGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -244,20 +257,22 @@ func (i *IPGroupsServerTransport) dispatchNewListPager(req *http.Request) (*http
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := i.srv.NewListPager(nil)
-		i.newListPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListPager, req, func(page *armnetwork.IPGroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		i.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.IPGroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListPager) {
-		i.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		i.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -266,7 +281,8 @@ func (i *IPGroupsServerTransport) dispatchNewListByResourceGroupPager(req *http.
 	if i.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if i.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := i.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ipGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (i *IPGroupsServerTransport) dispatchNewListByResourceGroupPager(req *http.
 			return nil, err
 		}
 		resp := i.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		i.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(i.newListByResourceGroupPager, req, func(page *armnetwork.IPGroupsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		i.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.IPGroupsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(i.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		i.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(i.newListByResourceGroupPager) {
-		i.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		i.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerbackendaddresspools_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerbackendaddresspools_server.go
@@ -45,16 +45,21 @@ type LoadBalancerBackendAddressPoolsServer struct {
 // The returned LoadBalancerBackendAddressPoolsServerTransport instance is connected to an instance of armnetwork.LoadBalancerBackendAddressPoolsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerBackendAddressPoolsServerTransport(srv *LoadBalancerBackendAddressPoolsServer) *LoadBalancerBackendAddressPoolsServerTransport {
-	return &LoadBalancerBackendAddressPoolsServerTransport{srv: srv}
+	return &LoadBalancerBackendAddressPoolsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientListResponse]](),
+	}
 }
 
 // LoadBalancerBackendAddressPoolsServerTransport connects instances of armnetwork.LoadBalancerBackendAddressPoolsClient to instances of LoadBalancerBackendAddressPoolsServer.
 // Don't use this type directly, use NewLoadBalancerBackendAddressPoolsServerTransport instead.
 type LoadBalancerBackendAddressPoolsServerTransport struct {
 	srv                 *LoadBalancerBackendAddressPoolsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.LoadBalancerBackendAddressPoolsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerBackendAddressPoolsServerTransport.
@@ -92,7 +97,8 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchBeginCreateOrUp
 	if l.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if l.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := l.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backendAddressPools/(?P<backendAddressPoolName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchBeginCreateOrUp
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		l.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginCreateOrUpdate) {
-		l.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		l.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchBeginDelete(req
 	if l.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if l.beginDelete == nil {
+	beginDelete := l.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backendAddressPools/(?P<backendAddressPoolName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchBeginDelete(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete = &respr
+		beginDelete = &respr
+		l.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		l.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete) {
-		l.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		l.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchNewListPager(re
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backendAddressPools`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (l *LoadBalancerBackendAddressPoolsServerTransport) dispatchNewListPager(re
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerBackendAddressPoolsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerBackendAddressPoolsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerfrontendipconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerfrontendipconfigurations_server.go
@@ -37,14 +37,17 @@ type LoadBalancerFrontendIPConfigurationsServer struct {
 // The returned LoadBalancerFrontendIPConfigurationsServerTransport instance is connected to an instance of armnetwork.LoadBalancerFrontendIPConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerFrontendIPConfigurationsServerTransport(srv *LoadBalancerFrontendIPConfigurationsServer) *LoadBalancerFrontendIPConfigurationsServerTransport {
-	return &LoadBalancerFrontendIPConfigurationsServerTransport{srv: srv}
+	return &LoadBalancerFrontendIPConfigurationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.LoadBalancerFrontendIPConfigurationsClientListResponse]](),
+	}
 }
 
 // LoadBalancerFrontendIPConfigurationsServerTransport connects instances of armnetwork.LoadBalancerFrontendIPConfigurationsClient to instances of LoadBalancerFrontendIPConfigurationsServer.
 // Don't use this type directly, use NewLoadBalancerFrontendIPConfigurationsServerTransport instead.
 type LoadBalancerFrontendIPConfigurationsServerTransport struct {
 	srv          *LoadBalancerFrontendIPConfigurationsServer
-	newListPager *azfake.PagerResponder[armnetwork.LoadBalancerFrontendIPConfigurationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.LoadBalancerFrontendIPConfigurationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerFrontendIPConfigurationsServerTransport.
@@ -115,7 +118,8 @@ func (l *LoadBalancerFrontendIPConfigurationsServerTransport) dispatchNewListPag
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/frontendIPConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (l *LoadBalancerFrontendIPConfigurationsServerTransport) dispatchNewListPag
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerFrontendIPConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerFrontendIPConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerloadbalancingrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerloadbalancingrules_server.go
@@ -37,14 +37,17 @@ type LoadBalancerLoadBalancingRulesServer struct {
 // The returned LoadBalancerLoadBalancingRulesServerTransport instance is connected to an instance of armnetwork.LoadBalancerLoadBalancingRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerLoadBalancingRulesServerTransport(srv *LoadBalancerLoadBalancingRulesServer) *LoadBalancerLoadBalancingRulesServerTransport {
-	return &LoadBalancerLoadBalancingRulesServerTransport{srv: srv}
+	return &LoadBalancerLoadBalancingRulesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.LoadBalancerLoadBalancingRulesClientListResponse]](),
+	}
 }
 
 // LoadBalancerLoadBalancingRulesServerTransport connects instances of armnetwork.LoadBalancerLoadBalancingRulesClient to instances of LoadBalancerLoadBalancingRulesServer.
 // Don't use this type directly, use NewLoadBalancerLoadBalancingRulesServerTransport instead.
 type LoadBalancerLoadBalancingRulesServerTransport struct {
 	srv          *LoadBalancerLoadBalancingRulesServer
-	newListPager *azfake.PagerResponder[armnetwork.LoadBalancerLoadBalancingRulesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.LoadBalancerLoadBalancingRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerLoadBalancingRulesServerTransport.
@@ -115,7 +118,8 @@ func (l *LoadBalancerLoadBalancingRulesServerTransport) dispatchNewListPager(req
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/loadBalancingRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (l *LoadBalancerLoadBalancingRulesServerTransport) dispatchNewListPager(req
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerLoadBalancingRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerLoadBalancingRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancernetworkinterfaces_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancernetworkinterfaces_server.go
@@ -32,14 +32,17 @@ type LoadBalancerNetworkInterfacesServer struct {
 // The returned LoadBalancerNetworkInterfacesServerTransport instance is connected to an instance of armnetwork.LoadBalancerNetworkInterfacesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerNetworkInterfacesServerTransport(srv *LoadBalancerNetworkInterfacesServer) *LoadBalancerNetworkInterfacesServerTransport {
-	return &LoadBalancerNetworkInterfacesServerTransport{srv: srv}
+	return &LoadBalancerNetworkInterfacesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.LoadBalancerNetworkInterfacesClientListResponse]](),
+	}
 }
 
 // LoadBalancerNetworkInterfacesServerTransport connects instances of armnetwork.LoadBalancerNetworkInterfacesClient to instances of LoadBalancerNetworkInterfacesServer.
 // Don't use this type directly, use NewLoadBalancerNetworkInterfacesServerTransport instead.
 type LoadBalancerNetworkInterfacesServerTransport struct {
 	srv          *LoadBalancerNetworkInterfacesServer
-	newListPager *azfake.PagerResponder[armnetwork.LoadBalancerNetworkInterfacesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.LoadBalancerNetworkInterfacesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerNetworkInterfacesServerTransport.
@@ -71,7 +74,8 @@ func (l *LoadBalancerNetworkInterfacesServerTransport) dispatchNewListPager(req 
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -87,20 +91,22 @@ func (l *LoadBalancerNetworkInterfacesServerTransport) dispatchNewListPager(req 
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerNetworkInterfacesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerNetworkInterfacesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalanceroutboundrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalanceroutboundrules_server.go
@@ -37,14 +37,17 @@ type LoadBalancerOutboundRulesServer struct {
 // The returned LoadBalancerOutboundRulesServerTransport instance is connected to an instance of armnetwork.LoadBalancerOutboundRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerOutboundRulesServerTransport(srv *LoadBalancerOutboundRulesServer) *LoadBalancerOutboundRulesServerTransport {
-	return &LoadBalancerOutboundRulesServerTransport{srv: srv}
+	return &LoadBalancerOutboundRulesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.LoadBalancerOutboundRulesClientListResponse]](),
+	}
 }
 
 // LoadBalancerOutboundRulesServerTransport connects instances of armnetwork.LoadBalancerOutboundRulesClient to instances of LoadBalancerOutboundRulesServer.
 // Don't use this type directly, use NewLoadBalancerOutboundRulesServerTransport instead.
 type LoadBalancerOutboundRulesServerTransport struct {
 	srv          *LoadBalancerOutboundRulesServer
-	newListPager *azfake.PagerResponder[armnetwork.LoadBalancerOutboundRulesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.LoadBalancerOutboundRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerOutboundRulesServerTransport.
@@ -115,7 +118,8 @@ func (l *LoadBalancerOutboundRulesServerTransport) dispatchNewListPager(req *htt
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/outboundRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (l *LoadBalancerOutboundRulesServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerOutboundRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerOutboundRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerprobes_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancerprobes_server.go
@@ -37,14 +37,17 @@ type LoadBalancerProbesServer struct {
 // The returned LoadBalancerProbesServerTransport instance is connected to an instance of armnetwork.LoadBalancerProbesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancerProbesServerTransport(srv *LoadBalancerProbesServer) *LoadBalancerProbesServerTransport {
-	return &LoadBalancerProbesServerTransport{srv: srv}
+	return &LoadBalancerProbesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.LoadBalancerProbesClientListResponse]](),
+	}
 }
 
 // LoadBalancerProbesServerTransport connects instances of armnetwork.LoadBalancerProbesClient to instances of LoadBalancerProbesServer.
 // Don't use this type directly, use NewLoadBalancerProbesServerTransport instead.
 type LoadBalancerProbesServerTransport struct {
 	srv          *LoadBalancerProbesServer
-	newListPager *azfake.PagerResponder[armnetwork.LoadBalancerProbesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.LoadBalancerProbesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancerProbesServerTransport.
@@ -115,7 +118,8 @@ func (l *LoadBalancerProbesServerTransport) dispatchNewListPager(req *http.Reque
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/probes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (l *LoadBalancerProbesServerTransport) dispatchNewListPager(req *http.Reque
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, loadBalancerNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancerProbesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancerProbesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancers_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_loadbalancers_server.go
@@ -61,19 +61,27 @@ type LoadBalancersServer struct {
 // The returned LoadBalancersServerTransport instance is connected to an instance of armnetwork.LoadBalancersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLoadBalancersServerTransport(srv *LoadBalancersServer) *LoadBalancersServerTransport {
-	return &LoadBalancersServerTransport{srv: srv}
+	return &LoadBalancersServerTransport{
+		srv:                                 srv,
+		beginCreateOrUpdate:                 newTracker[azfake.PollerResponder[armnetwork.LoadBalancersClientCreateOrUpdateResponse]](),
+		beginDelete:                         newTracker[azfake.PollerResponder[armnetwork.LoadBalancersClientDeleteResponse]](),
+		newListPager:                        newTracker[azfake.PagerResponder[armnetwork.LoadBalancersClientListResponse]](),
+		newListAllPager:                     newTracker[azfake.PagerResponder[armnetwork.LoadBalancersClientListAllResponse]](),
+		beginListInboundNatRulePortMappings: newTracker[azfake.PollerResponder[armnetwork.LoadBalancersClientListInboundNatRulePortMappingsResponse]](),
+		beginSwapPublicIPAddresses:          newTracker[azfake.PollerResponder[armnetwork.LoadBalancersClientSwapPublicIPAddressesResponse]](),
+	}
 }
 
 // LoadBalancersServerTransport connects instances of armnetwork.LoadBalancersClient to instances of LoadBalancersServer.
 // Don't use this type directly, use NewLoadBalancersServerTransport instead.
 type LoadBalancersServerTransport struct {
 	srv                                 *LoadBalancersServer
-	beginCreateOrUpdate                 *azfake.PollerResponder[armnetwork.LoadBalancersClientCreateOrUpdateResponse]
-	beginDelete                         *azfake.PollerResponder[armnetwork.LoadBalancersClientDeleteResponse]
-	newListPager                        *azfake.PagerResponder[armnetwork.LoadBalancersClientListResponse]
-	newListAllPager                     *azfake.PagerResponder[armnetwork.LoadBalancersClientListAllResponse]
-	beginListInboundNatRulePortMappings *azfake.PollerResponder[armnetwork.LoadBalancersClientListInboundNatRulePortMappingsResponse]
-	beginSwapPublicIPAddresses          *azfake.PollerResponder[armnetwork.LoadBalancersClientSwapPublicIPAddressesResponse]
+	beginCreateOrUpdate                 *tracker[azfake.PollerResponder[armnetwork.LoadBalancersClientCreateOrUpdateResponse]]
+	beginDelete                         *tracker[azfake.PollerResponder[armnetwork.LoadBalancersClientDeleteResponse]]
+	newListPager                        *tracker[azfake.PagerResponder[armnetwork.LoadBalancersClientListResponse]]
+	newListAllPager                     *tracker[azfake.PagerResponder[armnetwork.LoadBalancersClientListAllResponse]]
+	beginListInboundNatRulePortMappings *tracker[azfake.PollerResponder[armnetwork.LoadBalancersClientListInboundNatRulePortMappingsResponse]]
+	beginSwapPublicIPAddresses          *tracker[azfake.PollerResponder[armnetwork.LoadBalancersClientSwapPublicIPAddressesResponse]]
 }
 
 // Do implements the policy.Transporter interface for LoadBalancersServerTransport.
@@ -119,7 +127,8 @@ func (l *LoadBalancersServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if l.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if l.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := l.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -142,19 +151,21 @@ func (l *LoadBalancersServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		l.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginCreateOrUpdate) {
-		l.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		l.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -164,7 +175,8 @@ func (l *LoadBalancersServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if l.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if l.beginDelete == nil {
+	beginDelete := l.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -183,19 +195,21 @@ func (l *LoadBalancersServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete = &respr
+		beginDelete = &respr
+		l.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		l.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete) {
-		l.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		l.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -250,7 +264,8 @@ func (l *LoadBalancersServerTransport) dispatchNewListPager(req *http.Request) (
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -262,20 +277,22 @@ func (l *LoadBalancersServerTransport) dispatchNewListPager(req *http.Request) (
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LoadBalancersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LoadBalancersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -284,7 +301,8 @@ func (l *LoadBalancersServerTransport) dispatchNewListAllPager(req *http.Request
 	if l.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if l.newListAllPager == nil {
+	newListAllPager := l.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -292,20 +310,22 @@ func (l *LoadBalancersServerTransport) dispatchNewListAllPager(req *http.Request
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := l.srv.NewListAllPager(nil)
-		l.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListAllPager, req, func(page *armnetwork.LoadBalancersClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		l.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.LoadBalancersClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListAllPager) {
-		l.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		l.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -314,7 +334,8 @@ func (l *LoadBalancersServerTransport) dispatchBeginListInboundNatRulePortMappin
 	if l.srv.BeginListInboundNatRulePortMappings == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListInboundNatRulePortMappings not implemented")}
 	}
-	if l.beginListInboundNatRulePortMappings == nil {
+	beginListInboundNatRulePortMappings := l.beginListInboundNatRulePortMappings.get(req)
+	if beginListInboundNatRulePortMappings == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<groupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/loadBalancers/(?P<loadBalancerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/backendAddressPools/(?P<backendPoolName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/queryInboundNatRulePortMapping`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -341,19 +362,21 @@ func (l *LoadBalancersServerTransport) dispatchBeginListInboundNatRulePortMappin
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginListInboundNatRulePortMappings = &respr
+		beginListInboundNatRulePortMappings = &respr
+		l.beginListInboundNatRulePortMappings.add(req, beginListInboundNatRulePortMappings)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginListInboundNatRulePortMappings, req)
+	resp, err := server.PollerResponderNext(beginListInboundNatRulePortMappings, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginListInboundNatRulePortMappings.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginListInboundNatRulePortMappings) {
-		l.beginListInboundNatRulePortMappings = nil
+	if !server.PollerResponderMore(beginListInboundNatRulePortMappings) {
+		l.beginListInboundNatRulePortMappings.remove(req)
 	}
 
 	return resp, nil
@@ -363,7 +386,8 @@ func (l *LoadBalancersServerTransport) dispatchBeginSwapPublicIPAddresses(req *h
 	if l.srv.BeginSwapPublicIPAddresses == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginSwapPublicIPAddresses not implemented")}
 	}
-	if l.beginSwapPublicIPAddresses == nil {
+	beginSwapPublicIPAddresses := l.beginSwapPublicIPAddresses.get(req)
+	if beginSwapPublicIPAddresses == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/setLoadBalancerFrontendPublicIpAddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -382,19 +406,21 @@ func (l *LoadBalancersServerTransport) dispatchBeginSwapPublicIPAddresses(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginSwapPublicIPAddresses = &respr
+		beginSwapPublicIPAddresses = &respr
+		l.beginSwapPublicIPAddresses.add(req, beginSwapPublicIPAddresses)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginSwapPublicIPAddresses, req)
+	resp, err := server.PollerResponderNext(beginSwapPublicIPAddresses, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		l.beginSwapPublicIPAddresses.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginSwapPublicIPAddresses) {
-		l.beginSwapPublicIPAddresses = nil
+	if !server.PollerResponderMore(beginSwapPublicIPAddresses) {
+		l.beginSwapPublicIPAddresses.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_localnetworkgateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_localnetworkgateways_server.go
@@ -49,16 +49,21 @@ type LocalNetworkGatewaysServer struct {
 // The returned LocalNetworkGatewaysServerTransport instance is connected to an instance of armnetwork.LocalNetworkGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewLocalNetworkGatewaysServerTransport(srv *LocalNetworkGatewaysServer) *LocalNetworkGatewaysServerTransport {
-	return &LocalNetworkGatewaysServerTransport{srv: srv}
+	return &LocalNetworkGatewaysServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.LocalNetworkGatewaysClientListResponse]](),
+	}
 }
 
 // LocalNetworkGatewaysServerTransport connects instances of armnetwork.LocalNetworkGatewaysClient to instances of LocalNetworkGatewaysServer.
 // Don't use this type directly, use NewLocalNetworkGatewaysServerTransport instead.
 type LocalNetworkGatewaysServerTransport struct {
 	srv                 *LocalNetworkGatewaysServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.LocalNetworkGatewaysClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.LocalNetworkGatewaysClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.LocalNetworkGatewaysClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for LocalNetworkGatewaysServerTransport.
@@ -98,7 +103,8 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if l.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if l.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := l.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/localNetworkGateways/(?P<localNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -121,19 +127,21 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		l.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		l.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginCreateOrUpdate) {
-		l.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		l.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -143,7 +151,8 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchBeginDelete(req *http.Requ
 	if l.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if l.beginDelete == nil {
+	beginDelete := l.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/localNetworkGateways/(?P<localNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -162,19 +171,21 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		l.beginDelete = &respr
+		beginDelete = &respr
+		l.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(l.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		l.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(l.beginDelete) {
-		l.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		l.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -217,7 +228,8 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchNewListPager(req *http.Req
 	if l.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if l.newListPager == nil {
+	newListPager := l.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/localNetworkGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -229,20 +241,22 @@ func (l *LocalNetworkGatewaysServerTransport) dispatchNewListPager(req *http.Req
 			return nil, err
 		}
 		resp := l.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		l.newListPager = &resp
-		server.PagerResponderInjectNextLinks(l.newListPager, req, func(page *armnetwork.LocalNetworkGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		l.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.LocalNetworkGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(l.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		l.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(l.newListPager) {
-		l.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		l.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_management_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_management_server.go
@@ -82,19 +82,27 @@ type ManagementServer struct {
 // The returned ManagementServerTransport instance is connected to an instance of armnetwork.ManagementClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewManagementServerTransport(srv *ManagementServer) *ManagementServerTransport {
-	return &ManagementServerTransport{srv: srv}
+	return &ManagementServerTransport{
+		srv:                              srv,
+		beginDeleteBastionShareableLink:  newTracker[azfake.PollerResponder[armnetwork.ManagementClientDeleteBastionShareableLinkResponse]](),
+		newDisconnectActiveSessionsPager: newTracker[azfake.PagerResponder[armnetwork.ManagementClientDisconnectActiveSessionsResponse]](),
+		beginGeneratevirtualwanvpnserverconfigurationvpnprofile: newTracker[azfake.PollerResponder[armnetwork.ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse]](),
+		beginGetActiveSessions:          newTracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientGetActiveSessionsResponse]]](),
+		newGetBastionShareableLinkPager: newTracker[azfake.PagerResponder[armnetwork.ManagementClientGetBastionShareableLinkResponse]](),
+		beginPutBastionShareableLink:    newTracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientPutBastionShareableLinkResponse]]](),
+	}
 }
 
 // ManagementServerTransport connects instances of armnetwork.ManagementClient to instances of ManagementServer.
 // Don't use this type directly, use NewManagementServerTransport instead.
 type ManagementServerTransport struct {
 	srv                                                     *ManagementServer
-	beginDeleteBastionShareableLink                         *azfake.PollerResponder[armnetwork.ManagementClientDeleteBastionShareableLinkResponse]
-	newDisconnectActiveSessionsPager                        *azfake.PagerResponder[armnetwork.ManagementClientDisconnectActiveSessionsResponse]
-	beginGeneratevirtualwanvpnserverconfigurationvpnprofile *azfake.PollerResponder[armnetwork.ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse]
-	beginGetActiveSessions                                  *azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientGetActiveSessionsResponse]]
-	newGetBastionShareableLinkPager                         *azfake.PagerResponder[armnetwork.ManagementClientGetBastionShareableLinkResponse]
-	beginPutBastionShareableLink                            *azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientPutBastionShareableLinkResponse]]
+	beginDeleteBastionShareableLink                         *tracker[azfake.PollerResponder[armnetwork.ManagementClientDeleteBastionShareableLinkResponse]]
+	newDisconnectActiveSessionsPager                        *tracker[azfake.PagerResponder[armnetwork.ManagementClientDisconnectActiveSessionsResponse]]
+	beginGeneratevirtualwanvpnserverconfigurationvpnprofile *tracker[azfake.PollerResponder[armnetwork.ManagementClientGeneratevirtualwanvpnserverconfigurationvpnprofileResponse]]
+	beginGetActiveSessions                                  *tracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientGetActiveSessionsResponse]]]
+	newGetBastionShareableLinkPager                         *tracker[azfake.PagerResponder[armnetwork.ManagementClientGetBastionShareableLinkResponse]]
+	beginPutBastionShareableLink                            *tracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.ManagementClientPutBastionShareableLinkResponse]]]
 }
 
 // Do implements the policy.Transporter interface for ManagementServerTransport.
@@ -184,7 +192,8 @@ func (m *ManagementServerTransport) dispatchBeginDeleteBastionShareableLink(req 
 	if m.srv.BeginDeleteBastionShareableLink == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeleteBastionShareableLink not implemented")}
 	}
-	if m.beginDeleteBastionShareableLink == nil {
+	beginDeleteBastionShareableLink := m.beginDeleteBastionShareableLink.get(req)
+	if beginDeleteBastionShareableLink == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/deleteShareableLinks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -207,19 +216,21 @@ func (m *ManagementServerTransport) dispatchBeginDeleteBastionShareableLink(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginDeleteBastionShareableLink = &respr
+		beginDeleteBastionShareableLink = &respr
+		m.beginDeleteBastionShareableLink.add(req, beginDeleteBastionShareableLink)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginDeleteBastionShareableLink, req)
+	resp, err := server.PollerResponderNext(beginDeleteBastionShareableLink, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		m.beginDeleteBastionShareableLink.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginDeleteBastionShareableLink) {
-		m.beginDeleteBastionShareableLink = nil
+	if !server.PollerResponderMore(beginDeleteBastionShareableLink) {
+		m.beginDeleteBastionShareableLink.remove(req)
 	}
 
 	return resp, nil
@@ -229,7 +240,8 @@ func (m *ManagementServerTransport) dispatchNewDisconnectActiveSessionsPager(req
 	if m.srv.NewDisconnectActiveSessionsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewDisconnectActiveSessionsPager not implemented")}
 	}
-	if m.newDisconnectActiveSessionsPager == nil {
+	newDisconnectActiveSessionsPager := m.newDisconnectActiveSessionsPager.get(req)
+	if newDisconnectActiveSessionsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/disconnectActiveSessions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -249,20 +261,22 @@ func (m *ManagementServerTransport) dispatchNewDisconnectActiveSessionsPager(req
 			return nil, err
 		}
 		resp := m.srv.NewDisconnectActiveSessionsPager(resourceGroupNameUnescaped, bastionHostNameUnescaped, body, nil)
-		m.newDisconnectActiveSessionsPager = &resp
-		server.PagerResponderInjectNextLinks(m.newDisconnectActiveSessionsPager, req, func(page *armnetwork.ManagementClientDisconnectActiveSessionsResponse, createLink func() string) {
+		newDisconnectActiveSessionsPager = &resp
+		m.newDisconnectActiveSessionsPager.add(req, newDisconnectActiveSessionsPager)
+		server.PagerResponderInjectNextLinks(newDisconnectActiveSessionsPager, req, func(page *armnetwork.ManagementClientDisconnectActiveSessionsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(m.newDisconnectActiveSessionsPager, req)
+	resp, err := server.PagerResponderNext(newDisconnectActiveSessionsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		m.newDisconnectActiveSessionsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(m.newDisconnectActiveSessionsPager) {
-		m.newDisconnectActiveSessionsPager = nil
+	if !server.PagerResponderMore(newDisconnectActiveSessionsPager) {
+		m.newDisconnectActiveSessionsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -300,7 +314,8 @@ func (m *ManagementServerTransport) dispatchBeginGeneratevirtualwanvpnserverconf
 	if m.srv.BeginGeneratevirtualwanvpnserverconfigurationvpnprofile == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGeneratevirtualwanvpnserverconfigurationvpnprofile not implemented")}
 	}
-	if m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile == nil {
+	beginGeneratevirtualwanvpnserverconfigurationvpnprofile := m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile.get(req)
+	if beginGeneratevirtualwanvpnserverconfigurationvpnprofile == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans/(?P<virtualWANName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/GenerateVpnProfile`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -323,19 +338,21 @@ func (m *ManagementServerTransport) dispatchBeginGeneratevirtualwanvpnserverconf
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile = &respr
+		beginGeneratevirtualwanvpnserverconfigurationvpnprofile = &respr
+		m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile.add(req, beginGeneratevirtualwanvpnserverconfigurationvpnprofile)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile, req)
+	resp, err := server.PollerResponderNext(beginGeneratevirtualwanvpnserverconfigurationvpnprofile, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile) {
-		m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile = nil
+	if !server.PollerResponderMore(beginGeneratevirtualwanvpnserverconfigurationvpnprofile) {
+		m.beginGeneratevirtualwanvpnserverconfigurationvpnprofile.remove(req)
 	}
 
 	return resp, nil
@@ -345,7 +362,8 @@ func (m *ManagementServerTransport) dispatchBeginGetActiveSessions(req *http.Req
 	if m.srv.BeginGetActiveSessions == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetActiveSessions not implemented")}
 	}
-	if m.beginGetActiveSessions == nil {
+	beginGetActiveSessions := m.beginGetActiveSessions.get(req)
+	if beginGetActiveSessions == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getActiveSessions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -364,19 +382,21 @@ func (m *ManagementServerTransport) dispatchBeginGetActiveSessions(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginGetActiveSessions = &respr
+		beginGetActiveSessions = &respr
+		m.beginGetActiveSessions.add(req, beginGetActiveSessions)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginGetActiveSessions, req)
+	resp, err := server.PollerResponderNext(beginGetActiveSessions, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		m.beginGetActiveSessions.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginGetActiveSessions) {
-		m.beginGetActiveSessions = nil
+	if !server.PollerResponderMore(beginGetActiveSessions) {
+		m.beginGetActiveSessions.remove(req)
 	}
 
 	return resp, nil
@@ -386,7 +406,8 @@ func (m *ManagementServerTransport) dispatchNewGetBastionShareableLinkPager(req 
 	if m.srv.NewGetBastionShareableLinkPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewGetBastionShareableLinkPager not implemented")}
 	}
-	if m.newGetBastionShareableLinkPager == nil {
+	newGetBastionShareableLinkPager := m.newGetBastionShareableLinkPager.get(req)
+	if newGetBastionShareableLinkPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getShareableLinks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -406,20 +427,22 @@ func (m *ManagementServerTransport) dispatchNewGetBastionShareableLinkPager(req 
 			return nil, err
 		}
 		resp := m.srv.NewGetBastionShareableLinkPager(resourceGroupNameUnescaped, bastionHostNameUnescaped, body, nil)
-		m.newGetBastionShareableLinkPager = &resp
-		server.PagerResponderInjectNextLinks(m.newGetBastionShareableLinkPager, req, func(page *armnetwork.ManagementClientGetBastionShareableLinkResponse, createLink func() string) {
+		newGetBastionShareableLinkPager = &resp
+		m.newGetBastionShareableLinkPager.add(req, newGetBastionShareableLinkPager)
+		server.PagerResponderInjectNextLinks(newGetBastionShareableLinkPager, req, func(page *armnetwork.ManagementClientGetBastionShareableLinkResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(m.newGetBastionShareableLinkPager, req)
+	resp, err := server.PagerResponderNext(newGetBastionShareableLinkPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		m.newGetBastionShareableLinkPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(m.newGetBastionShareableLinkPager) {
-		m.newGetBastionShareableLinkPager = nil
+	if !server.PagerResponderMore(newGetBastionShareableLinkPager) {
+		m.newGetBastionShareableLinkPager.remove(req)
 	}
 	return resp, nil
 }
@@ -660,7 +683,8 @@ func (m *ManagementServerTransport) dispatchBeginPutBastionShareableLink(req *ht
 	if m.srv.BeginPutBastionShareableLink == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPutBastionShareableLink not implemented")}
 	}
-	if m.beginPutBastionShareableLink == nil {
+	beginPutBastionShareableLink := m.beginPutBastionShareableLink.get(req)
+	if beginPutBastionShareableLink == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/bastionHosts/(?P<bastionHostName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/createShareableLinks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -683,19 +707,21 @@ func (m *ManagementServerTransport) dispatchBeginPutBastionShareableLink(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginPutBastionShareableLink = &respr
+		beginPutBastionShareableLink = &respr
+		m.beginPutBastionShareableLink.add(req, beginPutBastionShareableLink)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginPutBastionShareableLink, req)
+	resp, err := server.PollerResponderNext(beginPutBastionShareableLink, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		m.beginPutBastionShareableLink.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginPutBastionShareableLink) {
-		m.beginPutBastionShareableLink = nil
+	if !server.PollerResponderMore(beginPutBastionShareableLink) {
+		m.beginPutBastionShareableLink.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_managementgroupnetworkmanagerconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_managementgroupnetworkmanagerconnections_server.go
@@ -46,14 +46,17 @@ type ManagementGroupNetworkManagerConnectionsServer struct {
 // The returned ManagementGroupNetworkManagerConnectionsServerTransport instance is connected to an instance of armnetwork.ManagementGroupNetworkManagerConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewManagementGroupNetworkManagerConnectionsServerTransport(srv *ManagementGroupNetworkManagerConnectionsServer) *ManagementGroupNetworkManagerConnectionsServerTransport {
-	return &ManagementGroupNetworkManagerConnectionsServerTransport{srv: srv}
+	return &ManagementGroupNetworkManagerConnectionsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ManagementGroupNetworkManagerConnectionsClientListResponse]](),
+	}
 }
 
 // ManagementGroupNetworkManagerConnectionsServerTransport connects instances of armnetwork.ManagementGroupNetworkManagerConnectionsClient to instances of ManagementGroupNetworkManagerConnectionsServer.
 // Don't use this type directly, use NewManagementGroupNetworkManagerConnectionsServerTransport instead.
 type ManagementGroupNetworkManagerConnectionsServerTransport struct {
 	srv          *ManagementGroupNetworkManagerConnectionsServer
-	newListPager *azfake.PagerResponder[armnetwork.ManagementGroupNetworkManagerConnectionsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ManagementGroupNetworkManagerConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ManagementGroupNetworkManagerConnectionsServerTransport.
@@ -194,7 +197,8 @@ func (m *ManagementGroupNetworkManagerConnectionsServerTransport) dispatchNewLis
 	if m.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if m.newListPager == nil {
+	newListPager := m.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/providers/Microsoft.Management/managementGroups/(?P<managementGroupId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagerConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -233,20 +237,22 @@ func (m *ManagementGroupNetworkManagerConnectionsServerTransport) dispatchNewLis
 			}
 		}
 		resp := m.srv.NewListPager(managementGroupIDUnescaped, options)
-		m.newListPager = &resp
-		server.PagerResponderInjectNextLinks(m.newListPager, req, func(page *armnetwork.ManagementGroupNetworkManagerConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		m.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ManagementGroupNetworkManagerConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(m.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		m.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(m.newListPager) {
-		m.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		m.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_managercommits_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_managercommits_server.go
@@ -32,14 +32,17 @@ type ManagerCommitsServer struct {
 // The returned ManagerCommitsServerTransport instance is connected to an instance of armnetwork.ManagerCommitsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewManagerCommitsServerTransport(srv *ManagerCommitsServer) *ManagerCommitsServerTransport {
-	return &ManagerCommitsServerTransport{srv: srv}
+	return &ManagerCommitsServerTransport{
+		srv:       srv,
+		beginPost: newTracker[azfake.PollerResponder[armnetwork.ManagerCommitsClientPostResponse]](),
+	}
 }
 
 // ManagerCommitsServerTransport connects instances of armnetwork.ManagerCommitsClient to instances of ManagerCommitsServer.
 // Don't use this type directly, use NewManagerCommitsServerTransport instead.
 type ManagerCommitsServerTransport struct {
 	srv       *ManagerCommitsServer
-	beginPost *azfake.PollerResponder[armnetwork.ManagerCommitsClientPostResponse]
+	beginPost *tracker[azfake.PollerResponder[armnetwork.ManagerCommitsClientPostResponse]]
 }
 
 // Do implements the policy.Transporter interface for ManagerCommitsServerTransport.
@@ -71,7 +74,8 @@ func (m *ManagerCommitsServerTransport) dispatchBeginPost(req *http.Request) (*h
 	if m.srv.BeginPost == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPost not implemented")}
 	}
-	if m.beginPost == nil {
+	beginPost := m.beginPost.get(req)
+	if beginPost == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/commit`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -94,19 +98,21 @@ func (m *ManagerCommitsServerTransport) dispatchBeginPost(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginPost = &respr
+		beginPost = &respr
+		m.beginPost.add(req, beginPost)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginPost, req)
+	resp, err := server.PollerResponderNext(beginPost, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		m.beginPost.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginPost) {
-		m.beginPost = nil
+	if !server.PollerResponderMore(beginPost) {
+		m.beginPost.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_managers_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_managers_server.go
@@ -54,16 +54,21 @@ type ManagersServer struct {
 // The returned ManagersServerTransport instance is connected to an instance of armnetwork.ManagersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewManagersServerTransport(srv *ManagersServer) *ManagersServerTransport {
-	return &ManagersServerTransport{srv: srv}
+	return &ManagersServerTransport{
+		srv:                        srv,
+		beginDelete:                newTracker[azfake.PollerResponder[armnetwork.ManagersClientDeleteResponse]](),
+		newListPager:               newTracker[azfake.PagerResponder[armnetwork.ManagersClientListResponse]](),
+		newListBySubscriptionPager: newTracker[azfake.PagerResponder[armnetwork.ManagersClientListBySubscriptionResponse]](),
+	}
 }
 
 // ManagersServerTransport connects instances of armnetwork.ManagersClient to instances of ManagersServer.
 // Don't use this type directly, use NewManagersServerTransport instead.
 type ManagersServerTransport struct {
 	srv                        *ManagersServer
-	beginDelete                *azfake.PollerResponder[armnetwork.ManagersClientDeleteResponse]
-	newListPager               *azfake.PagerResponder[armnetwork.ManagersClientListResponse]
-	newListBySubscriptionPager *azfake.PagerResponder[armnetwork.ManagersClientListBySubscriptionResponse]
+	beginDelete                *tracker[azfake.PollerResponder[armnetwork.ManagersClientDeleteResponse]]
+	newListPager               *tracker[azfake.PagerResponder[armnetwork.ManagersClientListResponse]]
+	newListBySubscriptionPager *tracker[azfake.PagerResponder[armnetwork.ManagersClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for ManagersServerTransport.
@@ -142,7 +147,8 @@ func (m *ManagersServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if m.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if m.beginDelete == nil {
+	beginDelete := m.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -176,19 +182,21 @@ func (m *ManagersServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		m.beginDelete = &respr
+		beginDelete = &respr
+		m.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(m.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		m.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(m.beginDelete) {
-		m.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		m.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -231,7 +239,8 @@ func (m *ManagersServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if m.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if m.newListPager == nil {
+	newListPager := m.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -270,20 +279,22 @@ func (m *ManagersServerTransport) dispatchNewListPager(req *http.Request) (*http
 			}
 		}
 		resp := m.srv.NewListPager(resourceGroupNameUnescaped, options)
-		m.newListPager = &resp
-		server.PagerResponderInjectNextLinks(m.newListPager, req, func(page *armnetwork.ManagersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		m.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ManagersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(m.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		m.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(m.newListPager) {
-		m.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		m.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -292,7 +303,8 @@ func (m *ManagersServerTransport) dispatchNewListBySubscriptionPager(req *http.R
 	if m.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if m.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := m.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -327,20 +339,22 @@ func (m *ManagersServerTransport) dispatchNewListBySubscriptionPager(req *http.R
 			}
 		}
 		resp := m.srv.NewListBySubscriptionPager(options)
-		m.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(m.newListBySubscriptionPager, req, func(page *armnetwork.ManagersClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		m.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armnetwork.ManagersClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(m.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		m.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(m.newListBySubscriptionPager) {
-		m.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		m.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_natgateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_natgateways_server.go
@@ -53,17 +53,23 @@ type NatGatewaysServer struct {
 // The returned NatGatewaysServerTransport instance is connected to an instance of armnetwork.NatGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewNatGatewaysServerTransport(srv *NatGatewaysServer) *NatGatewaysServerTransport {
-	return &NatGatewaysServerTransport{srv: srv}
+	return &NatGatewaysServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.NatGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.NatGatewaysClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.NatGatewaysClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.NatGatewaysClientListAllResponse]](),
+	}
 }
 
 // NatGatewaysServerTransport connects instances of armnetwork.NatGatewaysClient to instances of NatGatewaysServer.
 // Don't use this type directly, use NewNatGatewaysServerTransport instead.
 type NatGatewaysServerTransport struct {
 	srv                 *NatGatewaysServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.NatGatewaysClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.NatGatewaysClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.NatGatewaysClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.NatGatewaysClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.NatGatewaysClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.NatGatewaysClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.NatGatewaysClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.NatGatewaysClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for NatGatewaysServerTransport.
@@ -105,7 +111,8 @@ func (n *NatGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 	if n.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if n.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := n.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/natGateways/(?P<natGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (n *NatGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		n.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		n.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(n.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated, http.StatusAccepted}, resp.StatusCode) {
+		n.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(n.beginCreateOrUpdate) {
-		n.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		n.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (n *NatGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 	if n.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if n.beginDelete == nil {
+	beginDelete := n.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/natGateways/(?P<natGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (n *NatGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		n.beginDelete = &respr
+		beginDelete = &respr
+		n.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(n.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		n.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(n.beginDelete) {
-		n.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		n.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (n *NatGatewaysServerTransport) dispatchNewListPager(req *http.Request) (*h
 	if n.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if n.newListPager == nil {
+	newListPager := n.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/natGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (n *NatGatewaysServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, err
 		}
 		resp := n.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		n.newListPager = &resp
-		server.PagerResponderInjectNextLinks(n.newListPager, req, func(page *armnetwork.NatGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		n.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.NatGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(n.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		n.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(n.newListPager) {
-		n.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		n.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (n *NatGatewaysServerTransport) dispatchNewListAllPager(req *http.Request) 
 	if n.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if n.newListAllPager == nil {
+	newListAllPager := n.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/natGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (n *NatGatewaysServerTransport) dispatchNewListAllPager(req *http.Request) 
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := n.srv.NewListAllPager(nil)
-		n.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(n.newListAllPager, req, func(page *armnetwork.NatGatewaysClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		n.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.NatGatewaysClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(n.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		n.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(n.newListAllPager) {
-		n.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		n.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_natrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_natrules_server.go
@@ -45,16 +45,21 @@ type NatRulesServer struct {
 // The returned NatRulesServerTransport instance is connected to an instance of armnetwork.NatRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewNatRulesServerTransport(srv *NatRulesServer) *NatRulesServerTransport {
-	return &NatRulesServerTransport{srv: srv}
+	return &NatRulesServerTransport{
+		srv:                      srv,
+		beginCreateOrUpdate:      newTracker[azfake.PollerResponder[armnetwork.NatRulesClientCreateOrUpdateResponse]](),
+		beginDelete:              newTracker[azfake.PollerResponder[armnetwork.NatRulesClientDeleteResponse]](),
+		newListByVPNGatewayPager: newTracker[azfake.PagerResponder[armnetwork.NatRulesClientListByVPNGatewayResponse]](),
+	}
 }
 
 // NatRulesServerTransport connects instances of armnetwork.NatRulesClient to instances of NatRulesServer.
 // Don't use this type directly, use NewNatRulesServerTransport instead.
 type NatRulesServerTransport struct {
 	srv                      *NatRulesServer
-	beginCreateOrUpdate      *azfake.PollerResponder[armnetwork.NatRulesClientCreateOrUpdateResponse]
-	beginDelete              *azfake.PollerResponder[armnetwork.NatRulesClientDeleteResponse]
-	newListByVPNGatewayPager *azfake.PagerResponder[armnetwork.NatRulesClientListByVPNGatewayResponse]
+	beginCreateOrUpdate      *tracker[azfake.PollerResponder[armnetwork.NatRulesClientCreateOrUpdateResponse]]
+	beginDelete              *tracker[azfake.PollerResponder[armnetwork.NatRulesClientDeleteResponse]]
+	newListByVPNGatewayPager *tracker[azfake.PagerResponder[armnetwork.NatRulesClientListByVPNGatewayResponse]]
 }
 
 // Do implements the policy.Transporter interface for NatRulesServerTransport.
@@ -92,7 +97,8 @@ func (n *NatRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 	if n.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if n.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := n.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules/(?P<natRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (n *NatRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		n.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		n.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(n.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		n.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(n.beginCreateOrUpdate) {
-		n.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		n.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (n *NatRulesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if n.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if n.beginDelete == nil {
+	beginDelete := n.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules/(?P<natRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (n *NatRulesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		n.beginDelete = &respr
+		beginDelete = &respr
+		n.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(n.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		n.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(n.beginDelete) {
-		n.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		n.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (n *NatRulesServerTransport) dispatchNewListByVPNGatewayPager(req *http.Req
 	if n.srv.NewListByVPNGatewayPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVPNGatewayPager not implemented")}
 	}
-	if n.newListByVPNGatewayPager == nil {
+	newListByVPNGatewayPager := n.newListByVPNGatewayPager.get(req)
+	if newListByVPNGatewayPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (n *NatRulesServerTransport) dispatchNewListByVPNGatewayPager(req *http.Req
 			return nil, err
 		}
 		resp := n.srv.NewListByVPNGatewayPager(resourceGroupNameUnescaped, gatewayNameUnescaped, nil)
-		n.newListByVPNGatewayPager = &resp
-		server.PagerResponderInjectNextLinks(n.newListByVPNGatewayPager, req, func(page *armnetwork.NatRulesClientListByVPNGatewayResponse, createLink func() string) {
+		newListByVPNGatewayPager = &resp
+		n.newListByVPNGatewayPager.add(req, newListByVPNGatewayPager)
+		server.PagerResponderInjectNextLinks(newListByVPNGatewayPager, req, func(page *armnetwork.NatRulesClientListByVPNGatewayResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(n.newListByVPNGatewayPager, req)
+	resp, err := server.PagerResponderNext(newListByVPNGatewayPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		n.newListByVPNGatewayPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(n.newListByVPNGatewayPager) {
-		n.newListByVPNGatewayPager = nil
+	if !server.PagerResponderMore(newListByVPNGatewayPager) {
+		n.newListByVPNGatewayPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_operations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_operations_server.go
@@ -30,14 +30,17 @@ type OperationsServer struct {
 // The returned OperationsServerTransport instance is connected to an instance of armnetwork.OperationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewOperationsServerTransport(srv *OperationsServer) *OperationsServerTransport {
-	return &OperationsServerTransport{srv: srv}
+	return &OperationsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.OperationsClientListResponse]](),
+	}
 }
 
 // OperationsServerTransport connects instances of armnetwork.OperationsClient to instances of OperationsServer.
 // Don't use this type directly, use NewOperationsServerTransport instead.
 type OperationsServerTransport struct {
 	srv          *OperationsServer
-	newListPager *azfake.PagerResponder[armnetwork.OperationsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.OperationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for OperationsServerTransport.
@@ -69,22 +72,25 @@ func (o *OperationsServerTransport) dispatchNewListPager(req *http.Request) (*ht
 	if o.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if o.newListPager == nil {
+	newListPager := o.newListPager.get(req)
+	if newListPager == nil {
 		resp := o.srv.NewListPager(nil)
-		o.newListPager = &resp
-		server.PagerResponderInjectNextLinks(o.newListPager, req, func(page *armnetwork.OperationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		o.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.OperationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(o.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		o.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(o.newListPager) {
-		o.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		o.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_p2svpngateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_p2svpngateways_server.go
@@ -73,23 +73,35 @@ type P2SVPNGatewaysServer struct {
 // The returned P2SVPNGatewaysServerTransport instance is connected to an instance of armnetwork.P2SVPNGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewP2SVPNGatewaysServerTransport(srv *P2SVPNGatewaysServer) *P2SVPNGatewaysServerTransport {
-	return &P2SVPNGatewaysServerTransport{srv: srv}
+	return &P2SVPNGatewaysServerTransport{
+		srv:                                    srv,
+		beginCreateOrUpdate:                    newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:                            newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDeleteResponse]](),
+		beginDisconnectP2SVPNConnections:       newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse]](),
+		beginGenerateVPNProfile:                newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGenerateVPNProfileResponse]](),
+		beginGetP2SVPNConnectionHealth:         newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse]](),
+		beginGetP2SVPNConnectionHealthDetailed: newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse]](),
+		newListPager:                           newTracker[azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListResponse]](),
+		newListByResourceGroupPager:            newTracker[azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListByResourceGroupResponse]](),
+		beginReset:                             newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientResetResponse]](),
+		beginUpdateTags:                        newTracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientUpdateTagsResponse]](),
+	}
 }
 
 // P2SVPNGatewaysServerTransport connects instances of armnetwork.P2SVPNGatewaysClient to instances of P2SVPNGatewaysServer.
 // Don't use this type directly, use NewP2SVPNGatewaysServerTransport instead.
 type P2SVPNGatewaysServerTransport struct {
 	srv                                    *P2SVPNGatewaysServer
-	beginCreateOrUpdate                    *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientCreateOrUpdateResponse]
-	beginDelete                            *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDeleteResponse]
-	beginDisconnectP2SVPNConnections       *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse]
-	beginGenerateVPNProfile                *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGenerateVPNProfileResponse]
-	beginGetP2SVPNConnectionHealth         *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse]
-	beginGetP2SVPNConnectionHealthDetailed *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse]
-	newListPager                           *azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListResponse]
-	newListByResourceGroupPager            *azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListByResourceGroupResponse]
-	beginReset                             *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientResetResponse]
-	beginUpdateTags                        *azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientUpdateTagsResponse]
+	beginCreateOrUpdate                    *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientCreateOrUpdateResponse]]
+	beginDelete                            *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDeleteResponse]]
+	beginDisconnectP2SVPNConnections       *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientDisconnectP2SVPNConnectionsResponse]]
+	beginGenerateVPNProfile                *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGenerateVPNProfileResponse]]
+	beginGetP2SVPNConnectionHealth         *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthResponse]]
+	beginGetP2SVPNConnectionHealthDetailed *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientGetP2SVPNConnectionHealthDetailedResponse]]
+	newListPager                           *tracker[azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListResponse]]
+	newListByResourceGroupPager            *tracker[azfake.PagerResponder[armnetwork.P2SVPNGatewaysClientListByResourceGroupResponse]]
+	beginReset                             *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientResetResponse]]
+	beginUpdateTags                        *tracker[azfake.PollerResponder[armnetwork.P2SVPNGatewaysClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for P2SVPNGatewaysServerTransport.
@@ -141,7 +153,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +177,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -186,7 +201,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -205,19 +221,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -227,7 +245,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginDisconnectP2SVPNConnections
 	if p.srv.BeginDisconnectP2SVPNConnections == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDisconnectP2SVPNConnections not implemented")}
 	}
-	if p.beginDisconnectP2SVPNConnections == nil {
+	beginDisconnectP2SVPNConnections := p.beginDisconnectP2SVPNConnections.get(req)
+	if beginDisconnectP2SVPNConnections == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<p2sVpnGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/disconnectP2sVpnConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -250,19 +269,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginDisconnectP2SVPNConnections
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDisconnectP2SVPNConnections = &respr
+		beginDisconnectP2SVPNConnections = &respr
+		p.beginDisconnectP2SVPNConnections.add(req, beginDisconnectP2SVPNConnections)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDisconnectP2SVPNConnections, req)
+	resp, err := server.PollerResponderNext(beginDisconnectP2SVPNConnections, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginDisconnectP2SVPNConnections.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDisconnectP2SVPNConnections) {
-		p.beginDisconnectP2SVPNConnections = nil
+	if !server.PollerResponderMore(beginDisconnectP2SVPNConnections) {
+		p.beginDisconnectP2SVPNConnections.remove(req)
 	}
 
 	return resp, nil
@@ -272,7 +293,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGenerateVPNProfile(req *htt
 	if p.srv.BeginGenerateVPNProfile == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGenerateVPNProfile not implemented")}
 	}
-	if p.beginGenerateVPNProfile == nil {
+	beginGenerateVPNProfile := p.beginGenerateVPNProfile.get(req)
+	if beginGenerateVPNProfile == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/generatevpnprofile`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -295,19 +317,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGenerateVPNProfile(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginGenerateVPNProfile = &respr
+		beginGenerateVPNProfile = &respr
+		p.beginGenerateVPNProfile.add(req, beginGenerateVPNProfile)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginGenerateVPNProfile, req)
+	resp, err := server.PollerResponderNext(beginGenerateVPNProfile, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginGenerateVPNProfile.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginGenerateVPNProfile) {
-		p.beginGenerateVPNProfile = nil
+	if !server.PollerResponderMore(beginGenerateVPNProfile) {
+		p.beginGenerateVPNProfile.remove(req)
 	}
 
 	return resp, nil
@@ -350,7 +374,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGetP2SVPNConnectionHealth(r
 	if p.srv.BeginGetP2SVPNConnectionHealth == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetP2SVPNConnectionHealth not implemented")}
 	}
-	if p.beginGetP2SVPNConnectionHealth == nil {
+	beginGetP2SVPNConnectionHealth := p.beginGetP2SVPNConnectionHealth.get(req)
+	if beginGetP2SVPNConnectionHealth == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getP2sVpnConnectionHealth`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -369,19 +394,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGetP2SVPNConnectionHealth(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginGetP2SVPNConnectionHealth = &respr
+		beginGetP2SVPNConnectionHealth = &respr
+		p.beginGetP2SVPNConnectionHealth.add(req, beginGetP2SVPNConnectionHealth)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginGetP2SVPNConnectionHealth, req)
+	resp, err := server.PollerResponderNext(beginGetP2SVPNConnectionHealth, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginGetP2SVPNConnectionHealth.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginGetP2SVPNConnectionHealth) {
-		p.beginGetP2SVPNConnectionHealth = nil
+	if !server.PollerResponderMore(beginGetP2SVPNConnectionHealth) {
+		p.beginGetP2SVPNConnectionHealth.remove(req)
 	}
 
 	return resp, nil
@@ -391,7 +418,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGetP2SVPNConnectionHealthDe
 	if p.srv.BeginGetP2SVPNConnectionHealthDetailed == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetP2SVPNConnectionHealthDetailed not implemented")}
 	}
-	if p.beginGetP2SVPNConnectionHealthDetailed == nil {
+	beginGetP2SVPNConnectionHealthDetailed := p.beginGetP2SVPNConnectionHealthDetailed.get(req)
+	if beginGetP2SVPNConnectionHealthDetailed == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getP2sVpnConnectionHealthDetailed`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -414,19 +442,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginGetP2SVPNConnectionHealthDe
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginGetP2SVPNConnectionHealthDetailed = &respr
+		beginGetP2SVPNConnectionHealthDetailed = &respr
+		p.beginGetP2SVPNConnectionHealthDetailed.add(req, beginGetP2SVPNConnectionHealthDetailed)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginGetP2SVPNConnectionHealthDetailed, req)
+	resp, err := server.PollerResponderNext(beginGetP2SVPNConnectionHealthDetailed, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginGetP2SVPNConnectionHealthDetailed.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginGetP2SVPNConnectionHealthDetailed) {
-		p.beginGetP2SVPNConnectionHealthDetailed = nil
+	if !server.PollerResponderMore(beginGetP2SVPNConnectionHealthDetailed) {
+		p.beginGetP2SVPNConnectionHealthDetailed.remove(req)
 	}
 
 	return resp, nil
@@ -436,7 +466,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchNewListPager(req *http.Request) 
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -444,20 +475,22 @@ func (p *P2SVPNGatewaysServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListPager(nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.P2SVPNGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.P2SVPNGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -466,7 +499,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchNewListByResourceGroupPager(req 
 	if p.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if p.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := p.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -478,20 +512,22 @@ func (p *P2SVPNGatewaysServerTransport) dispatchNewListByResourceGroupPager(req 
 			return nil, err
 		}
 		resp := p.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		p.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListByResourceGroupPager, req, func(page *armnetwork.P2SVPNGatewaysClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		p.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.P2SVPNGatewaysClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListByResourceGroupPager) {
-		p.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		p.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -500,7 +536,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginReset(req *http.Request) (*
 	if p.srv.BeginReset == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReset not implemented")}
 	}
-	if p.beginReset == nil {
+	beginReset := p.beginReset.get(req)
+	if beginReset == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reset`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -519,19 +556,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginReset(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginReset = &respr
+		beginReset = &respr
+		p.beginReset.add(req, beginReset)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginReset, req)
+	resp, err := server.PollerResponderNext(beginReset, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginReset.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginReset) {
-		p.beginReset = nil
+	if !server.PollerResponderMore(beginReset) {
+		p.beginReset.remove(req)
 	}
 
 	return resp, nil
@@ -541,7 +580,8 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginUpdateTags(req *http.Reques
 	if p.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if p.beginUpdateTags == nil {
+	beginUpdateTags := p.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/p2svpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -564,19 +604,21 @@ func (p *P2SVPNGatewaysServerTransport) dispatchBeginUpdateTags(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		p.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginUpdateTags) {
-		p.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		p.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_packetcaptures_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_packetcaptures_server.go
@@ -52,18 +52,25 @@ type PacketCapturesServer struct {
 // The returned PacketCapturesServerTransport instance is connected to an instance of armnetwork.PacketCapturesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPacketCapturesServerTransport(srv *PacketCapturesServer) *PacketCapturesServerTransport {
-	return &PacketCapturesServerTransport{srv: srv}
+	return &PacketCapturesServerTransport{
+		srv:            srv,
+		beginCreate:    newTracker[azfake.PollerResponder[armnetwork.PacketCapturesClientCreateResponse]](),
+		beginDelete:    newTracker[azfake.PollerResponder[armnetwork.PacketCapturesClientDeleteResponse]](),
+		beginGetStatus: newTracker[azfake.PollerResponder[armnetwork.PacketCapturesClientGetStatusResponse]](),
+		newListPager:   newTracker[azfake.PagerResponder[armnetwork.PacketCapturesClientListResponse]](),
+		beginStop:      newTracker[azfake.PollerResponder[armnetwork.PacketCapturesClientStopResponse]](),
+	}
 }
 
 // PacketCapturesServerTransport connects instances of armnetwork.PacketCapturesClient to instances of PacketCapturesServer.
 // Don't use this type directly, use NewPacketCapturesServerTransport instead.
 type PacketCapturesServerTransport struct {
 	srv            *PacketCapturesServer
-	beginCreate    *azfake.PollerResponder[armnetwork.PacketCapturesClientCreateResponse]
-	beginDelete    *azfake.PollerResponder[armnetwork.PacketCapturesClientDeleteResponse]
-	beginGetStatus *azfake.PollerResponder[armnetwork.PacketCapturesClientGetStatusResponse]
-	newListPager   *azfake.PagerResponder[armnetwork.PacketCapturesClientListResponse]
-	beginStop      *azfake.PollerResponder[armnetwork.PacketCapturesClientStopResponse]
+	beginCreate    *tracker[azfake.PollerResponder[armnetwork.PacketCapturesClientCreateResponse]]
+	beginDelete    *tracker[azfake.PollerResponder[armnetwork.PacketCapturesClientDeleteResponse]]
+	beginGetStatus *tracker[azfake.PollerResponder[armnetwork.PacketCapturesClientGetStatusResponse]]
+	newListPager   *tracker[azfake.PagerResponder[armnetwork.PacketCapturesClientListResponse]]
+	beginStop      *tracker[azfake.PollerResponder[armnetwork.PacketCapturesClientStopResponse]]
 }
 
 // Do implements the policy.Transporter interface for PacketCapturesServerTransport.
@@ -105,7 +112,8 @@ func (p *PacketCapturesServerTransport) dispatchBeginCreate(req *http.Request) (
 	if p.srv.BeginCreate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreate not implemented")}
 	}
-	if p.beginCreate == nil {
+	beginCreate := p.beginCreate.get(req)
+	if beginCreate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/packetCaptures/(?P<packetCaptureName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -132,19 +140,21 @@ func (p *PacketCapturesServerTransport) dispatchBeginCreate(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreate = &respr
+		beginCreate = &respr
+		p.beginCreate.add(req, beginCreate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreate, req)
+	resp, err := server.PollerResponderNext(beginCreate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusCreated}, resp.StatusCode) {
+		p.beginCreate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreate) {
-		p.beginCreate = nil
+	if !server.PollerResponderMore(beginCreate) {
+		p.beginCreate.remove(req)
 	}
 
 	return resp, nil
@@ -154,7 +164,8 @@ func (p *PacketCapturesServerTransport) dispatchBeginDelete(req *http.Request) (
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/packetCaptures/(?P<packetCaptureName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -177,19 +188,21 @@ func (p *PacketCapturesServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +249,8 @@ func (p *PacketCapturesServerTransport) dispatchBeginGetStatus(req *http.Request
 	if p.srv.BeginGetStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetStatus not implemented")}
 	}
-	if p.beginGetStatus == nil {
+	beginGetStatus := p.beginGetStatus.get(req)
+	if beginGetStatus == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/packetCaptures/(?P<packetCaptureName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/queryStatus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -259,19 +273,21 @@ func (p *PacketCapturesServerTransport) dispatchBeginGetStatus(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginGetStatus = &respr
+		beginGetStatus = &respr
+		p.beginGetStatus.add(req, beginGetStatus)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginGetStatus, req)
+	resp, err := server.PollerResponderNext(beginGetStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginGetStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginGetStatus) {
-		p.beginGetStatus = nil
+	if !server.PollerResponderMore(beginGetStatus) {
+		p.beginGetStatus.remove(req)
 	}
 
 	return resp, nil
@@ -281,7 +297,8 @@ func (p *PacketCapturesServerTransport) dispatchNewListPager(req *http.Request) 
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/packetCaptures`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -297,17 +314,19 @@ func (p *PacketCapturesServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, networkWatcherNameUnescaped, nil)
-		p.newListPager = &resp
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -316,7 +335,8 @@ func (p *PacketCapturesServerTransport) dispatchBeginStop(req *http.Request) (*h
 	if p.srv.BeginStop == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStop not implemented")}
 	}
-	if p.beginStop == nil {
+	beginStop := p.beginStop.get(req)
+	if beginStop == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/packetCaptures/(?P<packetCaptureName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stop`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -339,19 +359,21 @@ func (p *PacketCapturesServerTransport) dispatchBeginStop(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginStop = &respr
+		beginStop = &respr
+		p.beginStop.add(req, beginStop)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginStop, req)
+	resp, err := server.PollerResponderNext(beginStop, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginStop.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginStop) {
-		p.beginStop = nil
+	if !server.PollerResponderMore(beginStop) {
+		p.beginStop.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_peerexpressroutecircuitconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_peerexpressroutecircuitconnections_server.go
@@ -37,14 +37,17 @@ type PeerExpressRouteCircuitConnectionsServer struct {
 // The returned PeerExpressRouteCircuitConnectionsServerTransport instance is connected to an instance of armnetwork.PeerExpressRouteCircuitConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPeerExpressRouteCircuitConnectionsServerTransport(srv *PeerExpressRouteCircuitConnectionsServer) *PeerExpressRouteCircuitConnectionsServerTransport {
-	return &PeerExpressRouteCircuitConnectionsServerTransport{srv: srv}
+	return &PeerExpressRouteCircuitConnectionsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.PeerExpressRouteCircuitConnectionsClientListResponse]](),
+	}
 }
 
 // PeerExpressRouteCircuitConnectionsServerTransport connects instances of armnetwork.PeerExpressRouteCircuitConnectionsClient to instances of PeerExpressRouteCircuitConnectionsServer.
 // Don't use this type directly, use NewPeerExpressRouteCircuitConnectionsServerTransport instead.
 type PeerExpressRouteCircuitConnectionsServerTransport struct {
 	srv          *PeerExpressRouteCircuitConnectionsServer
-	newListPager *azfake.PagerResponder[armnetwork.PeerExpressRouteCircuitConnectionsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.PeerExpressRouteCircuitConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for PeerExpressRouteCircuitConnectionsServerTransport.
@@ -119,7 +122,8 @@ func (p *PeerExpressRouteCircuitConnectionsServerTransport) dispatchNewListPager
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/expressRouteCircuits/(?P<circuitName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -139,20 +143,22 @@ func (p *PeerExpressRouteCircuitConnectionsServerTransport) dispatchNewListPager
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, circuitNameUnescaped, peeringNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PeerExpressRouteCircuitConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PeerExpressRouteCircuitConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_privatednszonegroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_privatednszonegroups_server.go
@@ -45,16 +45,21 @@ type PrivateDNSZoneGroupsServer struct {
 // The returned PrivateDNSZoneGroupsServerTransport instance is connected to an instance of armnetwork.PrivateDNSZoneGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPrivateDNSZoneGroupsServerTransport(srv *PrivateDNSZoneGroupsServer) *PrivateDNSZoneGroupsServerTransport {
-	return &PrivateDNSZoneGroupsServerTransport{srv: srv}
+	return &PrivateDNSZoneGroupsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.PrivateDNSZoneGroupsClientListResponse]](),
+	}
 }
 
 // PrivateDNSZoneGroupsServerTransport connects instances of armnetwork.PrivateDNSZoneGroupsClient to instances of PrivateDNSZoneGroupsServer.
 // Don't use this type directly, use NewPrivateDNSZoneGroupsServerTransport instead.
 type PrivateDNSZoneGroupsServerTransport struct {
 	srv                 *PrivateDNSZoneGroupsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.PrivateDNSZoneGroupsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.PrivateDNSZoneGroupsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.PrivateDNSZoneGroupsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for PrivateDNSZoneGroupsServerTransport.
@@ -92,7 +97,8 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchBeginCreateOrUpdate(req *h
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints/(?P<privateEndpointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateDnsZoneGroups/(?P<privateDnsZoneGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchBeginCreateOrUpdate(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchBeginDelete(req *http.Requ
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints/(?P<privateEndpointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateDnsZoneGroups/(?P<privateDnsZoneGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchBeginDelete(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchNewListPager(req *http.Req
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints/(?P<privateEndpointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateDnsZoneGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (p *PrivateDNSZoneGroupsServerTransport) dispatchNewListPager(req *http.Req
 			return nil, err
 		}
 		resp := p.srv.NewListPager(privateEndpointNameUnescaped, resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PrivateDNSZoneGroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PrivateDNSZoneGroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_privateendpoints_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_privateendpoints_server.go
@@ -49,17 +49,23 @@ type PrivateEndpointsServer struct {
 // The returned PrivateEndpointsServerTransport instance is connected to an instance of armnetwork.PrivateEndpointsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPrivateEndpointsServerTransport(srv *PrivateEndpointsServer) *PrivateEndpointsServerTransport {
-	return &PrivateEndpointsServerTransport{srv: srv}
+	return &PrivateEndpointsServerTransport{
+		srv:                        srv,
+		beginCreateOrUpdate:        newTracker[azfake.PollerResponder[armnetwork.PrivateEndpointsClientCreateOrUpdateResponse]](),
+		beginDelete:                newTracker[azfake.PollerResponder[armnetwork.PrivateEndpointsClientDeleteResponse]](),
+		newListPager:               newTracker[azfake.PagerResponder[armnetwork.PrivateEndpointsClientListResponse]](),
+		newListBySubscriptionPager: newTracker[azfake.PagerResponder[armnetwork.PrivateEndpointsClientListBySubscriptionResponse]](),
+	}
 }
 
 // PrivateEndpointsServerTransport connects instances of armnetwork.PrivateEndpointsClient to instances of PrivateEndpointsServer.
 // Don't use this type directly, use NewPrivateEndpointsServerTransport instead.
 type PrivateEndpointsServerTransport struct {
 	srv                        *PrivateEndpointsServer
-	beginCreateOrUpdate        *azfake.PollerResponder[armnetwork.PrivateEndpointsClientCreateOrUpdateResponse]
-	beginDelete                *azfake.PollerResponder[armnetwork.PrivateEndpointsClientDeleteResponse]
-	newListPager               *azfake.PagerResponder[armnetwork.PrivateEndpointsClientListResponse]
-	newListBySubscriptionPager *azfake.PagerResponder[armnetwork.PrivateEndpointsClientListBySubscriptionResponse]
+	beginCreateOrUpdate        *tracker[azfake.PollerResponder[armnetwork.PrivateEndpointsClientCreateOrUpdateResponse]]
+	beginDelete                *tracker[azfake.PollerResponder[armnetwork.PrivateEndpointsClientDeleteResponse]]
+	newListPager               *tracker[azfake.PagerResponder[armnetwork.PrivateEndpointsClientListResponse]]
+	newListBySubscriptionPager *tracker[azfake.PagerResponder[armnetwork.PrivateEndpointsClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for PrivateEndpointsServerTransport.
@@ -99,7 +105,8 @@ func (p *PrivateEndpointsServerTransport) dispatchBeginCreateOrUpdate(req *http.
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints/(?P<privateEndpointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -122,19 +129,21 @@ func (p *PrivateEndpointsServerTransport) dispatchBeginCreateOrUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -144,7 +153,8 @@ func (p *PrivateEndpointsServerTransport) dispatchBeginDelete(req *http.Request)
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints/(?P<privateEndpointName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -163,19 +173,21 @@ func (p *PrivateEndpointsServerTransport) dispatchBeginDelete(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +242,8 @@ func (p *PrivateEndpointsServerTransport) dispatchNewListPager(req *http.Request
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -242,20 +255,22 @@ func (p *PrivateEndpointsServerTransport) dispatchNewListPager(req *http.Request
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PrivateEndpointsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PrivateEndpointsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -264,7 +279,8 @@ func (p *PrivateEndpointsServerTransport) dispatchNewListBySubscriptionPager(req
 	if p.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if p.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := p.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateEndpoints`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -272,20 +288,22 @@ func (p *PrivateEndpointsServerTransport) dispatchNewListBySubscriptionPager(req
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListBySubscriptionPager(nil)
-		p.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListBySubscriptionPager, req, func(page *armnetwork.PrivateEndpointsClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		p.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armnetwork.PrivateEndpointsClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListBySubscriptionPager) {
-		p.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		p.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_privatelinkservices_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_privatelinkservices_server.go
@@ -81,23 +81,35 @@ type PrivateLinkServicesServer struct {
 // The returned PrivateLinkServicesServerTransport instance is connected to an instance of armnetwork.PrivateLinkServicesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPrivateLinkServicesServerTransport(srv *PrivateLinkServicesServer) *PrivateLinkServicesServerTransport {
-	return &PrivateLinkServicesServerTransport{srv: srv}
+	return &PrivateLinkServicesServerTransport{
+		srv:                                    srv,
+		beginCheckPrivateLinkServiceVisibility: newTracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse]](),
+		beginCheckPrivateLinkServiceVisibilityByResourceGroup: newTracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse]](),
+		beginCreateOrUpdate:                         newTracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCreateOrUpdateResponse]](),
+		beginDelete:                                 newTracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeleteResponse]](),
+		beginDeletePrivateEndpointConnection:        newTracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse]](),
+		newListPager:                                newTracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListResponse]](),
+		newListAutoApprovedPrivateLinkServicesPager: newTracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse]](),
+		newListAutoApprovedPrivateLinkServicesByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse]](),
+		newListBySubscriptionPager:                                 newTracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListBySubscriptionResponse]](),
+		newListPrivateEndpointConnectionsPager:                     newTracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListPrivateEndpointConnectionsResponse]](),
+	}
 }
 
 // PrivateLinkServicesServerTransport connects instances of armnetwork.PrivateLinkServicesClient to instances of PrivateLinkServicesServer.
 // Don't use this type directly, use NewPrivateLinkServicesServerTransport instead.
 type PrivateLinkServicesServerTransport struct {
 	srv                                                        *PrivateLinkServicesServer
-	beginCheckPrivateLinkServiceVisibility                     *azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse]
-	beginCheckPrivateLinkServiceVisibilityByResourceGroup      *azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse]
-	beginCreateOrUpdate                                        *azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCreateOrUpdateResponse]
-	beginDelete                                                *azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeleteResponse]
-	beginDeletePrivateEndpointConnection                       *azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse]
-	newListPager                                               *azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListResponse]
-	newListAutoApprovedPrivateLinkServicesPager                *azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse]
-	newListAutoApprovedPrivateLinkServicesByResourceGroupPager *azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse]
-	newListBySubscriptionPager                                 *azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListBySubscriptionResponse]
-	newListPrivateEndpointConnectionsPager                     *azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListPrivateEndpointConnectionsResponse]
+	beginCheckPrivateLinkServiceVisibility                     *tracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityResponse]]
+	beginCheckPrivateLinkServiceVisibilityByResourceGroup      *tracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCheckPrivateLinkServiceVisibilityByResourceGroupResponse]]
+	beginCreateOrUpdate                                        *tracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientCreateOrUpdateResponse]]
+	beginDelete                                                *tracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeleteResponse]]
+	beginDeletePrivateEndpointConnection                       *tracker[azfake.PollerResponder[armnetwork.PrivateLinkServicesClientDeletePrivateEndpointConnectionResponse]]
+	newListPager                                               *tracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListResponse]]
+	newListAutoApprovedPrivateLinkServicesPager                *tracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse]]
+	newListAutoApprovedPrivateLinkServicesByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse]]
+	newListBySubscriptionPager                                 *tracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListBySubscriptionResponse]]
+	newListPrivateEndpointConnectionsPager                     *tracker[azfake.PagerResponder[armnetwork.PrivateLinkServicesClientListPrivateEndpointConnectionsResponse]]
 }
 
 // Do implements the policy.Transporter interface for PrivateLinkServicesServerTransport.
@@ -153,7 +165,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCheckPrivateLinkServic
 	if p.srv.BeginCheckPrivateLinkServiceVisibility == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCheckPrivateLinkServiceVisibility not implemented")}
 	}
-	if p.beginCheckPrivateLinkServiceVisibility == nil {
+	beginCheckPrivateLinkServiceVisibility := p.beginCheckPrivateLinkServiceVisibility.get(req)
+	if beginCheckPrivateLinkServiceVisibility == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/checkPrivateLinkServiceVisibility`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -172,19 +185,21 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCheckPrivateLinkServic
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCheckPrivateLinkServiceVisibility = &respr
+		beginCheckPrivateLinkServiceVisibility = &respr
+		p.beginCheckPrivateLinkServiceVisibility.add(req, beginCheckPrivateLinkServiceVisibility)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCheckPrivateLinkServiceVisibility, req)
+	resp, err := server.PollerResponderNext(beginCheckPrivateLinkServiceVisibility, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginCheckPrivateLinkServiceVisibility.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCheckPrivateLinkServiceVisibility) {
-		p.beginCheckPrivateLinkServiceVisibility = nil
+	if !server.PollerResponderMore(beginCheckPrivateLinkServiceVisibility) {
+		p.beginCheckPrivateLinkServiceVisibility.remove(req)
 	}
 
 	return resp, nil
@@ -194,7 +209,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCheckPrivateLinkServic
 	if p.srv.BeginCheckPrivateLinkServiceVisibilityByResourceGroup == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCheckPrivateLinkServiceVisibilityByResourceGroup not implemented")}
 	}
-	if p.beginCheckPrivateLinkServiceVisibilityByResourceGroup == nil {
+	beginCheckPrivateLinkServiceVisibilityByResourceGroup := p.beginCheckPrivateLinkServiceVisibilityByResourceGroup.get(req)
+	if beginCheckPrivateLinkServiceVisibilityByResourceGroup == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/checkPrivateLinkServiceVisibility`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -217,19 +233,21 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCheckPrivateLinkServic
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCheckPrivateLinkServiceVisibilityByResourceGroup = &respr
+		beginCheckPrivateLinkServiceVisibilityByResourceGroup = &respr
+		p.beginCheckPrivateLinkServiceVisibilityByResourceGroup.add(req, beginCheckPrivateLinkServiceVisibilityByResourceGroup)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCheckPrivateLinkServiceVisibilityByResourceGroup, req)
+	resp, err := server.PollerResponderNext(beginCheckPrivateLinkServiceVisibilityByResourceGroup, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginCheckPrivateLinkServiceVisibilityByResourceGroup.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCheckPrivateLinkServiceVisibilityByResourceGroup) {
-		p.beginCheckPrivateLinkServiceVisibilityByResourceGroup = nil
+	if !server.PollerResponderMore(beginCheckPrivateLinkServiceVisibilityByResourceGroup) {
+		p.beginCheckPrivateLinkServiceVisibilityByResourceGroup.remove(req)
 	}
 
 	return resp, nil
@@ -239,7 +257,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCreateOrUpdate(req *ht
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices/(?P<serviceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -262,19 +281,21 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginCreateOrUpdate(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -284,7 +305,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginDelete(req *http.Reque
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices/(?P<serviceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -303,19 +325,21 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginDelete(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -325,7 +349,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginDeletePrivateEndpointC
 	if p.srv.BeginDeletePrivateEndpointConnection == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDeletePrivateEndpointConnection not implemented")}
 	}
-	if p.beginDeletePrivateEndpointConnection == nil {
+	beginDeletePrivateEndpointConnection := p.beginDeletePrivateEndpointConnection.get(req)
+	if beginDeletePrivateEndpointConnection == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices/(?P<serviceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections/(?P<peConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -348,19 +373,21 @@ func (p *PrivateLinkServicesServerTransport) dispatchBeginDeletePrivateEndpointC
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDeletePrivateEndpointConnection = &respr
+		beginDeletePrivateEndpointConnection = &respr
+		p.beginDeletePrivateEndpointConnection.add(req, beginDeletePrivateEndpointConnection)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDeletePrivateEndpointConnection, req)
+	resp, err := server.PollerResponderNext(beginDeletePrivateEndpointConnection, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDeletePrivateEndpointConnection.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDeletePrivateEndpointConnection) {
-		p.beginDeletePrivateEndpointConnection = nil
+	if !server.PollerResponderMore(beginDeletePrivateEndpointConnection) {
+		p.beginDeletePrivateEndpointConnection.remove(req)
 	}
 
 	return resp, nil
@@ -464,7 +491,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListPager(req *http.Requ
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -476,20 +504,22 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListPager(req *http.Requ
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PrivateLinkServicesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PrivateLinkServicesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -498,7 +528,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListAutoApprovedPrivateL
 	if p.srv.NewListAutoApprovedPrivateLinkServicesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAutoApprovedPrivateLinkServicesPager not implemented")}
 	}
-	if p.newListAutoApprovedPrivateLinkServicesPager == nil {
+	newListAutoApprovedPrivateLinkServicesPager := p.newListAutoApprovedPrivateLinkServicesPager.get(req)
+	if newListAutoApprovedPrivateLinkServicesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/autoApprovedPrivateLinkServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -510,20 +541,22 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListAutoApprovedPrivateL
 			return nil, err
 		}
 		resp := p.srv.NewListAutoApprovedPrivateLinkServicesPager(locationUnescaped, nil)
-		p.newListAutoApprovedPrivateLinkServicesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListAutoApprovedPrivateLinkServicesPager, req, func(page *armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse, createLink func() string) {
+		newListAutoApprovedPrivateLinkServicesPager = &resp
+		p.newListAutoApprovedPrivateLinkServicesPager.add(req, newListAutoApprovedPrivateLinkServicesPager)
+		server.PagerResponderInjectNextLinks(newListAutoApprovedPrivateLinkServicesPager, req, func(page *armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListAutoApprovedPrivateLinkServicesPager, req)
+	resp, err := server.PagerResponderNext(newListAutoApprovedPrivateLinkServicesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListAutoApprovedPrivateLinkServicesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListAutoApprovedPrivateLinkServicesPager) {
-		p.newListAutoApprovedPrivateLinkServicesPager = nil
+	if !server.PagerResponderMore(newListAutoApprovedPrivateLinkServicesPager) {
+		p.newListAutoApprovedPrivateLinkServicesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -532,7 +565,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListAutoApprovedPrivateL
 	if p.srv.NewListAutoApprovedPrivateLinkServicesByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAutoApprovedPrivateLinkServicesByResourceGroupPager not implemented")}
 	}
-	if p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager == nil {
+	newListAutoApprovedPrivateLinkServicesByResourceGroupPager := p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager.get(req)
+	if newListAutoApprovedPrivateLinkServicesByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/autoApprovedPrivateLinkServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -548,20 +582,22 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListAutoApprovedPrivateL
 			return nil, err
 		}
 		resp := p.srv.NewListAutoApprovedPrivateLinkServicesByResourceGroupPager(locationUnescaped, resourceGroupNameUnescaped, nil)
-		p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager, req, func(page *armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse, createLink func() string) {
+		newListAutoApprovedPrivateLinkServicesByResourceGroupPager = &resp
+		p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager.add(req, newListAutoApprovedPrivateLinkServicesByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListAutoApprovedPrivateLinkServicesByResourceGroupPager, req, func(page *armnetwork.PrivateLinkServicesClientListAutoApprovedPrivateLinkServicesByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListAutoApprovedPrivateLinkServicesByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager) {
-		p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListAutoApprovedPrivateLinkServicesByResourceGroupPager) {
+		p.newListAutoApprovedPrivateLinkServicesByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -570,7 +606,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListBySubscriptionPager(
 	if p.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if p.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := p.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -578,20 +615,22 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListBySubscriptionPager(
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListBySubscriptionPager(nil)
-		p.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListBySubscriptionPager, req, func(page *armnetwork.PrivateLinkServicesClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		p.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armnetwork.PrivateLinkServicesClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListBySubscriptionPager) {
-		p.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		p.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }
@@ -600,7 +639,8 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListPrivateEndpointConne
 	if p.srv.NewListPrivateEndpointConnectionsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPrivateEndpointConnectionsPager not implemented")}
 	}
-	if p.newListPrivateEndpointConnectionsPager == nil {
+	newListPrivateEndpointConnectionsPager := p.newListPrivateEndpointConnectionsPager.get(req)
+	if newListPrivateEndpointConnectionsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/privateLinkServices/(?P<serviceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/privateEndpointConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -616,20 +656,22 @@ func (p *PrivateLinkServicesServerTransport) dispatchNewListPrivateEndpointConne
 			return nil, err
 		}
 		resp := p.srv.NewListPrivateEndpointConnectionsPager(resourceGroupNameUnescaped, serviceNameUnescaped, nil)
-		p.newListPrivateEndpointConnectionsPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPrivateEndpointConnectionsPager, req, func(page *armnetwork.PrivateLinkServicesClientListPrivateEndpointConnectionsResponse, createLink func() string) {
+		newListPrivateEndpointConnectionsPager = &resp
+		p.newListPrivateEndpointConnectionsPager.add(req, newListPrivateEndpointConnectionsPager)
+		server.PagerResponderInjectNextLinks(newListPrivateEndpointConnectionsPager, req, func(page *armnetwork.PrivateLinkServicesClientListPrivateEndpointConnectionsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPrivateEndpointConnectionsPager, req)
+	resp, err := server.PagerResponderNext(newListPrivateEndpointConnectionsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPrivateEndpointConnectionsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPrivateEndpointConnectionsPager) {
-		p.newListPrivateEndpointConnectionsPager = nil
+	if !server.PagerResponderMore(newListPrivateEndpointConnectionsPager) {
+		p.newListPrivateEndpointConnectionsPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_profiles_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_profiles_server.go
@@ -53,16 +53,21 @@ type ProfilesServer struct {
 // The returned ProfilesServerTransport instance is connected to an instance of armnetwork.ProfilesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewProfilesServerTransport(srv *ProfilesServer) *ProfilesServerTransport {
-	return &ProfilesServerTransport{srv: srv}
+	return &ProfilesServerTransport{
+		srv:             srv,
+		beginDelete:     newTracker[azfake.PollerResponder[armnetwork.ProfilesClientDeleteResponse]](),
+		newListPager:    newTracker[azfake.PagerResponder[armnetwork.ProfilesClientListResponse]](),
+		newListAllPager: newTracker[azfake.PagerResponder[armnetwork.ProfilesClientListAllResponse]](),
+	}
 }
 
 // ProfilesServerTransport connects instances of armnetwork.ProfilesClient to instances of ProfilesServer.
 // Don't use this type directly, use NewProfilesServerTransport instead.
 type ProfilesServerTransport struct {
 	srv             *ProfilesServer
-	beginDelete     *azfake.PollerResponder[armnetwork.ProfilesClientDeleteResponse]
-	newListPager    *azfake.PagerResponder[armnetwork.ProfilesClientListResponse]
-	newListAllPager *azfake.PagerResponder[armnetwork.ProfilesClientListAllResponse]
+	beginDelete     *tracker[azfake.PollerResponder[armnetwork.ProfilesClientDeleteResponse]]
+	newListPager    *tracker[azfake.PagerResponder[armnetwork.ProfilesClientListResponse]]
+	newListAllPager *tracker[azfake.PagerResponder[armnetwork.ProfilesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for ProfilesServerTransport.
@@ -141,7 +146,8 @@ func (p *ProfilesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkProfiles/(?P<networkProfileName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -160,19 +166,21 @@ func (p *ProfilesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -227,7 +235,8 @@ func (p *ProfilesServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkProfiles`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +248,22 @@ func (p *ProfilesServerTransport) dispatchNewListPager(req *http.Request) (*http
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.ProfilesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ProfilesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -261,7 +272,8 @@ func (p *ProfilesServerTransport) dispatchNewListAllPager(req *http.Request) (*h
 	if p.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if p.newListAllPager == nil {
+	newListAllPager := p.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkProfiles`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -269,20 +281,22 @@ func (p *ProfilesServerTransport) dispatchNewListAllPager(req *http.Request) (*h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListAllPager(nil)
-		p.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListAllPager, req, func(page *armnetwork.ProfilesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		p.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.ProfilesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListAllPager) {
-		p.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		p.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_publicipaddresses_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_publicipaddresses_server.go
@@ -81,22 +81,33 @@ type PublicIPAddressesServer struct {
 // The returned PublicIPAddressesServerTransport instance is connected to an instance of armnetwork.PublicIPAddressesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPublicIPAddressesServerTransport(srv *PublicIPAddressesServer) *PublicIPAddressesServerTransport {
-	return &PublicIPAddressesServerTransport{srv: srv}
+	return &PublicIPAddressesServerTransport{
+		srv:                       srv,
+		beginCreateOrUpdate:       newTracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientCreateOrUpdateResponse]](),
+		beginDdosProtectionStatus: newTracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientDdosProtectionStatusResponse]](),
+		beginDelete:               newTracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientDeleteResponse]](),
+		newListPager:              newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListResponse]](),
+		newListAllPager:           newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListAllResponse]](),
+		newListCloudServicePublicIPAddressesPager:             newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServicePublicIPAddressesResponse]](),
+		newListCloudServiceRoleInstancePublicIPAddressesPager: newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse]](),
+		newListVirtualMachineScaleSetPublicIPAddressesPager:   newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse]](),
+		newListVirtualMachineScaleSetVMPublicIPAddressesPager: newTracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse]](),
+	}
 }
 
 // PublicIPAddressesServerTransport connects instances of armnetwork.PublicIPAddressesClient to instances of PublicIPAddressesServer.
 // Don't use this type directly, use NewPublicIPAddressesServerTransport instead.
 type PublicIPAddressesServerTransport struct {
 	srv                                                   *PublicIPAddressesServer
-	beginCreateOrUpdate                                   *azfake.PollerResponder[armnetwork.PublicIPAddressesClientCreateOrUpdateResponse]
-	beginDdosProtectionStatus                             *azfake.PollerResponder[armnetwork.PublicIPAddressesClientDdosProtectionStatusResponse]
-	beginDelete                                           *azfake.PollerResponder[armnetwork.PublicIPAddressesClientDeleteResponse]
-	newListPager                                          *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListResponse]
-	newListAllPager                                       *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListAllResponse]
-	newListCloudServicePublicIPAddressesPager             *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServicePublicIPAddressesResponse]
-	newListCloudServiceRoleInstancePublicIPAddressesPager *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse]
-	newListVirtualMachineScaleSetPublicIPAddressesPager   *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse]
-	newListVirtualMachineScaleSetVMPublicIPAddressesPager *azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse]
+	beginCreateOrUpdate                                   *tracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientCreateOrUpdateResponse]]
+	beginDdosProtectionStatus                             *tracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientDdosProtectionStatusResponse]]
+	beginDelete                                           *tracker[azfake.PollerResponder[armnetwork.PublicIPAddressesClientDeleteResponse]]
+	newListPager                                          *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListResponse]]
+	newListAllPager                                       *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListAllResponse]]
+	newListCloudServicePublicIPAddressesPager             *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServicePublicIPAddressesResponse]]
+	newListCloudServiceRoleInstancePublicIPAddressesPager *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse]]
+	newListVirtualMachineScaleSetPublicIPAddressesPager   *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse]]
+	newListVirtualMachineScaleSetVMPublicIPAddressesPager *tracker[azfake.PagerResponder[armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse]]
 }
 
 // Do implements the policy.Transporter interface for PublicIPAddressesServerTransport.
@@ -152,7 +163,8 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginCreateOrUpdate(req *http
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPAddresses/(?P<publicIpAddressName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -175,19 +187,21 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginCreateOrUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -197,7 +211,8 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginDdosProtectionStatus(req
 	if p.srv.BeginDdosProtectionStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDdosProtectionStatus not implemented")}
 	}
-	if p.beginDdosProtectionStatus == nil {
+	beginDdosProtectionStatus := p.beginDdosProtectionStatus.get(req)
+	if beginDdosProtectionStatus == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPAddresses/(?P<publicIpAddressName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ddosProtectionStatus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -216,19 +231,21 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginDdosProtectionStatus(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDdosProtectionStatus = &respr
+		beginDdosProtectionStatus = &respr
+		p.beginDdosProtectionStatus.add(req, beginDdosProtectionStatus)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDdosProtectionStatus, req)
+	resp, err := server.PollerResponderNext(beginDdosProtectionStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		p.beginDdosProtectionStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDdosProtectionStatus) {
-		p.beginDdosProtectionStatus = nil
+	if !server.PollerResponderMore(beginDdosProtectionStatus) {
+		p.beginDdosProtectionStatus.remove(req)
 	}
 
 	return resp, nil
@@ -238,7 +255,8 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginDelete(req *http.Request
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPAddresses/(?P<publicIpAddressName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -257,19 +275,21 @@ func (p *PublicIPAddressesServerTransport) dispatchBeginDelete(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -446,7 +466,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListPager(req *http.Reques
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPAddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -458,20 +479,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PublicIPAddressesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PublicIPAddressesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -480,7 +503,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListAllPager(req *http.Req
 	if p.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if p.newListAllPager == nil {
+	newListAllPager := p.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPAddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -488,20 +512,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListAllPager(req *http.Req
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListAllPager(nil)
-		p.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListAllPager, req, func(page *armnetwork.PublicIPAddressesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		p.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.PublicIPAddressesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListAllPager) {
-		p.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		p.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -510,7 +536,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListCloudServicePublicIPAd
 	if p.srv.NewListCloudServicePublicIPAddressesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListCloudServicePublicIPAddressesPager not implemented")}
 	}
-	if p.newListCloudServicePublicIPAddressesPager == nil {
+	newListCloudServicePublicIPAddressesPager := p.newListCloudServicePublicIPAddressesPager.get(req)
+	if newListCloudServicePublicIPAddressesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/publicipaddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -526,20 +553,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListCloudServicePublicIPAd
 			return nil, err
 		}
 		resp := p.srv.NewListCloudServicePublicIPAddressesPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, nil)
-		p.newListCloudServicePublicIPAddressesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListCloudServicePublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListCloudServicePublicIPAddressesResponse, createLink func() string) {
+		newListCloudServicePublicIPAddressesPager = &resp
+		p.newListCloudServicePublicIPAddressesPager.add(req, newListCloudServicePublicIPAddressesPager)
+		server.PagerResponderInjectNextLinks(newListCloudServicePublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListCloudServicePublicIPAddressesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListCloudServicePublicIPAddressesPager, req)
+	resp, err := server.PagerResponderNext(newListCloudServicePublicIPAddressesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListCloudServicePublicIPAddressesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListCloudServicePublicIPAddressesPager) {
-		p.newListCloudServicePublicIPAddressesPager = nil
+	if !server.PagerResponderMore(newListCloudServicePublicIPAddressesPager) {
+		p.newListCloudServicePublicIPAddressesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -548,7 +577,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListCloudServiceRoleInstan
 	if p.srv.NewListCloudServiceRoleInstancePublicIPAddressesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListCloudServiceRoleInstancePublicIPAddressesPager not implemented")}
 	}
-	if p.newListCloudServiceRoleInstancePublicIPAddressesPager == nil {
+	newListCloudServiceRoleInstancePublicIPAddressesPager := p.newListCloudServiceRoleInstancePublicIPAddressesPager.get(req)
+	if newListCloudServiceRoleInstancePublicIPAddressesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<cloudServiceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/roleInstances/(?P<roleInstanceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipconfigurations/(?P<ipConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/publicipaddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -576,20 +606,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListCloudServiceRoleInstan
 			return nil, err
 		}
 		resp := p.srv.NewListCloudServiceRoleInstancePublicIPAddressesPager(resourceGroupNameUnescaped, cloudServiceNameUnescaped, roleInstanceNameUnescaped, networkInterfaceNameUnescaped, ipConfigurationNameUnescaped, nil)
-		p.newListCloudServiceRoleInstancePublicIPAddressesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListCloudServiceRoleInstancePublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse, createLink func() string) {
+		newListCloudServiceRoleInstancePublicIPAddressesPager = &resp
+		p.newListCloudServiceRoleInstancePublicIPAddressesPager.add(req, newListCloudServiceRoleInstancePublicIPAddressesPager)
+		server.PagerResponderInjectNextLinks(newListCloudServiceRoleInstancePublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListCloudServiceRoleInstancePublicIPAddressesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListCloudServiceRoleInstancePublicIPAddressesPager, req)
+	resp, err := server.PagerResponderNext(newListCloudServiceRoleInstancePublicIPAddressesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListCloudServiceRoleInstancePublicIPAddressesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListCloudServiceRoleInstancePublicIPAddressesPager) {
-		p.newListCloudServiceRoleInstancePublicIPAddressesPager = nil
+	if !server.PagerResponderMore(newListCloudServiceRoleInstancePublicIPAddressesPager) {
+		p.newListCloudServiceRoleInstancePublicIPAddressesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -598,7 +630,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListVirtualMachineScaleSet
 	if p.srv.NewListVirtualMachineScaleSetPublicIPAddressesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListVirtualMachineScaleSetPublicIPAddressesPager not implemented")}
 	}
-	if p.newListVirtualMachineScaleSetPublicIPAddressesPager == nil {
+	newListVirtualMachineScaleSetPublicIPAddressesPager := p.newListVirtualMachineScaleSetPublicIPAddressesPager.get(req)
+	if newListVirtualMachineScaleSetPublicIPAddressesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/publicipaddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -614,20 +647,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListVirtualMachineScaleSet
 			return nil, err
 		}
 		resp := p.srv.NewListVirtualMachineScaleSetPublicIPAddressesPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, nil)
-		p.newListVirtualMachineScaleSetPublicIPAddressesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListVirtualMachineScaleSetPublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse, createLink func() string) {
+		newListVirtualMachineScaleSetPublicIPAddressesPager = &resp
+		p.newListVirtualMachineScaleSetPublicIPAddressesPager.add(req, newListVirtualMachineScaleSetPublicIPAddressesPager)
+		server.PagerResponderInjectNextLinks(newListVirtualMachineScaleSetPublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetPublicIPAddressesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListVirtualMachineScaleSetPublicIPAddressesPager, req)
+	resp, err := server.PagerResponderNext(newListVirtualMachineScaleSetPublicIPAddressesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListVirtualMachineScaleSetPublicIPAddressesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListVirtualMachineScaleSetPublicIPAddressesPager) {
-		p.newListVirtualMachineScaleSetPublicIPAddressesPager = nil
+	if !server.PagerResponderMore(newListVirtualMachineScaleSetPublicIPAddressesPager) {
+		p.newListVirtualMachineScaleSetPublicIPAddressesPager.remove(req)
 	}
 	return resp, nil
 }
@@ -636,7 +671,8 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListVirtualMachineScaleSet
 	if p.srv.NewListVirtualMachineScaleSetVMPublicIPAddressesPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListVirtualMachineScaleSetVMPublicIPAddressesPager not implemented")}
 	}
-	if p.newListVirtualMachineScaleSetVMPublicIPAddressesPager == nil {
+	newListVirtualMachineScaleSetVMPublicIPAddressesPager := p.newListVirtualMachineScaleSetVMPublicIPAddressesPager.get(req)
+	if newListVirtualMachineScaleSetVMPublicIPAddressesPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/virtualMachineScaleSets/(?P<virtualMachineScaleSetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualMachines/(?P<virtualmachineIndex>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkInterfaces/(?P<networkInterfaceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipconfigurations/(?P<ipConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/publicipaddresses`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -664,20 +700,22 @@ func (p *PublicIPAddressesServerTransport) dispatchNewListVirtualMachineScaleSet
 			return nil, err
 		}
 		resp := p.srv.NewListVirtualMachineScaleSetVMPublicIPAddressesPager(resourceGroupNameUnescaped, virtualMachineScaleSetNameUnescaped, virtualmachineIndexUnescaped, networkInterfaceNameUnescaped, ipConfigurationNameUnescaped, nil)
-		p.newListVirtualMachineScaleSetVMPublicIPAddressesPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListVirtualMachineScaleSetVMPublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse, createLink func() string) {
+		newListVirtualMachineScaleSetVMPublicIPAddressesPager = &resp
+		p.newListVirtualMachineScaleSetVMPublicIPAddressesPager.add(req, newListVirtualMachineScaleSetVMPublicIPAddressesPager)
+		server.PagerResponderInjectNextLinks(newListVirtualMachineScaleSetVMPublicIPAddressesPager, req, func(page *armnetwork.PublicIPAddressesClientListVirtualMachineScaleSetVMPublicIPAddressesResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListVirtualMachineScaleSetVMPublicIPAddressesPager, req)
+	resp, err := server.PagerResponderNext(newListVirtualMachineScaleSetVMPublicIPAddressesPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListVirtualMachineScaleSetVMPublicIPAddressesPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListVirtualMachineScaleSetVMPublicIPAddressesPager) {
-		p.newListVirtualMachineScaleSetVMPublicIPAddressesPager = nil
+	if !server.PagerResponderMore(newListVirtualMachineScaleSetVMPublicIPAddressesPager) {
+		p.newListVirtualMachineScaleSetVMPublicIPAddressesPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_publicipprefixes_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_publicipprefixes_server.go
@@ -53,17 +53,23 @@ type PublicIPPrefixesServer struct {
 // The returned PublicIPPrefixesServerTransport instance is connected to an instance of armnetwork.PublicIPPrefixesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewPublicIPPrefixesServerTransport(srv *PublicIPPrefixesServer) *PublicIPPrefixesServerTransport {
-	return &PublicIPPrefixesServerTransport{srv: srv}
+	return &PublicIPPrefixesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.PublicIPPrefixesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.PublicIPPrefixesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListAllResponse]](),
+	}
 }
 
 // PublicIPPrefixesServerTransport connects instances of armnetwork.PublicIPPrefixesClient to instances of PublicIPPrefixesServer.
 // Don't use this type directly, use NewPublicIPPrefixesServerTransport instead.
 type PublicIPPrefixesServerTransport struct {
 	srv                 *PublicIPPrefixesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.PublicIPPrefixesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.PublicIPPrefixesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.PublicIPPrefixesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.PublicIPPrefixesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.PublicIPPrefixesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for PublicIPPrefixesServerTransport.
@@ -105,7 +111,8 @@ func (p *PublicIPPrefixesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 	if p.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if p.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := p.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPPrefixes/(?P<publicIpPrefixName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (p *PublicIPPrefixesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		p.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		p.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginCreateOrUpdate) {
-		p.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		p.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (p *PublicIPPrefixesServerTransport) dispatchBeginDelete(req *http.Request)
 	if p.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if p.beginDelete == nil {
+	beginDelete := p.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPPrefixes/(?P<publicIpPrefixName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (p *PublicIPPrefixesServerTransport) dispatchBeginDelete(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		p.beginDelete = &respr
+		beginDelete = &respr
+		p.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(p.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		p.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(p.beginDelete) {
-		p.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		p.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (p *PublicIPPrefixesServerTransport) dispatchNewListPager(req *http.Request
 	if p.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if p.newListPager == nil {
+	newListPager := p.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPPrefixes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (p *PublicIPPrefixesServerTransport) dispatchNewListPager(req *http.Request
 			return nil, err
 		}
 		resp := p.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		p.newListPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListPager, req, func(page *armnetwork.PublicIPPrefixesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		p.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.PublicIPPrefixesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListPager) {
-		p.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		p.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (p *PublicIPPrefixesServerTransport) dispatchNewListAllPager(req *http.Requ
 	if p.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if p.newListAllPager == nil {
+	newListAllPager := p.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/publicIPPrefixes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (p *PublicIPPrefixesServerTransport) dispatchNewListAllPager(req *http.Requ
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := p.srv.NewListAllPager(nil)
-		p.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(p.newListAllPager, req, func(page *armnetwork.PublicIPPrefixesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		p.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.PublicIPPrefixesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(p.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		p.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(p.newListAllPager) {
-		p.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		p.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routefilterrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routefilterrules_server.go
@@ -45,16 +45,21 @@ type RouteFilterRulesServer struct {
 // The returned RouteFilterRulesServerTransport instance is connected to an instance of armnetwork.RouteFilterRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRouteFilterRulesServerTransport(srv *RouteFilterRulesServer) *RouteFilterRulesServerTransport {
-	return &RouteFilterRulesServerTransport{srv: srv}
+	return &RouteFilterRulesServerTransport{
+		srv:                       srv,
+		beginCreateOrUpdate:       newTracker[azfake.PollerResponder[armnetwork.RouteFilterRulesClientCreateOrUpdateResponse]](),
+		beginDelete:               newTracker[azfake.PollerResponder[armnetwork.RouteFilterRulesClientDeleteResponse]](),
+		newListByRouteFilterPager: newTracker[azfake.PagerResponder[armnetwork.RouteFilterRulesClientListByRouteFilterResponse]](),
+	}
 }
 
 // RouteFilterRulesServerTransport connects instances of armnetwork.RouteFilterRulesClient to instances of RouteFilterRulesServer.
 // Don't use this type directly, use NewRouteFilterRulesServerTransport instead.
 type RouteFilterRulesServerTransport struct {
 	srv                       *RouteFilterRulesServer
-	beginCreateOrUpdate       *azfake.PollerResponder[armnetwork.RouteFilterRulesClientCreateOrUpdateResponse]
-	beginDelete               *azfake.PollerResponder[armnetwork.RouteFilterRulesClientDeleteResponse]
-	newListByRouteFilterPager *azfake.PagerResponder[armnetwork.RouteFilterRulesClientListByRouteFilterResponse]
+	beginCreateOrUpdate       *tracker[azfake.PollerResponder[armnetwork.RouteFilterRulesClientCreateOrUpdateResponse]]
+	beginDelete               *tracker[azfake.PollerResponder[armnetwork.RouteFilterRulesClientDeleteResponse]]
+	newListByRouteFilterPager *tracker[azfake.PagerResponder[armnetwork.RouteFilterRulesClientListByRouteFilterResponse]]
 }
 
 // Do implements the policy.Transporter interface for RouteFilterRulesServerTransport.
@@ -92,7 +97,8 @@ func (r *RouteFilterRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters/(?P<routeFilterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeFilterRules/(?P<ruleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (r *RouteFilterRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (r *RouteFilterRulesServerTransport) dispatchBeginDelete(req *http.Request)
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters/(?P<routeFilterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeFilterRules/(?P<ruleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (r *RouteFilterRulesServerTransport) dispatchBeginDelete(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (r *RouteFilterRulesServerTransport) dispatchNewListByRouteFilterPager(req 
 	if r.srv.NewListByRouteFilterPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByRouteFilterPager not implemented")}
 	}
-	if r.newListByRouteFilterPager == nil {
+	newListByRouteFilterPager := r.newListByRouteFilterPager.get(req)
+	if newListByRouteFilterPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters/(?P<routeFilterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeFilterRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (r *RouteFilterRulesServerTransport) dispatchNewListByRouteFilterPager(req 
 			return nil, err
 		}
 		resp := r.srv.NewListByRouteFilterPager(resourceGroupNameUnescaped, routeFilterNameUnescaped, nil)
-		r.newListByRouteFilterPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListByRouteFilterPager, req, func(page *armnetwork.RouteFilterRulesClientListByRouteFilterResponse, createLink func() string) {
+		newListByRouteFilterPager = &resp
+		r.newListByRouteFilterPager.add(req, newListByRouteFilterPager)
+		server.PagerResponderInjectNextLinks(newListByRouteFilterPager, req, func(page *armnetwork.RouteFilterRulesClientListByRouteFilterResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListByRouteFilterPager, req)
+	resp, err := server.PagerResponderNext(newListByRouteFilterPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListByRouteFilterPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListByRouteFilterPager) {
-		r.newListByRouteFilterPager = nil
+	if !server.PagerResponderMore(newListByRouteFilterPager) {
+		r.newListByRouteFilterPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routefilters_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routefilters_server.go
@@ -53,17 +53,23 @@ type RouteFiltersServer struct {
 // The returned RouteFiltersServerTransport instance is connected to an instance of armnetwork.RouteFiltersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRouteFiltersServerTransport(srv *RouteFiltersServer) *RouteFiltersServerTransport {
-	return &RouteFiltersServerTransport{srv: srv}
+	return &RouteFiltersServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.RouteFiltersClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.RouteFiltersClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.RouteFiltersClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.RouteFiltersClientListByResourceGroupResponse]](),
+	}
 }
 
 // RouteFiltersServerTransport connects instances of armnetwork.RouteFiltersClient to instances of RouteFiltersServer.
 // Don't use this type directly, use NewRouteFiltersServerTransport instead.
 type RouteFiltersServerTransport struct {
 	srv                         *RouteFiltersServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.RouteFiltersClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.RouteFiltersClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.RouteFiltersClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.RouteFiltersClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.RouteFiltersClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.RouteFiltersClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.RouteFiltersClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.RouteFiltersClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for RouteFiltersServerTransport.
@@ -105,7 +111,8 @@ func (r *RouteFiltersServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters/(?P<routeFilterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (r *RouteFiltersServerTransport) dispatchBeginCreateOrUpdate(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (r *RouteFiltersServerTransport) dispatchBeginDelete(req *http.Request) (*h
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters/(?P<routeFilterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (r *RouteFiltersServerTransport) dispatchBeginDelete(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (r *RouteFiltersServerTransport) dispatchNewListPager(req *http.Request) (*
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -244,20 +257,22 @@ func (r *RouteFiltersServerTransport) dispatchNewListPager(req *http.Request) (*
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := r.srv.NewListPager(nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armnetwork.RouteFiltersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.RouteFiltersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -266,7 +281,8 @@ func (r *RouteFiltersServerTransport) dispatchNewListByResourceGroupPager(req *h
 	if r.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if r.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := r.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeFilters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (r *RouteFiltersServerTransport) dispatchNewListByResourceGroupPager(req *h
 			return nil, err
 		}
 		resp := r.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		r.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListByResourceGroupPager, req, func(page *armnetwork.RouteFiltersClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		r.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.RouteFiltersClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListByResourceGroupPager) {
-		r.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		r.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routemaps_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routemaps_server.go
@@ -45,16 +45,21 @@ type RouteMapsServer struct {
 // The returned RouteMapsServerTransport instance is connected to an instance of armnetwork.RouteMapsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRouteMapsServerTransport(srv *RouteMapsServer) *RouteMapsServerTransport {
-	return &RouteMapsServerTransport{srv: srv}
+	return &RouteMapsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.RouteMapsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.RouteMapsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.RouteMapsClientListResponse]](),
+	}
 }
 
 // RouteMapsServerTransport connects instances of armnetwork.RouteMapsClient to instances of RouteMapsServer.
 // Don't use this type directly, use NewRouteMapsServerTransport instead.
 type RouteMapsServerTransport struct {
 	srv                 *RouteMapsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.RouteMapsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.RouteMapsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.RouteMapsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.RouteMapsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.RouteMapsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.RouteMapsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for RouteMapsServerTransport.
@@ -92,7 +97,8 @@ func (r *RouteMapsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeMaps/(?P<routeMapName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (r *RouteMapsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (r *RouteMapsServerTransport) dispatchBeginDelete(req *http.Request) (*http
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeMaps/(?P<routeMapName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (r *RouteMapsServerTransport) dispatchBeginDelete(req *http.Request) (*http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (r *RouteMapsServerTransport) dispatchNewListPager(req *http.Request) (*htt
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeMaps`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (r *RouteMapsServerTransport) dispatchNewListPager(req *http.Request) (*htt
 			return nil, err
 		}
 		resp := r.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armnetwork.RouteMapsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.RouteMapsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routes_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routes_server.go
@@ -45,16 +45,21 @@ type RoutesServer struct {
 // The returned RoutesServerTransport instance is connected to an instance of armnetwork.RoutesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRoutesServerTransport(srv *RoutesServer) *RoutesServerTransport {
-	return &RoutesServerTransport{srv: srv}
+	return &RoutesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.RoutesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.RoutesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.RoutesClientListResponse]](),
+	}
 }
 
 // RoutesServerTransport connects instances of armnetwork.RoutesClient to instances of RoutesServer.
 // Don't use this type directly, use NewRoutesServerTransport instead.
 type RoutesServerTransport struct {
 	srv                 *RoutesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.RoutesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.RoutesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.RoutesClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.RoutesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.RoutesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.RoutesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for RoutesServerTransport.
@@ -92,7 +97,8 @@ func (r *RoutesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routes/(?P<routeName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (r *RoutesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (r *RoutesServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routes/(?P<routeName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (r *RoutesServerTransport) dispatchBeginDelete(req *http.Request) (*http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (r *RoutesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (r *RoutesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 			return nil, err
 		}
 		resp := r.srv.NewListPager(resourceGroupNameUnescaped, routeTableNameUnescaped, nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armnetwork.RoutesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.RoutesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routetables_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routetables_server.go
@@ -53,17 +53,23 @@ type RouteTablesServer struct {
 // The returned RouteTablesServerTransport instance is connected to an instance of armnetwork.RouteTablesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRouteTablesServerTransport(srv *RouteTablesServer) *RouteTablesServerTransport {
-	return &RouteTablesServerTransport{srv: srv}
+	return &RouteTablesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.RouteTablesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.RouteTablesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.RouteTablesClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.RouteTablesClientListAllResponse]](),
+	}
 }
 
 // RouteTablesServerTransport connects instances of armnetwork.RouteTablesClient to instances of RouteTablesServer.
 // Don't use this type directly, use NewRouteTablesServerTransport instead.
 type RouteTablesServerTransport struct {
 	srv                 *RouteTablesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.RouteTablesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.RouteTablesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.RouteTablesClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.RouteTablesClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.RouteTablesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.RouteTablesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.RouteTablesClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.RouteTablesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for RouteTablesServerTransport.
@@ -105,7 +111,8 @@ func (r *RouteTablesServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (r *RouteTablesServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (r *RouteTablesServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (r *RouteTablesServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (r *RouteTablesServerTransport) dispatchNewListPager(req *http.Request) (*h
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (r *RouteTablesServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, err
 		}
 		resp := r.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armnetwork.RouteTablesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.RouteTablesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (r *RouteTablesServerTransport) dispatchNewListAllPager(req *http.Request) 
 	if r.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if r.newListAllPager == nil {
+	newListAllPager := r.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/routeTables`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (r *RouteTablesServerTransport) dispatchNewListAllPager(req *http.Request) 
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := r.srv.NewListAllPager(nil)
-		r.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListAllPager, req, func(page *armnetwork.RouteTablesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		r.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.RouteTablesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListAllPager) {
-		r.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		r.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_routingintent_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_routingintent_server.go
@@ -45,16 +45,21 @@ type RoutingIntentServer struct {
 // The returned RoutingIntentServerTransport instance is connected to an instance of armnetwork.RoutingIntentClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewRoutingIntentServerTransport(srv *RoutingIntentServer) *RoutingIntentServerTransport {
-	return &RoutingIntentServerTransport{srv: srv}
+	return &RoutingIntentServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.RoutingIntentClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.RoutingIntentClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.RoutingIntentClientListResponse]](),
+	}
 }
 
 // RoutingIntentServerTransport connects instances of armnetwork.RoutingIntentClient to instances of RoutingIntentServer.
 // Don't use this type directly, use NewRoutingIntentServerTransport instead.
 type RoutingIntentServerTransport struct {
 	srv                 *RoutingIntentServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.RoutingIntentClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.RoutingIntentClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.RoutingIntentClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.RoutingIntentClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.RoutingIntentClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.RoutingIntentClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for RoutingIntentServerTransport.
@@ -92,7 +97,8 @@ func (r *RoutingIntentServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if r.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if r.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := r.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routingIntent/(?P<routingIntentName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (r *RoutingIntentServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		r.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		r.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginCreateOrUpdate) {
-		r.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		r.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (r *RoutingIntentServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if r.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if r.beginDelete == nil {
+	beginDelete := r.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routingIntent/(?P<routingIntentName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (r *RoutingIntentServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		r.beginDelete = &respr
+		beginDelete = &respr
+		r.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(r.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		r.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(r.beginDelete) {
-		r.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		r.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (r *RoutingIntentServerTransport) dispatchNewListPager(req *http.Request) (
 	if r.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if r.newListPager == nil {
+	newListPager := r.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routingIntent`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (r *RoutingIntentServerTransport) dispatchNewListPager(req *http.Request) (
 			return nil, err
 		}
 		resp := r.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		r.newListPager = &resp
-		server.PagerResponderInjectNextLinks(r.newListPager, req, func(page *armnetwork.RoutingIntentClientListResponse, createLink func() string) {
+		newListPager = &resp
+		r.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.RoutingIntentClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(r.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		r.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(r.newListPager) {
-		r.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		r.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_scopeconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_scopeconnections_server.go
@@ -46,14 +46,17 @@ type ScopeConnectionsServer struct {
 // The returned ScopeConnectionsServerTransport instance is connected to an instance of armnetwork.ScopeConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewScopeConnectionsServerTransport(srv *ScopeConnectionsServer) *ScopeConnectionsServerTransport {
-	return &ScopeConnectionsServerTransport{srv: srv}
+	return &ScopeConnectionsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ScopeConnectionsClientListResponse]](),
+	}
 }
 
 // ScopeConnectionsServerTransport connects instances of armnetwork.ScopeConnectionsClient to instances of ScopeConnectionsServer.
 // Don't use this type directly, use NewScopeConnectionsServerTransport instead.
 type ScopeConnectionsServerTransport struct {
 	srv          *ScopeConnectionsServer
-	newListPager *azfake.PagerResponder[armnetwork.ScopeConnectionsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ScopeConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ScopeConnectionsServerTransport.
@@ -206,7 +209,8 @@ func (s *ScopeConnectionsServerTransport) dispatchNewListPager(req *http.Request
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/scopeConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -249,20 +253,22 @@ func (s *ScopeConnectionsServerTransport) dispatchNewListPager(req *http.Request
 			}
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.ScopeConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ScopeConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_securityadminconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_securityadminconfigurations_server.go
@@ -46,15 +46,19 @@ type SecurityAdminConfigurationsServer struct {
 // The returned SecurityAdminConfigurationsServerTransport instance is connected to an instance of armnetwork.SecurityAdminConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSecurityAdminConfigurationsServerTransport(srv *SecurityAdminConfigurationsServer) *SecurityAdminConfigurationsServerTransport {
-	return &SecurityAdminConfigurationsServerTransport{srv: srv}
+	return &SecurityAdminConfigurationsServerTransport{
+		srv:          srv,
+		beginDelete:  newTracker[azfake.PollerResponder[armnetwork.SecurityAdminConfigurationsClientDeleteResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.SecurityAdminConfigurationsClientListResponse]](),
+	}
 }
 
 // SecurityAdminConfigurationsServerTransport connects instances of armnetwork.SecurityAdminConfigurationsClient to instances of SecurityAdminConfigurationsServer.
 // Don't use this type directly, use NewSecurityAdminConfigurationsServerTransport instead.
 type SecurityAdminConfigurationsServerTransport struct {
 	srv          *SecurityAdminConfigurationsServer
-	beginDelete  *azfake.PollerResponder[armnetwork.SecurityAdminConfigurationsClientDeleteResponse]
-	newListPager *azfake.PagerResponder[armnetwork.SecurityAdminConfigurationsClientListResponse]
+	beginDelete  *tracker[azfake.PollerResponder[armnetwork.SecurityAdminConfigurationsClientDeleteResponse]]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.SecurityAdminConfigurationsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SecurityAdminConfigurationsServerTransport.
@@ -133,7 +137,8 @@ func (s *SecurityAdminConfigurationsServerTransport) dispatchBeginDelete(req *ht
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations/(?P<configurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +176,21 @@ func (s *SecurityAdminConfigurationsServerTransport) dispatchBeginDelete(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +237,8 @@ func (s *SecurityAdminConfigurationsServerTransport) dispatchNewListPager(req *h
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityAdminConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -273,20 +281,22 @@ func (s *SecurityAdminConfigurationsServerTransport) dispatchNewListPager(req *h
 			}
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SecurityAdminConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SecurityAdminConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_securitygroups_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_securitygroups_server.go
@@ -53,17 +53,23 @@ type SecurityGroupsServer struct {
 // The returned SecurityGroupsServerTransport instance is connected to an instance of armnetwork.SecurityGroupsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSecurityGroupsServerTransport(srv *SecurityGroupsServer) *SecurityGroupsServerTransport {
-	return &SecurityGroupsServerTransport{srv: srv}
+	return &SecurityGroupsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.SecurityGroupsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.SecurityGroupsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.SecurityGroupsClientListResponse]](),
+		newListAllPager:     newTracker[azfake.PagerResponder[armnetwork.SecurityGroupsClientListAllResponse]](),
+	}
 }
 
 // SecurityGroupsServerTransport connects instances of armnetwork.SecurityGroupsClient to instances of SecurityGroupsServer.
 // Don't use this type directly, use NewSecurityGroupsServerTransport instead.
 type SecurityGroupsServerTransport struct {
 	srv                 *SecurityGroupsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.SecurityGroupsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.SecurityGroupsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.SecurityGroupsClientListResponse]
-	newListAllPager     *azfake.PagerResponder[armnetwork.SecurityGroupsClientListAllResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.SecurityGroupsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.SecurityGroupsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.SecurityGroupsClientListResponse]]
+	newListAllPager     *tracker[azfake.PagerResponder[armnetwork.SecurityGroupsClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for SecurityGroupsServerTransport.
@@ -105,7 +111,8 @@ func (s *SecurityGroupsServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (s *SecurityGroupsServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (s *SecurityGroupsServerTransport) dispatchBeginDelete(req *http.Request) (
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (s *SecurityGroupsServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (s *SecurityGroupsServerTransport) dispatchNewListPager(req *http.Request) 
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -248,20 +261,22 @@ func (s *SecurityGroupsServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, err
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SecurityGroupsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SecurityGroupsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -270,7 +285,8 @@ func (s *SecurityGroupsServerTransport) dispatchNewListAllPager(req *http.Reques
 	if s.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if s.newListAllPager == nil {
+	newListAllPager := s.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (s *SecurityGroupsServerTransport) dispatchNewListAllPager(req *http.Reques
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := s.srv.NewListAllPager(nil)
-		s.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListAllPager, req, func(page *armnetwork.SecurityGroupsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		s.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.SecurityGroupsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListAllPager) {
-		s.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		s.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_securitypartnerproviders_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_securitypartnerproviders_server.go
@@ -53,17 +53,23 @@ type SecurityPartnerProvidersServer struct {
 // The returned SecurityPartnerProvidersServerTransport instance is connected to an instance of armnetwork.SecurityPartnerProvidersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSecurityPartnerProvidersServerTransport(srv *SecurityPartnerProvidersServer) *SecurityPartnerProvidersServerTransport {
-	return &SecurityPartnerProvidersServerTransport{srv: srv}
+	return &SecurityPartnerProvidersServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListByResourceGroupResponse]](),
+	}
 }
 
 // SecurityPartnerProvidersServerTransport connects instances of armnetwork.SecurityPartnerProvidersClient to instances of SecurityPartnerProvidersServer.
 // Don't use this type directly, use NewSecurityPartnerProvidersServerTransport instead.
 type SecurityPartnerProvidersServerTransport struct {
 	srv                         *SecurityPartnerProvidersServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.SecurityPartnerProvidersClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.SecurityPartnerProvidersClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for SecurityPartnerProvidersServerTransport.
@@ -105,7 +111,8 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchBeginCreateOrUpdate(re
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/securityPartnerProviders/(?P<securityPartnerProviderName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchBeginCreateOrUpdate(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchBeginDelete(req *http.
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/securityPartnerProviders/(?P<securityPartnerProviderName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchBeginDelete(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchNewListPager(req *http
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/securityPartnerProviders`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchNewListPager(req *http
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := s.srv.NewListPager(nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SecurityPartnerProvidersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SecurityPartnerProvidersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchNewListByResourceGroup
 	if s.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if s.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := s.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/securityPartnerProviders`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (s *SecurityPartnerProvidersServerTransport) dispatchNewListByResourceGroup
 			return nil, err
 		}
 		resp := s.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		s.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListByResourceGroupPager, req, func(page *armnetwork.SecurityPartnerProvidersClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		s.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.SecurityPartnerProvidersClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListByResourceGroupPager) {
-		s.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		s.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_securityrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_securityrules_server.go
@@ -45,16 +45,21 @@ type SecurityRulesServer struct {
 // The returned SecurityRulesServerTransport instance is connected to an instance of armnetwork.SecurityRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSecurityRulesServerTransport(srv *SecurityRulesServer) *SecurityRulesServerTransport {
-	return &SecurityRulesServerTransport{srv: srv}
+	return &SecurityRulesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.SecurityRulesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.SecurityRulesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.SecurityRulesClientListResponse]](),
+	}
 }
 
 // SecurityRulesServerTransport connects instances of armnetwork.SecurityRulesClient to instances of SecurityRulesServer.
 // Don't use this type directly, use NewSecurityRulesServerTransport instead.
 type SecurityRulesServerTransport struct {
 	srv                 *SecurityRulesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.SecurityRulesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.SecurityRulesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.SecurityRulesClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.SecurityRulesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.SecurityRulesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.SecurityRulesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SecurityRulesServerTransport.
@@ -92,7 +97,8 @@ func (s *SecurityRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityRules/(?P<securityRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (s *SecurityRulesServerTransport) dispatchBeginCreateOrUpdate(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (s *SecurityRulesServerTransport) dispatchBeginDelete(req *http.Request) (*
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityRules/(?P<securityRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (s *SecurityRulesServerTransport) dispatchBeginDelete(req *http.Request) (*
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (s *SecurityRulesServerTransport) dispatchNewListPager(req *http.Request) (
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkSecurityGroups/(?P<networkSecurityGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (s *SecurityRulesServerTransport) dispatchNewListPager(req *http.Request) (
 			return nil, err
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, networkSecurityGroupNameUnescaped, nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SecurityRulesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SecurityRulesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_serviceendpointpolicies_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_serviceendpointpolicies_server.go
@@ -53,17 +53,23 @@ type ServiceEndpointPoliciesServer struct {
 // The returned ServiceEndpointPoliciesServerTransport instance is connected to an instance of armnetwork.ServiceEndpointPoliciesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewServiceEndpointPoliciesServerTransport(srv *ServiceEndpointPoliciesServer) *ServiceEndpointPoliciesServerTransport {
-	return &ServiceEndpointPoliciesServerTransport{srv: srv}
+	return &ServiceEndpointPoliciesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListByResourceGroupResponse]](),
+	}
 }
 
 // ServiceEndpointPoliciesServerTransport connects instances of armnetwork.ServiceEndpointPoliciesClient to instances of ServiceEndpointPoliciesServer.
 // Don't use this type directly, use NewServiceEndpointPoliciesServerTransport instead.
 type ServiceEndpointPoliciesServerTransport struct {
 	srv                         *ServiceEndpointPoliciesServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.ServiceEndpointPoliciesClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.ServiceEndpointPoliciesClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for ServiceEndpointPoliciesServerTransport.
@@ -105,7 +111,8 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchBeginCreateOrUpdate(req
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies/(?P<serviceEndpointPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchBeginDelete(req *http.R
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies/(?P<serviceEndpointPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchNewListPager(req *http.
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ServiceEndpointPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -244,20 +257,22 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchNewListPager(req *http.
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := s.srv.NewListPager(nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.ServiceEndpointPoliciesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ServiceEndpointPoliciesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -266,7 +281,8 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchNewListByResourceGroupP
 	if s.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if s.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := s.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (s *ServiceEndpointPoliciesServerTransport) dispatchNewListByResourceGroupP
 			return nil, err
 		}
 		resp := s.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		s.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListByResourceGroupPager, req, func(page *armnetwork.ServiceEndpointPoliciesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		s.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.ServiceEndpointPoliciesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListByResourceGroupPager) {
-		s.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		s.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_serviceendpointpolicydefinitions_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_serviceendpointpolicydefinitions_server.go
@@ -45,16 +45,21 @@ type ServiceEndpointPolicyDefinitionsServer struct {
 // The returned ServiceEndpointPolicyDefinitionsServerTransport instance is connected to an instance of armnetwork.ServiceEndpointPolicyDefinitionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewServiceEndpointPolicyDefinitionsServerTransport(srv *ServiceEndpointPolicyDefinitionsServer) *ServiceEndpointPolicyDefinitionsServerTransport {
-	return &ServiceEndpointPolicyDefinitionsServerTransport{srv: srv}
+	return &ServiceEndpointPolicyDefinitionsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientDeleteResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse]](),
+	}
 }
 
 // ServiceEndpointPolicyDefinitionsServerTransport connects instances of armnetwork.ServiceEndpointPolicyDefinitionsClient to instances of ServiceEndpointPolicyDefinitionsServer.
 // Don't use this type directly, use NewServiceEndpointPolicyDefinitionsServerTransport instead.
 type ServiceEndpointPolicyDefinitionsServerTransport struct {
 	srv                         *ServiceEndpointPolicyDefinitionsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientDeleteResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientDeleteResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for ServiceEndpointPolicyDefinitionsServerTransport.
@@ -92,7 +97,8 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchBeginCreateOrU
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies/(?P<serviceEndpointPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/serviceEndpointPolicyDefinitions/(?P<serviceEndpointPolicyDefinitionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchBeginCreateOrU
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchBeginDelete(re
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies/(?P<serviceEndpointPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/serviceEndpointPolicyDefinitions/(?P<serviceEndpointPolicyDefinitionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchBeginDelete(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchNewListByResou
 	if s.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if s.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := s.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/serviceEndpointPolicies/(?P<serviceEndpointPolicyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/serviceEndpointPolicyDefinitions`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (s *ServiceEndpointPolicyDefinitionsServerTransport) dispatchNewListByResou
 			return nil, err
 		}
 		resp := s.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, serviceEndpointPolicyNameUnescaped, nil)
-		s.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListByResourceGroupPager, req, func(page *armnetwork.ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		s.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.ServiceEndpointPolicyDefinitionsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListByResourceGroupPager) {
-		s.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		s.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_servicetaginformation_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_servicetaginformation_server.go
@@ -33,14 +33,17 @@ type ServiceTagInformationServer struct {
 // The returned ServiceTagInformationServerTransport instance is connected to an instance of armnetwork.ServiceTagInformationClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewServiceTagInformationServerTransport(srv *ServiceTagInformationServer) *ServiceTagInformationServerTransport {
-	return &ServiceTagInformationServerTransport{srv: srv}
+	return &ServiceTagInformationServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.ServiceTagInformationClientListResponse]](),
+	}
 }
 
 // ServiceTagInformationServerTransport connects instances of armnetwork.ServiceTagInformationClient to instances of ServiceTagInformationServer.
 // Don't use this type directly, use NewServiceTagInformationServerTransport instead.
 type ServiceTagInformationServerTransport struct {
 	srv          *ServiceTagInformationServer
-	newListPager *azfake.PagerResponder[armnetwork.ServiceTagInformationClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.ServiceTagInformationClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for ServiceTagInformationServerTransport.
@@ -72,7 +75,8 @@ func (s *ServiceTagInformationServerTransport) dispatchNewListPager(req *http.Re
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/serviceTagDetails`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -105,20 +109,22 @@ func (s *ServiceTagInformationServerTransport) dispatchNewListPager(req *http.Re
 			}
 		}
 		resp := s.srv.NewListPager(locationUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.ServiceTagInformationClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.ServiceTagInformationClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_staticmembers_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_staticmembers_server.go
@@ -46,14 +46,17 @@ type StaticMembersServer struct {
 // The returned StaticMembersServerTransport instance is connected to an instance of armnetwork.StaticMembersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewStaticMembersServerTransport(srv *StaticMembersServer) *StaticMembersServerTransport {
-	return &StaticMembersServerTransport{srv: srv}
+	return &StaticMembersServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.StaticMembersClientListResponse]](),
+	}
 }
 
 // StaticMembersServerTransport connects instances of armnetwork.StaticMembersClient to instances of StaticMembersServer.
 // Don't use this type directly, use NewStaticMembersServerTransport instead.
 type StaticMembersServerTransport struct {
 	srv          *StaticMembersServer
-	newListPager *azfake.PagerResponder[armnetwork.StaticMembersClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.StaticMembersClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for StaticMembersServerTransport.
@@ -218,7 +221,8 @@ func (s *StaticMembersServerTransport) dispatchNewListPager(req *http.Request) (
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagers/(?P<networkManagerName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkGroups/(?P<networkGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/staticMembers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -265,20 +269,22 @@ func (s *StaticMembersServerTransport) dispatchNewListPager(req *http.Request) (
 			}
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, networkManagerNameUnescaped, networkGroupNameUnescaped, options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.StaticMembersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.StaticMembersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_subnets_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_subnets_server.go
@@ -53,18 +53,25 @@ type SubnetsServer struct {
 // The returned SubnetsServerTransport instance is connected to an instance of armnetwork.SubnetsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSubnetsServerTransport(srv *SubnetsServer) *SubnetsServerTransport {
-	return &SubnetsServerTransport{srv: srv}
+	return &SubnetsServerTransport{
+		srv:                           srv,
+		beginCreateOrUpdate:           newTracker[azfake.PollerResponder[armnetwork.SubnetsClientCreateOrUpdateResponse]](),
+		beginDelete:                   newTracker[azfake.PollerResponder[armnetwork.SubnetsClientDeleteResponse]](),
+		newListPager:                  newTracker[azfake.PagerResponder[armnetwork.SubnetsClientListResponse]](),
+		beginPrepareNetworkPolicies:   newTracker[azfake.PollerResponder[armnetwork.SubnetsClientPrepareNetworkPoliciesResponse]](),
+		beginUnprepareNetworkPolicies: newTracker[azfake.PollerResponder[armnetwork.SubnetsClientUnprepareNetworkPoliciesResponse]](),
+	}
 }
 
 // SubnetsServerTransport connects instances of armnetwork.SubnetsClient to instances of SubnetsServer.
 // Don't use this type directly, use NewSubnetsServerTransport instead.
 type SubnetsServerTransport struct {
 	srv                           *SubnetsServer
-	beginCreateOrUpdate           *azfake.PollerResponder[armnetwork.SubnetsClientCreateOrUpdateResponse]
-	beginDelete                   *azfake.PollerResponder[armnetwork.SubnetsClientDeleteResponse]
-	newListPager                  *azfake.PagerResponder[armnetwork.SubnetsClientListResponse]
-	beginPrepareNetworkPolicies   *azfake.PollerResponder[armnetwork.SubnetsClientPrepareNetworkPoliciesResponse]
-	beginUnprepareNetworkPolicies *azfake.PollerResponder[armnetwork.SubnetsClientUnprepareNetworkPoliciesResponse]
+	beginCreateOrUpdate           *tracker[azfake.PollerResponder[armnetwork.SubnetsClientCreateOrUpdateResponse]]
+	beginDelete                   *tracker[azfake.PollerResponder[armnetwork.SubnetsClientDeleteResponse]]
+	newListPager                  *tracker[azfake.PagerResponder[armnetwork.SubnetsClientListResponse]]
+	beginPrepareNetworkPolicies   *tracker[azfake.PollerResponder[armnetwork.SubnetsClientPrepareNetworkPoliciesResponse]]
+	beginUnprepareNetworkPolicies *tracker[azfake.PollerResponder[armnetwork.SubnetsClientUnprepareNetworkPoliciesResponse]]
 }
 
 // Do implements the policy.Transporter interface for SubnetsServerTransport.
@@ -106,7 +113,8 @@ func (s *SubnetsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) 
 	if s.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if s.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := s.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/subnets/(?P<subnetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -133,19 +141,21 @@ func (s *SubnetsServerTransport) dispatchBeginCreateOrUpdate(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		s.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		s.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginCreateOrUpdate) {
-		s.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		s.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -155,7 +165,8 @@ func (s *SubnetsServerTransport) dispatchBeginDelete(req *http.Request) (*http.R
 	if s.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if s.beginDelete == nil {
+	beginDelete := s.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/subnets/(?P<subnetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -178,19 +189,21 @@ func (s *SubnetsServerTransport) dispatchBeginDelete(req *http.Request) (*http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginDelete = &respr
+		beginDelete = &respr
+		s.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		s.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginDelete) {
-		s.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		s.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -249,7 +262,8 @@ func (s *SubnetsServerTransport) dispatchNewListPager(req *http.Request) (*http.
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/subnets`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -265,20 +279,22 @@ func (s *SubnetsServerTransport) dispatchNewListPager(req *http.Request) (*http.
 			return nil, err
 		}
 		resp := s.srv.NewListPager(resourceGroupNameUnescaped, virtualNetworkNameUnescaped, nil)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SubnetsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SubnetsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -287,7 +303,8 @@ func (s *SubnetsServerTransport) dispatchBeginPrepareNetworkPolicies(req *http.R
 	if s.srv.BeginPrepareNetworkPolicies == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginPrepareNetworkPolicies not implemented")}
 	}
-	if s.beginPrepareNetworkPolicies == nil {
+	beginPrepareNetworkPolicies := s.beginPrepareNetworkPolicies.get(req)
+	if beginPrepareNetworkPolicies == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/subnets/(?P<subnetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/PrepareNetworkPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -314,19 +331,21 @@ func (s *SubnetsServerTransport) dispatchBeginPrepareNetworkPolicies(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginPrepareNetworkPolicies = &respr
+		beginPrepareNetworkPolicies = &respr
+		s.beginPrepareNetworkPolicies.add(req, beginPrepareNetworkPolicies)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginPrepareNetworkPolicies, req)
+	resp, err := server.PollerResponderNext(beginPrepareNetworkPolicies, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginPrepareNetworkPolicies.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginPrepareNetworkPolicies) {
-		s.beginPrepareNetworkPolicies = nil
+	if !server.PollerResponderMore(beginPrepareNetworkPolicies) {
+		s.beginPrepareNetworkPolicies.remove(req)
 	}
 
 	return resp, nil
@@ -336,7 +355,8 @@ func (s *SubnetsServerTransport) dispatchBeginUnprepareNetworkPolicies(req *http
 	if s.srv.BeginUnprepareNetworkPolicies == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUnprepareNetworkPolicies not implemented")}
 	}
-	if s.beginUnprepareNetworkPolicies == nil {
+	beginUnprepareNetworkPolicies := s.beginUnprepareNetworkPolicies.get(req)
+	if beginUnprepareNetworkPolicies == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/subnets/(?P<subnetName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/UnprepareNetworkPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -363,19 +383,21 @@ func (s *SubnetsServerTransport) dispatchBeginUnprepareNetworkPolicies(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		s.beginUnprepareNetworkPolicies = &respr
+		beginUnprepareNetworkPolicies = &respr
+		s.beginUnprepareNetworkPolicies.add(req, beginUnprepareNetworkPolicies)
 	}
 
-	resp, err := server.PollerResponderNext(s.beginUnprepareNetworkPolicies, req)
+	resp, err := server.PollerResponderNext(beginUnprepareNetworkPolicies, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		s.beginUnprepareNetworkPolicies.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(s.beginUnprepareNetworkPolicies) {
-		s.beginUnprepareNetworkPolicies = nil
+	if !server.PollerResponderMore(beginUnprepareNetworkPolicies) {
+		s.beginUnprepareNetworkPolicies.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_subscriptionnetworkmanagerconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_subscriptionnetworkmanagerconnections_server.go
@@ -46,14 +46,17 @@ type SubscriptionNetworkManagerConnectionsServer struct {
 // The returned SubscriptionNetworkManagerConnectionsServerTransport instance is connected to an instance of armnetwork.SubscriptionNetworkManagerConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewSubscriptionNetworkManagerConnectionsServerTransport(srv *SubscriptionNetworkManagerConnectionsServer) *SubscriptionNetworkManagerConnectionsServerTransport {
-	return &SubscriptionNetworkManagerConnectionsServerTransport{srv: srv}
+	return &SubscriptionNetworkManagerConnectionsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.SubscriptionNetworkManagerConnectionsClientListResponse]](),
+	}
 }
 
 // SubscriptionNetworkManagerConnectionsServerTransport connects instances of armnetwork.SubscriptionNetworkManagerConnectionsClient to instances of SubscriptionNetworkManagerConnectionsServer.
 // Don't use this type directly, use NewSubscriptionNetworkManagerConnectionsServerTransport instead.
 type SubscriptionNetworkManagerConnectionsServerTransport struct {
 	srv          *SubscriptionNetworkManagerConnectionsServer
-	newListPager *azfake.PagerResponder[armnetwork.SubscriptionNetworkManagerConnectionsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.SubscriptionNetworkManagerConnectionsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for SubscriptionNetworkManagerConnectionsServerTransport.
@@ -182,7 +185,8 @@ func (s *SubscriptionNetworkManagerConnectionsServerTransport) dispatchNewListPa
 	if s.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if s.newListPager == nil {
+	newListPager := s.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkManagerConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -217,20 +221,22 @@ func (s *SubscriptionNetworkManagerConnectionsServerTransport) dispatchNewListPa
 			}
 		}
 		resp := s.srv.NewListPager(options)
-		s.newListPager = &resp
-		server.PagerResponderInjectNextLinks(s.newListPager, req, func(page *armnetwork.SubscriptionNetworkManagerConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		s.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.SubscriptionNetworkManagerConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(s.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(s.newListPager) {
-		s.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		s.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_usages_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_usages_server.go
@@ -32,14 +32,17 @@ type UsagesServer struct {
 // The returned UsagesServerTransport instance is connected to an instance of armnetwork.UsagesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewUsagesServerTransport(srv *UsagesServer) *UsagesServerTransport {
-	return &UsagesServerTransport{srv: srv}
+	return &UsagesServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.UsagesClientListResponse]](),
+	}
 }
 
 // UsagesServerTransport connects instances of armnetwork.UsagesClient to instances of UsagesServer.
 // Don't use this type directly, use NewUsagesServerTransport instead.
 type UsagesServerTransport struct {
 	srv          *UsagesServer
-	newListPager *azfake.PagerResponder[armnetwork.UsagesClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.UsagesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for UsagesServerTransport.
@@ -71,7 +74,8 @@ func (u *UsagesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 	if u.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if u.newListPager == nil {
+	newListPager := u.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/locations/(?P<location>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/usages`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -83,20 +87,22 @@ func (u *UsagesServerTransport) dispatchNewListPager(req *http.Request) (*http.R
 			return nil, err
 		}
 		resp := u.srv.NewListPager(locationUnescaped, nil)
-		u.newListPager = &resp
-		server.PagerResponderInjectNextLinks(u.newListPager, req, func(page *armnetwork.UsagesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		u.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.UsagesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(u.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		u.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(u.newListPager) {
-		u.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		u.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vipswap_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vipswap_server.go
@@ -40,14 +40,17 @@ type VipSwapServer struct {
 // The returned VipSwapServerTransport instance is connected to an instance of armnetwork.VipSwapClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVipSwapServerTransport(srv *VipSwapServer) *VipSwapServerTransport {
-	return &VipSwapServerTransport{srv: srv}
+	return &VipSwapServerTransport{
+		srv:         srv,
+		beginCreate: newTracker[azfake.PollerResponder[armnetwork.VipSwapClientCreateResponse]](),
+	}
 }
 
 // VipSwapServerTransport connects instances of armnetwork.VipSwapClient to instances of VipSwapServer.
 // Don't use this type directly, use NewVipSwapServerTransport instead.
 type VipSwapServerTransport struct {
 	srv         *VipSwapServer
-	beginCreate *azfake.PollerResponder[armnetwork.VipSwapClientCreateResponse]
+	beginCreate *tracker[azfake.PollerResponder[armnetwork.VipSwapClientCreateResponse]]
 }
 
 // Do implements the policy.Transporter interface for VipSwapServerTransport.
@@ -83,7 +86,8 @@ func (v *VipSwapServerTransport) dispatchBeginCreate(req *http.Request) (*http.R
 	if v.srv.BeginCreate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreate not implemented")}
 	}
-	if v.beginCreate == nil {
+	beginCreate := v.beginCreate.get(req)
+	if beginCreate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<groupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Compute/cloudServices/(?P<resourceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/cloudServiceSlots/(?P<singletonResource>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -106,19 +110,21 @@ func (v *VipSwapServerTransport) dispatchBeginCreate(req *http.Request) (*http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreate = &respr
+		beginCreate = &respr
+		v.beginCreate.add(req, beginCreate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreate, req)
+	resp, err := server.PollerResponderNext(beginCreate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginCreate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreate) {
-		v.beginCreate = nil
+	if !server.PollerResponderMore(beginCreate) {
+		v.beginCreate.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualappliances_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualappliances_server.go
@@ -53,17 +53,23 @@ type VirtualAppliancesServer struct {
 // The returned VirtualAppliancesServerTransport instance is connected to an instance of armnetwork.VirtualAppliancesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualAppliancesServerTransport(srv *VirtualAppliancesServer) *VirtualAppliancesServerTransport {
-	return &VirtualAppliancesServerTransport{srv: srv}
+	return &VirtualAppliancesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VirtualAppliancesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VirtualAppliancesClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VirtualAppliancesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VirtualAppliancesClientListByResourceGroupResponse]](),
+	}
 }
 
 // VirtualAppliancesServerTransport connects instances of armnetwork.VirtualAppliancesClient to instances of VirtualAppliancesServer.
 // Don't use this type directly, use NewVirtualAppliancesServerTransport instead.
 type VirtualAppliancesServerTransport struct {
 	srv                         *VirtualAppliancesServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VirtualAppliancesClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VirtualAppliancesClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VirtualAppliancesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VirtualAppliancesClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VirtualAppliancesClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VirtualAppliancesClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VirtualAppliancesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VirtualAppliancesClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualAppliancesServerTransport.
@@ -105,7 +111,8 @@ func (v *VirtualAppliancesServerTransport) dispatchBeginCreateOrUpdate(req *http
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (v *VirtualAppliancesServerTransport) dispatchBeginCreateOrUpdate(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (v *VirtualAppliancesServerTransport) dispatchBeginDelete(req *http.Request
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (v *VirtualAppliancesServerTransport) dispatchBeginDelete(req *http.Request
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -236,7 +248,8 @@ func (v *VirtualAppliancesServerTransport) dispatchNewListPager(req *http.Reques
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -244,20 +257,22 @@ func (v *VirtualAppliancesServerTransport) dispatchNewListPager(req *http.Reques
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualAppliancesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualAppliancesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -266,7 +281,8 @@ func (v *VirtualAppliancesServerTransport) dispatchNewListByResourceGroupPager(r
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -278,20 +294,22 @@ func (v *VirtualAppliancesServerTransport) dispatchNewListByResourceGroupPager(r
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VirtualAppliancesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VirtualAppliancesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualappliancesites_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualappliancesites_server.go
@@ -45,16 +45,21 @@ type VirtualApplianceSitesServer struct {
 // The returned VirtualApplianceSitesServerTransport instance is connected to an instance of armnetwork.VirtualApplianceSitesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualApplianceSitesServerTransport(srv *VirtualApplianceSitesServer) *VirtualApplianceSitesServerTransport {
-	return &VirtualApplianceSitesServerTransport{srv: srv}
+	return &VirtualApplianceSitesServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.VirtualApplianceSitesClientListResponse]](),
+	}
 }
 
 // VirtualApplianceSitesServerTransport connects instances of armnetwork.VirtualApplianceSitesClient to instances of VirtualApplianceSitesServer.
 // Don't use this type directly, use NewVirtualApplianceSitesServerTransport instead.
 type VirtualApplianceSitesServerTransport struct {
 	srv                 *VirtualApplianceSitesServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.VirtualApplianceSitesClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualApplianceSitesClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.VirtualApplianceSitesClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualApplianceSitesServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualApplianceSitesServerTransport) dispatchBeginCreateOrUpdate(req *
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualApplianceSites/(?P<siteName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (v *VirtualApplianceSitesServerTransport) dispatchBeginCreateOrUpdate(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (v *VirtualApplianceSitesServerTransport) dispatchBeginDelete(req *http.Req
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualApplianceSites/(?P<siteName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (v *VirtualApplianceSitesServerTransport) dispatchBeginDelete(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (v *VirtualApplianceSitesServerTransport) dispatchNewListPager(req *http.Re
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualAppliances/(?P<networkVirtualApplianceName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualApplianceSites`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (v *VirtualApplianceSitesServerTransport) dispatchNewListPager(req *http.Re
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, networkVirtualApplianceNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualApplianceSitesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualApplianceSitesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualapplianceskus_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualapplianceskus_server.go
@@ -37,14 +37,17 @@ type VirtualApplianceSKUsServer struct {
 // The returned VirtualApplianceSKUsServerTransport instance is connected to an instance of armnetwork.VirtualApplianceSKUsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualApplianceSKUsServerTransport(srv *VirtualApplianceSKUsServer) *VirtualApplianceSKUsServerTransport {
-	return &VirtualApplianceSKUsServerTransport{srv: srv}
+	return &VirtualApplianceSKUsServerTransport{
+		srv:          srv,
+		newListPager: newTracker[azfake.PagerResponder[armnetwork.VirtualApplianceSKUsClientListResponse]](),
+	}
 }
 
 // VirtualApplianceSKUsServerTransport connects instances of armnetwork.VirtualApplianceSKUsClient to instances of VirtualApplianceSKUsServer.
 // Don't use this type directly, use NewVirtualApplianceSKUsServerTransport instead.
 type VirtualApplianceSKUsServerTransport struct {
 	srv          *VirtualApplianceSKUsServer
-	newListPager *azfake.PagerResponder[armnetwork.VirtualApplianceSKUsClientListResponse]
+	newListPager *tracker[azfake.PagerResponder[armnetwork.VirtualApplianceSKUsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualApplianceSKUsServerTransport.
@@ -107,7 +110,8 @@ func (v *VirtualApplianceSKUsServerTransport) dispatchNewListPager(req *http.Req
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkVirtualApplianceSkus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -115,20 +119,22 @@ func (v *VirtualApplianceSKUsServerTransport) dispatchNewListPager(req *http.Req
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualApplianceSKUsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualApplianceSKUsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubbgpconnection_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubbgpconnection_server.go
@@ -40,15 +40,19 @@ type VirtualHubBgpConnectionServer struct {
 // The returned VirtualHubBgpConnectionServerTransport instance is connected to an instance of armnetwork.VirtualHubBgpConnectionClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualHubBgpConnectionServerTransport(srv *VirtualHubBgpConnectionServer) *VirtualHubBgpConnectionServerTransport {
-	return &VirtualHubBgpConnectionServerTransport{srv: srv}
+	return &VirtualHubBgpConnectionServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientDeleteResponse]](),
+	}
 }
 
 // VirtualHubBgpConnectionServerTransport connects instances of armnetwork.VirtualHubBgpConnectionClient to instances of VirtualHubBgpConnectionServer.
 // Don't use this type directly, use NewVirtualHubBgpConnectionServerTransport instead.
 type VirtualHubBgpConnectionServerTransport struct {
 	srv                 *VirtualHubBgpConnectionServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientDeleteResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionClientDeleteResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualHubBgpConnectionServerTransport.
@@ -84,7 +88,8 @@ func (v *VirtualHubBgpConnectionServerTransport) dispatchBeginCreateOrUpdate(req
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/bgpConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -111,19 +116,21 @@ func (v *VirtualHubBgpConnectionServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -133,7 +140,8 @@ func (v *VirtualHubBgpConnectionServerTransport) dispatchBeginDelete(req *http.R
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/bgpConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -156,19 +164,21 @@ func (v *VirtualHubBgpConnectionServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubbgpconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubbgpconnections_server.go
@@ -41,16 +41,21 @@ type VirtualHubBgpConnectionsServer struct {
 // The returned VirtualHubBgpConnectionsServerTransport instance is connected to an instance of armnetwork.VirtualHubBgpConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualHubBgpConnectionsServerTransport(srv *VirtualHubBgpConnectionsServer) *VirtualHubBgpConnectionsServerTransport {
-	return &VirtualHubBgpConnectionsServerTransport{srv: srv}
+	return &VirtualHubBgpConnectionsServerTransport{
+		srv:                       srv,
+		newListPager:              newTracker[azfake.PagerResponder[armnetwork.VirtualHubBgpConnectionsClientListResponse]](),
+		beginListAdvertisedRoutes: newTracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListAdvertisedRoutesResponse]](),
+		beginListLearnedRoutes:    newTracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListLearnedRoutesResponse]](),
+	}
 }
 
 // VirtualHubBgpConnectionsServerTransport connects instances of armnetwork.VirtualHubBgpConnectionsClient to instances of VirtualHubBgpConnectionsServer.
 // Don't use this type directly, use NewVirtualHubBgpConnectionsServerTransport instead.
 type VirtualHubBgpConnectionsServerTransport struct {
 	srv                       *VirtualHubBgpConnectionsServer
-	newListPager              *azfake.PagerResponder[armnetwork.VirtualHubBgpConnectionsClientListResponse]
-	beginListAdvertisedRoutes *azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListAdvertisedRoutesResponse]
-	beginListLearnedRoutes    *azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListLearnedRoutesResponse]
+	newListPager              *tracker[azfake.PagerResponder[armnetwork.VirtualHubBgpConnectionsClientListResponse]]
+	beginListAdvertisedRoutes *tracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListAdvertisedRoutesResponse]]
+	beginListLearnedRoutes    *tracker[azfake.PollerResponder[armnetwork.VirtualHubBgpConnectionsClientListLearnedRoutesResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualHubBgpConnectionsServerTransport.
@@ -86,7 +91,8 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchNewListPager(req *http
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/bgpConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -102,20 +108,22 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchNewListPager(req *http
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualHubBgpConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualHubBgpConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -124,7 +132,8 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchBeginListAdvertisedRou
 	if v.srv.BeginListAdvertisedRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListAdvertisedRoutes not implemented")}
 	}
-	if v.beginListAdvertisedRoutes == nil {
+	beginListAdvertisedRoutes := v.beginListAdvertisedRoutes.get(req)
+	if beginListAdvertisedRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<hubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/bgpConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/advertisedRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -147,19 +156,21 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchBeginListAdvertisedRou
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginListAdvertisedRoutes = &respr
+		beginListAdvertisedRoutes = &respr
+		v.beginListAdvertisedRoutes.add(req, beginListAdvertisedRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginListAdvertisedRoutes, req)
+	resp, err := server.PollerResponderNext(beginListAdvertisedRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginListAdvertisedRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginListAdvertisedRoutes) {
-		v.beginListAdvertisedRoutes = nil
+	if !server.PollerResponderMore(beginListAdvertisedRoutes) {
+		v.beginListAdvertisedRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -169,7 +180,8 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchBeginListLearnedRoutes
 	if v.srv.BeginListLearnedRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListLearnedRoutes not implemented")}
 	}
-	if v.beginListLearnedRoutes == nil {
+	beginListLearnedRoutes := v.beginListLearnedRoutes.get(req)
+	if beginListLearnedRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<hubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/bgpConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/learnedRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -192,19 +204,21 @@ func (v *VirtualHubBgpConnectionsServerTransport) dispatchBeginListLearnedRoutes
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginListLearnedRoutes = &respr
+		beginListLearnedRoutes = &respr
+		v.beginListLearnedRoutes.add(req, beginListLearnedRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginListLearnedRoutes, req)
+	resp, err := server.PollerResponderNext(beginListLearnedRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginListLearnedRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginListLearnedRoutes) {
-		v.beginListLearnedRoutes = nil
+	if !server.PollerResponderMore(beginListLearnedRoutes) {
+		v.beginListLearnedRoutes.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubipconfiguration_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubipconfiguration_server.go
@@ -45,16 +45,21 @@ type VirtualHubIPConfigurationServer struct {
 // The returned VirtualHubIPConfigurationServerTransport instance is connected to an instance of armnetwork.VirtualHubIPConfigurationClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualHubIPConfigurationServerTransport(srv *VirtualHubIPConfigurationServer) *VirtualHubIPConfigurationServerTransport {
-	return &VirtualHubIPConfigurationServerTransport{srv: srv}
+	return &VirtualHubIPConfigurationServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.VirtualHubIPConfigurationClientListResponse]](),
+	}
 }
 
 // VirtualHubIPConfigurationServerTransport connects instances of armnetwork.VirtualHubIPConfigurationClient to instances of VirtualHubIPConfigurationServer.
 // Don't use this type directly, use NewVirtualHubIPConfigurationServerTransport instead.
 type VirtualHubIPConfigurationServerTransport struct {
 	srv                 *VirtualHubIPConfigurationServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.VirtualHubIPConfigurationClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualHubIPConfigurationClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.VirtualHubIPConfigurationClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualHubIPConfigurationServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchBeginCreateOrUpdate(r
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipConfigurations/(?P<ipConfigName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchBeginCreateOrUpdate(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchBeginDelete(req *http
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipConfigurations/(?P<ipConfigName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchBeginDelete(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchNewListPager(req *htt
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (v *VirtualHubIPConfigurationServerTransport) dispatchNewListPager(req *htt
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualHubIPConfigurationClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualHubIPConfigurationClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubroutetablev2s_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubroutetablev2s_server.go
@@ -45,16 +45,21 @@ type VirtualHubRouteTableV2SServer struct {
 // The returned VirtualHubRouteTableV2SServerTransport instance is connected to an instance of armnetwork.VirtualHubRouteTableV2SClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualHubRouteTableV2SServerTransport(srv *VirtualHubRouteTableV2SServer) *VirtualHubRouteTableV2SServerTransport {
-	return &VirtualHubRouteTableV2SServerTransport{srv: srv}
+	return &VirtualHubRouteTableV2SServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.VirtualHubRouteTableV2SClientListResponse]](),
+	}
 }
 
 // VirtualHubRouteTableV2SServerTransport connects instances of armnetwork.VirtualHubRouteTableV2SClient to instances of VirtualHubRouteTableV2SServer.
 // Don't use this type directly, use NewVirtualHubRouteTableV2SServerTransport instead.
 type VirtualHubRouteTableV2SServerTransport struct {
 	srv                 *VirtualHubRouteTableV2SServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.VirtualHubRouteTableV2SClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualHubRouteTableV2SClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.VirtualHubRouteTableV2SClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualHubRouteTableV2SServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchBeginCreateOrUpdate(req
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchBeginDelete(req *http.R
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTables/(?P<routeTableName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchNewListPager(req *http.
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/routeTables`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (v *VirtualHubRouteTableV2SServerTransport) dispatchNewListPager(req *http.
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualHubNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualHubRouteTableV2SClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualHubRouteTableV2SClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubs_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualhubs_server.go
@@ -66,20 +66,29 @@ type VirtualHubsServer struct {
 // The returned VirtualHubsServerTransport instance is connected to an instance of armnetwork.VirtualHubsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualHubsServerTransport(srv *VirtualHubsServer) *VirtualHubsServerTransport {
-	return &VirtualHubsServerTransport{srv: srv}
+	return &VirtualHubsServerTransport{
+		srv:                               srv,
+		beginCreateOrUpdate:               newTracker[azfake.PollerResponder[armnetwork.VirtualHubsClientCreateOrUpdateResponse]](),
+		beginDelete:                       newTracker[azfake.PollerResponder[armnetwork.VirtualHubsClientDeleteResponse]](),
+		beginGetEffectiveVirtualHubRoutes: newTracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetEffectiveVirtualHubRoutesResponse]](),
+		beginGetInboundRoutes:             newTracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetInboundRoutesResponse]](),
+		beginGetOutboundRoutes:            newTracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetOutboundRoutesResponse]](),
+		newListPager:                      newTracker[azfake.PagerResponder[armnetwork.VirtualHubsClientListResponse]](),
+		newListByResourceGroupPager:       newTracker[azfake.PagerResponder[armnetwork.VirtualHubsClientListByResourceGroupResponse]](),
+	}
 }
 
 // VirtualHubsServerTransport connects instances of armnetwork.VirtualHubsClient to instances of VirtualHubsServer.
 // Don't use this type directly, use NewVirtualHubsServerTransport instead.
 type VirtualHubsServerTransport struct {
 	srv                               *VirtualHubsServer
-	beginCreateOrUpdate               *azfake.PollerResponder[armnetwork.VirtualHubsClientCreateOrUpdateResponse]
-	beginDelete                       *azfake.PollerResponder[armnetwork.VirtualHubsClientDeleteResponse]
-	beginGetEffectiveVirtualHubRoutes *azfake.PollerResponder[armnetwork.VirtualHubsClientGetEffectiveVirtualHubRoutesResponse]
-	beginGetInboundRoutes             *azfake.PollerResponder[armnetwork.VirtualHubsClientGetInboundRoutesResponse]
-	beginGetOutboundRoutes            *azfake.PollerResponder[armnetwork.VirtualHubsClientGetOutboundRoutesResponse]
-	newListPager                      *azfake.PagerResponder[armnetwork.VirtualHubsClientListResponse]
-	newListByResourceGroupPager       *azfake.PagerResponder[armnetwork.VirtualHubsClientListByResourceGroupResponse]
+	beginCreateOrUpdate               *tracker[azfake.PollerResponder[armnetwork.VirtualHubsClientCreateOrUpdateResponse]]
+	beginDelete                       *tracker[azfake.PollerResponder[armnetwork.VirtualHubsClientDeleteResponse]]
+	beginGetEffectiveVirtualHubRoutes *tracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetEffectiveVirtualHubRoutesResponse]]
+	beginGetInboundRoutes             *tracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetInboundRoutesResponse]]
+	beginGetOutboundRoutes            *tracker[azfake.PollerResponder[armnetwork.VirtualHubsClientGetOutboundRoutesResponse]]
+	newListPager                      *tracker[azfake.PagerResponder[armnetwork.VirtualHubsClientListResponse]]
+	newListByResourceGroupPager       *tracker[azfake.PagerResponder[armnetwork.VirtualHubsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualHubsServerTransport.
@@ -127,7 +136,8 @@ func (v *VirtualHubsServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -150,19 +160,21 @@ func (v *VirtualHubsServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -172,7 +184,8 @@ func (v *VirtualHubsServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -191,19 +204,21 @@ func (v *VirtualHubsServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -246,7 +261,8 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetEffectiveVirtualHubRoutes(r
 	if v.srv.BeginGetEffectiveVirtualHubRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetEffectiveVirtualHubRoutes not implemented")}
 	}
-	if v.beginGetEffectiveVirtualHubRoutes == nil {
+	beginGetEffectiveVirtualHubRoutes := v.beginGetEffectiveVirtualHubRoutes.get(req)
+	if beginGetEffectiveVirtualHubRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/effectiveRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -275,19 +291,21 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetEffectiveVirtualHubRoutes(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetEffectiveVirtualHubRoutes = &respr
+		beginGetEffectiveVirtualHubRoutes = &respr
+		v.beginGetEffectiveVirtualHubRoutes.add(req, beginGetEffectiveVirtualHubRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetEffectiveVirtualHubRoutes, req)
+	resp, err := server.PollerResponderNext(beginGetEffectiveVirtualHubRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetEffectiveVirtualHubRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetEffectiveVirtualHubRoutes) {
-		v.beginGetEffectiveVirtualHubRoutes = nil
+	if !server.PollerResponderMore(beginGetEffectiveVirtualHubRoutes) {
+		v.beginGetEffectiveVirtualHubRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -297,7 +315,8 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetInboundRoutes(req *http.Req
 	if v.srv.BeginGetInboundRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetInboundRoutes not implemented")}
 	}
-	if v.beginGetInboundRoutes == nil {
+	beginGetInboundRoutes := v.beginGetInboundRoutes.get(req)
+	if beginGetInboundRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/inboundRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -320,19 +339,21 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetInboundRoutes(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetInboundRoutes = &respr
+		beginGetInboundRoutes = &respr
+		v.beginGetInboundRoutes.add(req, beginGetInboundRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetInboundRoutes, req)
+	resp, err := server.PollerResponderNext(beginGetInboundRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetInboundRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetInboundRoutes) {
-		v.beginGetInboundRoutes = nil
+	if !server.PollerResponderMore(beginGetInboundRoutes) {
+		v.beginGetInboundRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -342,7 +363,8 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetOutboundRoutes(req *http.Re
 	if v.srv.BeginGetOutboundRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetOutboundRoutes not implemented")}
 	}
-	if v.beginGetOutboundRoutes == nil {
+	beginGetOutboundRoutes := v.beginGetOutboundRoutes.get(req)
+	if beginGetOutboundRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs/(?P<virtualHubName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/outboundRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -365,19 +387,21 @@ func (v *VirtualHubsServerTransport) dispatchBeginGetOutboundRoutes(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetOutboundRoutes = &respr
+		beginGetOutboundRoutes = &respr
+		v.beginGetOutboundRoutes.add(req, beginGetOutboundRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetOutboundRoutes, req)
+	resp, err := server.PollerResponderNext(beginGetOutboundRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetOutboundRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetOutboundRoutes) {
-		v.beginGetOutboundRoutes = nil
+	if !server.PollerResponderMore(beginGetOutboundRoutes) {
+		v.beginGetOutboundRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -387,7 +411,8 @@ func (v *VirtualHubsServerTransport) dispatchNewListPager(req *http.Request) (*h
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -395,20 +420,22 @@ func (v *VirtualHubsServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualHubsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualHubsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -417,7 +444,8 @@ func (v *VirtualHubsServerTransport) dispatchNewListByResourceGroupPager(req *ht
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualHubs`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -429,20 +457,22 @@ func (v *VirtualHubsServerTransport) dispatchNewListByResourceGroupPager(req *ht
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VirtualHubsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VirtualHubsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgatewayconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgatewayconnections_server.go
@@ -78,23 +78,35 @@ type VirtualNetworkGatewayConnectionsServer struct {
 // The returned VirtualNetworkGatewayConnectionsServerTransport instance is connected to an instance of armnetwork.VirtualNetworkGatewayConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworkGatewayConnectionsServerTransport(srv *VirtualNetworkGatewayConnectionsServer) *VirtualNetworkGatewayConnectionsServerTransport {
-	return &VirtualNetworkGatewayConnectionsServerTransport{srv: srv}
+	return &VirtualNetworkGatewayConnectionsServerTransport{
+		srv:                     srv,
+		beginCreateOrUpdate:     newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse]](),
+		beginDelete:             newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientDeleteResponse]](),
+		beginGetIkeSas:          newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientGetIkeSasResponse]](),
+		newListPager:            newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientListResponse]](),
+		beginResetConnection:    newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetConnectionResponse]](),
+		beginResetSharedKey:     newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse]](),
+		beginSetSharedKey:       newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse]](),
+		beginStartPacketCapture: newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse]](),
+		beginStopPacketCapture:  newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse]](),
+		beginUpdateTags:         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientUpdateTagsResponse]](),
+	}
 }
 
 // VirtualNetworkGatewayConnectionsServerTransport connects instances of armnetwork.VirtualNetworkGatewayConnectionsClient to instances of VirtualNetworkGatewayConnectionsServer.
 // Don't use this type directly, use NewVirtualNetworkGatewayConnectionsServerTransport instead.
 type VirtualNetworkGatewayConnectionsServerTransport struct {
 	srv                     *VirtualNetworkGatewayConnectionsServer
-	beginCreateOrUpdate     *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse]
-	beginDelete             *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientDeleteResponse]
-	beginGetIkeSas          *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientGetIkeSasResponse]
-	newListPager            *azfake.PagerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientListResponse]
-	beginResetConnection    *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetConnectionResponse]
-	beginResetSharedKey     *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse]
-	beginSetSharedKey       *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse]
-	beginStartPacketCapture *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse]
-	beginStopPacketCapture  *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse]
-	beginUpdateTags         *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientUpdateTagsResponse]
+	beginCreateOrUpdate     *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientCreateOrUpdateResponse]]
+	beginDelete             *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientDeleteResponse]]
+	beginGetIkeSas          *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientGetIkeSasResponse]]
+	newListPager            *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientListResponse]]
+	beginResetConnection    *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetConnectionResponse]]
+	beginResetSharedKey     *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientResetSharedKeyResponse]]
+	beginSetSharedKey       *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientSetSharedKeyResponse]]
+	beginStartPacketCapture *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStartPacketCaptureResponse]]
+	beginStopPacketCapture  *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientStopPacketCaptureResponse]]
+	beginUpdateTags         *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayConnectionsClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworkGatewayConnectionsServerTransport.
@@ -148,7 +160,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginCreateOrU
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -171,19 +184,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginCreateOrU
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -193,7 +208,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginDelete(re
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -212,19 +228,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginDelete(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -267,7 +285,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginGetIkeSas
 	if v.srv.BeginGetIkeSas == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetIkeSas not implemented")}
 	}
-	if v.beginGetIkeSas == nil {
+	beginGetIkeSas := v.beginGetIkeSas.get(req)
+	if beginGetIkeSas == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getikesas`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -286,19 +305,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginGetIkeSas
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetIkeSas = &respr
+		beginGetIkeSas = &respr
+		v.beginGetIkeSas.add(req, beginGetIkeSas)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetIkeSas, req)
+	resp, err := server.PollerResponderNext(beginGetIkeSas, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetIkeSas.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetIkeSas) {
-		v.beginGetIkeSas = nil
+	if !server.PollerResponderMore(beginGetIkeSas) {
+		v.beginGetIkeSas.remove(req)
 	}
 
 	return resp, nil
@@ -341,7 +362,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchNewListPager(r
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -353,20 +375,22 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchNewListPager(r
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualNetworkGatewayConnectionsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualNetworkGatewayConnectionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -375,7 +399,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginResetConn
 	if v.srv.BeginResetConnection == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginResetConnection not implemented")}
 	}
-	if v.beginResetConnection == nil {
+	beginResetConnection := v.beginResetConnection.get(req)
+	if beginResetConnection == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resetconnection`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -394,19 +419,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginResetConn
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginResetConnection = &respr
+		beginResetConnection = &respr
+		v.beginResetConnection.add(req, beginResetConnection)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginResetConnection, req)
+	resp, err := server.PollerResponderNext(beginResetConnection, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		v.beginResetConnection.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginResetConnection) {
-		v.beginResetConnection = nil
+	if !server.PollerResponderMore(beginResetConnection) {
+		v.beginResetConnection.remove(req)
 	}
 
 	return resp, nil
@@ -416,7 +443,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginResetShar
 	if v.srv.BeginResetSharedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginResetSharedKey not implemented")}
 	}
-	if v.beginResetSharedKey == nil {
+	beginResetSharedKey := v.beginResetSharedKey.get(req)
+	if beginResetSharedKey == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sharedkey/reset`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -439,19 +467,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginResetShar
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginResetSharedKey = &respr
+		beginResetSharedKey = &respr
+		v.beginResetSharedKey.add(req, beginResetSharedKey)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginResetSharedKey, req)
+	resp, err := server.PollerResponderNext(beginResetSharedKey, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginResetSharedKey.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginResetSharedKey) {
-		v.beginResetSharedKey = nil
+	if !server.PollerResponderMore(beginResetSharedKey) {
+		v.beginResetSharedKey.remove(req)
 	}
 
 	return resp, nil
@@ -461,7 +491,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginSetShared
 	if v.srv.BeginSetSharedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginSetSharedKey not implemented")}
 	}
-	if v.beginSetSharedKey == nil {
+	beginSetSharedKey := v.beginSetSharedKey.get(req)
+	if beginSetSharedKey == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/sharedkey`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -484,19 +515,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginSetShared
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginSetSharedKey = &respr
+		beginSetSharedKey = &respr
+		v.beginSetSharedKey.add(req, beginSetSharedKey)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginSetSharedKey, req)
+	resp, err := server.PollerResponderNext(beginSetSharedKey, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginSetSharedKey.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginSetSharedKey) {
-		v.beginSetSharedKey = nil
+	if !server.PollerResponderMore(beginSetSharedKey) {
+		v.beginSetSharedKey.remove(req)
 	}
 
 	return resp, nil
@@ -506,7 +539,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginStartPack
 	if v.srv.BeginStartPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartPacketCapture not implemented")}
 	}
-	if v.beginStartPacketCapture == nil {
+	beginStartPacketCapture := v.beginStartPacketCapture.get(req)
+	if beginStartPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/startPacketCapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -535,19 +569,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginStartPack
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartPacketCapture = &respr
+		beginStartPacketCapture = &respr
+		v.beginStartPacketCapture.add(req, beginStartPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStartPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartPacketCapture) {
-		v.beginStartPacketCapture = nil
+	if !server.PollerResponderMore(beginStartPacketCapture) {
+		v.beginStartPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -557,7 +593,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginStopPacke
 	if v.srv.BeginStopPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStopPacketCapture not implemented")}
 	}
-	if v.beginStopPacketCapture == nil {
+	beginStopPacketCapture := v.beginStopPacketCapture.get(req)
+	if beginStopPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stopPacketCapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -580,19 +617,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginStopPacke
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStopPacketCapture = &respr
+		beginStopPacketCapture = &respr
+		v.beginStopPacketCapture.add(req, beginStopPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStopPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStopPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStopPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStopPacketCapture) {
-		v.beginStopPacketCapture = nil
+	if !server.PollerResponderMore(beginStopPacketCapture) {
+		v.beginStopPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -602,7 +641,8 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginUpdateTag
 	if v.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if v.beginUpdateTags == nil {
+	beginUpdateTags := v.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/connections/(?P<virtualNetworkGatewayConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -625,19 +665,21 @@ func (v *VirtualNetworkGatewayConnectionsServerTransport) dispatchBeginUpdateTag
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		v.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdateTags) {
-		v.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		v.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgatewaynatrules_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgatewaynatrules_server.go
@@ -45,16 +45,21 @@ type VirtualNetworkGatewayNatRulesServer struct {
 // The returned VirtualNetworkGatewayNatRulesServerTransport instance is connected to an instance of armnetwork.VirtualNetworkGatewayNatRulesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworkGatewayNatRulesServerTransport(srv *VirtualNetworkGatewayNatRulesServer) *VirtualNetworkGatewayNatRulesServerTransport {
-	return &VirtualNetworkGatewayNatRulesServerTransport{srv: srv}
+	return &VirtualNetworkGatewayNatRulesServerTransport{
+		srv:                                 srv,
+		beginCreateOrUpdate:                 newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientCreateOrUpdateResponse]](),
+		beginDelete:                         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientDeleteResponse]](),
+		newListByVirtualNetworkGatewayPager: newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse]](),
+	}
 }
 
 // VirtualNetworkGatewayNatRulesServerTransport connects instances of armnetwork.VirtualNetworkGatewayNatRulesClient to instances of VirtualNetworkGatewayNatRulesServer.
 // Don't use this type directly, use NewVirtualNetworkGatewayNatRulesServerTransport instead.
 type VirtualNetworkGatewayNatRulesServerTransport struct {
 	srv                                 *VirtualNetworkGatewayNatRulesServer
-	beginCreateOrUpdate                 *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientCreateOrUpdateResponse]
-	beginDelete                         *azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientDeleteResponse]
-	newListByVirtualNetworkGatewayPager *azfake.PagerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse]
+	beginCreateOrUpdate                 *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientCreateOrUpdateResponse]]
+	beginDelete                         *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientDeleteResponse]]
+	newListByVirtualNetworkGatewayPager *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworkGatewayNatRulesServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchBeginCreateOrUpda
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules/(?P<natRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchBeginCreateOrUpda
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchBeginDelete(req *
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules/(?P<natRuleName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchBeginDelete(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchNewListByVirtualN
 	if v.srv.NewListByVirtualNetworkGatewayPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVirtualNetworkGatewayPager not implemented")}
 	}
-	if v.newListByVirtualNetworkGatewayPager == nil {
+	newListByVirtualNetworkGatewayPager := v.newListByVirtualNetworkGatewayPager.get(req)
+	if newListByVirtualNetworkGatewayPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/natRules`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (v *VirtualNetworkGatewayNatRulesServerTransport) dispatchNewListByVirtualN
 			return nil, err
 		}
 		resp := v.srv.NewListByVirtualNetworkGatewayPager(resourceGroupNameUnescaped, virtualNetworkGatewayNameUnescaped, nil)
-		v.newListByVirtualNetworkGatewayPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByVirtualNetworkGatewayPager, req, func(page *armnetwork.VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse, createLink func() string) {
+		newListByVirtualNetworkGatewayPager = &resp
+		v.newListByVirtualNetworkGatewayPager.add(req, newListByVirtualNetworkGatewayPager)
+		server.PagerResponderInjectNextLinks(newListByVirtualNetworkGatewayPager, req, func(page *armnetwork.VirtualNetworkGatewayNatRulesClientListByVirtualNetworkGatewayResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByVirtualNetworkGatewayPager, req)
+	resp, err := server.PagerResponderNext(newListByVirtualNetworkGatewayPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByVirtualNetworkGatewayPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByVirtualNetworkGatewayPager) {
-		v.newListByVirtualNetworkGatewayPager = nil
+	if !server.PagerResponderMore(newListByVirtualNetworkGatewayPager) {
+		v.newListByVirtualNetworkGatewayPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkgateways_server.go
@@ -118,32 +118,53 @@ type VirtualNetworkGatewaysServer struct {
 // The returned VirtualNetworkGatewaysServerTransport instance is connected to an instance of armnetwork.VirtualNetworkGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworkGatewaysServerTransport(srv *VirtualNetworkGatewaysServer) *VirtualNetworkGatewaysServerTransport {
-	return &VirtualNetworkGatewaysServerTransport{srv: srv}
+	return &VirtualNetworkGatewaysServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDeleteResponse]](),
+		beginDisconnectVirtualNetworkGatewayVPNConnections: newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse]](),
+		beginGenerateVPNProfile:                            newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGenerateVPNProfileResponse]](),
+		beginGeneratevpnclientpackage:                      newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse]](),
+		beginGetAdvertisedRoutes:                           newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse]](),
+		beginGetBgpPeerStatus:                              newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetBgpPeerStatusResponse]](),
+		beginGetLearnedRoutes:                              newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetLearnedRoutesResponse]](),
+		beginGetVPNProfilePackageURL:                       newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse]](),
+		beginGetVpnclientConnectionHealth:                  newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse]](),
+		beginGetVpnclientIPSecParameters:                   newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse]](),
+		newListPager:                                       newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListResponse]](),
+		newListConnectionsPager:                            newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListConnectionsResponse]](),
+		beginReset:                                         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetResponse]](),
+		beginResetVPNClientSharedKey:                       newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse]](),
+		beginSetVpnclientIPSecParameters:                   newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse]](),
+		beginStartPacketCapture:                            newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStartPacketCaptureResponse]](),
+		beginStopPacketCapture:                             newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStopPacketCaptureResponse]](),
+		beginUpdateTags:                                    newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientUpdateTagsResponse]](),
+	}
 }
 
 // VirtualNetworkGatewaysServerTransport connects instances of armnetwork.VirtualNetworkGatewaysClient to instances of VirtualNetworkGatewaysServer.
 // Don't use this type directly, use NewVirtualNetworkGatewaysServerTransport instead.
 type VirtualNetworkGatewaysServerTransport struct {
 	srv                                                *VirtualNetworkGatewaysServer
-	beginCreateOrUpdate                                *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientCreateOrUpdateResponse]
-	beginDelete                                        *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDeleteResponse]
-	beginDisconnectVirtualNetworkGatewayVPNConnections *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse]
-	beginGenerateVPNProfile                            *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGenerateVPNProfileResponse]
-	beginGeneratevpnclientpackage                      *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse]
-	beginGetAdvertisedRoutes                           *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse]
-	beginGetBgpPeerStatus                              *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetBgpPeerStatusResponse]
-	beginGetLearnedRoutes                              *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetLearnedRoutesResponse]
-	beginGetVPNProfilePackageURL                       *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse]
-	beginGetVpnclientConnectionHealth                  *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse]
-	beginGetVpnclientIPSecParameters                   *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse]
-	newListPager                                       *azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListResponse]
-	newListConnectionsPager                            *azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListConnectionsResponse]
-	beginReset                                         *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetResponse]
-	beginResetVPNClientSharedKey                       *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse]
-	beginSetVpnclientIPSecParameters                   *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse]
-	beginStartPacketCapture                            *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStartPacketCaptureResponse]
-	beginStopPacketCapture                             *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStopPacketCaptureResponse]
-	beginUpdateTags                                    *azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientUpdateTagsResponse]
+	beginCreateOrUpdate                                *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientCreateOrUpdateResponse]]
+	beginDelete                                        *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDeleteResponse]]
+	beginDisconnectVirtualNetworkGatewayVPNConnections *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientDisconnectVirtualNetworkGatewayVPNConnectionsResponse]]
+	beginGenerateVPNProfile                            *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGenerateVPNProfileResponse]]
+	beginGeneratevpnclientpackage                      *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGeneratevpnclientpackageResponse]]
+	beginGetAdvertisedRoutes                           *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetAdvertisedRoutesResponse]]
+	beginGetBgpPeerStatus                              *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetBgpPeerStatusResponse]]
+	beginGetLearnedRoutes                              *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetLearnedRoutesResponse]]
+	beginGetVPNProfilePackageURL                       *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVPNProfilePackageURLResponse]]
+	beginGetVpnclientConnectionHealth                  *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientConnectionHealthResponse]]
+	beginGetVpnclientIPSecParameters                   *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientGetVpnclientIPSecParametersResponse]]
+	newListPager                                       *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListResponse]]
+	newListConnectionsPager                            *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkGatewaysClientListConnectionsResponse]]
+	beginReset                                         *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetResponse]]
+	beginResetVPNClientSharedKey                       *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientResetVPNClientSharedKeyResponse]]
+	beginSetVpnclientIPSecParameters                   *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientSetVpnclientIPSecParametersResponse]]
+	beginStartPacketCapture                            *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStartPacketCaptureResponse]]
+	beginStopPacketCapture                             *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientStopPacketCaptureResponse]]
+	beginUpdateTags                                    *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkGatewaysClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworkGatewaysServerTransport.
@@ -217,7 +238,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginCreateOrUpdate(req 
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -240,19 +262,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginCreateOrUpdate(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -262,7 +286,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginDelete(req *http.Re
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -281,19 +306,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginDelete(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -303,7 +330,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginDisconnectVirtualNe
 	if v.srv.BeginDisconnectVirtualNetworkGatewayVPNConnections == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDisconnectVirtualNetworkGatewayVPNConnections not implemented")}
 	}
-	if v.beginDisconnectVirtualNetworkGatewayVPNConnections == nil {
+	beginDisconnectVirtualNetworkGatewayVPNConnections := v.beginDisconnectVirtualNetworkGatewayVPNConnections.get(req)
+	if beginDisconnectVirtualNetworkGatewayVPNConnections == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/disconnectVirtualNetworkGatewayVpnConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -326,19 +354,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginDisconnectVirtualNe
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDisconnectVirtualNetworkGatewayVPNConnections = &respr
+		beginDisconnectVirtualNetworkGatewayVPNConnections = &respr
+		v.beginDisconnectVirtualNetworkGatewayVPNConnections.add(req, beginDisconnectVirtualNetworkGatewayVPNConnections)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDisconnectVirtualNetworkGatewayVPNConnections, req)
+	resp, err := server.PollerResponderNext(beginDisconnectVirtualNetworkGatewayVPNConnections, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDisconnectVirtualNetworkGatewayVPNConnections.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDisconnectVirtualNetworkGatewayVPNConnections) {
-		v.beginDisconnectVirtualNetworkGatewayVPNConnections = nil
+	if !server.PollerResponderMore(beginDisconnectVirtualNetworkGatewayVPNConnections) {
+		v.beginDisconnectVirtualNetworkGatewayVPNConnections.remove(req)
 	}
 
 	return resp, nil
@@ -348,7 +378,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGenerateVPNProfile(
 	if v.srv.BeginGenerateVPNProfile == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGenerateVPNProfile not implemented")}
 	}
-	if v.beginGenerateVPNProfile == nil {
+	beginGenerateVPNProfile := v.beginGenerateVPNProfile.get(req)
+	if beginGenerateVPNProfile == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/generatevpnprofile`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -371,19 +402,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGenerateVPNProfile(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGenerateVPNProfile = &respr
+		beginGenerateVPNProfile = &respr
+		v.beginGenerateVPNProfile.add(req, beginGenerateVPNProfile)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGenerateVPNProfile, req)
+	resp, err := server.PollerResponderNext(beginGenerateVPNProfile, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGenerateVPNProfile.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGenerateVPNProfile) {
-		v.beginGenerateVPNProfile = nil
+	if !server.PollerResponderMore(beginGenerateVPNProfile) {
+		v.beginGenerateVPNProfile.remove(req)
 	}
 
 	return resp, nil
@@ -393,7 +426,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGeneratevpnclientpa
 	if v.srv.BeginGeneratevpnclientpackage == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGeneratevpnclientpackage not implemented")}
 	}
-	if v.beginGeneratevpnclientpackage == nil {
+	beginGeneratevpnclientpackage := v.beginGeneratevpnclientpackage.get(req)
+	if beginGeneratevpnclientpackage == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/generatevpnclientpackage`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -416,19 +450,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGeneratevpnclientpa
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGeneratevpnclientpackage = &respr
+		beginGeneratevpnclientpackage = &respr
+		v.beginGeneratevpnclientpackage.add(req, beginGeneratevpnclientpackage)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGeneratevpnclientpackage, req)
+	resp, err := server.PollerResponderNext(beginGeneratevpnclientpackage, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGeneratevpnclientpackage.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGeneratevpnclientpackage) {
-		v.beginGeneratevpnclientpackage = nil
+	if !server.PollerResponderMore(beginGeneratevpnclientpackage) {
+		v.beginGeneratevpnclientpackage.remove(req)
 	}
 
 	return resp, nil
@@ -471,7 +507,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetAdvertisedRoutes
 	if v.srv.BeginGetAdvertisedRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetAdvertisedRoutes not implemented")}
 	}
-	if v.beginGetAdvertisedRoutes == nil {
+	beginGetAdvertisedRoutes := v.beginGetAdvertisedRoutes.get(req)
+	if beginGetAdvertisedRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getAdvertisedRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -495,19 +532,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetAdvertisedRoutes
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetAdvertisedRoutes = &respr
+		beginGetAdvertisedRoutes = &respr
+		v.beginGetAdvertisedRoutes.add(req, beginGetAdvertisedRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetAdvertisedRoutes, req)
+	resp, err := server.PollerResponderNext(beginGetAdvertisedRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetAdvertisedRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetAdvertisedRoutes) {
-		v.beginGetAdvertisedRoutes = nil
+	if !server.PollerResponderMore(beginGetAdvertisedRoutes) {
+		v.beginGetAdvertisedRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -517,7 +556,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetBgpPeerStatus(re
 	if v.srv.BeginGetBgpPeerStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetBgpPeerStatus not implemented")}
 	}
-	if v.beginGetBgpPeerStatus == nil {
+	beginGetBgpPeerStatus := v.beginGetBgpPeerStatus.get(req)
+	if beginGetBgpPeerStatus == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getBgpPeerStatus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -548,19 +588,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetBgpPeerStatus(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetBgpPeerStatus = &respr
+		beginGetBgpPeerStatus = &respr
+		v.beginGetBgpPeerStatus.add(req, beginGetBgpPeerStatus)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetBgpPeerStatus, req)
+	resp, err := server.PollerResponderNext(beginGetBgpPeerStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetBgpPeerStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetBgpPeerStatus) {
-		v.beginGetBgpPeerStatus = nil
+	if !server.PollerResponderMore(beginGetBgpPeerStatus) {
+		v.beginGetBgpPeerStatus.remove(req)
 	}
 
 	return resp, nil
@@ -570,7 +612,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetLearnedRoutes(re
 	if v.srv.BeginGetLearnedRoutes == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetLearnedRoutes not implemented")}
 	}
-	if v.beginGetLearnedRoutes == nil {
+	beginGetLearnedRoutes := v.beginGetLearnedRoutes.get(req)
+	if beginGetLearnedRoutes == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getLearnedRoutes`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -589,19 +632,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetLearnedRoutes(re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetLearnedRoutes = &respr
+		beginGetLearnedRoutes = &respr
+		v.beginGetLearnedRoutes.add(req, beginGetLearnedRoutes)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetLearnedRoutes, req)
+	resp, err := server.PollerResponderNext(beginGetLearnedRoutes, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetLearnedRoutes.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetLearnedRoutes) {
-		v.beginGetLearnedRoutes = nil
+	if !server.PollerResponderMore(beginGetLearnedRoutes) {
+		v.beginGetLearnedRoutes.remove(req)
 	}
 
 	return resp, nil
@@ -611,7 +656,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVPNProfilePackag
 	if v.srv.BeginGetVPNProfilePackageURL == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetVPNProfilePackageURL not implemented")}
 	}
-	if v.beginGetVPNProfilePackageURL == nil {
+	beginGetVPNProfilePackageURL := v.beginGetVPNProfilePackageURL.get(req)
+	if beginGetVPNProfilePackageURL == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getvpnprofilepackageurl`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -630,19 +676,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVPNProfilePackag
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetVPNProfilePackageURL = &respr
+		beginGetVPNProfilePackageURL = &respr
+		v.beginGetVPNProfilePackageURL.add(req, beginGetVPNProfilePackageURL)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetVPNProfilePackageURL, req)
+	resp, err := server.PollerResponderNext(beginGetVPNProfilePackageURL, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetVPNProfilePackageURL.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetVPNProfilePackageURL) {
-		v.beginGetVPNProfilePackageURL = nil
+	if !server.PollerResponderMore(beginGetVPNProfilePackageURL) {
+		v.beginGetVPNProfilePackageURL.remove(req)
 	}
 
 	return resp, nil
@@ -652,7 +700,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVpnclientConnect
 	if v.srv.BeginGetVpnclientConnectionHealth == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetVpnclientConnectionHealth not implemented")}
 	}
-	if v.beginGetVpnclientConnectionHealth == nil {
+	beginGetVpnclientConnectionHealth := v.beginGetVpnclientConnectionHealth.get(req)
+	if beginGetVpnclientConnectionHealth == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getVpnClientConnectionHealth`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -671,19 +720,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVpnclientConnect
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetVpnclientConnectionHealth = &respr
+		beginGetVpnclientConnectionHealth = &respr
+		v.beginGetVpnclientConnectionHealth.add(req, beginGetVpnclientConnectionHealth)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetVpnclientConnectionHealth, req)
+	resp, err := server.PollerResponderNext(beginGetVpnclientConnectionHealth, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetVpnclientConnectionHealth.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetVpnclientConnectionHealth) {
-		v.beginGetVpnclientConnectionHealth = nil
+	if !server.PollerResponderMore(beginGetVpnclientConnectionHealth) {
+		v.beginGetVpnclientConnectionHealth.remove(req)
 	}
 
 	return resp, nil
@@ -693,7 +744,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVpnclientIPSecPa
 	if v.srv.BeginGetVpnclientIPSecParameters == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetVpnclientIPSecParameters not implemented")}
 	}
-	if v.beginGetVpnclientIPSecParameters == nil {
+	beginGetVpnclientIPSecParameters := v.beginGetVpnclientIPSecParameters.get(req)
+	if beginGetVpnclientIPSecParameters == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getvpnclientipsecparameters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -712,19 +764,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginGetVpnclientIPSecPa
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetVpnclientIPSecParameters = &respr
+		beginGetVpnclientIPSecParameters = &respr
+		v.beginGetVpnclientIPSecParameters.add(req, beginGetVpnclientIPSecParameters)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetVpnclientIPSecParameters, req)
+	resp, err := server.PollerResponderNext(beginGetVpnclientIPSecParameters, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.beginGetVpnclientIPSecParameters.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetVpnclientIPSecParameters) {
-		v.beginGetVpnclientIPSecParameters = nil
+	if !server.PollerResponderMore(beginGetVpnclientIPSecParameters) {
+		v.beginGetVpnclientIPSecParameters.remove(req)
 	}
 
 	return resp, nil
@@ -734,7 +788,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchNewListPager(req *http.R
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -746,20 +801,22 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchNewListPager(req *http.R
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualNetworkGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualNetworkGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -768,7 +825,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchNewListConnectionsPager(
 	if v.srv.NewListConnectionsPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListConnectionsPager not implemented")}
 	}
-	if v.newListConnectionsPager == nil {
+	newListConnectionsPager := v.newListConnectionsPager.get(req)
+	if newListConnectionsPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -784,20 +842,22 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchNewListConnectionsPager(
 			return nil, err
 		}
 		resp := v.srv.NewListConnectionsPager(resourceGroupNameUnescaped, virtualNetworkGatewayNameUnescaped, nil)
-		v.newListConnectionsPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListConnectionsPager, req, func(page *armnetwork.VirtualNetworkGatewaysClientListConnectionsResponse, createLink func() string) {
+		newListConnectionsPager = &resp
+		v.newListConnectionsPager.add(req, newListConnectionsPager)
+		server.PagerResponderInjectNextLinks(newListConnectionsPager, req, func(page *armnetwork.VirtualNetworkGatewaysClientListConnectionsResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListConnectionsPager, req)
+	resp, err := server.PagerResponderNext(newListConnectionsPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListConnectionsPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListConnectionsPager) {
-		v.newListConnectionsPager = nil
+	if !server.PagerResponderMore(newListConnectionsPager) {
+		v.newListConnectionsPager.remove(req)
 	}
 	return resp, nil
 }
@@ -806,7 +866,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginReset(req *http.Req
 	if v.srv.BeginReset == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReset not implemented")}
 	}
-	if v.beginReset == nil {
+	beginReset := v.beginReset.get(req)
+	if beginReset == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reset`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -837,19 +898,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginReset(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReset = &respr
+		beginReset = &respr
+		v.beginReset.add(req, beginReset)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReset, req)
+	resp, err := server.PollerResponderNext(beginReset, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReset.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReset) {
-		v.beginReset = nil
+	if !server.PollerResponderMore(beginReset) {
+		v.beginReset.remove(req)
 	}
 
 	return resp, nil
@@ -859,7 +922,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginResetVPNClientShare
 	if v.srv.BeginResetVPNClientSharedKey == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginResetVPNClientSharedKey not implemented")}
 	}
-	if v.beginResetVPNClientSharedKey == nil {
+	beginResetVPNClientSharedKey := v.beginResetVPNClientSharedKey.get(req)
+	if beginResetVPNClientSharedKey == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resetvpnclientsharedkey`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -878,19 +942,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginResetVPNClientShare
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginResetVPNClientSharedKey = &respr
+		beginResetVPNClientSharedKey = &respr
+		v.beginResetVPNClientSharedKey.add(req, beginResetVPNClientSharedKey)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginResetVPNClientSharedKey, req)
+	resp, err := server.PollerResponderNext(beginResetVPNClientSharedKey, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginResetVPNClientSharedKey.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginResetVPNClientSharedKey) {
-		v.beginResetVPNClientSharedKey = nil
+	if !server.PollerResponderMore(beginResetVPNClientSharedKey) {
+		v.beginResetVPNClientSharedKey.remove(req)
 	}
 
 	return resp, nil
@@ -900,7 +966,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginSetVpnclientIPSecPa
 	if v.srv.BeginSetVpnclientIPSecParameters == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginSetVpnclientIPSecParameters not implemented")}
 	}
-	if v.beginSetVpnclientIPSecParameters == nil {
+	beginSetVpnclientIPSecParameters := v.beginSetVpnclientIPSecParameters.get(req)
+	if beginSetVpnclientIPSecParameters == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/setvpnclientipsecparameters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -923,19 +990,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginSetVpnclientIPSecPa
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginSetVpnclientIPSecParameters = &respr
+		beginSetVpnclientIPSecParameters = &respr
+		v.beginSetVpnclientIPSecParameters.add(req, beginSetVpnclientIPSecParameters)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginSetVpnclientIPSecParameters, req)
+	resp, err := server.PollerResponderNext(beginSetVpnclientIPSecParameters, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginSetVpnclientIPSecParameters.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginSetVpnclientIPSecParameters) {
-		v.beginSetVpnclientIPSecParameters = nil
+	if !server.PollerResponderMore(beginSetVpnclientIPSecParameters) {
+		v.beginSetVpnclientIPSecParameters.remove(req)
 	}
 
 	return resp, nil
@@ -945,7 +1014,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginStartPacketCapture(
 	if v.srv.BeginStartPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartPacketCapture not implemented")}
 	}
-	if v.beginStartPacketCapture == nil {
+	beginStartPacketCapture := v.beginStartPacketCapture.get(req)
+	if beginStartPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/startPacketCapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -974,19 +1044,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginStartPacketCapture(
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartPacketCapture = &respr
+		beginStartPacketCapture = &respr
+		v.beginStartPacketCapture.add(req, beginStartPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStartPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartPacketCapture) {
-		v.beginStartPacketCapture = nil
+	if !server.PollerResponderMore(beginStartPacketCapture) {
+		v.beginStartPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -996,7 +1068,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginStopPacketCapture(r
 	if v.srv.BeginStopPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStopPacketCapture not implemented")}
 	}
-	if v.beginStopPacketCapture == nil {
+	beginStopPacketCapture := v.beginStopPacketCapture.get(req)
+	if beginStopPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stopPacketCapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1019,19 +1092,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginStopPacketCapture(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStopPacketCapture = &respr
+		beginStopPacketCapture = &respr
+		v.beginStopPacketCapture.add(req, beginStopPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStopPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStopPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStopPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStopPacketCapture) {
-		v.beginStopPacketCapture = nil
+	if !server.PollerResponderMore(beginStopPacketCapture) {
+		v.beginStopPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -1074,7 +1149,8 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginUpdateTags(req *htt
 	if v.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if v.beginUpdateTags == nil {
+	beginUpdateTags := v.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkGateways/(?P<virtualNetworkGatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -1097,19 +1173,21 @@ func (v *VirtualNetworkGatewaysServerTransport) dispatchBeginUpdateTags(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		v.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdateTags) {
-		v.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		v.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkpeerings_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworkpeerings_server.go
@@ -45,16 +45,21 @@ type VirtualNetworkPeeringsServer struct {
 // The returned VirtualNetworkPeeringsServerTransport instance is connected to an instance of armnetwork.VirtualNetworkPeeringsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworkPeeringsServerTransport(srv *VirtualNetworkPeeringsServer) *VirtualNetworkPeeringsServerTransport {
-	return &VirtualNetworkPeeringsServerTransport{srv: srv}
+	return &VirtualNetworkPeeringsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkPeeringsClientListResponse]](),
+	}
 }
 
 // VirtualNetworkPeeringsServerTransport connects instances of armnetwork.VirtualNetworkPeeringsClient to instances of VirtualNetworkPeeringsServer.
 // Don't use this type directly, use NewVirtualNetworkPeeringsServerTransport instead.
 type VirtualNetworkPeeringsServerTransport struct {
 	srv                 *VirtualNetworkPeeringsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.VirtualNetworkPeeringsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkPeeringsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkPeeringsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworkPeeringsServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchBeginCreateOrUpdate(req 
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualNetworkPeerings/(?P<virtualNetworkPeeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,19 +137,21 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchBeginCreateOrUpdate(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -153,7 +161,8 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchBeginDelete(req *http.Re
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualNetworkPeerings/(?P<virtualNetworkPeeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -176,19 +185,21 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchBeginDelete(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -235,7 +246,8 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchNewListPager(req *http.R
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/virtualNetworkPeerings`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -251,20 +263,22 @@ func (v *VirtualNetworkPeeringsServerTransport) dispatchNewListPager(req *http.R
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualNetworkNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualNetworkPeeringsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualNetworkPeeringsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworks_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworks_server.go
@@ -66,19 +66,27 @@ type VirtualNetworksServer struct {
 // The returned VirtualNetworksServerTransport instance is connected to an instance of armnetwork.VirtualNetworksClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworksServerTransport(srv *VirtualNetworksServer) *VirtualNetworksServerTransport {
-	return &VirtualNetworksServerTransport{srv: srv}
+	return &VirtualNetworksServerTransport{
+		srv:                           srv,
+		beginCreateOrUpdate:           newTracker[azfake.PollerResponder[armnetwork.VirtualNetworksClientCreateOrUpdateResponse]](),
+		beginDelete:                   newTracker[azfake.PollerResponder[armnetwork.VirtualNetworksClientDeleteResponse]](),
+		newListPager:                  newTracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListResponse]](),
+		newListAllPager:               newTracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListAllResponse]](),
+		beginListDdosProtectionStatus: newTracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.VirtualNetworksClientListDdosProtectionStatusResponse]]](),
+		newListUsagePager:             newTracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListUsageResponse]](),
+	}
 }
 
 // VirtualNetworksServerTransport connects instances of armnetwork.VirtualNetworksClient to instances of VirtualNetworksServer.
 // Don't use this type directly, use NewVirtualNetworksServerTransport instead.
 type VirtualNetworksServerTransport struct {
 	srv                           *VirtualNetworksServer
-	beginCreateOrUpdate           *azfake.PollerResponder[armnetwork.VirtualNetworksClientCreateOrUpdateResponse]
-	beginDelete                   *azfake.PollerResponder[armnetwork.VirtualNetworksClientDeleteResponse]
-	newListPager                  *azfake.PagerResponder[armnetwork.VirtualNetworksClientListResponse]
-	newListAllPager               *azfake.PagerResponder[armnetwork.VirtualNetworksClientListAllResponse]
-	beginListDdosProtectionStatus *azfake.PollerResponder[azfake.PagerResponder[armnetwork.VirtualNetworksClientListDdosProtectionStatusResponse]]
-	newListUsagePager             *azfake.PagerResponder[armnetwork.VirtualNetworksClientListUsageResponse]
+	beginCreateOrUpdate           *tracker[azfake.PollerResponder[armnetwork.VirtualNetworksClientCreateOrUpdateResponse]]
+	beginDelete                   *tracker[azfake.PollerResponder[armnetwork.VirtualNetworksClientDeleteResponse]]
+	newListPager                  *tracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListResponse]]
+	newListAllPager               *tracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListAllResponse]]
+	beginListDdosProtectionStatus *tracker[azfake.PollerResponder[azfake.PagerResponder[armnetwork.VirtualNetworksClientListDdosProtectionStatusResponse]]]
+	newListUsagePager             *tracker[azfake.PagerResponder[armnetwork.VirtualNetworksClientListUsageResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworksServerTransport.
@@ -164,7 +172,8 @@ func (v *VirtualNetworksServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -187,19 +196,21 @@ func (v *VirtualNetworksServerTransport) dispatchBeginCreateOrUpdate(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -209,7 +220,8 @@ func (v *VirtualNetworksServerTransport) dispatchBeginDelete(req *http.Request) 
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -228,19 +240,21 @@ func (v *VirtualNetworksServerTransport) dispatchBeginDelete(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -295,7 +309,8 @@ func (v *VirtualNetworksServerTransport) dispatchNewListPager(req *http.Request)
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -307,20 +322,22 @@ func (v *VirtualNetworksServerTransport) dispatchNewListPager(req *http.Request)
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualNetworksClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualNetworksClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -329,7 +346,8 @@ func (v *VirtualNetworksServerTransport) dispatchNewListAllPager(req *http.Reque
 	if v.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if v.newListAllPager == nil {
+	newListAllPager := v.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -337,20 +355,22 @@ func (v *VirtualNetworksServerTransport) dispatchNewListAllPager(req *http.Reque
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListAllPager(nil)
-		v.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListAllPager, req, func(page *armnetwork.VirtualNetworksClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		v.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.VirtualNetworksClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListAllPager) {
-		v.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		v.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -359,7 +379,8 @@ func (v *VirtualNetworksServerTransport) dispatchBeginListDdosProtectionStatus(r
 	if v.srv.BeginListDdosProtectionStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListDdosProtectionStatus not implemented")}
 	}
-	if v.beginListDdosProtectionStatus == nil {
+	beginListDdosProtectionStatus := v.beginListDdosProtectionStatus.get(req)
+	if beginListDdosProtectionStatus == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ddosProtectionStatus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -405,19 +426,21 @@ func (v *VirtualNetworksServerTransport) dispatchBeginListDdosProtectionStatus(r
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginListDdosProtectionStatus = &respr
+		beginListDdosProtectionStatus = &respr
+		v.beginListDdosProtectionStatus.add(req, beginListDdosProtectionStatus)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginListDdosProtectionStatus, req)
+	resp, err := server.PollerResponderNext(beginListDdosProtectionStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginListDdosProtectionStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginListDdosProtectionStatus) {
-		v.beginListDdosProtectionStatus = nil
+	if !server.PollerResponderMore(beginListDdosProtectionStatus) {
+		v.beginListDdosProtectionStatus.remove(req)
 	}
 
 	return resp, nil
@@ -427,7 +450,8 @@ func (v *VirtualNetworksServerTransport) dispatchNewListUsagePager(req *http.Req
 	if v.srv.NewListUsagePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListUsagePager not implemented")}
 	}
-	if v.newListUsagePager == nil {
+	newListUsagePager := v.newListUsagePager.get(req)
+	if newListUsagePager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworks/(?P<virtualNetworkName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/usages`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -443,20 +467,22 @@ func (v *VirtualNetworksServerTransport) dispatchNewListUsagePager(req *http.Req
 			return nil, err
 		}
 		resp := v.srv.NewListUsagePager(resourceGroupNameUnescaped, virtualNetworkNameUnescaped, nil)
-		v.newListUsagePager = &resp
-		server.PagerResponderInjectNextLinks(v.newListUsagePager, req, func(page *armnetwork.VirtualNetworksClientListUsageResponse, createLink func() string) {
+		newListUsagePager = &resp
+		v.newListUsagePager.add(req, newListUsagePager)
+		server.PagerResponderInjectNextLinks(newListUsagePager, req, func(page *armnetwork.VirtualNetworksClientListUsageResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListUsagePager, req)
+	resp, err := server.PagerResponderNext(newListUsagePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListUsagePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListUsagePager) {
-		v.newListUsagePager = nil
+	if !server.PagerResponderMore(newListUsagePager) {
+		v.newListUsagePager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworktaps_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualnetworktaps_server.go
@@ -53,17 +53,23 @@ type VirtualNetworkTapsServer struct {
 // The returned VirtualNetworkTapsServerTransport instance is connected to an instance of armnetwork.VirtualNetworkTapsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualNetworkTapsServerTransport(srv *VirtualNetworkTapsServer) *VirtualNetworkTapsServerTransport {
-	return &VirtualNetworkTapsServerTransport{srv: srv}
+	return &VirtualNetworkTapsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientDeleteResponse]](),
+		newListAllPager:             newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListAllResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListByResourceGroupResponse]](),
+	}
 }
 
 // VirtualNetworkTapsServerTransport connects instances of armnetwork.VirtualNetworkTapsClient to instances of VirtualNetworkTapsServer.
 // Don't use this type directly, use NewVirtualNetworkTapsServerTransport instead.
 type VirtualNetworkTapsServerTransport struct {
 	srv                         *VirtualNetworkTapsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientDeleteResponse]
-	newListAllPager             *azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListAllResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VirtualNetworkTapsClientDeleteResponse]]
+	newListAllPager             *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListAllResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VirtualNetworkTapsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualNetworkTapsServerTransport.
@@ -105,7 +111,8 @@ func (v *VirtualNetworkTapsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkTaps/(?P<tapName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (v *VirtualNetworkTapsServerTransport) dispatchBeginCreateOrUpdate(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (v *VirtualNetworkTapsServerTransport) dispatchBeginDelete(req *http.Reques
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkTaps/(?P<tapName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (v *VirtualNetworkTapsServerTransport) dispatchBeginDelete(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (v *VirtualNetworkTapsServerTransport) dispatchNewListAllPager(req *http.Re
 	if v.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if v.newListAllPager == nil {
+	newListAllPager := v.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkTaps`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (v *VirtualNetworkTapsServerTransport) dispatchNewListAllPager(req *http.Re
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListAllPager(nil)
-		v.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListAllPager, req, func(page *armnetwork.VirtualNetworkTapsClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		v.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.VirtualNetworkTapsClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListAllPager) {
-		v.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		v.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (v *VirtualNetworkTapsServerTransport) dispatchNewListByResourceGroupPager(
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualNetworkTaps`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (v *VirtualNetworkTapsServerTransport) dispatchNewListByResourceGroupPager(
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VirtualNetworkTapsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VirtualNetworkTapsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualrouterpeerings_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualrouterpeerings_server.go
@@ -45,16 +45,21 @@ type VirtualRouterPeeringsServer struct {
 // The returned VirtualRouterPeeringsServerTransport instance is connected to an instance of armnetwork.VirtualRouterPeeringsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualRouterPeeringsServerTransport(srv *VirtualRouterPeeringsServer) *VirtualRouterPeeringsServerTransport {
-	return &VirtualRouterPeeringsServerTransport{srv: srv}
+	return &VirtualRouterPeeringsServerTransport{
+		srv:                 srv,
+		beginCreateOrUpdate: newTracker[azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientCreateOrUpdateResponse]](),
+		beginDelete:         newTracker[azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientDeleteResponse]](),
+		newListPager:        newTracker[azfake.PagerResponder[armnetwork.VirtualRouterPeeringsClientListResponse]](),
+	}
 }
 
 // VirtualRouterPeeringsServerTransport connects instances of armnetwork.VirtualRouterPeeringsClient to instances of VirtualRouterPeeringsServer.
 // Don't use this type directly, use NewVirtualRouterPeeringsServerTransport instead.
 type VirtualRouterPeeringsServerTransport struct {
 	srv                 *VirtualRouterPeeringsServer
-	beginCreateOrUpdate *azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientCreateOrUpdateResponse]
-	beginDelete         *azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientDeleteResponse]
-	newListPager        *azfake.PagerResponder[armnetwork.VirtualRouterPeeringsClientListResponse]
+	beginCreateOrUpdate *tracker[azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientCreateOrUpdateResponse]]
+	beginDelete         *tracker[azfake.PollerResponder[armnetwork.VirtualRouterPeeringsClientDeleteResponse]]
+	newListPager        *tracker[azfake.PagerResponder[armnetwork.VirtualRouterPeeringsClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualRouterPeeringsServerTransport.
@@ -92,7 +97,8 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchBeginCreateOrUpdate(req *
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters/(?P<virtualRouterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -119,19 +125,21 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchBeginCreateOrUpdate(req *
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -141,7 +149,8 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchBeginDelete(req *http.Req
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters/(?P<virtualRouterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings/(?P<peeringName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -164,19 +173,21 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchBeginDelete(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -223,7 +234,8 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchNewListPager(req *http.Re
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters/(?P<virtualRouterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/peerings`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -239,20 +251,22 @@ func (v *VirtualRouterPeeringsServerTransport) dispatchNewListPager(req *http.Re
 			return nil, err
 		}
 		resp := v.srv.NewListPager(resourceGroupNameUnescaped, virtualRouterNameUnescaped, nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualRouterPeeringsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualRouterPeeringsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualrouters_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualrouters_server.go
@@ -49,17 +49,23 @@ type VirtualRoutersServer struct {
 // The returned VirtualRoutersServerTransport instance is connected to an instance of armnetwork.VirtualRoutersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualRoutersServerTransport(srv *VirtualRoutersServer) *VirtualRoutersServerTransport {
-	return &VirtualRoutersServerTransport{srv: srv}
+	return &VirtualRoutersServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VirtualRoutersClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VirtualRoutersClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VirtualRoutersClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VirtualRoutersClientListByResourceGroupResponse]](),
+	}
 }
 
 // VirtualRoutersServerTransport connects instances of armnetwork.VirtualRoutersClient to instances of VirtualRoutersServer.
 // Don't use this type directly, use NewVirtualRoutersServerTransport instead.
 type VirtualRoutersServerTransport struct {
 	srv                         *VirtualRoutersServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VirtualRoutersClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VirtualRoutersClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VirtualRoutersClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VirtualRoutersClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VirtualRoutersClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VirtualRoutersClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VirtualRoutersClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VirtualRoutersClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualRoutersServerTransport.
@@ -99,7 +105,8 @@ func (v *VirtualRoutersServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters/(?P<virtualRouterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -122,19 +129,21 @@ func (v *VirtualRoutersServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -144,7 +153,8 @@ func (v *VirtualRoutersServerTransport) dispatchBeginDelete(req *http.Request) (
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters/(?P<virtualRouterName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -163,19 +173,21 @@ func (v *VirtualRoutersServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -230,7 +242,8 @@ func (v *VirtualRoutersServerTransport) dispatchNewListPager(req *http.Request) 
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -238,20 +251,22 @@ func (v *VirtualRoutersServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualRoutersClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualRoutersClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -260,7 +275,8 @@ func (v *VirtualRoutersServerTransport) dispatchNewListByResourceGroupPager(req 
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualRouters`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -272,20 +288,22 @@ func (v *VirtualRoutersServerTransport) dispatchNewListByResourceGroupPager(req 
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VirtualRoutersClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VirtualRoutersClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_virtualwans_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_virtualwans_server.go
@@ -53,17 +53,23 @@ type VirtualWansServer struct {
 // The returned VirtualWansServerTransport instance is connected to an instance of armnetwork.VirtualWansClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVirtualWansServerTransport(srv *VirtualWansServer) *VirtualWansServerTransport {
-	return &VirtualWansServerTransport{srv: srv}
+	return &VirtualWansServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VirtualWansClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VirtualWansClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VirtualWansClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VirtualWansClientListByResourceGroupResponse]](),
+	}
 }
 
 // VirtualWansServerTransport connects instances of armnetwork.VirtualWansClient to instances of VirtualWansServer.
 // Don't use this type directly, use NewVirtualWansServerTransport instead.
 type VirtualWansServerTransport struct {
 	srv                         *VirtualWansServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VirtualWansClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VirtualWansClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VirtualWansClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VirtualWansClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VirtualWansClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VirtualWansClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VirtualWansClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VirtualWansClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VirtualWansServerTransport.
@@ -105,7 +111,8 @@ func (v *VirtualWansServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans/(?P<VirtualWANName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (v *VirtualWansServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (v *VirtualWansServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans/(?P<VirtualWANName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (v *VirtualWansServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (v *VirtualWansServerTransport) dispatchNewListPager(req *http.Request) (*h
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (v *VirtualWansServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VirtualWansClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VirtualWansClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (v *VirtualWansServerTransport) dispatchNewListByResourceGroupPager(req *ht
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (v *VirtualWansServerTransport) dispatchNewListByResourceGroupPager(req *ht
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VirtualWansClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VirtualWansClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnconnections_server.go
@@ -54,18 +54,25 @@ type VPNConnectionsServer struct {
 // The returned VPNConnectionsServerTransport instance is connected to an instance of armnetwork.VPNConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNConnectionsServerTransport(srv *VPNConnectionsServer) *VPNConnectionsServerTransport {
-	return &VPNConnectionsServerTransport{srv: srv}
+	return &VPNConnectionsServerTransport{
+		srv:                      srv,
+		beginCreateOrUpdate:      newTracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientCreateOrUpdateResponse]](),
+		beginDelete:              newTracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientDeleteResponse]](),
+		newListByVPNGatewayPager: newTracker[azfake.PagerResponder[armnetwork.VPNConnectionsClientListByVPNGatewayResponse]](),
+		beginStartPacketCapture:  newTracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientStartPacketCaptureResponse]](),
+		beginStopPacketCapture:   newTracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientStopPacketCaptureResponse]](),
+	}
 }
 
 // VPNConnectionsServerTransport connects instances of armnetwork.VPNConnectionsClient to instances of VPNConnectionsServer.
 // Don't use this type directly, use NewVPNConnectionsServerTransport instead.
 type VPNConnectionsServerTransport struct {
 	srv                      *VPNConnectionsServer
-	beginCreateOrUpdate      *azfake.PollerResponder[armnetwork.VPNConnectionsClientCreateOrUpdateResponse]
-	beginDelete              *azfake.PollerResponder[armnetwork.VPNConnectionsClientDeleteResponse]
-	newListByVPNGatewayPager *azfake.PagerResponder[armnetwork.VPNConnectionsClientListByVPNGatewayResponse]
-	beginStartPacketCapture  *azfake.PollerResponder[armnetwork.VPNConnectionsClientStartPacketCaptureResponse]
-	beginStopPacketCapture   *azfake.PollerResponder[armnetwork.VPNConnectionsClientStopPacketCaptureResponse]
+	beginCreateOrUpdate      *tracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientCreateOrUpdateResponse]]
+	beginDelete              *tracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientDeleteResponse]]
+	newListByVPNGatewayPager *tracker[azfake.PagerResponder[armnetwork.VPNConnectionsClientListByVPNGatewayResponse]]
+	beginStartPacketCapture  *tracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientStartPacketCaptureResponse]]
+	beginStopPacketCapture   *tracker[azfake.PollerResponder[armnetwork.VPNConnectionsClientStopPacketCaptureResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNConnectionsServerTransport.
@@ -107,7 +114,8 @@ func (v *VPNConnectionsServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -134,19 +142,21 @@ func (v *VPNConnectionsServerTransport) dispatchBeginCreateOrUpdate(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -156,7 +166,8 @@ func (v *VPNConnectionsServerTransport) dispatchBeginDelete(req *http.Request) (
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -179,19 +190,21 @@ func (v *VPNConnectionsServerTransport) dispatchBeginDelete(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -238,7 +251,8 @@ func (v *VPNConnectionsServerTransport) dispatchNewListByVPNGatewayPager(req *ht
 	if v.srv.NewListByVPNGatewayPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVPNGatewayPager not implemented")}
 	}
-	if v.newListByVPNGatewayPager == nil {
+	newListByVPNGatewayPager := v.newListByVPNGatewayPager.get(req)
+	if newListByVPNGatewayPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -254,20 +268,22 @@ func (v *VPNConnectionsServerTransport) dispatchNewListByVPNGatewayPager(req *ht
 			return nil, err
 		}
 		resp := v.srv.NewListByVPNGatewayPager(resourceGroupNameUnescaped, gatewayNameUnescaped, nil)
-		v.newListByVPNGatewayPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByVPNGatewayPager, req, func(page *armnetwork.VPNConnectionsClientListByVPNGatewayResponse, createLink func() string) {
+		newListByVPNGatewayPager = &resp
+		v.newListByVPNGatewayPager.add(req, newListByVPNGatewayPager)
+		server.PagerResponderInjectNextLinks(newListByVPNGatewayPager, req, func(page *armnetwork.VPNConnectionsClientListByVPNGatewayResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByVPNGatewayPager, req)
+	resp, err := server.PagerResponderNext(newListByVPNGatewayPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByVPNGatewayPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByVPNGatewayPager) {
-		v.newListByVPNGatewayPager = nil
+	if !server.PagerResponderMore(newListByVPNGatewayPager) {
+		v.newListByVPNGatewayPager.remove(req)
 	}
 	return resp, nil
 }
@@ -276,7 +292,8 @@ func (v *VPNConnectionsServerTransport) dispatchBeginStartPacketCapture(req *htt
 	if v.srv.BeginStartPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartPacketCapture not implemented")}
 	}
-	if v.beginStartPacketCapture == nil {
+	beginStartPacketCapture := v.beginStartPacketCapture.get(req)
+	if beginStartPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<vpnConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/startpacketcapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -309,19 +326,21 @@ func (v *VPNConnectionsServerTransport) dispatchBeginStartPacketCapture(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartPacketCapture = &respr
+		beginStartPacketCapture = &respr
+		v.beginStartPacketCapture.add(req, beginStartPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStartPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartPacketCapture) {
-		v.beginStartPacketCapture = nil
+	if !server.PollerResponderMore(beginStartPacketCapture) {
+		v.beginStartPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -331,7 +350,8 @@ func (v *VPNConnectionsServerTransport) dispatchBeginStopPacketCapture(req *http
 	if v.srv.BeginStopPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStopPacketCapture not implemented")}
 	}
-	if v.beginStopPacketCapture == nil {
+	beginStopPacketCapture := v.beginStopPacketCapture.get(req)
+	if beginStopPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<vpnConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stoppacketcapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -364,19 +384,21 @@ func (v *VPNConnectionsServerTransport) dispatchBeginStopPacketCapture(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStopPacketCapture = &respr
+		beginStopPacketCapture = &respr
+		v.beginStopPacketCapture.add(req, beginStopPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStopPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStopPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStopPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStopPacketCapture) {
-		v.beginStopPacketCapture = nil
+	if !server.PollerResponderMore(beginStopPacketCapture) {
+		v.beginStopPacketCapture.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpngateways_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpngateways_server.go
@@ -66,21 +66,31 @@ type VPNGatewaysServer struct {
 // The returned VPNGatewaysServerTransport instance is connected to an instance of armnetwork.VPNGatewaysClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNGatewaysServerTransport(srv *VPNGatewaysServer) *VPNGatewaysServerTransport {
-	return &VPNGatewaysServerTransport{srv: srv}
+	return &VPNGatewaysServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VPNGatewaysClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VPNGatewaysClientListByResourceGroupResponse]](),
+		beginReset:                  newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientResetResponse]](),
+		beginStartPacketCapture:     newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientStartPacketCaptureResponse]](),
+		beginStopPacketCapture:      newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientStopPacketCaptureResponse]](),
+		beginUpdateTags:             newTracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientUpdateTagsResponse]](),
+	}
 }
 
 // VPNGatewaysServerTransport connects instances of armnetwork.VPNGatewaysClient to instances of VPNGatewaysServer.
 // Don't use this type directly, use NewVPNGatewaysServerTransport instead.
 type VPNGatewaysServerTransport struct {
 	srv                         *VPNGatewaysServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VPNGatewaysClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VPNGatewaysClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VPNGatewaysClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VPNGatewaysClientListByResourceGroupResponse]
-	beginReset                  *azfake.PollerResponder[armnetwork.VPNGatewaysClientResetResponse]
-	beginStartPacketCapture     *azfake.PollerResponder[armnetwork.VPNGatewaysClientStartPacketCaptureResponse]
-	beginStopPacketCapture      *azfake.PollerResponder[armnetwork.VPNGatewaysClientStopPacketCaptureResponse]
-	beginUpdateTags             *azfake.PollerResponder[armnetwork.VPNGatewaysClientUpdateTagsResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VPNGatewaysClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VPNGatewaysClientListByResourceGroupResponse]]
+	beginReset                  *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientResetResponse]]
+	beginStartPacketCapture     *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientStartPacketCaptureResponse]]
+	beginStopPacketCapture      *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientStopPacketCaptureResponse]]
+	beginUpdateTags             *tracker[azfake.PollerResponder[armnetwork.VPNGatewaysClientUpdateTagsResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNGatewaysServerTransport.
@@ -128,7 +138,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -151,19 +162,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginCreateOrUpdate(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -173,7 +186,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -192,19 +206,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginDelete(req *http.Request) (*ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -247,7 +263,8 @@ func (v *VPNGatewaysServerTransport) dispatchNewListPager(req *http.Request) (*h
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -255,20 +272,22 @@ func (v *VPNGatewaysServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VPNGatewaysClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VPNGatewaysClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -277,7 +296,8 @@ func (v *VPNGatewaysServerTransport) dispatchNewListByResourceGroupPager(req *ht
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -289,20 +309,22 @@ func (v *VPNGatewaysServerTransport) dispatchNewListByResourceGroupPager(req *ht
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VPNGatewaysClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VPNGatewaysClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }
@@ -311,7 +333,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginReset(req *http.Request) (*htt
 	if v.srv.BeginReset == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginReset not implemented")}
 	}
-	if v.beginReset == nil {
+	beginReset := v.beginReset.get(req)
+	if beginReset == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/reset`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -342,19 +365,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginReset(req *http.Request) (*htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginReset = &respr
+		beginReset = &respr
+		v.beginReset.add(req, beginReset)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginReset, req)
+	resp, err := server.PollerResponderNext(beginReset, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginReset.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginReset) {
-		v.beginReset = nil
+	if !server.PollerResponderMore(beginReset) {
+		v.beginReset.remove(req)
 	}
 
 	return resp, nil
@@ -364,7 +389,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginStartPacketCapture(req *http.R
 	if v.srv.BeginStartPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStartPacketCapture not implemented")}
 	}
-	if v.beginStartPacketCapture == nil {
+	beginStartPacketCapture := v.beginStartPacketCapture.get(req)
+	if beginStartPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/startpacketcapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -393,19 +419,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginStartPacketCapture(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStartPacketCapture = &respr
+		beginStartPacketCapture = &respr
+		v.beginStartPacketCapture.add(req, beginStartPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStartPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStartPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStartPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStartPacketCapture) {
-		v.beginStartPacketCapture = nil
+	if !server.PollerResponderMore(beginStartPacketCapture) {
+		v.beginStartPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -415,7 +443,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginStopPacketCapture(req *http.Re
 	if v.srv.BeginStopPacketCapture == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginStopPacketCapture not implemented")}
 	}
-	if v.beginStopPacketCapture == nil {
+	beginStopPacketCapture := v.beginStopPacketCapture.get(req)
+	if beginStopPacketCapture == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/stoppacketcapture`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -444,19 +473,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginStopPacketCapture(req *http.Re
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginStopPacketCapture = &respr
+		beginStopPacketCapture = &respr
+		v.beginStopPacketCapture.add(req, beginStopPacketCapture)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginStopPacketCapture, req)
+	resp, err := server.PollerResponderNext(beginStopPacketCapture, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginStopPacketCapture.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginStopPacketCapture) {
-		v.beginStopPacketCapture = nil
+	if !server.PollerResponderMore(beginStopPacketCapture) {
+		v.beginStopPacketCapture.remove(req)
 	}
 
 	return resp, nil
@@ -466,7 +497,8 @@ func (v *VPNGatewaysServerTransport) dispatchBeginUpdateTags(req *http.Request) 
 	if v.srv.BeginUpdateTags == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginUpdateTags not implemented")}
 	}
-	if v.beginUpdateTags == nil {
+	beginUpdateTags := v.beginUpdateTags.get(req)
+	if beginUpdateTags == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -489,19 +521,21 @@ func (v *VPNGatewaysServerTransport) dispatchBeginUpdateTags(req *http.Request) 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginUpdateTags = &respr
+		beginUpdateTags = &respr
+		v.beginUpdateTags.add(req, beginUpdateTags)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginUpdateTags, req)
+	resp, err := server.PollerResponderNext(beginUpdateTags, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginUpdateTags.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginUpdateTags) {
-		v.beginUpdateTags = nil
+	if !server.PollerResponderMore(beginUpdateTags) {
+		v.beginUpdateTags.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnlinkconnections_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnlinkconnections_server.go
@@ -41,16 +41,21 @@ type VPNLinkConnectionsServer struct {
 // The returned VPNLinkConnectionsServerTransport instance is connected to an instance of armnetwork.VPNLinkConnectionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNLinkConnectionsServerTransport(srv *VPNLinkConnectionsServer) *VPNLinkConnectionsServerTransport {
-	return &VPNLinkConnectionsServerTransport{srv: srv}
+	return &VPNLinkConnectionsServerTransport{
+		srv:                         srv,
+		beginGetIkeSas:              newTracker[azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientGetIkeSasResponse]](),
+		newListByVPNConnectionPager: newTracker[azfake.PagerResponder[armnetwork.VPNLinkConnectionsClientListByVPNConnectionResponse]](),
+		beginResetConnection:        newTracker[azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientResetConnectionResponse]](),
+	}
 }
 
 // VPNLinkConnectionsServerTransport connects instances of armnetwork.VPNLinkConnectionsClient to instances of VPNLinkConnectionsServer.
 // Don't use this type directly, use NewVPNLinkConnectionsServerTransport instead.
 type VPNLinkConnectionsServerTransport struct {
 	srv                         *VPNLinkConnectionsServer
-	beginGetIkeSas              *azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientGetIkeSasResponse]
-	newListByVPNConnectionPager *azfake.PagerResponder[armnetwork.VPNLinkConnectionsClientListByVPNConnectionResponse]
-	beginResetConnection        *azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientResetConnectionResponse]
+	beginGetIkeSas              *tracker[azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientGetIkeSasResponse]]
+	newListByVPNConnectionPager *tracker[azfake.PagerResponder[armnetwork.VPNLinkConnectionsClientListByVPNConnectionResponse]]
+	beginResetConnection        *tracker[azfake.PollerResponder[armnetwork.VPNLinkConnectionsClientResetConnectionResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNLinkConnectionsServerTransport.
@@ -86,7 +91,8 @@ func (v *VPNLinkConnectionsServerTransport) dispatchBeginGetIkeSas(req *http.Req
 	if v.srv.BeginGetIkeSas == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetIkeSas not implemented")}
 	}
-	if v.beginGetIkeSas == nil {
+	beginGetIkeSas := v.beginGetIkeSas.get(req)
+	if beginGetIkeSas == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnLinkConnections/(?P<linkConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/getikesas`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -113,19 +119,21 @@ func (v *VPNLinkConnectionsServerTransport) dispatchBeginGetIkeSas(req *http.Req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginGetIkeSas = &respr
+		beginGetIkeSas = &respr
+		v.beginGetIkeSas.add(req, beginGetIkeSas)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginGetIkeSas, req)
+	resp, err := server.PollerResponderNext(beginGetIkeSas, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginGetIkeSas.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginGetIkeSas) {
-		v.beginGetIkeSas = nil
+	if !server.PollerResponderMore(beginGetIkeSas) {
+		v.beginGetIkeSas.remove(req)
 	}
 
 	return resp, nil
@@ -135,7 +143,8 @@ func (v *VPNLinkConnectionsServerTransport) dispatchNewListByVPNConnectionPager(
 	if v.srv.NewListByVPNConnectionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVPNConnectionPager not implemented")}
 	}
-	if v.newListByVPNConnectionPager == nil {
+	newListByVPNConnectionPager := v.newListByVPNConnectionPager.get(req)
+	if newListByVPNConnectionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnLinkConnections`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -155,20 +164,22 @@ func (v *VPNLinkConnectionsServerTransport) dispatchNewListByVPNConnectionPager(
 			return nil, err
 		}
 		resp := v.srv.NewListByVPNConnectionPager(resourceGroupNameUnescaped, gatewayNameUnescaped, connectionNameUnescaped, nil)
-		v.newListByVPNConnectionPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByVPNConnectionPager, req, func(page *armnetwork.VPNLinkConnectionsClientListByVPNConnectionResponse, createLink func() string) {
+		newListByVPNConnectionPager = &resp
+		v.newListByVPNConnectionPager.add(req, newListByVPNConnectionPager)
+		server.PagerResponderInjectNextLinks(newListByVPNConnectionPager, req, func(page *armnetwork.VPNLinkConnectionsClientListByVPNConnectionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByVPNConnectionPager, req)
+	resp, err := server.PagerResponderNext(newListByVPNConnectionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByVPNConnectionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByVPNConnectionPager) {
-		v.newListByVPNConnectionPager = nil
+	if !server.PagerResponderMore(newListByVPNConnectionPager) {
+		v.newListByVPNConnectionPager.remove(req)
 	}
 	return resp, nil
 }
@@ -177,7 +188,8 @@ func (v *VPNLinkConnectionsServerTransport) dispatchBeginResetConnection(req *ht
 	if v.srv.BeginResetConnection == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginResetConnection not implemented")}
 	}
-	if v.beginResetConnection == nil {
+	beginResetConnection := v.beginResetConnection.get(req)
+	if beginResetConnection == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnGateways/(?P<gatewayName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConnections/(?P<connectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnLinkConnections/(?P<linkConnectionName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resetconnection`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -204,19 +216,21 @@ func (v *VPNLinkConnectionsServerTransport) dispatchBeginResetConnection(req *ht
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginResetConnection = &respr
+		beginResetConnection = &respr
+		v.beginResetConnection.add(req, beginResetConnection)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginResetConnection, req)
+	resp, err := server.PollerResponderNext(beginResetConnection, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted}, resp.StatusCode) {
+		v.beginResetConnection.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginResetConnection) {
-		v.beginResetConnection = nil
+	if !server.PollerResponderMore(beginResetConnection) {
+		v.beginResetConnection.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnserverconfigurations_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnserverconfigurations_server.go
@@ -53,17 +53,23 @@ type VPNServerConfigurationsServer struct {
 // The returned VPNServerConfigurationsServerTransport instance is connected to an instance of armnetwork.VPNServerConfigurationsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNServerConfigurationsServerTransport(srv *VPNServerConfigurationsServer) *VPNServerConfigurationsServerTransport {
-	return &VPNServerConfigurationsServerTransport{srv: srv}
+	return &VPNServerConfigurationsServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListByResourceGroupResponse]](),
+	}
 }
 
 // VPNServerConfigurationsServerTransport connects instances of armnetwork.VPNServerConfigurationsClient to instances of VPNServerConfigurationsServer.
 // Don't use this type directly, use NewVPNServerConfigurationsServerTransport instead.
 type VPNServerConfigurationsServerTransport struct {
 	srv                         *VPNServerConfigurationsServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VPNServerConfigurationsClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNServerConfigurationsServerTransport.
@@ -105,7 +111,8 @@ func (v *VPNServerConfigurationsServerTransport) dispatchBeginCreateOrUpdate(req
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations/(?P<vpnServerConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (v *VPNServerConfigurationsServerTransport) dispatchBeginCreateOrUpdate(req
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (v *VPNServerConfigurationsServerTransport) dispatchBeginDelete(req *http.R
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations/(?P<vpnServerConfigurationName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (v *VPNServerConfigurationsServerTransport) dispatchBeginDelete(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (v *VPNServerConfigurationsServerTransport) dispatchNewListPager(req *http.
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (v *VPNServerConfigurationsServerTransport) dispatchNewListPager(req *http.
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VPNServerConfigurationsClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VPNServerConfigurationsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (v *VPNServerConfigurationsServerTransport) dispatchNewListByResourceGroupP
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnServerConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (v *VPNServerConfigurationsServerTransport) dispatchNewListByResourceGroupP
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VPNServerConfigurationsClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VPNServerConfigurationsClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnserverconfigurationsassociatedwithvirtualwan_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnserverconfigurationsassociatedwithvirtualwan_server.go
@@ -32,14 +32,17 @@ type VPNServerConfigurationsAssociatedWithVirtualWanServer struct {
 // The returned VPNServerConfigurationsAssociatedWithVirtualWanServerTransport instance is connected to an instance of armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNServerConfigurationsAssociatedWithVirtualWanServerTransport(srv *VPNServerConfigurationsAssociatedWithVirtualWanServer) *VPNServerConfigurationsAssociatedWithVirtualWanServerTransport {
-	return &VPNServerConfigurationsAssociatedWithVirtualWanServerTransport{srv: srv}
+	return &VPNServerConfigurationsAssociatedWithVirtualWanServerTransport{
+		srv:       srv,
+		beginList: newTracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse]](),
+	}
 }
 
 // VPNServerConfigurationsAssociatedWithVirtualWanServerTransport connects instances of armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClient to instances of VPNServerConfigurationsAssociatedWithVirtualWanServer.
 // Don't use this type directly, use NewVPNServerConfigurationsAssociatedWithVirtualWanServerTransport instead.
 type VPNServerConfigurationsAssociatedWithVirtualWanServerTransport struct {
 	srv       *VPNServerConfigurationsAssociatedWithVirtualWanServer
-	beginList *azfake.PollerResponder[armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse]
+	beginList *tracker[azfake.PollerResponder[armnetwork.VPNServerConfigurationsAssociatedWithVirtualWanClientListResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNServerConfigurationsAssociatedWithVirtualWanServerTransport.
@@ -71,7 +74,8 @@ func (v *VPNServerConfigurationsAssociatedWithVirtualWanServerTransport) dispatc
 	if v.srv.BeginList == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginList not implemented")}
 	}
-	if v.beginList == nil {
+	beginList := v.beginList.get(req)
+	if beginList == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans/(?P<virtualWANName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnServerConfigurations`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -90,19 +94,21 @@ func (v *VPNServerConfigurationsAssociatedWithVirtualWanServerTransport) dispatc
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginList = &respr
+		beginList = &respr
+		v.beginList.add(req, beginList)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginList, req)
+	resp, err := server.PollerResponderNext(beginList, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginList.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginList) {
-		v.beginList = nil
+	if !server.PollerResponderMore(beginList) {
+		v.beginList.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsitelinks_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsitelinks_server.go
@@ -37,14 +37,17 @@ type VPNSiteLinksServer struct {
 // The returned VPNSiteLinksServerTransport instance is connected to an instance of armnetwork.VPNSiteLinksClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNSiteLinksServerTransport(srv *VPNSiteLinksServer) *VPNSiteLinksServerTransport {
-	return &VPNSiteLinksServerTransport{srv: srv}
+	return &VPNSiteLinksServerTransport{
+		srv:                   srv,
+		newListByVPNSitePager: newTracker[azfake.PagerResponder[armnetwork.VPNSiteLinksClientListByVPNSiteResponse]](),
+	}
 }
 
 // VPNSiteLinksServerTransport connects instances of armnetwork.VPNSiteLinksClient to instances of VPNSiteLinksServer.
 // Don't use this type directly, use NewVPNSiteLinksServerTransport instead.
 type VPNSiteLinksServerTransport struct {
 	srv                   *VPNSiteLinksServer
-	newListByVPNSitePager *azfake.PagerResponder[armnetwork.VPNSiteLinksClientListByVPNSiteResponse]
+	newListByVPNSitePager *tracker[azfake.PagerResponder[armnetwork.VPNSiteLinksClientListByVPNSiteResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNSiteLinksServerTransport.
@@ -115,7 +118,8 @@ func (v *VPNSiteLinksServerTransport) dispatchNewListByVPNSitePager(req *http.Re
 	if v.srv.NewListByVPNSitePager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByVPNSitePager not implemented")}
 	}
-	if v.newListByVPNSitePager == nil {
+	newListByVPNSitePager := v.newListByVPNSitePager.get(req)
+	if newListByVPNSitePager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnSites/(?P<vpnSiteName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnSiteLinks`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -131,20 +135,22 @@ func (v *VPNSiteLinksServerTransport) dispatchNewListByVPNSitePager(req *http.Re
 			return nil, err
 		}
 		resp := v.srv.NewListByVPNSitePager(resourceGroupNameUnescaped, vpnSiteNameUnescaped, nil)
-		v.newListByVPNSitePager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByVPNSitePager, req, func(page *armnetwork.VPNSiteLinksClientListByVPNSiteResponse, createLink func() string) {
+		newListByVPNSitePager = &resp
+		v.newListByVPNSitePager.add(req, newListByVPNSitePager)
+		server.PagerResponderInjectNextLinks(newListByVPNSitePager, req, func(page *armnetwork.VPNSiteLinksClientListByVPNSiteResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByVPNSitePager, req)
+	resp, err := server.PagerResponderNext(newListByVPNSitePager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByVPNSitePager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByVPNSitePager) {
-		v.newListByVPNSitePager = nil
+	if !server.PagerResponderMore(newListByVPNSitePager) {
+		v.newListByVPNSitePager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsites_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsites_server.go
@@ -53,17 +53,23 @@ type VPNSitesServer struct {
 // The returned VPNSitesServerTransport instance is connected to an instance of armnetwork.VPNSitesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNSitesServerTransport(srv *VPNSitesServer) *VPNSitesServerTransport {
-	return &VPNSitesServerTransport{srv: srv}
+	return &VPNSitesServerTransport{
+		srv:                         srv,
+		beginCreateOrUpdate:         newTracker[azfake.PollerResponder[armnetwork.VPNSitesClientCreateOrUpdateResponse]](),
+		beginDelete:                 newTracker[azfake.PollerResponder[armnetwork.VPNSitesClientDeleteResponse]](),
+		newListPager:                newTracker[azfake.PagerResponder[armnetwork.VPNSitesClientListResponse]](),
+		newListByResourceGroupPager: newTracker[azfake.PagerResponder[armnetwork.VPNSitesClientListByResourceGroupResponse]](),
+	}
 }
 
 // VPNSitesServerTransport connects instances of armnetwork.VPNSitesClient to instances of VPNSitesServer.
 // Don't use this type directly, use NewVPNSitesServerTransport instead.
 type VPNSitesServerTransport struct {
 	srv                         *VPNSitesServer
-	beginCreateOrUpdate         *azfake.PollerResponder[armnetwork.VPNSitesClientCreateOrUpdateResponse]
-	beginDelete                 *azfake.PollerResponder[armnetwork.VPNSitesClientDeleteResponse]
-	newListPager                *azfake.PagerResponder[armnetwork.VPNSitesClientListResponse]
-	newListByResourceGroupPager *azfake.PagerResponder[armnetwork.VPNSitesClientListByResourceGroupResponse]
+	beginCreateOrUpdate         *tracker[azfake.PollerResponder[armnetwork.VPNSitesClientCreateOrUpdateResponse]]
+	beginDelete                 *tracker[azfake.PollerResponder[armnetwork.VPNSitesClientDeleteResponse]]
+	newListPager                *tracker[azfake.PagerResponder[armnetwork.VPNSitesClientListResponse]]
+	newListByResourceGroupPager *tracker[azfake.PagerResponder[armnetwork.VPNSitesClientListByResourceGroupResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNSitesServerTransport.
@@ -105,7 +111,8 @@ func (v *VPNSitesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 	if v.srv.BeginCreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCreateOrUpdate not implemented")}
 	}
-	if v.beginCreateOrUpdate == nil {
+	beginCreateOrUpdate := v.beginCreateOrUpdate.get(req)
+	if beginCreateOrUpdate == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnSites/(?P<vpnSiteName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -128,19 +135,21 @@ func (v *VPNSitesServerTransport) dispatchBeginCreateOrUpdate(req *http.Request)
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginCreateOrUpdate = &respr
+		beginCreateOrUpdate = &respr
+		v.beginCreateOrUpdate.add(req, beginCreateOrUpdate)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginCreateOrUpdate, req)
+	resp, err := server.PollerResponderNext(beginCreateOrUpdate, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusCreated}, resp.StatusCode) {
+		v.beginCreateOrUpdate.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusCreated", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginCreateOrUpdate) {
-		v.beginCreateOrUpdate = nil
+	if !server.PollerResponderMore(beginCreateOrUpdate) {
+		v.beginCreateOrUpdate.remove(req)
 	}
 
 	return resp, nil
@@ -150,7 +159,8 @@ func (v *VPNSitesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if v.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if v.beginDelete == nil {
+	beginDelete := v.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnSites/(?P<vpnSiteName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -169,19 +179,21 @@ func (v *VPNSitesServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDelete = &respr
+		beginDelete = &respr
+		v.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		v.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDelete) {
-		v.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		v.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -224,7 +236,8 @@ func (v *VPNSitesServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if v.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if v.newListPager == nil {
+	newListPager := v.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnSites`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -232,20 +245,22 @@ func (v *VPNSitesServerTransport) dispatchNewListPager(req *http.Request) (*http
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := v.srv.NewListPager(nil)
-		v.newListPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListPager, req, func(page *armnetwork.VPNSitesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		v.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.VPNSitesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListPager) {
-		v.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		v.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -254,7 +269,8 @@ func (v *VPNSitesServerTransport) dispatchNewListByResourceGroupPager(req *http.
 	if v.srv.NewListByResourceGroupPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListByResourceGroupPager not implemented")}
 	}
-	if v.newListByResourceGroupPager == nil {
+	newListByResourceGroupPager := v.newListByResourceGroupPager.get(req)
+	if newListByResourceGroupPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/vpnSites`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -266,20 +282,22 @@ func (v *VPNSitesServerTransport) dispatchNewListByResourceGroupPager(req *http.
 			return nil, err
 		}
 		resp := v.srv.NewListByResourceGroupPager(resourceGroupNameUnescaped, nil)
-		v.newListByResourceGroupPager = &resp
-		server.PagerResponderInjectNextLinks(v.newListByResourceGroupPager, req, func(page *armnetwork.VPNSitesClientListByResourceGroupResponse, createLink func() string) {
+		newListByResourceGroupPager = &resp
+		v.newListByResourceGroupPager.add(req, newListByResourceGroupPager)
+		server.PagerResponderInjectNextLinks(newListByResourceGroupPager, req, func(page *armnetwork.VPNSitesClientListByResourceGroupResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(v.newListByResourceGroupPager, req)
+	resp, err := server.PagerResponderNext(newListByResourceGroupPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		v.newListByResourceGroupPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(v.newListByResourceGroupPager) {
-		v.newListByResourceGroupPager = nil
+	if !server.PagerResponderMore(newListByResourceGroupPager) {
+		v.newListByResourceGroupPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsitesconfiguration_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_vpnsitesconfiguration_server.go
@@ -32,14 +32,17 @@ type VPNSitesConfigurationServer struct {
 // The returned VPNSitesConfigurationServerTransport instance is connected to an instance of armnetwork.VPNSitesConfigurationClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewVPNSitesConfigurationServerTransport(srv *VPNSitesConfigurationServer) *VPNSitesConfigurationServerTransport {
-	return &VPNSitesConfigurationServerTransport{srv: srv}
+	return &VPNSitesConfigurationServerTransport{
+		srv:           srv,
+		beginDownload: newTracker[azfake.PollerResponder[armnetwork.VPNSitesConfigurationClientDownloadResponse]](),
+	}
 }
 
 // VPNSitesConfigurationServerTransport connects instances of armnetwork.VPNSitesConfigurationClient to instances of VPNSitesConfigurationServer.
 // Don't use this type directly, use NewVPNSitesConfigurationServerTransport instead.
 type VPNSitesConfigurationServerTransport struct {
 	srv           *VPNSitesConfigurationServer
-	beginDownload *azfake.PollerResponder[armnetwork.VPNSitesConfigurationClientDownloadResponse]
+	beginDownload *tracker[azfake.PollerResponder[armnetwork.VPNSitesConfigurationClientDownloadResponse]]
 }
 
 // Do implements the policy.Transporter interface for VPNSitesConfigurationServerTransport.
@@ -71,7 +74,8 @@ func (v *VPNSitesConfigurationServerTransport) dispatchBeginDownload(req *http.R
 	if v.srv.BeginDownload == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDownload not implemented")}
 	}
-	if v.beginDownload == nil {
+	beginDownload := v.beginDownload.get(req)
+	if beginDownload == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/virtualWans/(?P<virtualWANName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/vpnConfiguration`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -94,19 +98,21 @@ func (v *VPNSitesConfigurationServerTransport) dispatchBeginDownload(req *http.R
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		v.beginDownload = &respr
+		beginDownload = &respr
+		v.beginDownload.add(req, beginDownload)
 	}
 
-	resp, err := server.PollerResponderNext(v.beginDownload, req)
+	resp, err := server.PollerResponderNext(beginDownload, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		v.beginDownload.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(v.beginDownload) {
-		v.beginDownload = nil
+	if !server.PollerResponderMore(beginDownload) {
+		v.beginDownload.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_watchers_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_watchers_server.go
@@ -100,27 +100,43 @@ type WatchersServer struct {
 // The returned WatchersServerTransport instance is connected to an instance of armnetwork.WatchersClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewWatchersServerTransport(srv *WatchersServer) *WatchersServerTransport {
-	return &WatchersServerTransport{srv: srv}
+	return &WatchersServerTransport{
+		srv:                                    srv,
+		beginCheckConnectivity:                 newTracker[azfake.PollerResponder[armnetwork.WatchersClientCheckConnectivityResponse]](),
+		beginDelete:                            newTracker[azfake.PollerResponder[armnetwork.WatchersClientDeleteResponse]](),
+		beginGetAzureReachabilityReport:        newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetAzureReachabilityReportResponse]](),
+		beginGetFlowLogStatus:                  newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetFlowLogStatusResponse]](),
+		beginGetNetworkConfigurationDiagnostic: newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetNetworkConfigurationDiagnosticResponse]](),
+		beginGetNextHop:                        newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetNextHopResponse]](),
+		beginGetTroubleshooting:                newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResponse]](),
+		beginGetTroubleshootingResult:          newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResultResponse]](),
+		beginGetVMSecurityRules:                newTracker[azfake.PollerResponder[armnetwork.WatchersClientGetVMSecurityRulesResponse]](),
+		newListPager:                           newTracker[azfake.PagerResponder[armnetwork.WatchersClientListResponse]](),
+		newListAllPager:                        newTracker[azfake.PagerResponder[armnetwork.WatchersClientListAllResponse]](),
+		beginListAvailableProviders:            newTracker[azfake.PollerResponder[armnetwork.WatchersClientListAvailableProvidersResponse]](),
+		beginSetFlowLogConfiguration:           newTracker[azfake.PollerResponder[armnetwork.WatchersClientSetFlowLogConfigurationResponse]](),
+		beginVerifyIPFlow:                      newTracker[azfake.PollerResponder[armnetwork.WatchersClientVerifyIPFlowResponse]](),
+	}
 }
 
 // WatchersServerTransport connects instances of armnetwork.WatchersClient to instances of WatchersServer.
 // Don't use this type directly, use NewWatchersServerTransport instead.
 type WatchersServerTransport struct {
 	srv                                    *WatchersServer
-	beginCheckConnectivity                 *azfake.PollerResponder[armnetwork.WatchersClientCheckConnectivityResponse]
-	beginDelete                            *azfake.PollerResponder[armnetwork.WatchersClientDeleteResponse]
-	beginGetAzureReachabilityReport        *azfake.PollerResponder[armnetwork.WatchersClientGetAzureReachabilityReportResponse]
-	beginGetFlowLogStatus                  *azfake.PollerResponder[armnetwork.WatchersClientGetFlowLogStatusResponse]
-	beginGetNetworkConfigurationDiagnostic *azfake.PollerResponder[armnetwork.WatchersClientGetNetworkConfigurationDiagnosticResponse]
-	beginGetNextHop                        *azfake.PollerResponder[armnetwork.WatchersClientGetNextHopResponse]
-	beginGetTroubleshooting                *azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResponse]
-	beginGetTroubleshootingResult          *azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResultResponse]
-	beginGetVMSecurityRules                *azfake.PollerResponder[armnetwork.WatchersClientGetVMSecurityRulesResponse]
-	newListPager                           *azfake.PagerResponder[armnetwork.WatchersClientListResponse]
-	newListAllPager                        *azfake.PagerResponder[armnetwork.WatchersClientListAllResponse]
-	beginListAvailableProviders            *azfake.PollerResponder[armnetwork.WatchersClientListAvailableProvidersResponse]
-	beginSetFlowLogConfiguration           *azfake.PollerResponder[armnetwork.WatchersClientSetFlowLogConfigurationResponse]
-	beginVerifyIPFlow                      *azfake.PollerResponder[armnetwork.WatchersClientVerifyIPFlowResponse]
+	beginCheckConnectivity                 *tracker[azfake.PollerResponder[armnetwork.WatchersClientCheckConnectivityResponse]]
+	beginDelete                            *tracker[azfake.PollerResponder[armnetwork.WatchersClientDeleteResponse]]
+	beginGetAzureReachabilityReport        *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetAzureReachabilityReportResponse]]
+	beginGetFlowLogStatus                  *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetFlowLogStatusResponse]]
+	beginGetNetworkConfigurationDiagnostic *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetNetworkConfigurationDiagnosticResponse]]
+	beginGetNextHop                        *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetNextHopResponse]]
+	beginGetTroubleshooting                *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResponse]]
+	beginGetTroubleshootingResult          *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetTroubleshootingResultResponse]]
+	beginGetVMSecurityRules                *tracker[azfake.PollerResponder[armnetwork.WatchersClientGetVMSecurityRulesResponse]]
+	newListPager                           *tracker[azfake.PagerResponder[armnetwork.WatchersClientListResponse]]
+	newListAllPager                        *tracker[azfake.PagerResponder[armnetwork.WatchersClientListAllResponse]]
+	beginListAvailableProviders            *tracker[azfake.PollerResponder[armnetwork.WatchersClientListAvailableProvidersResponse]]
+	beginSetFlowLogConfiguration           *tracker[azfake.PollerResponder[armnetwork.WatchersClientSetFlowLogConfigurationResponse]]
+	beginVerifyIPFlow                      *tracker[azfake.PollerResponder[armnetwork.WatchersClientVerifyIPFlowResponse]]
 }
 
 // Do implements the policy.Transporter interface for WatchersServerTransport.
@@ -186,7 +202,8 @@ func (w *WatchersServerTransport) dispatchBeginCheckConnectivity(req *http.Reque
 	if w.srv.BeginCheckConnectivity == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginCheckConnectivity not implemented")}
 	}
-	if w.beginCheckConnectivity == nil {
+	beginCheckConnectivity := w.beginCheckConnectivity.get(req)
+	if beginCheckConnectivity == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/connectivityCheck`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -209,19 +226,21 @@ func (w *WatchersServerTransport) dispatchBeginCheckConnectivity(req *http.Reque
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginCheckConnectivity = &respr
+		beginCheckConnectivity = &respr
+		w.beginCheckConnectivity.add(req, beginCheckConnectivity)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginCheckConnectivity, req)
+	resp, err := server.PollerResponderNext(beginCheckConnectivity, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginCheckConnectivity.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginCheckConnectivity) {
-		w.beginCheckConnectivity = nil
+	if !server.PollerResponderMore(beginCheckConnectivity) {
+		w.beginCheckConnectivity.remove(req)
 	}
 
 	return resp, nil
@@ -268,7 +287,8 @@ func (w *WatchersServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 	if w.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if w.beginDelete == nil {
+	beginDelete := w.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -287,19 +307,21 @@ func (w *WatchersServerTransport) dispatchBeginDelete(req *http.Request) (*http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginDelete = &respr
+		beginDelete = &respr
+		w.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		w.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginDelete) {
-		w.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		w.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -342,7 +364,8 @@ func (w *WatchersServerTransport) dispatchBeginGetAzureReachabilityReport(req *h
 	if w.srv.BeginGetAzureReachabilityReport == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetAzureReachabilityReport not implemented")}
 	}
-	if w.beginGetAzureReachabilityReport == nil {
+	beginGetAzureReachabilityReport := w.beginGetAzureReachabilityReport.get(req)
+	if beginGetAzureReachabilityReport == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/azureReachabilityReport`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -365,19 +388,21 @@ func (w *WatchersServerTransport) dispatchBeginGetAzureReachabilityReport(req *h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetAzureReachabilityReport = &respr
+		beginGetAzureReachabilityReport = &respr
+		w.beginGetAzureReachabilityReport.add(req, beginGetAzureReachabilityReport)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetAzureReachabilityReport, req)
+	resp, err := server.PollerResponderNext(beginGetAzureReachabilityReport, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetAzureReachabilityReport.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetAzureReachabilityReport) {
-		w.beginGetAzureReachabilityReport = nil
+	if !server.PollerResponderMore(beginGetAzureReachabilityReport) {
+		w.beginGetAzureReachabilityReport.remove(req)
 	}
 
 	return resp, nil
@@ -387,7 +412,8 @@ func (w *WatchersServerTransport) dispatchBeginGetFlowLogStatus(req *http.Reques
 	if w.srv.BeginGetFlowLogStatus == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetFlowLogStatus not implemented")}
 	}
-	if w.beginGetFlowLogStatus == nil {
+	beginGetFlowLogStatus := w.beginGetFlowLogStatus.get(req)
+	if beginGetFlowLogStatus == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/queryFlowLogStatus`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -410,19 +436,21 @@ func (w *WatchersServerTransport) dispatchBeginGetFlowLogStatus(req *http.Reques
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetFlowLogStatus = &respr
+		beginGetFlowLogStatus = &respr
+		w.beginGetFlowLogStatus.add(req, beginGetFlowLogStatus)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetFlowLogStatus, req)
+	resp, err := server.PollerResponderNext(beginGetFlowLogStatus, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetFlowLogStatus.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetFlowLogStatus) {
-		w.beginGetFlowLogStatus = nil
+	if !server.PollerResponderMore(beginGetFlowLogStatus) {
+		w.beginGetFlowLogStatus.remove(req)
 	}
 
 	return resp, nil
@@ -432,7 +460,8 @@ func (w *WatchersServerTransport) dispatchBeginGetNetworkConfigurationDiagnostic
 	if w.srv.BeginGetNetworkConfigurationDiagnostic == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetNetworkConfigurationDiagnostic not implemented")}
 	}
-	if w.beginGetNetworkConfigurationDiagnostic == nil {
+	beginGetNetworkConfigurationDiagnostic := w.beginGetNetworkConfigurationDiagnostic.get(req)
+	if beginGetNetworkConfigurationDiagnostic == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/networkConfigurationDiagnostic`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -455,19 +484,21 @@ func (w *WatchersServerTransport) dispatchBeginGetNetworkConfigurationDiagnostic
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetNetworkConfigurationDiagnostic = &respr
+		beginGetNetworkConfigurationDiagnostic = &respr
+		w.beginGetNetworkConfigurationDiagnostic.add(req, beginGetNetworkConfigurationDiagnostic)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetNetworkConfigurationDiagnostic, req)
+	resp, err := server.PollerResponderNext(beginGetNetworkConfigurationDiagnostic, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetNetworkConfigurationDiagnostic.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetNetworkConfigurationDiagnostic) {
-		w.beginGetNetworkConfigurationDiagnostic = nil
+	if !server.PollerResponderMore(beginGetNetworkConfigurationDiagnostic) {
+		w.beginGetNetworkConfigurationDiagnostic.remove(req)
 	}
 
 	return resp, nil
@@ -477,7 +508,8 @@ func (w *WatchersServerTransport) dispatchBeginGetNextHop(req *http.Request) (*h
 	if w.srv.BeginGetNextHop == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetNextHop not implemented")}
 	}
-	if w.beginGetNextHop == nil {
+	beginGetNextHop := w.beginGetNextHop.get(req)
+	if beginGetNextHop == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/nextHop`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -500,19 +532,21 @@ func (w *WatchersServerTransport) dispatchBeginGetNextHop(req *http.Request) (*h
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetNextHop = &respr
+		beginGetNextHop = &respr
+		w.beginGetNextHop.add(req, beginGetNextHop)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetNextHop, req)
+	resp, err := server.PollerResponderNext(beginGetNextHop, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetNextHop.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetNextHop) {
-		w.beginGetNextHop = nil
+	if !server.PollerResponderMore(beginGetNextHop) {
+		w.beginGetNextHop.remove(req)
 	}
 
 	return resp, nil
@@ -559,7 +593,8 @@ func (w *WatchersServerTransport) dispatchBeginGetTroubleshooting(req *http.Requ
 	if w.srv.BeginGetTroubleshooting == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetTroubleshooting not implemented")}
 	}
-	if w.beginGetTroubleshooting == nil {
+	beginGetTroubleshooting := w.beginGetTroubleshooting.get(req)
+	if beginGetTroubleshooting == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/troubleshoot`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -582,19 +617,21 @@ func (w *WatchersServerTransport) dispatchBeginGetTroubleshooting(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetTroubleshooting = &respr
+		beginGetTroubleshooting = &respr
+		w.beginGetTroubleshooting.add(req, beginGetTroubleshooting)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetTroubleshooting, req)
+	resp, err := server.PollerResponderNext(beginGetTroubleshooting, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetTroubleshooting.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetTroubleshooting) {
-		w.beginGetTroubleshooting = nil
+	if !server.PollerResponderMore(beginGetTroubleshooting) {
+		w.beginGetTroubleshooting.remove(req)
 	}
 
 	return resp, nil
@@ -604,7 +641,8 @@ func (w *WatchersServerTransport) dispatchBeginGetTroubleshootingResult(req *htt
 	if w.srv.BeginGetTroubleshootingResult == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetTroubleshootingResult not implemented")}
 	}
-	if w.beginGetTroubleshootingResult == nil {
+	beginGetTroubleshootingResult := w.beginGetTroubleshootingResult.get(req)
+	if beginGetTroubleshootingResult == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/queryTroubleshootResult`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -627,19 +665,21 @@ func (w *WatchersServerTransport) dispatchBeginGetTroubleshootingResult(req *htt
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetTroubleshootingResult = &respr
+		beginGetTroubleshootingResult = &respr
+		w.beginGetTroubleshootingResult.add(req, beginGetTroubleshootingResult)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetTroubleshootingResult, req)
+	resp, err := server.PollerResponderNext(beginGetTroubleshootingResult, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetTroubleshootingResult.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetTroubleshootingResult) {
-		w.beginGetTroubleshootingResult = nil
+	if !server.PollerResponderMore(beginGetTroubleshootingResult) {
+		w.beginGetTroubleshootingResult.remove(req)
 	}
 
 	return resp, nil
@@ -649,7 +689,8 @@ func (w *WatchersServerTransport) dispatchBeginGetVMSecurityRules(req *http.Requ
 	if w.srv.BeginGetVMSecurityRules == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginGetVMSecurityRules not implemented")}
 	}
-	if w.beginGetVMSecurityRules == nil {
+	beginGetVMSecurityRules := w.beginGetVMSecurityRules.get(req)
+	if beginGetVMSecurityRules == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/securityGroupView`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -672,19 +713,21 @@ func (w *WatchersServerTransport) dispatchBeginGetVMSecurityRules(req *http.Requ
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginGetVMSecurityRules = &respr
+		beginGetVMSecurityRules = &respr
+		w.beginGetVMSecurityRules.add(req, beginGetVMSecurityRules)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginGetVMSecurityRules, req)
+	resp, err := server.PollerResponderNext(beginGetVMSecurityRules, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginGetVMSecurityRules.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginGetVMSecurityRules) {
-		w.beginGetVMSecurityRules = nil
+	if !server.PollerResponderMore(beginGetVMSecurityRules) {
+		w.beginGetVMSecurityRules.remove(req)
 	}
 
 	return resp, nil
@@ -694,7 +737,8 @@ func (w *WatchersServerTransport) dispatchNewListPager(req *http.Request) (*http
 	if w.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if w.newListPager == nil {
+	newListPager := w.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -706,17 +750,19 @@ func (w *WatchersServerTransport) dispatchNewListPager(req *http.Request) (*http
 			return nil, err
 		}
 		resp := w.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		w.newListPager = &resp
+		newListPager = &resp
+		w.newListPager.add(req, newListPager)
 	}
-	resp, err := server.PagerResponderNext(w.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		w.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(w.newListPager) {
-		w.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		w.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -725,7 +771,8 @@ func (w *WatchersServerTransport) dispatchNewListAllPager(req *http.Request) (*h
 	if w.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if w.newListAllPager == nil {
+	newListAllPager := w.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -733,17 +780,19 @@ func (w *WatchersServerTransport) dispatchNewListAllPager(req *http.Request) (*h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := w.srv.NewListAllPager(nil)
-		w.newListAllPager = &resp
+		newListAllPager = &resp
+		w.newListAllPager.add(req, newListAllPager)
 	}
-	resp, err := server.PagerResponderNext(w.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		w.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(w.newListAllPager) {
-		w.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		w.newListAllPager.remove(req)
 	}
 	return resp, nil
 }
@@ -752,7 +801,8 @@ func (w *WatchersServerTransport) dispatchBeginListAvailableProviders(req *http.
 	if w.srv.BeginListAvailableProviders == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginListAvailableProviders not implemented")}
 	}
-	if w.beginListAvailableProviders == nil {
+	beginListAvailableProviders := w.beginListAvailableProviders.get(req)
+	if beginListAvailableProviders == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/availableProvidersList`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -775,19 +825,21 @@ func (w *WatchersServerTransport) dispatchBeginListAvailableProviders(req *http.
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginListAvailableProviders = &respr
+		beginListAvailableProviders = &respr
+		w.beginListAvailableProviders.add(req, beginListAvailableProviders)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginListAvailableProviders, req)
+	resp, err := server.PollerResponderNext(beginListAvailableProviders, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginListAvailableProviders.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginListAvailableProviders) {
-		w.beginListAvailableProviders = nil
+	if !server.PollerResponderMore(beginListAvailableProviders) {
+		w.beginListAvailableProviders.remove(req)
 	}
 
 	return resp, nil
@@ -797,7 +849,8 @@ func (w *WatchersServerTransport) dispatchBeginSetFlowLogConfiguration(req *http
 	if w.srv.BeginSetFlowLogConfiguration == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginSetFlowLogConfiguration not implemented")}
 	}
-	if w.beginSetFlowLogConfiguration == nil {
+	beginSetFlowLogConfiguration := w.beginSetFlowLogConfiguration.get(req)
+	if beginSetFlowLogConfiguration == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/configureFlowLog`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -820,19 +873,21 @@ func (w *WatchersServerTransport) dispatchBeginSetFlowLogConfiguration(req *http
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginSetFlowLogConfiguration = &respr
+		beginSetFlowLogConfiguration = &respr
+		w.beginSetFlowLogConfiguration.add(req, beginSetFlowLogConfiguration)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginSetFlowLogConfiguration, req)
+	resp, err := server.PollerResponderNext(beginSetFlowLogConfiguration, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginSetFlowLogConfiguration.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginSetFlowLogConfiguration) {
-		w.beginSetFlowLogConfiguration = nil
+	if !server.PollerResponderMore(beginSetFlowLogConfiguration) {
+		w.beginSetFlowLogConfiguration.remove(req)
 	}
 
 	return resp, nil
@@ -879,7 +934,8 @@ func (w *WatchersServerTransport) dispatchBeginVerifyIPFlow(req *http.Request) (
 	if w.srv.BeginVerifyIPFlow == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginVerifyIPFlow not implemented")}
 	}
-	if w.beginVerifyIPFlow == nil {
+	beginVerifyIPFlow := w.beginVerifyIPFlow.get(req)
+	if beginVerifyIPFlow == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/networkWatchers/(?P<networkWatcherName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/ipFlowVerify`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -902,19 +958,21 @@ func (w *WatchersServerTransport) dispatchBeginVerifyIPFlow(req *http.Request) (
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginVerifyIPFlow = &respr
+		beginVerifyIPFlow = &respr
+		w.beginVerifyIPFlow.add(req, beginVerifyIPFlow)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginVerifyIPFlow, req)
+	resp, err := server.PollerResponderNext(beginVerifyIPFlow, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted}, resp.StatusCode) {
+		w.beginVerifyIPFlow.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginVerifyIPFlow) {
-		w.beginVerifyIPFlow = nil
+	if !server.PollerResponderMore(beginVerifyIPFlow) {
+		w.beginVerifyIPFlow.remove(req)
 	}
 
 	return resp, nil

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_webapplicationfirewallpolicies_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_webapplicationfirewallpolicies_server.go
@@ -49,16 +49,21 @@ type WebApplicationFirewallPoliciesServer struct {
 // The returned WebApplicationFirewallPoliciesServerTransport instance is connected to an instance of armnetwork.WebApplicationFirewallPoliciesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewWebApplicationFirewallPoliciesServerTransport(srv *WebApplicationFirewallPoliciesServer) *WebApplicationFirewallPoliciesServerTransport {
-	return &WebApplicationFirewallPoliciesServerTransport{srv: srv}
+	return &WebApplicationFirewallPoliciesServerTransport{
+		srv:             srv,
+		beginDelete:     newTracker[azfake.PollerResponder[armnetwork.WebApplicationFirewallPoliciesClientDeleteResponse]](),
+		newListPager:    newTracker[azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListResponse]](),
+		newListAllPager: newTracker[azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListAllResponse]](),
+	}
 }
 
 // WebApplicationFirewallPoliciesServerTransport connects instances of armnetwork.WebApplicationFirewallPoliciesClient to instances of WebApplicationFirewallPoliciesServer.
 // Don't use this type directly, use NewWebApplicationFirewallPoliciesServerTransport instead.
 type WebApplicationFirewallPoliciesServerTransport struct {
 	srv             *WebApplicationFirewallPoliciesServer
-	beginDelete     *azfake.PollerResponder[armnetwork.WebApplicationFirewallPoliciesClientDeleteResponse]
-	newListPager    *azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListResponse]
-	newListAllPager *azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListAllResponse]
+	beginDelete     *tracker[azfake.PollerResponder[armnetwork.WebApplicationFirewallPoliciesClientDeleteResponse]]
+	newListPager    *tracker[azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListResponse]]
+	newListAllPager *tracker[azfake.PagerResponder[armnetwork.WebApplicationFirewallPoliciesClientListAllResponse]]
 }
 
 // Do implements the policy.Transporter interface for WebApplicationFirewallPoliciesServerTransport.
@@ -135,7 +140,8 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchBeginDelete(req 
 	if w.srv.BeginDelete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginDelete not implemented")}
 	}
-	if w.beginDelete == nil {
+	beginDelete := w.beginDelete.get(req)
+	if beginDelete == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/(?P<policyName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -154,19 +160,21 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchBeginDelete(req 
 		if respErr := server.GetError(errRespr, req); respErr != nil {
 			return nil, respErr
 		}
-		w.beginDelete = &respr
+		beginDelete = &respr
+		w.beginDelete.add(req, beginDelete)
 	}
 
-	resp, err := server.PollerResponderNext(w.beginDelete, req)
+	resp, err := server.PollerResponderNext(beginDelete, req)
 	if err != nil {
 		return nil, err
 	}
 
 	if !contains([]int{http.StatusOK, http.StatusAccepted, http.StatusNoContent}, resp.StatusCode) {
+		w.beginDelete.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK, http.StatusAccepted, http.StatusNoContent", resp.StatusCode)}
 	}
-	if !server.PollerResponderMore(w.beginDelete) {
-		w.beginDelete = nil
+	if !server.PollerResponderMore(beginDelete) {
+		w.beginDelete.remove(req)
 	}
 
 	return resp, nil
@@ -209,7 +217,8 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchNewListPager(req
 	if w.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
-	if w.newListPager == nil {
+	newListPager := w.newListPager.get(req)
+	if newListPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/resourceGroups/(?P<resourceGroupName>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -221,20 +230,22 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchNewListPager(req
 			return nil, err
 		}
 		resp := w.srv.NewListPager(resourceGroupNameUnescaped, nil)
-		w.newListPager = &resp
-		server.PagerResponderInjectNextLinks(w.newListPager, req, func(page *armnetwork.WebApplicationFirewallPoliciesClientListResponse, createLink func() string) {
+		newListPager = &resp
+		w.newListPager.add(req, newListPager)
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armnetwork.WebApplicationFirewallPoliciesClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(w.newListPager, req)
+	resp, err := server.PagerResponderNext(newListPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		w.newListPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(w.newListPager) {
-		w.newListPager = nil
+	if !server.PagerResponderMore(newListPager) {
+		w.newListPager.remove(req)
 	}
 	return resp, nil
 }
@@ -243,7 +254,8 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchNewListAllPager(
 	if w.srv.NewListAllPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListAllPager not implemented")}
 	}
-	if w.newListAllPager == nil {
+	newListAllPager := w.newListAllPager.get(req)
+	if newListAllPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -251,20 +263,22 @@ func (w *WebApplicationFirewallPoliciesServerTransport) dispatchNewListAllPager(
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := w.srv.NewListAllPager(nil)
-		w.newListAllPager = &resp
-		server.PagerResponderInjectNextLinks(w.newListAllPager, req, func(page *armnetwork.WebApplicationFirewallPoliciesClientListAllResponse, createLink func() string) {
+		newListAllPager = &resp
+		w.newListAllPager.add(req, newListAllPager)
+		server.PagerResponderInjectNextLinks(newListAllPager, req, func(page *armnetwork.WebApplicationFirewallPoliciesClientListAllResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(w.newListAllPager, req)
+	resp, err := server.PagerResponderNext(newListAllPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		w.newListAllPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(w.newListAllPager) {
-		w.newListAllPager = nil
+	if !server.PagerResponderMore(newListAllPager) {
+		w.newListAllPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_webcategories_server.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_webcategories_server.go
@@ -37,14 +37,17 @@ type WebCategoriesServer struct {
 // The returned WebCategoriesServerTransport instance is connected to an instance of armnetwork.WebCategoriesClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewWebCategoriesServerTransport(srv *WebCategoriesServer) *WebCategoriesServerTransport {
-	return &WebCategoriesServerTransport{srv: srv}
+	return &WebCategoriesServerTransport{
+		srv:                        srv,
+		newListBySubscriptionPager: newTracker[azfake.PagerResponder[armnetwork.WebCategoriesClientListBySubscriptionResponse]](),
+	}
 }
 
 // WebCategoriesServerTransport connects instances of armnetwork.WebCategoriesClient to instances of WebCategoriesServer.
 // Don't use this type directly, use NewWebCategoriesServerTransport instead.
 type WebCategoriesServerTransport struct {
 	srv                        *WebCategoriesServer
-	newListBySubscriptionPager *azfake.PagerResponder[armnetwork.WebCategoriesClientListBySubscriptionResponse]
+	newListBySubscriptionPager *tracker[azfake.PagerResponder[armnetwork.WebCategoriesClientListBySubscriptionResponse]]
 }
 
 // Do implements the policy.Transporter interface for WebCategoriesServerTransport.
@@ -119,7 +122,8 @@ func (w *WebCategoriesServerTransport) dispatchNewListBySubscriptionPager(req *h
 	if w.srv.NewListBySubscriptionPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListBySubscriptionPager not implemented")}
 	}
-	if w.newListBySubscriptionPager == nil {
+	newListBySubscriptionPager := w.newListBySubscriptionPager.get(req)
+	if newListBySubscriptionPager == nil {
 		const regexStr = `/subscriptions/(?P<subscriptionId>[!#&$-;=?-\[\]_a-zA-Z0-9~%@]+)/providers/Microsoft.Network/azureWebCategories`
 		regex := regexp.MustCompile(regexStr)
 		matches := regex.FindStringSubmatch(req.URL.EscapedPath())
@@ -127,20 +131,22 @@ func (w *WebCategoriesServerTransport) dispatchNewListBySubscriptionPager(req *h
 			return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 		}
 		resp := w.srv.NewListBySubscriptionPager(nil)
-		w.newListBySubscriptionPager = &resp
-		server.PagerResponderInjectNextLinks(w.newListBySubscriptionPager, req, func(page *armnetwork.WebCategoriesClientListBySubscriptionResponse, createLink func() string) {
+		newListBySubscriptionPager = &resp
+		w.newListBySubscriptionPager.add(req, newListBySubscriptionPager)
+		server.PagerResponderInjectNextLinks(newListBySubscriptionPager, req, func(page *armnetwork.WebCategoriesClientListBySubscriptionResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
-	resp, err := server.PagerResponderNext(w.newListBySubscriptionPager, req)
+	resp, err := server.PagerResponderNext(newListBySubscriptionPager, req)
 	if err != nil {
 		return nil, err
 	}
 	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		w.newListBySubscriptionPager.remove(req)
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
 	}
-	if !server.PagerResponderMore(w.newListBySubscriptionPager) {
-		w.newListBySubscriptionPager = nil
+	if !server.PagerResponderMore(newListBySubscriptionPager) {
+		w.newListBySubscriptionPager.remove(req)
 	}
 	return resp, nil
 }


### PR DESCRIPTION
Create a pager/poller state machine per combination of HTTP verb and URL path so that API calls for different resources don't overlap. Bump version number in preparation for release.

Fixes the issue reported in https://github.com/Azure/azure-sdk-for-go/issues/16613#issuecomment-1640192507