### PR TITLE
Propagate azcore-version param value to GoCodeModel

### DIFF
--- a/packages/autorest.go/src/generator/gomod.ts
+++ b/packages/autorest.go/src/generator/gomod.ts
@@ -19,7 +19,7 @@ export async function generateGoModFile(codeModel: GoCodeModel, existingGoMod: s
 
   // here we specify the minimum version of azcore as required by the code generator.
   // the version can be overwritten by passing the --azcore-version switch during generation.
-  let version = '1.6.1';
+  let version = '1.7.2';
   if (codeModel.options.azcoreVersion) {
     // when matching versions, we need to handle beta, non-beta, and pseudo versions
     // 1.2.3-beta.1, 1.2.3, 0.22.1-0.20220315231014-ed309e73db6b

--- a/packages/autorest.go/src/m4togocodemodel/adapter.ts
+++ b/packages/autorest.go/src/m4togocodemodel/adapter.ts
@@ -21,6 +21,10 @@ export async function m4ToGoCodeModel(host: AutorestExtensionHost) {
 
     const info = new go.Info(session.model.info.title);
     const options = new go.Options(await session.getValue('header-text', 'MISSING LICENSE HEADER'), await session.getValue('generate-fakes', false), await session.getValue('inject-spans', false));
+    const azcoreVersion = await session.getValue('azcore-version', '');
+    if (azcoreVersion !== '') {
+      options.azcoreVersion = azcoreVersion;
+    }
 
     let type: go.CodeModelType = 'data-plane';
     if (session.model.language.go!.azureARM) {

--- a/packages/autorest.go/test/consumption/armconsumption/go.mod
+++ b/packages/autorest.go/test/consumption/armconsumption/go.mod
@@ -2,7 +2,7 @@ module armconsumption
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/consumption/armconsumption/go.sum
+++ b/packages/autorest.go/test/consumption/armconsumption/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/go.mod
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/go.mod
@@ -2,7 +2,7 @@ module armdataboxedge/v2
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/go.sum
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/keyvault/azkeyvault/go.mod
+++ b/packages/autorest.go/test/keyvault/azkeyvault/go.mod
@@ -2,7 +2,7 @@ module azkeyvault
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/keyvault/azkeyvault/go.sum
+++ b/packages/autorest.go/test/keyvault/azkeyvault/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/go.mod
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/go.mod
@@ -2,7 +2,7 @@ module armmachinelearning
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/go.sum
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/synapse/azartifacts/go.mod
+++ b/packages/autorest.go/test/synapse/azartifacts/go.mod
@@ -2,7 +2,7 @@ module azartifacts
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/synapse/azartifacts/go.sum
+++ b/packages/autorest.go/test/synapse/azartifacts/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/synapse/azspark/go.mod
+++ b/packages/autorest.go/test/synapse/azspark/go.mod
@@ -2,7 +2,7 @@ module azspark
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/synapse/azspark/go.sum
+++ b/packages/autorest.go/test/synapse/azspark/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/packages/autorest.go/test/tables/aztables/go.mod
+++ b/packages/autorest.go/test/tables/aztables/go.mod
@@ -2,7 +2,7 @@ module aztables
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
+require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect

--- a/packages/autorest.go/test/tables/aztables/go.sum
+++ b/packages/autorest.go/test/tables/aztables/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 h1:SEy2xmstIphdPwNBUi7uhvjyjhVKISfwjfOJmuy7kg4=
-github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2 h1:t5+QXLCK9SVi0PPdaY0PrFvYUo24KwA0QwxnaHRSVd4=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.7.2/go.mod h1:bjGvMhVMb+EEm3VRNQawDMUyMMjo+S5ewNjflkep/0Q=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 h1:sXr+ck84g/ZlZUOZiNELInmMgOsuGwdjjVkEIde0OtY=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0/go.mod h1:okt5dMMTOFjX/aovMlrjvvXoPMBVSPzk9185BT0+eZM=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=


### PR DESCRIPTION
Bump the default version of azcore to latest at this time.

Fixes https://github.com/Azure/autorest.go/issues/1024