### PR TITLE
Only emit required internal helpers for fakes

### DIFF
--- a/packages/autorest.go/src/generator/generator.ts
+++ b/packages/autorest.go/src/generator/generator.ts
@@ -19,7 +19,6 @@ import { generatePolymorphicHelpers } from './polymorphics';
 import { generateGoModFile } from './gomod';
 import { generateXMLAdditionalPropsHelpers } from './xmlAdditionalProps';
 import { generateServers } from './fake/servers';
-import { generateServerInternal } from './fake/internal';
 import { sortAscending } from './helpers';
 
 // The generator emits Go source code files to disk.
@@ -158,8 +157,8 @@ export async function generateCode(host: AutorestExtensionHost) {
 
     const generateFakes = await session.getValue('generate-fakes', false);
     if (generateFakes) {
-      const operations = await generateServers(session.model);
-      for (const op of values(operations)) {
+      const serverContent = await generateServers(session.model);
+      for (const op of values(serverContent.servers)) {
         let fileName = op.name.toLowerCase();
         // op.name is the server name, e.g. FooServer.
         // insert a _ before Server, i.e. Foo_Server
@@ -174,10 +173,9 @@ export async function generateCode(host: AutorestExtensionHost) {
         });
       }
 
-      const internal = await generateServerInternal(session.model);
       host.writeFile({
         filename: `fake/${filePrefix}internal.go`,
-        content: internal,
+        content: serverContent.internals,
         artifactType: 'source-file-go'
       });
 

--- a/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_internal.go
@@ -10,7 +10,6 @@ package fake
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
-	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -24,11 +23,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -37,6 +38,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -48,35 +56,6 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 		return nil, err
 	}
 	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/autorest.go/test/autorest/additionalpropsgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/additionalpropsgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/azurereportgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/azurereportgroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "reflect"
 
 type nonRetriableError struct {
 	error
@@ -22,52 +18,6 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
 func contains[T comparable](s []T, v T) bool {
 	for _, vv := range s {
 		if vv == v {
@@ -75,4 +25,11 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }

--- a/packages/autorest.go/test/autorest/azurespecialsgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/azurespecialsgroup/fake/zz_internal.go
@@ -9,7 +9,6 @@
 package fake
 
 import (
-	"io"
 	"net/http"
 	"reflect"
 )
@@ -22,11 +21,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,6 +36,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -46,33 +54,4 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 		return nil, err
 	}
 	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/binarygroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/binarygroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/booleangroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/booleangroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/bytegroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/bytegroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_internal.go
@@ -11,7 +11,6 @@ package fake
 import (
 	"io"
 	"net/http"
-	"reflect"
 )
 
 type nonRetriableError struct {
@@ -22,38 +21,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
+	return false
 }
 
 func readRequestBody(req *http.Request) ([]byte, error) {
@@ -66,13 +40,4 @@ func readRequestBody(req *http.Request) ([]byte, error) {
 	}
 	req.Body.Close()
 	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/complexmodelgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/complexmodelgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/custombaseurlgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/custombaseurlgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/dategroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/dategroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/datetimegroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/durationgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/durationgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/errorsgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/errorsgroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "reflect"
 
 type nonRetriableError struct {
 	error
@@ -22,52 +18,6 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
 func contains[T comparable](s []T, v T) bool {
 	for _, vv := range s {
 		if vv == v {
@@ -75,4 +25,11 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }

--- a/packages/autorest.go/test/autorest/extenumsgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/extenumsgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/filegroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/filegroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/formdatagroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/formdatagroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/headergroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/headergroup/fake/zz_internal.go
@@ -9,7 +9,6 @@
 package fake
 
 import (
-	"io"
 	"net/http"
 	"reflect"
 )
@@ -22,11 +21,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,6 +36,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -54,25 +62,4 @@ func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) 
 		return *new(T), err
 	}
 	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/headgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/headgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/httpinfrastructuregroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/integergroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/integergroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/lrogroup/fake/zz_internal.go
@@ -10,9 +10,7 @@ package fake
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
-	"io"
 	"net/http"
-	"reflect"
 	"sync"
 )
 
@@ -22,52 +20,6 @@ type nonRetriableError struct {
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/mediatypesgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "net/http"
 
 type nonRetriableError struct {
 	error
@@ -22,11 +18,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,44 +33,4 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/mediatypesgroupwithnormailzedoperationname/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "net/http"
 
 type nonRetriableError struct {
 	error
@@ -22,11 +18,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,44 +33,4 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/migroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/migroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/morecustombaseurigroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/morecustombaseurigroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "reflect"
 
 type nonRetriableError struct {
 	error
@@ -22,52 +18,6 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
 func contains[T comparable](s []T, v T) bool {
 	for _, vv := range s {
 		if vv == v {
@@ -75,4 +25,11 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }

--- a/packages/autorest.go/test/autorest/nonstringenumgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/nonstringenumgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/numbergroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/numbergroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/objectgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/objectgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/optionalgroup/fake/zz_explicit_server.go
+++ b/packages/autorest.go/test/autorest/optionalgroup/fake/zz_explicit_server.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"reflect"
 	"strconv"
-	"strings"
 )
 
 // ExplicitServer is a fake server for instances of the optionalgroup.ExplicitClient type.
@@ -210,7 +209,7 @@ func (e *ExplicitServerTransport) dispatchPostOptionalArrayHeader(req *http.Requ
 	if e.srv.PostOptionalArrayHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method PostOptionalArrayHeader not implemented")}
 	}
-	headerParameterParam := strings.Split(getHeaderValue(req.Header, "headerParameter"), ",")
+	headerParameterParam := splitHelper(getHeaderValue(req.Header, "headerParameter"), ",")
 	var options *optionalgroup.ExplicitClientPostOptionalArrayHeaderOptions
 	if len(headerParameterParam) > 0 {
 		options = &optionalgroup.ExplicitClientPostOptionalArrayHeaderOptions{
@@ -529,7 +528,7 @@ func (e *ExplicitServerTransport) dispatchPostRequiredArrayHeader(req *http.Requ
 	if e.srv.PostRequiredArrayHeader == nil {
 		return nil, &nonRetriableError{errors.New("fake for method PostRequiredArrayHeader not implemented")}
 	}
-	respr, errRespr := e.srv.PostRequiredArrayHeader(req.Context(), strings.Split(getHeaderValue(req.Header, "headerParameter"), ","), nil)
+	respr, errRespr := e.srv.PostRequiredArrayHeader(req.Context(), splitHelper(getHeaderValue(req.Header, "headerParameter"), ","), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/optionalgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/optionalgroup/fake/zz_internal.go
@@ -9,9 +9,9 @@
 package fake
 
 import (
-	"io"
 	"net/http"
 	"reflect"
+	"strings"
 )
 
 type nonRetriableError struct {
@@ -22,11 +22,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,6 +37,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -56,23 +65,9 @@ func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) 
 	return t, err
 }
 
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
+func splitHelper(s, sep string) []string {
+	if s == "" {
+		return nil
 	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
+	return strings.Split(s, sep)
 }

--- a/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/paginggroup/fake/zz_internal.go
@@ -10,7 +10,6 @@ package fake
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
-	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -24,11 +23,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -37,6 +38,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -56,27 +64,6 @@ func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) 
 		return *new(T), err
 	}
 	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/autorest.go/test/autorest/paramgroupinggroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/paramgroupinggroup/fake/zz_internal.go
@@ -9,7 +9,6 @@
 package fake
 
 import (
-	"io"
 	"net/http"
 	"reflect"
 )
@@ -22,11 +21,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -35,6 +36,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -46,33 +54,4 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 		return nil, err
 	}
 	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }

--- a/packages/autorest.go/test/autorest/reportgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/reportgroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "reflect"
 
 type nonRetriableError struct {
 	error
@@ -22,52 +18,6 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
 func contains[T comparable](s []T, v T) bool {
 	for _, vv := range s {
 		if vv == v {
@@ -75,4 +25,11 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }

--- a/packages/autorest.go/test/autorest/stringgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/stringgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/autorest/urlgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/urlgroup/fake/zz_internal.go
@@ -9,9 +9,8 @@
 package fake
 
 import (
-	"io"
-	"net/http"
 	"reflect"
+	"strings"
 )
 
 type nonRetriableError struct {
@@ -22,19 +21,20 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}
+
 func getOptional[T any](v T) *T {
 	if reflect.ValueOf(v).IsZero() {
 		return nil
 	}
 	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -48,31 +48,9 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 	return &t, err
 }
 
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
+func splitHelper(s, sep string) []string {
+	if s == "" {
+		return nil
 	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
+	return strings.Split(s, sep)
 }

--- a/packages/autorest.go/test/autorest/urlgroup/fake/zz_paths_server.go
+++ b/packages/autorest.go/test/autorest/urlgroup/fake/zz_paths_server.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -240,7 +239,7 @@ func (p *PathsServerTransport) dispatchArrayCSVInPath(req *http.Request) (*http.
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := p.srv.ArrayCSVInPath(req.Context(), strings.Split(arrayPathUnescaped, ","), nil)
+	respr, errRespr := p.srv.ArrayCSVInPath(req.Context(), splitHelper(arrayPathUnescaped, ","), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/autorest.go/test/autorest/urlgroup/fake/zz_queries_server.go
+++ b/packages/autorest.go/test/autorest/urlgroup/fake/zz_queries_server.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -282,7 +281,7 @@ func (q *QueriesServerTransport) dispatchArrayStringCSVEmpty(req *http.Request) 
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlgroup.QueriesClientArrayStringCSVEmptyOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringCSVEmptyOptions{
@@ -313,7 +312,7 @@ func (q *QueriesServerTransport) dispatchArrayStringCSVNull(req *http.Request) (
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlgroup.QueriesClientArrayStringCSVNullOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringCSVNullOptions{
@@ -344,7 +343,7 @@ func (q *QueriesServerTransport) dispatchArrayStringCSVValid(req *http.Request) 
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlgroup.QueriesClientArrayStringCSVValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringCSVValidOptions{
@@ -375,7 +374,7 @@ func (q *QueriesServerTransport) dispatchArrayStringNoCollectionFormatEmpty(req 
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlgroup.QueriesClientArrayStringNoCollectionFormatEmptyOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringNoCollectionFormatEmptyOptions{
@@ -406,7 +405,7 @@ func (q *QueriesServerTransport) dispatchArrayStringPipesValid(req *http.Request
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, "|")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, "|")
 	var options *urlgroup.QueriesClientArrayStringPipesValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringPipesValidOptions{
@@ -437,7 +436,7 @@ func (q *QueriesServerTransport) dispatchArrayStringSsvValid(req *http.Request) 
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, " ")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, " ")
 	var options *urlgroup.QueriesClientArrayStringSsvValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringSsvValidOptions{
@@ -468,7 +467,7 @@ func (q *QueriesServerTransport) dispatchArrayStringTsvValid(req *http.Request) 
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, "\t")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, "\t")
 	var options *urlgroup.QueriesClientArrayStringTsvValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlgroup.QueriesClientArrayStringTsvValidOptions{

--- a/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_internal.go
@@ -8,11 +8,7 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
+import "strings"
 
 type nonRetriableError struct {
 	error
@@ -22,52 +18,6 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
 func contains[T comparable](s []T, v T) bool {
 	for _, vv := range s {
 		if vv == v {
@@ -75,4 +25,11 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func splitHelper(s, sep string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, sep)
 }

--- a/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
+++ b/packages/autorest.go/test/autorest/urlmultigroup/fake/zz_queries_server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
 // QueriesServer is a fake server for instances of the urlmultigroup.QueriesClient type.
@@ -87,7 +86,7 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiEmpty(req *http.Request
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlmultigroup.QueriesClientArrayStringMultiEmptyOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiEmptyOptions{
@@ -118,7 +117,7 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiNull(req *http.Request)
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlmultigroup.QueriesClientArrayStringMultiNullOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiNullOptions{
@@ -149,7 +148,7 @@ func (q *QueriesServerTransport) dispatchArrayStringMultiValid(req *http.Request
 	if err != nil {
 		return nil, err
 	}
-	arrayQueryParam := strings.Split(arrayQueryUnescaped, ",")
+	arrayQueryParam := splitHelper(arrayQueryUnescaped, ",")
 	var options *urlmultigroup.QueriesClientArrayStringMultiValidOptions
 	if len(arrayQueryParam) > 0 {
 		options = &urlmultigroup.QueriesClientArrayStringMultiValidOptions{

--- a/packages/autorest.go/test/autorest/validationgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/validationgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {
@@ -75,4 +23,12 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
+}
+
+func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
+	t, err := parse(v)
+	if err != nil {
+		return *new(T), err
+	}
+	return t, err
 }

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_internal.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_internal.go
@@ -8,64 +8,12 @@
 
 package fake
 
-import (
-	"io"
-	"net/http"
-	"reflect"
-)
-
 type nonRetriableError struct {
 	error
 }
 
 func (nonRetriableError) NonRetriable() {
 	// marker method
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
 }
 
 func contains[T comparable](s []T, v T) bool {

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_internal.go
@@ -10,7 +10,6 @@ package fake
 
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
-	"io"
 	"net/http"
 	"reflect"
 	"sync"
@@ -24,19 +23,20 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}
+
 func getOptional[T any](v T) *T {
 	if reflect.ValueOf(v).IsZero() {
 		return nil
 	}
 	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -56,27 +56,6 @@ func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) 
 		return *new(T), err
 	}
 	return t, err
-}
-
-func readRequestBody(req *http.Request) ([]byte, error) {
-	if req.Body == nil {
-		return nil, nil
-	}
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, err
-	}
-	req.Body.Close()
-	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_internal.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_internal.go
@@ -24,38 +24,20 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
+	}
+	return false
+}
+
 func getOptional[T any](v T) *T {
 	if reflect.ValueOf(v).IsZero() {
 		return nil
 	}
 	return &v
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
-	if v == "" {
-		return nil, nil
-	}
-	t, err := parse(v)
-	if err != nil {
-		return nil, err
-	}
-	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
 }
 
 func readRequestBody(req *http.Request) ([]byte, error) {
@@ -68,15 +50,6 @@ func readRequestBody(req *http.Request) ([]byte, error) {
 	}
 	req.Body.Close()
 	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_internal.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"sync"
 )
 
@@ -24,11 +25,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -37,6 +40,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -48,14 +58,6 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 		return nil, err
 	}
 	return &t, err
-}
-
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
 }
 
 func readRequestBody(req *http.Request) ([]byte, error) {
@@ -70,13 +72,11 @@ func readRequestBody(req *http.Request) ([]byte, error) {
 	return body, nil
 }
 
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
+func splitHelper(s, sep string) []string {
+	if s == "" {
+		return nil
 	}
-	return false
+	return strings.Split(s, sep)
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
 // Server is a fake server for instances of the azalias.Client type.
@@ -139,7 +138,7 @@ func (s *ServerTransport) dispatchCreate(req *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	groupByUnescapedElements := strings.Split(groupByUnescaped, ",")
+	groupByUnescapedElements := splitHelper(groupByUnescaped, ",")
 	groupByParam := make([]azalias.SomethingCount, len(groupByUnescapedElements))
 	for i := 0; i < len(groupByUnescapedElements); i++ {
 		var parsedInt int64
@@ -185,7 +184,7 @@ func (s *ServerTransport) dispatchGetScript(req *http.Request) (*http.Response, 
 		return nil, err
 	}
 	headerCountsHeader := getHeaderValue(req.Header, "headerCounts")
-	headerCountsHeaderElements := strings.Split(headerCountsHeader, ",")
+	headerCountsHeaderElements := splitHelper(headerCountsHeader, ",")
 	headerCountsParam := make([]int32, len(headerCountsHeaderElements))
 	for i := 0; i < len(headerCountsHeaderElements); i++ {
 		var parsedInt int64
@@ -199,7 +198,7 @@ func (s *ServerTransport) dispatchGetScript(req *http.Request) (*http.Response, 
 	if err != nil {
 		return nil, err
 	}
-	queryCountsUnescapedElements := strings.Split(queryCountsUnescaped, ",")
+	queryCountsUnescapedElements := splitHelper(queryCountsUnescaped, ",")
 	queryCountsParam := make([]int64, len(queryCountsUnescapedElements))
 	for i := 0; i < len(queryCountsUnescapedElements); i++ {
 		var parsedInt int64
@@ -235,7 +234,7 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 		if err != nil {
 			return nil, err
 		}
-		groupByUnescapedElements := strings.Split(groupByUnescaped, ",")
+		groupByUnescapedElements := splitHelper(groupByUnescaped, ",")
 		groupByParam := make([]azalias.LogMetricsGroupBy, len(groupByUnescapedElements))
 		for i := 0; i < len(groupByUnescapedElements); i++ {
 			groupByParam[i] = azalias.LogMetricsGroupBy(groupByUnescapedElements[i])
@@ -338,7 +337,7 @@ func (s *ServerTransport) dispatchPolicyAssignment(req *http.Request) (*http.Res
 	if err != nil {
 		return nil, err
 	}
-	thingsUnescapedElements := strings.Split(thingsUnescaped, ",")
+	thingsUnescapedElements := splitHelper(thingsUnescaped, ",")
 	thingsParam := make([]azalias.Things, len(thingsUnescapedElements))
 	for i := 0; i < len(thingsUnescapedElements); i++ {
 		thingsParam[i] = azalias.Things(thingsUnescapedElements[i])

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_internal.go
@@ -24,11 +24,13 @@ func (nonRetriableError) NonRetriable() {
 	// marker method
 }
 
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
+func contains[T comparable](s []T, v T) bool {
+	for _, vv := range s {
+		if vv == v {
+			return true
+		}
 	}
-	return &v
+	return false
 }
 
 func getHeaderValue(h http.Header, k string) string {
@@ -37,6 +39,13 @@ func getHeaderValue(h http.Header, k string) string {
 		return ""
 	}
 	return v[0]
+}
+
+func getOptional[T any](v T) *T {
+	if reflect.ValueOf(v).IsZero() {
+		return nil
+	}
+	return &v
 }
 
 func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error) {
@@ -50,14 +59,6 @@ func parseOptional[T any](v string, parse func(v string) (T, error)) (*T, error)
 	return &t, err
 }
 
-func parseWithCast[T any](v string, parse func(v string) (T, error)) (T, error) {
-	t, err := parse(v)
-	if err != nil {
-		return *new(T), err
-	}
-	return t, err
-}
-
 func readRequestBody(req *http.Request) ([]byte, error) {
 	if req.Body == nil {
 		return nil, nil
@@ -68,15 +69,6 @@ func readRequestBody(req *http.Request) ([]byte, error) {
 	}
 	req.Body.Close()
 	return body, nil
-}
-
-func contains[T comparable](s []T, v T) bool {
-	for _, vv := range s {
-		if vv == v {
-			return true
-		}
-	}
-	return false
 }
 
 func newTracker[T any]() *tracker[T] {


### PR DESCRIPTION
Added an internal splitHelper() func to better handle splitting an empty string (it returns nil instead of []string{""}).