### PR TITLE
Add missing helpers in a few cases

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.56",
+  "version": "4.0.0-preview.57",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/fake/servers.ts
+++ b/packages/autorest.go/src/generator/fake/servers.ts
@@ -609,6 +609,7 @@ function parseHeaderPathQueryParams(clientPkg: string, method: Method, imports: 
       let paramVar = createLocalVariableName(param, 'Unescaped');
       if (isRequiredParameter(param) && isConstantType(param.type) && param.type.type === 'string') {
         // for string-based enums, we perform the conversion as part of unescaping
+        requiredHelpers.parseWithCast = true;
         paramVar = createLocalVariableName(param, 'Param');
         content += `\t${paramVar}, err := parseWithCast(${paramValue}, func (v string) (${getTypeDeclaration(param.type, clientPkg)}, error) {\n`;
         content += `\t\tp, unescapeErr := url.${where}Unescape(v)\n`;
@@ -767,9 +768,13 @@ function parseHeaderPathQueryParams(clientPkg: string, method: Method, imports: 
       content += `\t\t\t${localVar}[hh[len("${headerPrefix}"):]] = to.Ptr(getHeaderValue(req.Header, hh))\n`;
       content += '\t\t}\n\t}\n';
     } else if (isConstantType(param.type) && param.type.type !== 'string') {
-      let parseHelper = 'parseWithCast';
+      let parseHelper: string;
       if (!isRequiredParameter(param)) {
+        requiredHelpers.parseOptional = true;
         parseHelper = 'parseOptional';
+      } else {
+        requiredHelpers.parseWithCast = true;
+        parseHelper = 'parseWithCast';
       }
       let parse: string;
       let zeroValue: string;


### PR DESCRIPTION
Whenever we use a parse helper, set the flag to generate them. Bump package version in prep for release.