### PR TITLE
Don't generate duplicate next page methods

### DIFF
--- a/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
+++ b/packages/autorest.go/test/autorest/paginggroup/zz_paging_client.go
@@ -381,25 +381,6 @@ func (client *PagingClient) getMultiplePagesFragmentNextLinkHandleResponse(resp 
 	return result, nil
 }
 
-// nextFragmentCreateRequest creates the nextFragmentCreateRequest request.
-func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string) (*policy.Request, error) {
-	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
-	if tenant == "" {
-		return nil, errors.New("parameter tenant cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
-	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api_version", apiVersion)
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, nil
-}
-
 // NewGetMultiplePagesFragmentWithGroupingNextLinkPager - A paging operation that doesn't return a full URL, just a fragment
 // with parameters grouped
 //
@@ -463,25 +444,6 @@ func (client *PagingClient) getMultiplePagesFragmentWithGroupingNextLinkHandleRe
 		return PagingClientGetMultiplePagesFragmentWithGroupingNextLinkResponse{}, err
 	}
 	return result, nil
-}
-
-// nextFragmentWithGroupingCreateRequest creates the nextFragmentWithGroupingCreateRequest request.
-func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Context, nextLink string, customParameterGroup CustomParameterGroup) (*policy.Request, error) {
-	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
-	if customParameterGroup.Tenant == "" {
-		return nil, errors.New("parameter customParameterGroup.Tenant cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
-	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
-	if err != nil {
-		return nil, err
-	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api_version", customParameterGroup.APIVersion)
-	req.Raw().URL.RawQuery = reqQP.Encode()
-	req.Raw().Header["Accept"] = []string{"application/json"}
-	return req, nil
 }
 
 // BeginGetMultiplePagesLRO - A long-running paging operation that includes a nextLink that has 10 pages
@@ -1150,6 +1112,44 @@ func (client *PagingClient) getWithQueryParamsHandleResponse(resp *http.Response
 		return PagingClientGetWithQueryParamsResponse{}, err
 	}
 	return result, nil
+}
+
+// nextFragmentCreateRequest creates the nextFragmentCreateRequest request.
+func (client *PagingClient) nextFragmentCreateRequest(ctx context.Context, apiVersion string, tenant string, nextLink string) (*policy.Request, error) {
+	urlPath := "/paging/multiple/fragment/{tenant}/{nextLink}"
+	if tenant == "" {
+		return nil, errors.New("parameter tenant cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(tenant))
+	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api_version", apiVersion)
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// nextFragmentWithGroupingCreateRequest creates the nextFragmentWithGroupingCreateRequest request.
+func (client *PagingClient) nextFragmentWithGroupingCreateRequest(ctx context.Context, nextLink string, customParameterGroup CustomParameterGroup) (*policy.Request, error) {
+	urlPath := "/paging/multiple/fragmentwithgrouping/{tenant}/{nextLink}"
+	if customParameterGroup.Tenant == "" {
+		return nil, errors.New("parameter customParameterGroup.Tenant cannot be empty")
+	}
+	urlPath = strings.ReplaceAll(urlPath, "{tenant}", url.PathEscape(customParameterGroup.Tenant))
+	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	reqQP := req.Raw().URL.Query()
+	reqQP.Set("api_version", customParameterGroup.APIVersion)
+	req.Raw().URL.RawQuery = reqQP.Encode()
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
 }
 
 // nextOperationWithQueryParamsCreateRequest creates the nextOperationWithQueryParamsCreateRequest request.

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -37,6 +37,14 @@ type Server struct {
 	// HTTP status codes to indicate success: http.StatusOK
 	NewListPager func(options *azalias.ClientListOptions) (resp azfake.PagerResponder[azalias.ClientListResponse])
 
+	// NewListWithSharedNextOnePager is the fake for method Client.NewListWithSharedNextOnePager
+	// HTTP status codes to indicate success: http.StatusOK
+	NewListWithSharedNextOnePager func(options *azalias.ClientListWithSharedNextOneOptions) (resp azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse])
+
+	// NewListWithSharedNextTwoPager is the fake for method Client.NewListWithSharedNextTwoPager
+	// HTTP status codes to indicate success: http.StatusOK
+	NewListWithSharedNextTwoPager func(options *azalias.ClientListWithSharedNextTwoOptions) (resp azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse])
+
 	// PolicyAssignment is the fake for method Client.PolicyAssignment
 	// HTTP status codes to indicate success: http.StatusOK
 	PolicyAssignment func(ctx context.Context, things []azalias.Things, polymorphicParam azalias.GeoJSONObjectClassification, options *azalias.ClientPolicyAssignmentOptions) (resp azfake.Responder[azalias.ClientPolicyAssignmentResponse], errResp azfake.ErrorResponder)
@@ -47,16 +55,20 @@ type Server struct {
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
 func NewServerTransport(srv *Server) *ServerTransport {
 	return &ServerTransport{
-		srv:          srv,
-		newListPager: newTracker[azfake.PagerResponder[azalias.ClientListResponse]](),
+		srv:                           srv,
+		newListPager:                  newTracker[azfake.PagerResponder[azalias.ClientListResponse]](),
+		newListWithSharedNextOnePager: newTracker[azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse]](),
+		newListWithSharedNextTwoPager: newTracker[azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse]](),
 	}
 }
 
 // ServerTransport connects instances of azalias.Client to instances of Server.
 // Don't use this type directly, use NewServerTransport instead.
 type ServerTransport struct {
-	srv          *Server
-	newListPager *tracker[azfake.PagerResponder[azalias.ClientListResponse]]
+	srv                           *Server
+	newListPager                  *tracker[azfake.PagerResponder[azalias.ClientListResponse]]
+	newListWithSharedNextOnePager *tracker[azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse]]
+	newListWithSharedNextTwoPager *tracker[azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse]]
 }
 
 // Do implements the policy.Transporter interface for ServerTransport.
@@ -77,6 +89,10 @@ func (s *ServerTransport) Do(req *http.Request) (*http.Response, error) {
 		resp, err = s.dispatchGetScript(req)
 	case "Client.NewListPager":
 		resp, err = s.dispatchNewListPager(req)
+	case "Client.NewListWithSharedNextOnePager":
+		resp, err = s.dispatchNewListWithSharedNextOnePager(req)
+	case "Client.NewListWithSharedNextTwoPager":
+		resp, err = s.dispatchNewListWithSharedNextTwoPager(req)
 	case "Client.PolicyAssignment":
 		resp, err = s.dispatchPolicyAssignment(req)
 	default:
@@ -221,6 +237,60 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 	}
 	if !server.PagerResponderMore(newListPager) {
 		s.newListPager.remove(req)
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchNewListWithSharedNextOnePager(req *http.Request) (*http.Response, error) {
+	if s.srv.NewListWithSharedNextOnePager == nil {
+		return nil, &nonRetriableError{errors.New("fake for method NewListWithSharedNextOnePager not implemented")}
+	}
+	newListWithSharedNextOnePager := s.newListWithSharedNextOnePager.get(req)
+	if newListWithSharedNextOnePager == nil {
+		resp := s.srv.NewListWithSharedNextOnePager(nil)
+		newListWithSharedNextOnePager = &resp
+		s.newListWithSharedNextOnePager.add(req, newListWithSharedNextOnePager)
+		server.PagerResponderInjectNextLinks(newListWithSharedNextOnePager, req, func(page *azalias.ClientListWithSharedNextOneResponse, createLink func() string) {
+			page.NextLink = to.Ptr(createLink())
+		})
+	}
+	resp, err := server.PagerResponderNext(newListWithSharedNextOnePager, req)
+	if err != nil {
+		return nil, err
+	}
+	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListWithSharedNextOnePager.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
+	}
+	if !server.PagerResponderMore(newListWithSharedNextOnePager) {
+		s.newListWithSharedNextOnePager.remove(req)
+	}
+	return resp, nil
+}
+
+func (s *ServerTransport) dispatchNewListWithSharedNextTwoPager(req *http.Request) (*http.Response, error) {
+	if s.srv.NewListWithSharedNextTwoPager == nil {
+		return nil, &nonRetriableError{errors.New("fake for method NewListWithSharedNextTwoPager not implemented")}
+	}
+	newListWithSharedNextTwoPager := s.newListWithSharedNextTwoPager.get(req)
+	if newListWithSharedNextTwoPager == nil {
+		resp := s.srv.NewListWithSharedNextTwoPager(nil)
+		newListWithSharedNextTwoPager = &resp
+		s.newListWithSharedNextTwoPager.add(req, newListWithSharedNextTwoPager)
+		server.PagerResponderInjectNextLinks(newListWithSharedNextTwoPager, req, func(page *azalias.ClientListWithSharedNextTwoResponse, createLink func() string) {
+			page.NextLink = to.Ptr(createLink())
+		})
+	}
+	resp, err := server.PagerResponderNext(newListWithSharedNextTwoPager, req)
+	if err != nil {
+		return nil, err
+	}
+	if !contains([]int{http.StatusOK}, resp.StatusCode) {
+		s.newListWithSharedNextTwoPager.remove(req)
+		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", resp.StatusCode)}
+	}
+	if !server.PagerResponderMore(newListWithSharedNextTwoPager) {
+		s.newListWithSharedNextTwoPager.remove(req)
 	}
 	return resp, nil
 }

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -243,6 +243,110 @@ func (client *Client) listHandleResponse(resp *http.Response) (ClientListRespons
 	return result, nil
 }
 
+//   - options - ClientListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager
+//     method.
+func (client *Client) NewListWithSharedNextOnePager(options *ClientListWithSharedNextOneOptions) *runtime.Pager[ClientListWithSharedNextOneResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ClientListWithSharedNextOneResponse]{
+		More: func(page ClientListWithSharedNextOneResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ClientListWithSharedNextOneResponse) (ClientListWithSharedNextOneResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextOnePager")
+			var req *policy.Request
+			var err error
+			if page == nil {
+				req, err = client.listWithSharedNextOneCreateRequest(ctx, options)
+			} else {
+				req, err = client.listWithSharedNextCreateRequest(ctx, *page.NextLink)
+			}
+			if err != nil {
+				return ClientListWithSharedNextOneResponse{}, err
+			}
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ClientListWithSharedNextOneResponse{}, err
+			}
+			if !runtime.HasStatusCode(resp, http.StatusOK) {
+				return ClientListWithSharedNextOneResponse{}, runtime.NewResponseError(resp)
+			}
+			return client.listWithSharedNextOneHandleResponse(resp)
+		},
+		Tracer: client.internal.Tracer(),
+	})
+}
+
+// listWithSharedNextOneCreateRequest creates the ListWithSharedNextOne request.
+func (client *Client) listWithSharedNextOneCreateRequest(ctx context.Context, options *ClientListWithSharedNextOneOptions) (*policy.Request, error) {
+	urlPath := "/listWithSharedNextOne"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// listWithSharedNextOneHandleResponse handles the ListWithSharedNextOne response.
+func (client *Client) listWithSharedNextOneHandleResponse(resp *http.Response) (ClientListWithSharedNextOneResponse, error) {
+	result := ClientListWithSharedNextOneResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
+		return ClientListWithSharedNextOneResponse{}, err
+	}
+	return result, nil
+}
+
+//   - options - ClientListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager
+//     method.
+func (client *Client) NewListWithSharedNextTwoPager(options *ClientListWithSharedNextTwoOptions) *runtime.Pager[ClientListWithSharedNextTwoResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ClientListWithSharedNextTwoResponse]{
+		More: func(page ClientListWithSharedNextTwoResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *ClientListWithSharedNextTwoResponse) (ClientListWithSharedNextTwoResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextTwoPager")
+			var req *policy.Request
+			var err error
+			if page == nil {
+				req, err = client.listWithSharedNextTwoCreateRequest(ctx, options)
+			} else {
+				req, err = client.listWithSharedNextCreateRequest(ctx, *page.NextLink)
+			}
+			if err != nil {
+				return ClientListWithSharedNextTwoResponse{}, err
+			}
+			resp, err := client.internal.Pipeline().Do(req)
+			if err != nil {
+				return ClientListWithSharedNextTwoResponse{}, err
+			}
+			if !runtime.HasStatusCode(resp, http.StatusOK) {
+				return ClientListWithSharedNextTwoResponse{}, runtime.NewResponseError(resp)
+			}
+			return client.listWithSharedNextTwoHandleResponse(resp)
+		},
+		Tracer: client.internal.Tracer(),
+	})
+}
+
+// listWithSharedNextTwoCreateRequest creates the ListWithSharedNextTwo request.
+func (client *Client) listWithSharedNextTwoCreateRequest(ctx context.Context, options *ClientListWithSharedNextTwoOptions) (*policy.Request, error) {
+	urlPath := "/listWithSharedNextTwo"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
+}
+
+// listWithSharedNextTwoHandleResponse handles the ListWithSharedNextTwo response.
+func (client *Client) listWithSharedNextTwoHandleResponse(resp *http.Response) (ClientListWithSharedNextTwoResponse, error) {
+	result := ClientListWithSharedNextTwoResponse{}
+	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
+		return ClientListWithSharedNextTwoResponse{}, err
+	}
+	return result, nil
+}
+
 // PolicyAssignment -
 // If the operation fails it returns an *azcore.ResponseError type.
 //
@@ -309,4 +413,16 @@ func (client *Client) policyAssignmentHandleResponse(resp *http.Response) (Clien
 		return ClientPolicyAssignmentResponse{}, err
 	}
 	return result, nil
+}
+
+// listWithSharedNextCreateRequest creates the listWithSharedNextCreateRequest request.
+func (client *Client) listWithSharedNextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
+	urlPath := "/listWithSharedNext"
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header["nextLink"] = []string{nextLink}
+	req.Raw().Header["Accept"] = []string{"application/json"}
+	return req, nil
 }

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -38,6 +38,16 @@ type ClientListOptions struct {
 	GroupBy []LogMetricsGroupBy
 }
 
+// ClientListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
+type ClientListWithSharedNextOneOptions struct {
+	// placeholder for future optional parameters
+}
+
+// ClientListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
+type ClientListWithSharedNextTwoOptions struct {
+	// placeholder for future optional parameters
+}
+
 // ClientOptionalGroup contains a group of parameters for the Client client.
 type ClientOptionalGroup struct {
 	// Index number of Azure Maps API.

--- a/packages/autorest.go/test/maps/azalias/zz_response_types.go
+++ b/packages/autorest.go/test/maps/azalias/zz_response_types.go
@@ -28,6 +28,18 @@ type ClientListResponse struct {
 	ListResponse
 }
 
+// ClientListWithSharedNextOneResponse contains the response from method Client.NewListWithSharedNextOnePager.
+type ClientListWithSharedNextOneResponse struct {
+	// The response model for the List API. Returns a list of all the previously created aliases.
+	ListResponse
+}
+
+// ClientListWithSharedNextTwoResponse contains the response from method Client.NewListWithSharedNextTwoPager.
+type ClientListWithSharedNextTwoResponse struct {
+	// The response model for the List API. Returns a list of all the previously created aliases.
+	ListResponse
+}
+
 // ClientPolicyAssignmentResponse contains the response from method Client.PolicyAssignment.
 type ClientPolicyAssignmentResponse struct {
 	PolicyAssignmentProperties

--- a/packages/autorest.go/test/swagger/alias.json
+++ b/packages/autorest.go/test/swagger/alias.json
@@ -315,6 +315,68 @@
         }
       }
     },
+    "/listWithSharedNextOne": {
+      "get": {
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink",
+          "itemName": "aliases",
+          "operationName": "Alias_listWithSharedNext"
+        },
+        "operationId": "Alias_listWithSharedNextOne",
+        "responses": {
+          "200": {
+            "description": "got the next page",
+            "schema": {
+              "$ref": "#/definitions/AliasListResponse"
+            }
+          }
+        }
+      }
+    },
+    "/listWithSharedNextTwo": {
+      "get": {
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink",
+          "itemName": "aliases",
+          "operationName": "Alias_listWithSharedNext"
+        },
+        "operationId": "Alias_listWithSharedNextTwo",
+        "responses": {
+          "200": {
+            "description": "got the next page",
+            "schema": {
+              "$ref": "#/definitions/AliasListResponse"
+            }
+          }
+        }
+      }
+    },
+    "/listWithSharedNext": {
+      "get": {
+        "x-ms-pageable": {
+          "nextLinkName": null,
+          "itemName": "values"
+        },
+        "operationId": "Alias_listWithSharedNext",
+        "description": "A shared next link operation",
+        "parameters": [
+          {
+            "name": "nextLink",
+            "in": "header",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "got the next page",
+            "schema": {
+              "$ref": "#/definitions/AliasListResponse"
+            }
+          }
+        }
+      }
+    },
     "/policy": {
       "put": {
         "operationId": "Alias_PolicyAssignment",


### PR DESCRIPTION
Track next page methods for generation, avoiding duplicates.  This has the side effect of emitting them last in the source files. Ensure that adapted NextPageMethod instances aren't duplicated.