### PR TITLE
Check for content type param for text media types

### DIFF
--- a/packages/autorest.go/test/autorest/mediatypesgroup/zz_mediatypes_client.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroup/zz_mediatypes_client.go
@@ -436,7 +436,7 @@ func (client *MediaTypesClient) putTextAndJSONBodyCreateRequest(ctx context.Cont
 	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
 	body := streaming.NopCloser(strings.NewReader(message))
-	if err := req.SetBody(body, "application/json"); err != nil {
+	if err := req.SetBody(body, string(contentType)); err != nil {
 		return nil, err
 	}
 

--- a/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/zz_mediatypes_client.go
@@ -437,7 +437,7 @@ func (client *MediaTypesClient) putTextAndJSONBodyWithTextCreateRequest(ctx cont
 	req.Raw().Header["Content-Type"] = []string{string(contentType)}
 	req.Raw().Header["Accept"] = []string{"text/plain"}
 	body := streaming.NopCloser(strings.NewReader(message))
-	if err := req.SetBody(body, "application/json"); err != nil {
+	if err := req.SetBody(body, string(contentType)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Use the content type param for setting the request's content type.