### PR TITLE
Handle nested collections of discriminated types

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.54",
+  "version": "4.0.0-preview.55",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/common/helpers.ts
+++ b/packages/autorest.go/src/common/helpers.ts
@@ -225,3 +225,11 @@ export function aggregateProperties(obj: ObjectSchema): Array<Property> {
   }
   return allProps;
 }
+
+// returns the leaf element type for an array or dictionary
+export function recursiveUnwrapArrayDictionary(item: ArraySchema | DictionarySchema): Schema {
+  if (isArraySchema(item.elementType) || isDictionarySchema(item.elementType)) {
+    return recursiveUnwrapArrayDictionary(item.elementType);
+  }
+  return item.elementType;
+}

--- a/packages/autorest.go/src/generator/models.ts
+++ b/packages/autorest.go/src/generator/models.ts
@@ -426,7 +426,7 @@ function generateDiscriminatorUnmarshaller(prop: Property, receiver: string): st
   // first, unmarshal the raw data
   const rawTargetVar = `${prop.serializedName}Raw`;
   let text = `${startingIndentation}var ${rawTargetVar} ${recursiveGetDiscriminatorTypeName(prop.schema, true)}\n`;
-  text += `${startingIndentation}if err := json.Unmarshal(val, &${rawTargetVar}); err != nil {\n`;
+  text += `${startingIndentation}if err = json.Unmarshal(val, &${rawTargetVar}); err != nil {\n`;
   text += `${startingIndentation}\treturn err\n${startingIndentation}}\n`;
 
   // create a local instantiation of the final type

--- a/packages/autorest.go/test/maps/azalias/fake/zz_polymorphic_helpers.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_polymorphic_helpers.go
@@ -34,6 +34,25 @@ func unmarshalGeoJSONObjectClassification(rawMsg json.RawMessage) (azalias.GeoJS
 	return b, nil
 }
 
+func unmarshalGeoJSONObjectClassificationArray(rawMsg json.RawMessage) ([]azalias.GeoJSONObjectClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []json.RawMessage
+	if err := json.Unmarshal(rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]azalias.GeoJSONObjectClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalGeoJSONObjectClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return fArray, nil
+}
+
 func unmarshalGeoJSONObjectClassificationMap(rawMsg json.RawMessage) (map[string]azalias.GeoJSONObjectClassification, error) {
 	if rawMsg == nil {
 		return nil, nil

--- a/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
+++ b/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
@@ -168,3 +168,95 @@ func TestInterfaceJSONNull(t *testing.T) {
 	require.Contains(t, string(b), `"anyObject":null`)
 	require.NotContains(t, string(b), "anything")
 }
+
+func TestGeoJSONRecursiveDisciminators(t *testing.T) {
+	obj1 := GeoJSONRecursiveDisciminators{
+		CombinedOne: []map[string]map[string]GeoJSONObjectClassification{
+			{
+				"entry": {
+					"thing": &GeoJSONFeature{
+						FeatureType: to.Ptr("slice-of-map-of-map-of-discriminators"),
+						ID:          to.Ptr("entry-one"),
+						Setting:     to.Ptr(DataSettingOne),
+						Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+					},
+				},
+			},
+		},
+		CombinedThree: map[string][]map[string]GeoJSONObjectClassification{
+			"entry": {
+				{
+					"thing": &GeoJSONFeature{
+						FeatureType: to.Ptr("map-of-slice-of-map-of-discriminators"),
+						ID:          to.Ptr("entry-one"),
+						Setting:     to.Ptr(DataSettingOne),
+						Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+					},
+				},
+			},
+		},
+		CombinedTwo: map[string]map[string][]GeoJSONObjectClassification{
+			"entry": {
+				"thing": {
+					&GeoJSONFeature{
+						FeatureType: to.Ptr("map-of-map-of-slice-of-discriminators"),
+						ID:          to.Ptr("0-0"),
+						Setting:     to.Ptr(DataSettingOne),
+						Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+					},
+					&GeoJSONFeature{
+						FeatureType: to.Ptr("map-of-map-of-slice-of-discriminators"),
+						ID:          to.Ptr("0-1"),
+						Setting:     to.Ptr(DataSettingTwo),
+						Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+					},
+				},
+			},
+		},
+		Items: [][]GeoJSONObjectClassification{
+			{
+				&GeoJSONFeature{
+					FeatureType: to.Ptr("slice-of-slice-discriminators"),
+					ID:          to.Ptr("0-0"),
+					Setting:     to.Ptr(DataSettingOne),
+					Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+				},
+				&GeoJSONFeature{
+					FeatureType: to.Ptr("slice-of-slice-discriminators"),
+					ID:          to.Ptr("0-1"),
+					Setting:     to.Ptr(DataSettingTwo),
+					Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+				},
+			},
+			{
+				&GeoJSONFeature{
+					FeatureType: to.Ptr("slice-of-slice-discriminators"),
+					ID:          to.Ptr("1-0"),
+					Setting:     to.Ptr(DataSettingTwo),
+					Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+				},
+				&GeoJSONFeature{
+					FeatureType: to.Ptr("slice-of-slice-discriminators"),
+					ID:          to.Ptr("1-1"),
+					Setting:     to.Ptr(DataSettingThree),
+					Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+				},
+			},
+		},
+		Objects: map[string]map[string]GeoJSONObjectClassification{
+			"entry": {
+				"thing": &GeoJSONFeature{
+					FeatureType: to.Ptr("map-of-map-of-discriminators"),
+					ID:          to.Ptr("entry-one"),
+					Setting:     to.Ptr(DataSettingOne),
+					Type:        to.Ptr(GeoJSONObjectTypeGeoJSONFeature), // set by marshaller but set here to simplify the test
+				},
+			},
+		},
+	}
+	b, err := json.Marshal(obj1)
+	require.NoError(t, err)
+	var obj2 GeoJSONRecursiveDisciminators
+	require.NoError(t, json.Unmarshal(b, &obj2))
+	require.EqualValues(t, obj1, obj2)
+}

--- a/packages/autorest.go/test/maps/azalias/zz_models.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models.go
@@ -102,6 +102,23 @@ type GeoJSONObjectNamedCollection struct {
 	Objects map[string]GeoJSONObjectClassification
 }
 
+type GeoJSONRecursiveDisciminators struct {
+	// slice of map of map of discriminators
+	CombinedOne []map[string]map[string]GeoJSONObjectClassification
+
+	// map of slice of map of discriminators
+	CombinedThree map[string][]map[string]GeoJSONObjectClassification
+
+	// map of map of slice of discriminators
+	CombinedTwo map[string]map[string][]GeoJSONObjectClassification
+
+	// slice of slice of discriminators
+	Items [][]GeoJSONObjectClassification
+
+	// map of map of discriminators
+	Objects map[string]map[string]GeoJSONObjectClassification
+}
+
 // ListResponse - The response model for the List API. Returns a list of all the previously created aliases.
 type ListResponse struct {
 	// READ-ONLY; A list of all the previously created aliases.

--- a/packages/autorest.go/test/maps/azalias/zz_models_serde.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models_serde.go
@@ -264,7 +264,7 @@ func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
 		switch key {
 		case "combinedOne":
 			var combinedOneRaw []map[string]json.RawMessage
-			if err := json.Unmarshal(val, &combinedOneRaw); err != nil {
+			if err = json.Unmarshal(val, &combinedOneRaw); err != nil {
 				return err
 			}
 			combinedOne := make([]map[string]map[string]GeoJSONObjectClassification, len(combinedOneRaw))
@@ -281,7 +281,7 @@ func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "combinedThree":
 			var combinedThreeRaw map[string][]json.RawMessage
-			if err := json.Unmarshal(val, &combinedThreeRaw); err != nil {
+			if err = json.Unmarshal(val, &combinedThreeRaw); err != nil {
 				return err
 			}
 			combinedThree := map[string][]map[string]GeoJSONObjectClassification{}
@@ -298,7 +298,7 @@ func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "combinedTwo":
 			var combinedTwoRaw map[string]map[string]json.RawMessage
-			if err := json.Unmarshal(val, &combinedTwoRaw); err != nil {
+			if err = json.Unmarshal(val, &combinedTwoRaw); err != nil {
 				return err
 			}
 			combinedTwo := map[string]map[string][]GeoJSONObjectClassification{}
@@ -315,7 +315,7 @@ func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "items":
 			var itemsRaw []json.RawMessage
-			if err := json.Unmarshal(val, &itemsRaw); err != nil {
+			if err = json.Unmarshal(val, &itemsRaw); err != nil {
 				return err
 			}
 			items := make([][]GeoJSONObjectClassification, len(itemsRaw))
@@ -329,7 +329,7 @@ func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
 			delete(rawMsg, key)
 		case "objects":
 			var objectsRaw map[string]json.RawMessage
-			if err := json.Unmarshal(val, &objectsRaw); err != nil {
+			if err = json.Unmarshal(val, &objectsRaw); err != nil {
 				return err
 			}
 			objects := map[string]map[string]GeoJSONObjectClassification{}

--- a/packages/autorest.go/test/maps/azalias/zz_models_serde.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models_serde.go
@@ -242,6 +242,113 @@ func (g *GeoJSONObjectNamedCollection) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type GeoJSONRecursiveDisciminators.
+func (g GeoJSONRecursiveDisciminators) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "combinedOne", g.CombinedOne)
+	populate(objectMap, "combinedThree", g.CombinedThree)
+	populate(objectMap, "combinedTwo", g.CombinedTwo)
+	populate(objectMap, "items", g.Items)
+	populate(objectMap, "objects", g.Objects)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type GeoJSONRecursiveDisciminators.
+func (g *GeoJSONRecursiveDisciminators) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", g, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "combinedOne":
+			var combinedOneRaw []map[string]json.RawMessage
+			if err := json.Unmarshal(val, &combinedOneRaw); err != nil {
+				return err
+			}
+			combinedOne := make([]map[string]map[string]GeoJSONObjectClassification, len(combinedOneRaw))
+			for i1 := range combinedOneRaw {
+				combinedOne[i1] = map[string]map[string]GeoJSONObjectClassification{}
+				for k2, v2 := range combinedOneRaw[i1] {
+					combinedOne[i1][k2], err = unmarshalGeoJSONObjectClassificationMap(v2)
+					if err != nil {
+						return fmt.Errorf("unmarshalling type %T: %v", g, err)
+					}
+				}
+			}
+			g.CombinedOne = combinedOne
+			delete(rawMsg, key)
+		case "combinedThree":
+			var combinedThreeRaw map[string][]json.RawMessage
+			if err := json.Unmarshal(val, &combinedThreeRaw); err != nil {
+				return err
+			}
+			combinedThree := map[string][]map[string]GeoJSONObjectClassification{}
+			for k1, v1 := range combinedThreeRaw {
+				combinedThree[k1] = make([]map[string]GeoJSONObjectClassification, len(v1))
+				for i2 := range v1 {
+					combinedThree[k1][i2], err = unmarshalGeoJSONObjectClassificationMap(v1[i2])
+					if err != nil {
+						return fmt.Errorf("unmarshalling type %T: %v", g, err)
+					}
+				}
+			}
+			g.CombinedThree = combinedThree
+			delete(rawMsg, key)
+		case "combinedTwo":
+			var combinedTwoRaw map[string]map[string]json.RawMessage
+			if err := json.Unmarshal(val, &combinedTwoRaw); err != nil {
+				return err
+			}
+			combinedTwo := map[string]map[string][]GeoJSONObjectClassification{}
+			for k1, v1 := range combinedTwoRaw {
+				combinedTwo[k1] = map[string][]GeoJSONObjectClassification{}
+				for k2, v2 := range v1 {
+					combinedTwo[k1][k2], err = unmarshalGeoJSONObjectClassificationArray(v2)
+					if err != nil {
+						return fmt.Errorf("unmarshalling type %T: %v", g, err)
+					}
+				}
+			}
+			g.CombinedTwo = combinedTwo
+			delete(rawMsg, key)
+		case "items":
+			var itemsRaw []json.RawMessage
+			if err := json.Unmarshal(val, &itemsRaw); err != nil {
+				return err
+			}
+			items := make([][]GeoJSONObjectClassification, len(itemsRaw))
+			for i1 := range itemsRaw {
+				items[i1], err = unmarshalGeoJSONObjectClassificationArray(itemsRaw[i1])
+				if err != nil {
+					return fmt.Errorf("unmarshalling type %T: %v", g, err)
+				}
+			}
+			g.Items = items
+			delete(rawMsg, key)
+		case "objects":
+			var objectsRaw map[string]json.RawMessage
+			if err := json.Unmarshal(val, &objectsRaw); err != nil {
+				return err
+			}
+			objects := map[string]map[string]GeoJSONObjectClassification{}
+			for k1, v1 := range objectsRaw {
+				objects[k1], err = unmarshalGeoJSONObjectClassificationMap(v1)
+				if err != nil {
+					return fmt.Errorf("unmarshalling type %T: %v", g, err)
+				}
+			}
+			g.Objects = objects
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", g, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type ListResponse.
 func (l ListResponse) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)

--- a/packages/autorest.go/test/maps/azalias/zz_polymorphic_helpers.go
+++ b/packages/autorest.go/test/maps/azalias/zz_polymorphic_helpers.go
@@ -31,6 +31,25 @@ func unmarshalGeoJSONObjectClassification(rawMsg json.RawMessage) (GeoJSONObject
 	return b, nil
 }
 
+func unmarshalGeoJSONObjectClassificationArray(rawMsg json.RawMessage) ([]GeoJSONObjectClassification, error) {
+	if rawMsg == nil {
+		return nil, nil
+	}
+	var rawMessages []json.RawMessage
+	if err := json.Unmarshal(rawMsg, &rawMessages); err != nil {
+		return nil, err
+	}
+	fArray := make([]GeoJSONObjectClassification, len(rawMessages))
+	for index, rawMessage := range rawMessages {
+		f, err := unmarshalGeoJSONObjectClassification(rawMessage)
+		if err != nil {
+			return nil, err
+		}
+		fArray[index] = f
+	}
+	return fArray, nil
+}
+
 func unmarshalGeoJSONObjectClassificationMap(rawMsg json.RawMessage) (map[string]GeoJSONObjectClassification, error) {
 	if rawMsg == nil {
 		return nil, nil

--- a/packages/autorest.go/test/swagger/alias.json
+++ b/packages/autorest.go/test/swagger/alias.json
@@ -577,6 +577,64 @@
         }
       ]
     },
+    "GeoJsonRecursiveDisciminators": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "description": "slice of slice of discriminators",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/GeoJsonObject"
+            }
+          }
+        },
+        "objects": {
+          "description": "map of map of discriminators",
+          "type": "object",
+          "additionalProperties": {
+            "additionalProperties": {
+              "$ref": "#/definitions/GeoJsonObject"
+            }
+          }
+        },
+        "combinedOne": {
+          "description": "slice of map of map of discriminators",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "$ref": "#/definitions/GeoJsonObject"
+              }
+            }
+          }
+        },
+        "combinedTwo": {
+          "description": "map of map of slice of discriminators",
+          "additionalProperties": {
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/GeoJsonObject"
+              }
+            }
+          }
+        },
+        "combinedThree": {
+          "description": "map of slice of map of discriminators",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/GeoJsonObject"
+              }
+            }
+          }
+        }
+      }
+    },
     "ScheduleCreateOrUpdateProperties": {
       "properties": {
         "description": {


### PR DESCRIPTION
Previously, only slices and maps of discriminated types were supported. The new implementation is recursive, supporting an arbitrary level of nested collections (e.g. map of slice of map of discriminated type).

Fixes https://github.com/Azure/autorest.go/issues/990