### PR TITLE
rollback node version in config

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -8,7 +8,7 @@
     "doc": "docs"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=10.12.0"
   },
   "scripts": {
     "start": "node --max_old_space_size=4096 ./dist/src/main.js",

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.53",
+  "version": "4.0.0-preview.54",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -8,7 +8,7 @@
     "doc": "docs"
   },
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "start": "node --max_old_space_size=4096 ./dist/src/main.js",


### PR DESCRIPTION
Be consistent with autorest's config: https://github.com/Azure/autorest/blob/main/packages/apps/autorest/package.json and prevent sdk automation failure because of low version of node in some ci env.

fix: #997