### PR TITLE
Fix various codegen bugs

### DIFF
--- a/.scripts/regeneration.js
+++ b/.scripts/regeneration.js
@@ -128,7 +128,7 @@ generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/da
 const acr = './swagger/specification/containerregistry/data-plane/Azure.ContainerRegistry/stable/2021-07-01/containerregistry.json';
 generate("azacr", acr, 'test/acr/azacr', '--module="azacr" --module-version=0.1.0 --openapi-type="data-plane" --rawjson-as-bytes --generate-fakes --azcore-version=1.8.0-beta.2');
 
-generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --azcore-version=1.8.0-beta.2');
+generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --azcore-version=1.8.0-beta.2 --slice-elements-byval');
 
 function should_generate(name) {
     if (filter !== undefined) {

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.55",
+  "version": "4.0.0-preview.56",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/helpers.ts
+++ b/packages/autorest.go/src/generator/helpers.ts
@@ -68,7 +68,8 @@ export function formatTypeName(schema: Schema, pkgName?: string): string {
   // for array/dictionary, we need to splice the package name into the correct location
   const elementType = unwrapSchemaType(schema);
   if (elementType.type === SchemaType.Choice || elementType.type === SchemaType.SealedChoice || elementType.type === SchemaType.Object) {
-    return typeName.replace(`*${elementType.language.go!.name}`, `*${pkgName}.${elementType.language.go!.name}`);
+    // don't use a * prefix on the type name as --slice-elements-byval will remove it for slices
+    return typeName.replace(`${elementType.language.go!.name}`, `${pkgName}.${elementType.language.go!.name}`);
   }
 
   return typeName;

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -123,11 +123,11 @@ func (s *ServerTransport) dispatchCreate(req *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	elements := strings.Split(groupByUnescaped, ",")
-	groupByParam := make([]azalias.SomethingCount, len(elements))
-	for i := 0; i < len(elements); i++ {
+	groupByUnescapedElements := strings.Split(groupByUnescaped, ",")
+	groupByParam := make([]azalias.SomethingCount, len(groupByUnescapedElements))
+	for i := 0; i < len(groupByUnescapedElements); i++ {
 		var parsedInt int64
-		parsedInt, err = strconv.ParseInt(elements[i], 10, 32)
+		parsedInt, err = strconv.ParseInt(groupByUnescapedElements[i], 10, 32)
 		if err != nil {
 			return nil, err
 		}
@@ -193,10 +193,10 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 		if err != nil {
 			return nil, err
 		}
-		elements := strings.Split(groupByUnescaped, ",")
-		groupByParam := make([]azalias.LogMetricsGroupBy, len(elements))
-		for i := 0; i < len(elements); i++ {
-			groupByParam[i] = azalias.LogMetricsGroupBy(elements[i])
+		groupByUnescapedElements := strings.Split(groupByUnescaped, ",")
+		groupByParam := make([]azalias.LogMetricsGroupBy, len(groupByUnescapedElements))
+		for i := 0; i < len(groupByUnescapedElements); i++ {
+			groupByParam[i] = azalias.LogMetricsGroupBy(groupByUnescapedElements[i])
 		}
 		var options *azalias.ClientListOptions
 		if len(groupByParam) > 0 {

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -39,7 +39,7 @@ type Server struct {
 
 	// PolicyAssignment is the fake for method Client.PolicyAssignment
 	// HTTP status codes to indicate success: http.StatusOK
-	PolicyAssignment func(ctx context.Context, props azalias.ScheduleCreateOrUpdateProperties, options *azalias.ClientPolicyAssignmentOptions) (resp azfake.Responder[azalias.ClientPolicyAssignmentResponse], errResp azfake.ErrorResponder)
+	PolicyAssignment func(ctx context.Context, things []azalias.Things, polymorphicParam azalias.GeoJSONObjectClassification, options *azalias.ClientPolicyAssignmentOptions) (resp azfake.Responder[azalias.ClientPolicyAssignmentResponse], errResp azfake.ErrorResponder)
 }
 
 // NewServerTransport creates a new instance of ServerTransport with the provided implementation.
@@ -230,22 +230,41 @@ func (s *ServerTransport) dispatchPolicyAssignment(req *http.Request) (*http.Res
 		return nil, &nonRetriableError{errors.New("fake for method PolicyAssignment not implemented")}
 	}
 	qp := req.URL.Query()
-	body, err := server.UnmarshalRequestAsJSON[azalias.ScheduleCreateOrUpdateProperties](req)
+	raw, err := readRequestBody(req)
 	if err != nil {
 		return nil, err
+	}
+	body, err := unmarshalGeoJSONObjectClassification(raw)
+	if err != nil {
+		return nil, err
+	}
+	thingsUnescaped, err := url.QueryUnescape(qp.Get("things"))
+	if err != nil {
+		return nil, err
+	}
+	thingsUnescapedElements := strings.Split(thingsUnescaped, ",")
+	thingsParam := make([]azalias.Things, len(thingsUnescapedElements))
+	for i := 0; i < len(thingsUnescapedElements); i++ {
+		thingsParam[i] = azalias.Things(thingsUnescapedElements[i])
 	}
 	intervalUnescaped, err := url.QueryUnescape(qp.Get("interval"))
 	if err != nil {
 		return nil, err
 	}
 	intervalParam := getOptional(intervalUnescaped)
+	uniqueUnescaped, err := url.QueryUnescape(qp.Get("unique"))
+	if err != nil {
+		return nil, err
+	}
+	uniqueParam := getOptional(uniqueUnescaped)
 	var options *azalias.ClientPolicyAssignmentOptions
-	if intervalParam != nil {
+	if intervalParam != nil || uniqueParam != nil {
 		options = &azalias.ClientPolicyAssignmentOptions{
 			Interval: intervalParam,
+			Unique:   uniqueParam,
 		}
 	}
-	respr, errRespr := s.srv.PolicyAssignment(req.Context(), body, options)
+	respr, errRespr := s.srv.PolicyAssignment(req.Context(), thingsParam, body, options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
+++ b/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
@@ -96,7 +96,7 @@ func TestGeoObjectNamedCollectionRoundTrip(t *testing.T) {
 
 func TestInterfaceRoundTrip(t *testing.T) {
 	props1 := ScheduleCreateOrUpdateProperties{
-		Aliases:     []*string{to.Ptr("foo")},
+		Aliases:     []string{"foo"},
 		Description: to.Ptr("funky"),
 		Interval:    false,
 		StartTime:   to.Ptr(time.Now().UTC()),
@@ -126,8 +126,8 @@ func TestInterfaceRoundTrip(t *testing.T) {
 	if *props1.StartTime != *props2.StartTime {
 		t.Fatalf("expected %v, got %v", *props1.StartTime, *props2.StartTime)
 	}
-	if *props1.Aliases[0] != *props2.Aliases[0] {
-		t.Fatalf("expected %v, got %v", *props1.Aliases[0], *props2.Aliases[0])
+	if props1.Aliases[0] != props2.Aliases[0] {
+		t.Fatalf("expected %v, got %v", props1.Aliases[0], props2.Aliases[0])
 	}
 }
 

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // Client contains the methods for the Alias group.
@@ -246,13 +247,13 @@ func (client *Client) listHandleResponse(resp *http.Response) (ClientListRespons
 //
 // Generated from API version 2.0
 //   - options - ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
-func (client *Client) PolicyAssignment(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (ClientPolicyAssignmentResponse, error) {
+func (client *Client) PolicyAssignment(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *ClientPolicyAssignmentOptions) (ClientPolicyAssignmentResponse, error) {
 	var err error
 	const operationName = "Client.PolicyAssignment"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.policyAssignmentCreateRequest(ctx, props, options)
+	req, err := client.policyAssignmentCreateRequest(ctx, things, polymorphicParam, options)
 	if err != nil {
 		return ClientPolicyAssignmentResponse{}, err
 	}
@@ -269,7 +270,7 @@ func (client *Client) PolicyAssignment(ctx context.Context, props ScheduleCreate
 }
 
 // policyAssignmentCreateRequest creates the PolicyAssignment request.
-func (client *Client) policyAssignmentCreateRequest(ctx context.Context, props ScheduleCreateOrUpdateProperties, options *ClientPolicyAssignmentOptions) (*policy.Request, error) {
+func (client *Client) policyAssignmentCreateRequest(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *ClientPolicyAssignmentOptions) (*policy.Request, error) {
 	urlPath := "/policy"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -279,15 +280,19 @@ func (client *Client) policyAssignmentCreateRequest(ctx context.Context, props S
 	if client.clientOptionalGroup != nil && client.clientOptionalGroup.OptionalVersion != nil {
 		reqQP.Set("optional-version", *client.clientOptionalGroup.OptionalVersion)
 	}
+	reqQP.Set("things", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(things), "[]")), ","))
 	if options != nil && options.Interval != nil {
 		reqQP.Set("interval", *options.Interval)
+	}
+	if options != nil && options.Unique != nil {
+		reqQP.Set("unique", *options.Unique)
 	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	if client.clientOptionalGroup != nil && client.clientOptionalGroup.OptionalIndex != nil {
 		req.Raw().Header["optional-index"] = []string{strconv.FormatInt(int64(*client.clientOptionalGroup.OptionalIndex), 10)}
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, props); err != nil {
+	if err := runtime.MarshalAsJSON(req, polymorphicParam); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/packages/autorest.go/test/maps/azalias/zz_constants.go
+++ b/packages/autorest.go/test/maps/azalias/zz_constants.go
@@ -139,3 +139,20 @@ func PossibleSomethingCountValues() []SomethingCount {
 		SomethingCountTwenty,
 	}
 }
+
+type Things string
+
+const (
+	ThingsOther Things = "other"
+	ThingsThat  Things = "that"
+	ThingsThis  Things = "this"
+)
+
+// PossibleThingsValues returns the possible values for the Things const type.
+func PossibleThingsValues() []Things {
+	return []Things{
+		ThingsOther,
+		ThingsThat,
+		ThingsThis,
+	}
+}

--- a/packages/autorest.go/test/maps/azalias/zz_models.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models.go
@@ -122,7 +122,7 @@ type GeoJSONRecursiveDisciminators struct {
 // ListResponse - The response model for the List API. Returns a list of all the previously created aliases.
 type ListResponse struct {
 	// READ-ONLY; A list of all the previously created aliases.
-	Aliases []*ListItem
+	Aliases []ListItem
 
 	// READ-ONLY; If present, the location of the next page of data.
 	NextLink *string
@@ -153,7 +153,7 @@ type PolicyAssignmentProperties struct {
 // ScheduleCreateOrUpdateProperties - The parameters supplied to the create or update schedule operation.
 type ScheduleCreateOrUpdateProperties struct {
 	// A list of all the previously created aliases.
-	Aliases []*string
+	Aliases []string
 
 	// Gets or sets the description of the schedule.
 	Description *string
@@ -171,4 +171,8 @@ type TypeWithRawJSON struct {
 
 	// any valid JSON
 	Anything any
+}
+
+type TypeWithSliceOfTimes struct {
+	Times []time.Time
 }

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -50,4 +50,5 @@ type ClientOptionalGroup struct {
 // ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
 type ClientPolicyAssignmentOptions struct {
 	Interval *string
+	Unique   *string
 }

--- a/packages/autorest.go/test/swagger/alias.json
+++ b/packages/autorest.go/test/swagger/alias.json
@@ -315,13 +315,35 @@
         ],
         "parameters": [
           {
-            "$ref": "#/parameters/ScheduleCreateOrUpdateProperties"
-          },
-          {
             "$ref": "#/parameters/OptionalClientVersion"
           },
           {
             "$ref": "#/parameters/OptionalClientIndex"
+          },
+          {
+            "name": "things",
+            "required": true,
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "this",
+                "that",
+                "other"
+              ],
+              "x-ms-enum": {
+                "name": "Things"
+              }
+            }
+          },
+          {
+            "name": "polymorphicParam",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/GeoJsonObject"
+            }
           },
           {
             "name": "interval",
@@ -329,6 +351,13 @@
             "type": "string",
             "required": false,
             "format": "duration"
+          },
+          {
+            "name": "unique",
+            "in": "query",
+            "type": "string",
+            "required": false,
+            "format": "uuid"
           }
         ],
         "responses": {
@@ -714,6 +743,18 @@
         "anyObject": {
           "type": "object",
           "description": "any JSON object"
+        }
+      }
+    },
+    "TypeWithSliceOfTimes": {
+      "type": "object",
+      "properties": {
+        "times": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       }
     }


### PR DESCRIPTION
Ensure unique var names when splitting arrays.
Fix fake type name generation for slices when slice-elements-byval is enabled.
Fix time serde codegen when slice-elements-byval is enabled. Include method parameter types when generating fake polymorphic helpers. Fix fake codegen for types that coalesce to string.