### PR TITLE
Fix multi-collection format in fakes

### DIFF
--- a/packages/autorest.go/src/generator/fake/servers.ts
+++ b/packages/autorest.go/src/generator/fake/servers.ts
@@ -543,8 +543,8 @@ function createParamGroupParams(clientPkg: string, method: Method, imports: Impo
         content += `\t${escapedParam} := ${paramValue}\n`;
         content += `\t${paramVar} := make([]string, len(${escapedParam}))\n`;
         content += `\tfor i, v := range ${escapedParam} {\n`;
-        content += '\t\tu, err := url.QueryUnescape(v)\n';
-        content += '\t\tif err != nil {\n\t\t\treturn nil, err\n\t\t}\n';
+        content += '\t\tu, unescapeErr := url.QueryUnescape(v)\n';
+        content += '\t\tif unescapeErr != nil {\n\t\t\treturn nil, unescapeErr\n\t\t}\n';
         content += `\t\t${paramVar}[i] = u\n\t}\n`;
       } else {
         let where: string;

--- a/packages/autorest.go/src/generator/generator.ts
+++ b/packages/autorest.go/src/generator/generator.ts
@@ -6,7 +6,7 @@
 import { serialize } from '@azure-tools/codegen';
 import { AutorestExtensionHost, startSession } from '@autorest/extension-base';
 import { values } from '@azure-tools/linq';
-import { Client, ConstantType, ConstantValue, GoCodeModel, HeaderResponse, InterfaceType, Method, ModelField, ModelType, PolymorphicType, ResponseEnvelope, StructField, StructType } from '../gocodemodel/gocodemodel';
+import { Client, ConstantType, ConstantValue, GoCodeModel, HeaderMapResponse, HeaderResponse, InterfaceType, Method, ModelField, ModelType, PolymorphicType, ResponseEnvelope, StructField, StructType } from '../gocodemodel/gocodemodel';
 import { generateClientFactory } from './clientFactory';
 import { generateOperations } from './operations';
 import { generateModels } from './models';
@@ -228,7 +228,7 @@ function sortContent(codeModel: GoCodeModel) {
 
   codeModel.responseEnvelopes.sort((a: ResponseEnvelope, b: ResponseEnvelope) => { return sortAscending(a.name, b.name); });
   for (const respEnv of values(codeModel.responseEnvelopes)) {
-    respEnv.headers.sort((a: HeaderResponse, b: HeaderResponse) => { return sortAscending(a.fieldName, b.fieldName); });
+    respEnv.headers.sort((a: HeaderResponse | HeaderMapResponse, b: HeaderResponse | HeaderMapResponse) => { return sortAscending(a.fieldName, b.fieldName); });
   }
 
   codeModel.clients.sort((a: Client, b: Client) => { return sortAscending(a.clientName, b.clientName); });

--- a/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_internal.go
@@ -8,8 +8,6 @@
 
 package fake
 
-import "strings"
-
 type nonRetriableError struct {
 	error
 }
@@ -25,11 +23,4 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
-}
-
-func splitHelper(s, sep string) []string {
-	if s == "" {
-		return nil
-	}
-	return strings.Split(s, sep)
 }

--- a/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
@@ -82,11 +82,16 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiEmpty(req *http.Request
 		return nil, &nonRetriableError{errors.New("fake for method ArrayStringMultiEmpty not implemented")}
 	}
 	qp := req.URL.Query()
-	arrayQueryUnescaped, err := url.QueryUnescape(qp.Get("arrayQuery"))
-	if err != nil {
-		return nil, err
+	arrayQueryEscaped := qp["arrayQuery"]
+	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
+	for i, v := range arrayQueryEscaped {
+		u, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+		arrayQueryUnescaped[i] = u
 	}
-	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
+	arrayQueryParam := arrayQueryUnescaped
 	var options *urlmultigroup.QueriesClientArrayStringMultiEmptyOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiEmptyOptions{
@@ -113,11 +118,16 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiNull(req *http.Request)
 		return nil, &nonRetriableError{errors.New("fake for method ArrayStringMultiNull not implemented")}
 	}
 	qp := req.URL.Query()
-	arrayQueryUnescaped, err := url.QueryUnescape(qp.Get("arrayQuery"))
-	if err != nil {
-		return nil, err
+	arrayQueryEscaped := qp["arrayQuery"]
+	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
+	for i, v := range arrayQueryEscaped {
+		u, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+		arrayQueryUnescaped[i] = u
 	}
-	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
+	arrayQueryParam := arrayQueryUnescaped
 	var options *urlmultigroup.QueriesClientArrayStringMultiNullOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiNullOptions{
@@ -144,11 +154,16 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiValid(req *http.Request
 		return nil, &nonRetriableError{errors.New("fake for method ArrayStringMultiValid not implemented")}
 	}
 	qp := req.URL.Query()
-	arrayQueryUnescaped, err := url.QueryUnescape(qp.Get("arrayQuery"))
-	if err != nil {
-		return nil, err
+	arrayQueryEscaped := qp["arrayQuery"]
+	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
+	for i, v := range arrayQueryEscaped {
+		u, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+		arrayQueryUnescaped[i] = u
 	}
-	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
+	arrayQueryParam := arrayQueryUnescaped
 	var options *urlmultigroup.QueriesClientArrayStringMultiValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiValidOptions{

--- a/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
@@ -85,9 +85,9 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiEmpty(req *http.Request
 	arrayQueryEscaped := qp["arrayQuery"]
 	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
 	for i, v := range arrayQueryEscaped {
-		u, err := url.QueryUnescape(v)
-		if err != nil {
-			return nil, err
+		u, unescapeErr := url.QueryUnescape(v)
+		if unescapeErr != nil {
+			return nil, unescapeErr
 		}
 		arrayQueryUnescaped[i] = u
 	}
@@ -121,9 +121,9 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiNull(req *http.Request)
 	arrayQueryEscaped := qp["arrayQuery"]
 	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
 	for i, v := range arrayQueryEscaped {
-		u, err := url.QueryUnescape(v)
-		if err != nil {
-			return nil, err
+		u, unescapeErr := url.QueryUnescape(v)
+		if unescapeErr != nil {
+			return nil, unescapeErr
 		}
 		arrayQueryUnescaped[i] = u
 	}
@@ -157,9 +157,9 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiValid(req *http.Request
 	arrayQueryEscaped := qp["arrayQuery"]
 	arrayQueryUnescaped := make([]string, len(arrayQueryEscaped))
 	for i, v := range arrayQueryEscaped {
-		u, err := url.QueryUnescape(v)
-		if err != nil {
-			return nil, err
+		u, unescapeErr := url.QueryUnescape(v)
+		if unescapeErr != nil {
+			return nil, unescapeErr
 		}
 		arrayQueryUnescaped[i] = u
 	}

--- a/packages/autorest.go/test/autorest/urlmultigroup/fakes_test.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fakes_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package urlmultigroup_test
+
+import (
+	"context"
+	"generatortests/urlmultigroup"
+	"generatortests/urlmultigroup/fake"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeArrayStringMultiValid(t *testing.T) {
+	content := []string{"one", "two", "three"}
+	server := fake.QueriesServer{
+		ArrayStringMultiValid: func(ctx context.Context, options *urlmultigroup.QueriesClientArrayStringMultiValidOptions) (resp azfake.Responder[urlmultigroup.QueriesClientArrayStringMultiValidResponse], errResp azfake.ErrorResponder) {
+			require.NotNil(t, options)
+			require.EqualValues(t, content, options.ArrayQuery)
+			resp.SetResponse(http.StatusOK, urlmultigroup.QueriesClientArrayStringMultiValidResponse{}, nil)
+			return
+		},
+	}
+	client, err := urlmultigroup.NewQueriesClient(&azcore.ClientOptions{
+		Transport: fake.NewQueriesServerTransport(&server),
+	})
+	require.NoError(t, err)
+	resp, err := client.ArrayStringMultiValid(context.Background(), &urlmultigroup.QueriesClientArrayStringMultiValidOptions{
+		ArrayQuery: content,
+	})
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/autorest.go/test/maps/azalias/custom_client.go
+++ b/packages/autorest.go/test/maps/azalias/custom_client.go
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azalias
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewClient(endpoint string, options *azcore.ClientOptions) (*Client, error) {
+	client, err := azcore.NewClient("azalias.Client", "v0.0.1", runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		internal: client,
+		endpoint: endpoint,
+	}, nil
+}

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -137,9 +137,9 @@ func (s *ServerTransport) dispatchCreate(req *http.Request) (*http.Response, err
 	groupByEscaped := qp["groupBy"]
 	groupByUnescaped := make([]string, len(groupByEscaped))
 	for i, v := range groupByEscaped {
-		u, err := url.QueryUnescape(v)
-		if err != nil {
-			return nil, err
+		u, unescapeErr := url.QueryUnescape(v)
+		if unescapeErr != nil {
+			return nil, unescapeErr
 		}
 		groupByUnescaped[i] = u
 	}
@@ -216,9 +216,9 @@ func (s *ServerTransport) dispatchGetScript(req *http.Request) (*http.Response, 
 	explodedStuffEscaped := qp["explodedStuff"]
 	explodedStuffUnescaped := make([]string, len(explodedStuffEscaped))
 	for i, v := range explodedStuffEscaped {
-		u, err := url.QueryUnescape(v)
-		if err != nil {
-			return nil, err
+		u, unescapeErr := url.QueryUnescape(v)
+		if unescapeErr != nil {
+			return nil, unescapeErr
 		}
 		explodedStuffUnescaped[i] = u
 	}
@@ -260,9 +260,9 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 		groupByEscaped := qp["groupBy"]
 		groupByUnescaped := make([]string, len(groupByEscaped))
 		for i, v := range groupByEscaped {
-			u, err := url.QueryUnescape(v)
-			if err != nil {
-				return nil, err
+			u, unescapeErr := url.QueryUnescape(v)
+			if unescapeErr != nil {
+				return nil, unescapeErr
 			}
 			groupByUnescaped[i] = u
 		}

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -30,7 +30,7 @@ type Server struct {
 
 	// GetScript is the fake for method Client.GetScript
 	// HTTP status codes to indicate success: http.StatusOK
-	GetScript func(ctx context.Context, headerCounts []int32, queryCounts []int64, props azalias.GeoJSONObjectNamedCollection, options *azalias.ClientGetScriptOptions) (resp azfake.Responder[azalias.ClientGetScriptResponse], errResp azfake.ErrorResponder)
+	GetScript func(ctx context.Context, headerCounts []int32, queryCounts []int64, props azalias.GeoJSONObjectNamedCollection, explodedGroup azalias.ExplodedGroup, options *azalias.ClientGetScriptOptions) (resp azfake.Responder[azalias.ClientGetScriptResponse], errResp azfake.ErrorResponder)
 
 	// NewListPager is the fake for method Client.NewListPager
 	// HTTP status codes to indicate success: http.StatusOK
@@ -134,11 +134,16 @@ func (s *ServerTransport) dispatchCreate(req *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	groupByUnescaped, err := url.QueryUnescape(qp.Get("groupBy"))
-	if err != nil {
-		return nil, err
+	groupByEscaped := qp["groupBy"]
+	groupByUnescaped := make([]string, len(groupByEscaped))
+	for i, v := range groupByEscaped {
+		u, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+		groupByUnescaped[i] = u
 	}
-	groupByUnescapedElements := splitHelper(groupByUnescaped, ",")
+	groupByUnescapedElements := groupByUnescaped
 	groupByParam := make([]azalias.SomethingCount, len(groupByUnescapedElements))
 	for i := 0; i < len(groupByUnescapedElements); i++ {
 		var parsedInt int64
@@ -208,7 +213,29 @@ func (s *ServerTransport) dispatchGetScript(req *http.Request) (*http.Response, 
 		}
 		queryCountsParam[i] = int64(parsedInt)
 	}
-	respr, errRespr := s.srv.GetScript(req.Context(), headerCountsParam, queryCountsParam, body, nil)
+	explodedStuffEscaped := qp["explodedStuff"]
+	explodedStuffUnescaped := make([]string, len(explodedStuffEscaped))
+	for i, v := range explodedStuffEscaped {
+		u, err := url.QueryUnescape(v)
+		if err != nil {
+			return nil, err
+		}
+		explodedStuffUnescaped[i] = u
+	}
+	explodedStuffUnescapedElements := explodedStuffUnescaped
+	explodedStuffParam := make([]int64, len(explodedStuffUnescapedElements))
+	for i := 0; i < len(explodedStuffUnescapedElements); i++ {
+		var parsedInt int64
+		parsedInt, err = strconv.ParseInt(explodedStuffUnescapedElements[i], 10, 32)
+		if err != nil {
+			return nil, err
+		}
+		explodedStuffParam[i] = int64(parsedInt)
+	}
+	explodedGroup := azalias.ExplodedGroup{
+		ExplodedStuff: explodedStuffParam,
+	}
+	respr, errRespr := s.srv.GetScript(req.Context(), headerCountsParam, queryCountsParam, body, explodedGroup, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -230,11 +257,16 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 	newListPager := s.newListPager.get(req)
 	if newListPager == nil {
 		qp := req.URL.Query()
-		groupByUnescaped, err := url.QueryUnescape(qp.Get("groupBy"))
-		if err != nil {
-			return nil, err
+		groupByEscaped := qp["groupBy"]
+		groupByUnescaped := make([]string, len(groupByEscaped))
+		for i, v := range groupByEscaped {
+			u, err := url.QueryUnescape(v)
+			if err != nil {
+				return nil, err
+			}
+			groupByUnescaped[i] = u
 		}
-		groupByUnescapedElements := splitHelper(groupByUnescaped, ",")
+		groupByUnescapedElements := groupByUnescaped
 		groupByParam := make([]azalias.LogMetricsGroupBy, len(groupByUnescapedElements))
 		for i := 0; i < len(groupByUnescapedElements); i++ {
 			groupByParam[i] = azalias.LogMetricsGroupBy(groupByUnescapedElements[i])

--- a/packages/autorest.go/test/maps/azalias/fakes_test.go
+++ b/packages/autorest.go/test/maps/azalias/fakes_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package azalias_test
+
+import (
+	"azalias"
+	"azalias/fake"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeGetScript(t *testing.T) {
+	headerContent := []int32{0, 2, 4}
+	queryContent := []int64{3, 6, 9}
+	explodedContent := []int64{9, 8, 7}
+	server := fake.Server{
+		GetScript: func(ctx context.Context, headerCounts []int32, queryCounts []int64, props azalias.GeoJSONObjectNamedCollection, explodedGroup azalias.ExplodedGroup, options *azalias.ClientGetScriptOptions) (resp azfake.Responder[azalias.ClientGetScriptResponse], errResp azfake.ErrorResponder) {
+			require.EqualValues(t, headerContent, headerCounts)
+			require.EqualValues(t, queryContent, queryCounts)
+			require.EqualValues(t, explodedContent, explodedGroup.ExplodedStuff)
+			resp.SetResponse(http.StatusOK, azalias.ClientGetScriptResponse{}, nil)
+			return
+		},
+	}
+	client, err := azalias.NewClient("https://contoso.com", &azcore.ClientOptions{
+		Transport: fake.NewServerTransport(&server),
+	})
+	require.NoError(t, err)
+	_, err = client.GetScript(context.Background(), headerContent, queryContent, azalias.GeoJSONObjectNamedCollection{}, azalias.ExplodedGroup{
+		ExplodedStuff: explodedContent,
+	}, nil)
+	require.NoError(t, err)
+}

--- a/packages/autorest.go/test/maps/azalias/models_test.go
+++ b/packages/autorest.go/test/maps/azalias/models_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 package azalias
 
 import (

--- a/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
+++ b/packages/autorest.go/test/maps/azalias/polymorphic_helpers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
 package azalias
 
 import (

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -115,14 +115,15 @@ func (client *Client) createHandleResponse(resp *http.Response) (ClientCreateRes
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2.0
+//   - ExplodedGroup - ExplodedGroup contains a group of parameters for the Client.GetScript method.
 //   - options - ClientGetScriptOptions contains the optional parameters for the Client.GetScript method.
-func (client *Client) GetScript(ctx context.Context, headerCounts []int32, queryCounts []int64, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (ClientGetScriptResponse, error) {
+func (client *Client) GetScript(ctx context.Context, headerCounts []int32, queryCounts []int64, props GeoJSONObjectNamedCollection, explodedGroup ExplodedGroup, options *ClientGetScriptOptions) (ClientGetScriptResponse, error) {
 	var err error
 	const operationName = "Client.GetScript"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.getScriptCreateRequest(ctx, headerCounts, queryCounts, props, options)
+	req, err := client.getScriptCreateRequest(ctx, headerCounts, queryCounts, props, explodedGroup, options)
 	if err != nil {
 		return ClientGetScriptResponse{}, err
 	}
@@ -139,7 +140,7 @@ func (client *Client) GetScript(ctx context.Context, headerCounts []int32, query
 }
 
 // getScriptCreateRequest creates the GetScript request.
-func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts []int32, queryCounts []int64, props GeoJSONObjectNamedCollection, options *ClientGetScriptOptions) (*policy.Request, error) {
+func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts []int32, queryCounts []int64, props GeoJSONObjectNamedCollection, explodedGroup ExplodedGroup, options *ClientGetScriptOptions) (*policy.Request, error) {
 	urlPath := "/scripts"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -147,6 +148,9 @@ func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts [
 	}
 	reqQP := req.Raw().URL.Query()
 	reqQP.Set("queryCounts", strings.Join(strings.Fields(strings.Trim(fmt.Sprint(queryCounts), "[]")), ","))
+	for _, qv := range explodedGroup.ExplodedStuff {
+		reqQP.Add("explodedStuff", fmt.Sprintf("%v", qv))
+	}
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["headerCounts"] = []string{strings.Join(strings.Fields(strings.Trim(fmt.Sprint(headerCounts), "[]")), ",")}
 	req.Raw().Header["Accept"] = []string{"text/powershell"}

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -62,3 +62,8 @@ type ClientPolicyAssignmentOptions struct {
 	Interval *string
 	Unique   *string
 }
+
+// ExplodedGroup contains a group of parameters for the Client.GetScript method.
+type ExplodedGroup struct {
+	ExplodedStuff []int64
+}

--- a/packages/autorest.go/test/swagger/alias.json
+++ b/packages/autorest.go/test/swagger/alias.json
@@ -196,6 +196,21 @@
         "type": "integer",
         "format": "int64"
       }
+    },
+    "GroupedExplodedQueryCollection": {
+      "name": "explodedStuff",
+      "in": "query",
+      "required": true,
+      "x-ms-parameter-location": "method",
+      "type": "array",
+      "collectionFormat": "multi",
+      "items": {
+        "type": "integer",
+        "format": "int64"
+      },
+      "x-ms-parameter-grouping": {
+        "name": "exploded-group"
+      }
     }
   },
   "paths": {
@@ -332,6 +347,9 @@
           },
           {
             "$ref": "#/parameters/NumericQueryCollection"
+          },
+          {
+            "$ref": "#/parameters/GroupedExplodedQueryCollection"
           }
         ],
         "responses": {


### PR DESCRIPTION
Multi-collection format was being treated as a CSV which is incorrect. Add first-class support for parameter collection formats instead of relying on type inspection and optional field heuristics.