### PR TITLE
Fix various regressions introduced in GoCodeModel

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -232,13 +232,13 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.GoCodeMo
   } else if (getSchemaResponse(op)) {
     let modelType: go.ModelType | undefined;
     for (const model of codeModel.models) {
-      if (model.name === resultProp.schema.language.go!.name && go.isModelType(model)) {
+      if (model.name === resultProp.schema.language.go!.name) {
         modelType = model;
         break;
       }
     }
     if (!modelType) {
-      throw new Error(`didn't find ModelType for response envelope ${respEnv.name}`);
+      throw new Error(`didn't find type name ${resultProp.schema.language.go!.name} for response envelope ${respEnv.name}`);
     }
     respEnv.result = new go.ModelResult(modelType, adaptResultFormat(getSchemaResponse(op)!.protocol));
   } else {

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -309,15 +309,6 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       types.set(keyName, arrayType);
       return arrayType;
     }
-    case m4.SchemaType.Boolean: {
-      let primitiveBool = types.get(m4.SchemaType.Boolean);
-      if (primitiveBool) {
-        return primitiveBool;
-      }
-      primitiveBool = new go.PrimitiveType('bool');
-      types.set(m4.SchemaType.Boolean, primitiveBool);
-      return primitiveBool;
-    }
     case m4.SchemaType.Binary: {
       let binaryType = types.get(m4.SchemaType.Binary);
       if (binaryType) {
@@ -326,6 +317,15 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       binaryType = new go.StandardType('io.ReadSeekCloser', 'io');
       types.set(m4.SchemaType.Binary, binaryType);
       return binaryType;
+    }
+    case m4.SchemaType.Boolean: {
+      let primitiveBool = types.get(m4.SchemaType.Boolean);
+      if (primitiveBool) {
+        return primitiveBool;
+      }
+      primitiveBool = new go.PrimitiveType('bool');
+      types.set(m4.SchemaType.Boolean, primitiveBool);
+      return primitiveBool;
     }
     case m4.SchemaType.ByteArray:
       return adaptBytesType(<m4.ByteArraySchema>schema);
@@ -342,6 +342,15 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       return adaptConstantType(<m4.ChoiceSchema>schema);
     case m4.SchemaType.Constant:
       return adaptLiteralValue(<m4.ConstantSchema>schema);
+    case m4.SchemaType.Credential: {
+      let credType = types.get(m4.SchemaType.Credential);
+      if (credType) {
+        return credType;
+      }
+      credType = new go.PrimitiveType('string');
+      types.set(m4.SchemaType.Credential, credType);
+      return credType;
+    }
     case m4.SchemaType.Date:
     case m4.SchemaType.DateTime:
     case m4.SchemaType.Time:
@@ -416,6 +425,15 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
     }
     case m4.SchemaType.Object:
       return adaptModel(<m4.ObjectSchema>schema);
+    case m4.SchemaType.ODataQuery: {
+      let odataType = types.get(m4.SchemaType.ODataQuery);
+      if (odataType) {
+        return odataType;
+      }
+      odataType = new go.PrimitiveType('string');
+      types.set(m4.SchemaType.ODataQuery, odataType);
+      return odataType;
+    }
     case m4.SchemaType.SealedChoice:
       return adaptConstantType(<m4.SealedChoiceSchema>schema);
     case m4.SchemaType.String: {
@@ -564,7 +582,7 @@ function recursiveKeyName(root: string, obj: m4.Schema): string {
     case m4.SchemaType.Date:
     case m4.SchemaType.DateTime:
     case m4.SchemaType.UnixTime:
-      return obj.language.go!.internalTimeType;
+      return `${root}-${obj.language.go!.internalTimeType}`;
     default:
       return `${root}-${obj.language.go!.name}`;
   }


### PR DESCRIPTION
Include polymorphic concrete types when searching for a schema response. Added support for M4 Credential and ODataQuery types. This brings the adapter on par with the types supported in the transformer. Fixed incorrect key name generation for time types.