### PR TITLE
Fix client moduleName parameter

### DIFF
--- a/packages/autorest.go/.scripts/regeneration.js
+++ b/packages/autorest.go/.scripts/regeneration.js
@@ -99,13 +99,13 @@ for (namespace in goMappings) {
 }
 
 const blobStorage = './swagger/specification/storage/data-plane/Microsoft.BlobStorage/readme.md';
-generateFromReadme("azblob", blobStorage, 'package-2021-12', 'test/storage/azblob', '--module-version=0.1.0 --inject-spans --azcore-version=1.9.0-beta.1');
+generateFromReadme("azblob", blobStorage, 'package-2021-12', 'test/storage/azblob', '--module-version=0.1.0 --inject-spans');
 
 const network = './swagger/specification/network/resource-manager/readme.md';
-generateFromReadme("armnetwork", network, 'package-2022-09', 'test/network/armnetwork', '--module=armnetwork --module-version=0.1.0 --azure-arm=true --remove-unreferenced-types --azcore-version=1.9.0-beta.1');
+generateFromReadme("armnetwork", network, 'package-2022-09', 'test/network/armnetwork', '--module=armnetwork --module-version=0.1.0 --azure-arm=true --remove-unreferenced-types');
 
 const compute = './swagger/specification/compute/resource-manager/readme.md';
-generateFromReadme("armcompute", compute, 'package-2021-12-01', 'test/compute/armcompute', '--module=armcompute --module-version=0.1.0 --azure-arm=true --remove-unreferenced-types --azcore-version=1.9.0-beta.1 --slice-elements-byval');
+generateFromReadme("armcompute", compute, 'package-2021-12-01', 'test/compute/armcompute', '--module=armcompute --module-version=0.1.0 --azure-arm=true --remove-unreferenced-types --slice-elements-byval');
 
 const synapseArtifacts = './swagger/specification/synapse/data-plane/readme.md';
 generateFromReadme("azartifacts", synapseArtifacts, 'package-artifacts-composite-v6', 'test/synapse/azartifacts', '--security=AADToken --security-scopes="https://dev.azuresynapse.net/.default" --module="azartifacts" --module-version=0.1.0 --openapi-type="data-plane"');
@@ -123,15 +123,15 @@ const consumption = './swagger/specification/consumption/resource-manager/readme
 generateFromReadme("armconsumption", consumption, 'package-2019-10', 'test/consumption/armconsumption', '--module=armconsumption --module-version=1.0.0 --azure-arm=true --generate-fakes=false --inject-spans=false --remove-unreferenced-types');
 
 const databoxedge = './swagger/specification/databoxedge/resource-manager/readme.md';
-generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/databoxedge/armdataboxedge', '--module=armdataboxedge --module-version=2.0.0 --azure-arm=true --remove-unreferenced-types --inject-spans=false --azcore-version=1.9.0-beta.1');
+generateFromReadme("armdataboxedge", databoxedge, 'package-2021-02-01', 'test/databoxedge/armdataboxedge', '--module=armdataboxedge --module-version=2.0.0 --azure-arm=true --remove-unreferenced-types --inject-spans=false');
 
 const acr = './swagger/specification/containerregistry/data-plane/Azure.ContainerRegistry/stable/2021-07-01/containerregistry.json';
-generate("azacr", acr, 'test/acr/azacr', '--module="azacr" --module-version=0.1.0 --openapi-type="data-plane" --rawjson-as-bytes --generate-fakes --azcore-version=1.9.0-beta.1');
+generate("azacr", acr, 'test/acr/azacr', '--module="azacr" --module-version=0.1.0 --openapi-type="data-plane" --rawjson-as-bytes --generate-fakes');
 
 const machineLearning = './swagger/specification/machinelearningservices/resource-manager';
 generateFromReadme("armmachinelearning", machineLearning, 'package-2022-02-01-preview', 'test/machinelearning/armmachinelearning', '--module=armmachinelearning --module-version=1.0.0 --azure-arm=true --generate-fakes=false --inject-spans=false --remove-unreferenced-types');
 
-generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --azcore-version=1.9.0-beta.1  --slice-elements-byval');
+generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --slice-elements-byval');
 
 function should_generate(name) {
     if (filter !== undefined) {
@@ -158,7 +158,7 @@ function generate(name, inputFile, outputDir, additionalArgs) {
         console.log('generating ' + inputFile);
         outputDir = fullPath(outputDir);
         cleanGeneratedFiles(outputDir);
-        exec('autorest --use=./packages/autorest.go --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --generate-fakes --inject-spans --azcore-version=1.9.0-beta.1 --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
+        exec('autorest --use=./packages/autorest.go --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --generate-fakes --inject-spans --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
     });
 }
 

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.58",
+  "version": "4.0.0-preview.59",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/clientFactory.ts
+++ b/packages/autorest.go/src/generator/clientFactory.ts
@@ -52,7 +52,7 @@ export async function generateClientFactory(codeModel: GoCodeModel): Promise<str
     result += `${formatCommentAsBulletItem('options - pass nil to accept the default values.')}\n`;
 
     result += `func NewClientFactory(${allClientParams.map(each => { return `${each.paramName} ${formatParameterTypeName(each)}`; }).join(', ')}${allClientParams.length>0 ? ',' : ''} credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
-    result += '\t_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)\n';
+    result += '\t_, err := arm.NewClient(moduleName, moduleVersion, credential, options)\n';
     result += '\tif err != nil {\n';
     result += '\t\treturn nil, err\n';
     result += '\t}\n';

--- a/packages/autorest.go/src/generator/operations.ts
+++ b/packages/autorest.go/src/generator/operations.ts
@@ -152,7 +152,7 @@ export async function generateOperations(codeModel: GoCodeModel): Promise<Array<
       }
 
       clientText += `func ${client.ctorName}(${methodParams.join(', ')}) (*${clientName}, error) {\n`;
-      clientText += `\tcl, err := ${clientPkg}.NewClient(moduleName+".${clientName}", moduleVersion, credential, options)\n`;
+      clientText += `\tcl, err := ${clientPkg}.NewClient(moduleName, moduleVersion, credential, options)\n`;
       clientText += '\tif err != nil {\n';
       clientText += '\t\treturn nil, err\n';
       clientText += '\t}\n';

--- a/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_availabilitysets_client.go
@@ -33,7 +33,7 @@ type AvailabilitySetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailabilitySetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailabilitySetsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailabilitySetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservationgroups_client.go
@@ -33,7 +33,7 @@ type CapacityReservationGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCapacityReservationGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CapacityReservationGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CapacityReservationGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_capacityreservations_client.go
@@ -33,7 +33,7 @@ type CapacityReservationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCapacityReservationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CapacityReservationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CapacityReservationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_client_factory.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_client_factory.go
@@ -28,7 +28,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceoperatingsystems_client.go
@@ -33,7 +33,7 @@ type CloudServiceOperatingSystemsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCloudServiceOperatingSystemsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceOperatingSystemsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CloudServiceOperatingSystemsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroleinstances_client.go
@@ -33,7 +33,7 @@ type CloudServiceRoleInstancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCloudServiceRoleInstancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceRoleInstancesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CloudServiceRoleInstancesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudserviceroles_client.go
@@ -33,7 +33,7 @@ type CloudServiceRolesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCloudServiceRolesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServiceRolesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CloudServiceRolesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservices_client.go
@@ -33,7 +33,7 @@ type CloudServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCloudServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServicesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CloudServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_cloudservicesupdatedomain_client.go
@@ -34,7 +34,7 @@ type CloudServicesUpdateDomainClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCloudServicesUpdateDomainClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CloudServicesUpdateDomainClient, error) {
-	cl, err := arm.NewClient(moduleName+".CloudServicesUpdateDomainClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleries_client.go
@@ -33,7 +33,7 @@ type CommunityGalleriesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCommunityGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleriesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CommunityGalleriesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimages_client.go
@@ -33,7 +33,7 @@ type CommunityGalleryImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCommunityGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleryImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CommunityGalleryImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_communitygalleryimageversions_client.go
@@ -33,7 +33,7 @@ type CommunityGalleryImageVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCommunityGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CommunityGalleryImageVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CommunityGalleryImageVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhostgroups_client.go
@@ -33,7 +33,7 @@ type DedicatedHostGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDedicatedHostGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".DedicatedHostGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_dedicatedhosts_client.go
@@ -33,7 +33,7 @@ type DedicatedHostsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDedicatedHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DedicatedHostsClient, error) {
-	cl, err := arm.NewClient(moduleName+".DedicatedHostsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskaccesses_client.go
@@ -33,7 +33,7 @@ type DiskAccessesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiskAccessesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskAccessesClient, error) {
-	cl, err := arm.NewClient(moduleName+".DiskAccessesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskencryptionsets_client.go
@@ -33,7 +33,7 @@ type DiskEncryptionSetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiskEncryptionSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskEncryptionSetsClient, error) {
-	cl, err := arm.NewClient(moduleName+".DiskEncryptionSetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_diskrestorepoint_client.go
@@ -33,7 +33,7 @@ type DiskRestorePointClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiskRestorePointClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiskRestorePointClient, error) {
-	cl, err := arm.NewClient(moduleName+".DiskRestorePointClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_disks_client.go
@@ -33,7 +33,7 @@ type DisksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDisksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DisksClient, error) {
-	cl, err := arm.NewClient(moduleName+".DisksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleries_client.go
@@ -33,7 +33,7 @@ type GalleriesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleriesClient, error) {
-	cl, err := arm.NewClient(moduleName+".GalleriesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplications_client.go
@@ -33,7 +33,7 @@ type GalleryApplicationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryApplicationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".GalleryApplicationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryapplicationversions_client.go
@@ -33,7 +33,7 @@ type GalleryApplicationVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryApplicationVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryApplicationVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".GalleryApplicationVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimages_client.go
@@ -33,7 +33,7 @@ type GalleryImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".GalleryImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_galleryimageversions_client.go
@@ -33,7 +33,7 @@ type GalleryImageVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GalleryImageVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".GalleryImageVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_gallerysharingprofile_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_gallerysharingprofile_client.go
@@ -33,7 +33,7 @@ type GallerySharingProfileClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGallerySharingProfileClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GallerySharingProfileClient, error) {
-	cl, err := arm.NewClient(moduleName+".GallerySharingProfileClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_images_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_images_client.go
@@ -33,7 +33,7 @@ type ImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_loganalytics_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_loganalytics_client.go
@@ -33,7 +33,7 @@ type LogAnalyticsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLogAnalyticsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LogAnalyticsClient, error) {
-	cl, err := arm.NewClient(moduleName+".LogAnalyticsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_operations_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_operations_client.go
@@ -27,7 +27,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_proximityplacementgroups_client.go
@@ -33,7 +33,7 @@ type ProximityPlacementGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProximityPlacementGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProximityPlacementGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ProximityPlacementGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_resourceskus_client.go
@@ -33,7 +33,7 @@ type ResourceSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceSKUsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ResourceSKUsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_restorepointcollections_client.go
@@ -33,7 +33,7 @@ type RestorePointCollectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRestorePointCollectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RestorePointCollectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".RestorePointCollectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_restorepoints_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_restorepoints_client.go
@@ -33,7 +33,7 @@ type RestorePointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRestorePointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RestorePointsClient, error) {
-	cl, err := arm.NewClient(moduleName+".RestorePointsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleries_client.go
@@ -33,7 +33,7 @@ type SharedGalleriesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSharedGalleriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleriesClient, error) {
-	cl, err := arm.NewClient(moduleName+".SharedGalleriesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimages_client.go
@@ -33,7 +33,7 @@ type SharedGalleryImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSharedGalleryImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleryImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".SharedGalleryImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sharedgalleryimageversions_client.go
@@ -33,7 +33,7 @@ type SharedGalleryImageVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSharedGalleryImageVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharedGalleryImageVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SharedGalleryImageVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_snapshots_client.go
@@ -33,7 +33,7 @@ type SnapshotsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSnapshotsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SnapshotsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SnapshotsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_sshpublickeys_client.go
@@ -33,7 +33,7 @@ type SSHPublicKeysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSSHPublicKeysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SSHPublicKeysClient, error) {
-	cl, err := arm.NewClient(moduleName+".SSHPublicKeysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_usage_client.go
@@ -33,7 +33,7 @@ type UsageClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageClient, error) {
-	cl, err := arm.NewClient(moduleName+".UsageClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensionimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensionimages_client.go
@@ -34,7 +34,7 @@ type VirtualMachineExtensionImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineExtensionImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineExtensionImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineextensions_client.go
@@ -33,7 +33,7 @@ type VirtualMachineExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineExtensionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimages_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimages_client.go
@@ -34,7 +34,7 @@ type VirtualMachineImagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineImagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineImagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimagesedgezone_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineimagesedgezone_client.go
@@ -34,7 +34,7 @@ type VirtualMachineImagesEdgeZoneClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineImagesEdgeZoneClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineImagesEdgeZoneClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineImagesEdgeZoneClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachineruncommands_client.go
@@ -33,7 +33,7 @@ type VirtualMachineRunCommandsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineRunCommandsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineRunCommandsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachines_client.go
@@ -34,7 +34,7 @@ type VirtualMachinesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachinesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachinesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachinesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetextensions_client.go
@@ -33,7 +33,7 @@ type VirtualMachineScaleSetExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetExtensionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetrollingupgrades_client.go
@@ -33,7 +33,7 @@ type VirtualMachineScaleSetRollingUpgradesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetRollingUpgradesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetRollingUpgradesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetRollingUpgradesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesets_client.go
@@ -34,7 +34,7 @@ type VirtualMachineScaleSetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmextensions_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmextensions_client.go
@@ -33,7 +33,7 @@ type VirtualMachineScaleSetVMExtensionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMExtensionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMExtensionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetVMExtensionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvmruncommands_client.go
@@ -33,7 +33,7 @@ type VirtualMachineScaleSetVMRunCommandsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMRunCommandsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMRunCommandsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetVMRunCommandsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinescalesetvms_client.go
@@ -34,7 +34,7 @@ type VirtualMachineScaleSetVMsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineScaleSetVMsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineScaleSetVMsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineScaleSetVMsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/compute/armcompute/zz_virtualmachinesizes_client.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_virtualmachinesizes_client.go
@@ -33,7 +33,7 @@ type VirtualMachineSizesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineSizesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_aggregatedcost_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_aggregatedcost_client.go
@@ -30,7 +30,7 @@ type AggregatedCostClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAggregatedCostClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*AggregatedCostClient, error) {
-	cl, err := arm.NewClient(moduleName+".AggregatedCostClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_balances_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_balances_client.go
@@ -30,7 +30,7 @@ type BalancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBalancesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BalancesClient, error) {
-	cl, err := arm.NewClient(moduleName+".BalancesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_budgets_client.go
@@ -30,7 +30,7 @@ type BudgetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBudgetsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*BudgetsClient, error) {
-	cl, err := arm.NewClient(moduleName+".BudgetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_charges_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_charges_client.go
@@ -28,7 +28,7 @@ type ChargesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewChargesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ChargesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ChargesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_client_factory.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_client_factory.go
@@ -27,7 +27,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_credits_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_credits_client.go
@@ -28,7 +28,7 @@ type CreditsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCreditsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*CreditsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CreditsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_events_client.go
@@ -28,7 +28,7 @@ type EventsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewEventsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*EventsClient, error) {
-	cl, err := arm.NewClient(moduleName+".EventsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_forecasts_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_forecasts_client.go
@@ -32,7 +32,7 @@ type ForecastsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewForecastsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ForecastsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ForecastsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_lots_client.go
@@ -28,7 +28,7 @@ type LotsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLotsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*LotsClient, error) {
-	cl, err := arm.NewClient(moduleName+".LotsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_marketplaces_client.go
@@ -29,7 +29,7 @@ type MarketplacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewMarketplacesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*MarketplacesClient, error) {
-	cl, err := arm.NewClient(moduleName+".MarketplacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_operations_client.go
@@ -27,7 +27,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_pricesheet_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_pricesheet_client.go
@@ -33,7 +33,7 @@ type PriceSheetClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPriceSheetClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PriceSheetClient, error) {
-	cl, err := arm.NewClient(moduleName+".PriceSheetClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendationdetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendationdetails_client.go
@@ -28,7 +28,7 @@ type ReservationRecommendationDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationDetailsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ReservationRecommendationDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationrecommendations_client.go
@@ -28,7 +28,7 @@ type ReservationRecommendationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationRecommendationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationRecommendationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ReservationRecommendationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationsdetails_client.go
@@ -30,7 +30,7 @@ type ReservationsDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsDetailsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ReservationsDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationssummaries_client.go
@@ -30,7 +30,7 @@ type ReservationsSummariesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationsSummariesClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationsSummariesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ReservationsSummariesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_reservationtransactions_client.go
@@ -30,7 +30,7 @@ type ReservationTransactionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewReservationTransactionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ReservationTransactionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ReservationTransactionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_tags_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_tags_client.go
@@ -28,7 +28,7 @@ type TagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewTagsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*TagsClient, error) {
-	cl, err := arm.NewClient(moduleName+".TagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_usagedetails_client.go
@@ -29,7 +29,7 @@ type UsageDetailsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsageDetailsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*UsageDetailsClient, error) {
-	cl, err := arm.NewClient(moduleName+".UsageDetailsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_addons_client.go
@@ -32,7 +32,7 @@ type AddonsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAddonsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AddonsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AddonsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_alerts_client.go
@@ -32,7 +32,7 @@ type AlertsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAlertsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AlertsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AlertsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_availableskus_client.go
@@ -32,7 +32,7 @@ type AvailableSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableSKUsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailableSKUsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_bandwidthschedules_client.go
@@ -32,7 +32,7 @@ type BandwidthSchedulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBandwidthSchedulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BandwidthSchedulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".BandwidthSchedulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_client_factory.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_client_factory.go
@@ -27,7 +27,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_containers_client.go
@@ -32,7 +32,7 @@ type ContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".ContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_devices_client.go
@@ -32,7 +32,7 @@ type DevicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDevicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DevicesClient, error) {
-	cl, err := arm.NewClient(moduleName+".DevicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_diagnosticsettings_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_diagnosticsettings_client.go
@@ -32,7 +32,7 @@ type DiagnosticSettingsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDiagnosticSettingsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DiagnosticSettingsClient, error) {
-	cl, err := arm.NewClient(moduleName+".DiagnosticSettingsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_jobs_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_jobs_client.go
@@ -32,7 +32,7 @@ type JobsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
-	cl, err := arm.NewClient(moduleName+".JobsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_monitoringconfig_client.go
@@ -32,7 +32,7 @@ type MonitoringConfigClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewMonitoringConfigClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*MonitoringConfigClient, error) {
-	cl, err := arm.NewClient(moduleName+".MonitoringConfigClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_nodes_client.go
@@ -32,7 +32,7 @@ type NodesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNodesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NodesClient, error) {
-	cl, err := arm.NewClient(moduleName+".NodesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operations_client.go
@@ -27,7 +27,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operationsstatus_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_operationsstatus_client.go
@@ -32,7 +32,7 @@ type OperationsStatusClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsStatusClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsStatusClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_orders_client.go
@@ -32,7 +32,7 @@ type OrdersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOrdersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OrdersClient, error) {
-	cl, err := arm.NewClient(moduleName+".OrdersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_roles_client.go
@@ -32,7 +32,7 @@ type RolesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRolesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RolesClient, error) {
-	cl, err := arm.NewClient(moduleName+".RolesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_shares_client.go
@@ -32,7 +32,7 @@ type SharesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSharesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SharesClient, error) {
-	cl, err := arm.NewClient(moduleName+".SharesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccountcredentials_client.go
@@ -32,7 +32,7 @@ type StorageAccountCredentialsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewStorageAccountCredentialsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountCredentialsClient, error) {
-	cl, err := arm.NewClient(moduleName+".StorageAccountCredentialsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_storageaccounts_client.go
@@ -32,7 +32,7 @@ type StorageAccountsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewStorageAccountsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StorageAccountsClient, error) {
-	cl, err := arm.NewClient(moduleName+".StorageAccountsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_supportpackages_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_supportpackages_client.go
@@ -32,7 +32,7 @@ type SupportPackagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSupportPackagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SupportPackagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".SupportPackagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_triggers_client.go
@@ -32,7 +32,7 @@ type TriggersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewTriggersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*TriggersClient, error) {
-	cl, err := arm.NewClient(moduleName+".TriggersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_users_client.go
@@ -32,7 +32,7 @@ type UsersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsersClient, error) {
-	cl, err := arm.NewClient(moduleName+".UsersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchdeployments_client.go
@@ -33,7 +33,7 @@ type BatchDeploymentsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBatchDeploymentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BatchDeploymentsClient, error) {
-	cl, err := arm.NewClient(moduleName+".BatchDeploymentsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_batchendpoints_client.go
@@ -33,7 +33,7 @@ type BatchEndpointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBatchEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BatchEndpointsClient, error) {
-	cl, err := arm.NewClient(moduleName+".BatchEndpointsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_client_factory.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_client_factory.go
@@ -27,7 +27,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codecontainers_client.go
@@ -32,7 +32,7 @@ type CodeContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCodeContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CodeContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".CodeContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_codeversions_client.go
@@ -33,7 +33,7 @@ type CodeVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCodeVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CodeVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".CodeVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentcontainers_client.go
@@ -32,7 +32,7 @@ type ComponentContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewComponentContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComponentContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".ComponentContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_componentversions_client.go
@@ -33,7 +33,7 @@ type ComponentVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewComponentVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComponentVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ComponentVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_compute_client.go
@@ -32,7 +32,7 @@ type ComputeClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewComputeClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ComputeClient, error) {
-	cl, err := arm.NewClient(moduleName+".ComputeClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datacontainers_client.go
@@ -32,7 +32,7 @@ type DataContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDataContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DataContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".DataContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_datastores_client.go
@@ -33,7 +33,7 @@ type DatastoresClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDatastoresClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DatastoresClient, error) {
-	cl, err := arm.NewClient(moduleName+".DatastoresClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_dataversions_client.go
@@ -33,7 +33,7 @@ type DataVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDataVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DataVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".DataVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentcontainers_client.go
@@ -32,7 +32,7 @@ type EnvironmentContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewEnvironmentContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*EnvironmentContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".EnvironmentContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_environmentversions_client.go
@@ -33,7 +33,7 @@ type EnvironmentVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewEnvironmentVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*EnvironmentVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".EnvironmentVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_jobs_client.go
@@ -33,7 +33,7 @@ type JobsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewJobsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*JobsClient, error) {
-	cl, err := arm.NewClient(moduleName+".JobsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelcontainers_client.go
@@ -33,7 +33,7 @@ type ModelContainersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewModelContainersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ModelContainersClient, error) {
-	cl, err := arm.NewClient(moduleName+".ModelContainersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_modelversions_client.go
@@ -33,7 +33,7 @@ type ModelVersionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewModelVersionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ModelVersionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ModelVersionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlinedeployments_client.go
@@ -33,7 +33,7 @@ type OnlineDeploymentsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOnlineDeploymentsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OnlineDeploymentsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OnlineDeploymentsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_onlineendpoints_client.go
@@ -33,7 +33,7 @@ type OnlineEndpointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOnlineEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OnlineEndpointsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OnlineEndpointsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_operations_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_operations_client.go
@@ -27,7 +27,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privateendpointconnections_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privateendpointconnections_client.go
@@ -32,7 +32,7 @@ type PrivateEndpointConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".PrivateEndpointConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privatelinkresources_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_privatelinkresources_client.go
@@ -32,7 +32,7 @@ type PrivateLinkResourcesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateLinkResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkResourcesClient, error) {
-	cl, err := arm.NewClient(moduleName+".PrivateLinkResourcesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_quotas_client.go
@@ -32,7 +32,7 @@ type QuotasClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewQuotasClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*QuotasClient, error) {
-	cl, err := arm.NewClient(moduleName+".QuotasClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_usages_client.go
@@ -32,7 +32,7 @@ type UsagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".UsagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_virtualmachinesizes_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_virtualmachinesizes_client.go
@@ -32,7 +32,7 @@ type VirtualMachineSizesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualMachineSizesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualMachineSizesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualMachineSizesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaceconnections_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaceconnections_client.go
@@ -32,7 +32,7 @@ type WorkspaceConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWorkspaceConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspaceConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".WorkspaceConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspacefeatures_client.go
@@ -32,7 +32,7 @@ type WorkspaceFeaturesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWorkspaceFeaturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspaceFeaturesClient, error) {
-	cl, err := arm.NewClient(moduleName+".WorkspaceFeaturesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_workspaces_client.go
@@ -32,7 +32,7 @@ type WorkspacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWorkspacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WorkspacesClient, error) {
-	cl, err := arm.NewClient(moduleName+".WorkspacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrulecollections_client.go
@@ -34,7 +34,7 @@ type AdminRuleCollectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAdminRuleCollectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AdminRuleCollectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AdminRuleCollectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_adminrules_client.go
@@ -34,7 +34,7 @@ type AdminRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAdminRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AdminRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".AdminRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivateendpointconnections_client.go
@@ -33,7 +33,7 @@ type ApplicationGatewayPrivateEndpointConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewayPrivateEndpointConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayPrivateEndpointConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationGatewayPrivateEndpointConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewayprivatelinkresources_client.go
@@ -33,7 +33,7 @@ type ApplicationGatewayPrivateLinkResourcesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewayPrivateLinkResourcesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayPrivateLinkResourcesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationGatewayPrivateLinkResourcesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgateways_client.go
@@ -33,7 +33,7 @@ type ApplicationGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifests_client.go
@@ -33,7 +33,7 @@ type ApplicationGatewayWafDynamicManifestsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewayWafDynamicManifestsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayWafDynamicManifestsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationGatewayWafDynamicManifestsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifestsdefault_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationgatewaywafdynamicmanifestsdefault_client.go
@@ -33,7 +33,7 @@ type ApplicationGatewayWafDynamicManifestsDefaultClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationGatewayWafDynamicManifestsDefaultClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationGatewayWafDynamicManifestsDefaultClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationGatewayWafDynamicManifestsDefaultClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_applicationsecuritygroups_client.go
@@ -33,7 +33,7 @@ type ApplicationSecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewApplicationSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ApplicationSecurityGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ApplicationSecurityGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availabledelegations_client.go
@@ -33,7 +33,7 @@ type AvailableDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableDelegationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailableDelegationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableendpointservices_client.go
@@ -33,7 +33,7 @@ type AvailableEndpointServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableEndpointServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableEndpointServicesClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailableEndpointServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableprivateendpointtypes_client.go
@@ -33,7 +33,7 @@ type AvailablePrivateEndpointTypesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailablePrivateEndpointTypesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailablePrivateEndpointTypesClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailablePrivateEndpointTypesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableresourcegroupdelegations_client.go
@@ -33,7 +33,7 @@ type AvailableResourceGroupDelegationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableResourceGroupDelegationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableResourceGroupDelegationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailableResourceGroupDelegationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_availableservicealiases_client.go
@@ -33,7 +33,7 @@ type AvailableServiceAliasesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAvailableServiceAliasesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AvailableServiceAliasesClient, error) {
-	cl, err := arm.NewClient(moduleName+".AvailableServiceAliasesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewallfqdntags_client.go
@@ -33,7 +33,7 @@ type AzureFirewallFqdnTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallFqdnTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallFqdnTagsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AzureFirewallFqdnTagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_azurefirewalls_client.go
@@ -33,7 +33,7 @@ type AzureFirewallsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewAzureFirewallsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*AzureFirewallsClient, error) {
-	cl, err := arm.NewClient(moduleName+".AzureFirewallsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bastionhosts_client.go
@@ -33,7 +33,7 @@ type BastionHostsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBastionHostsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BastionHostsClient, error) {
-	cl, err := arm.NewClient(moduleName+".BastionHostsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_bgpservicecommunities_client.go
@@ -33,7 +33,7 @@ type BgpServiceCommunitiesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewBgpServiceCommunitiesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*BgpServiceCommunitiesClient, error) {
-	cl, err := arm.NewClient(moduleName+".BgpServiceCommunitiesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_client_factory.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_client_factory.go
@@ -28,7 +28,7 @@ type ClientFactory struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {
-	_, err := arm.NewClient(moduleName+".ClientFactory", moduleVersion, credential, options)
+	_, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_configurationpolicygroups_client.go
@@ -33,7 +33,7 @@ type ConfigurationPolicyGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewConfigurationPolicyGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConfigurationPolicyGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ConfigurationPolicyGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_connectionmonitors_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_connectionmonitors_client.go
@@ -33,7 +33,7 @@ type ConnectionMonitorsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewConnectionMonitorsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConnectionMonitorsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ConnectionMonitorsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_connectivityconfigurations_client.go
@@ -34,7 +34,7 @@ type ConnectivityConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewConnectivityConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ConnectivityConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ConnectivityConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_customipprefixes_client.go
@@ -33,7 +33,7 @@ type CustomIPPrefixesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewCustomIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*CustomIPPrefixesClient, error) {
-	cl, err := arm.NewClient(moduleName+".CustomIPPrefixesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_ddoscustompolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ddoscustompolicies_client.go
@@ -33,7 +33,7 @@ type DdosCustomPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosCustomPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosCustomPoliciesClient, error) {
-	cl, err := arm.NewClient(moduleName+".DdosCustomPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ddosprotectionplans_client.go
@@ -33,7 +33,7 @@ type DdosProtectionPlansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDdosProtectionPlansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DdosProtectionPlansClient, error) {
-	cl, err := arm.NewClient(moduleName+".DdosProtectionPlansClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_defaultsecurityrules_client.go
@@ -33,7 +33,7 @@ type DefaultSecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDefaultSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DefaultSecurityRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".DefaultSecurityRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_dscpconfiguration_client.go
@@ -33,7 +33,7 @@ type DscpConfigurationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewDscpConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*DscpConfigurationClient, error) {
-	cl, err := arm.NewClient(moduleName+".DscpConfigurationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitauthorizations_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCircuitAuthorizationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitAuthorizationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitAuthorizationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitconnections_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuitpeerings_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCircuitPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitPeeringsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecircuits_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCircuitsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCircuitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCircuitsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCircuitsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteconnections_client.go
@@ -33,7 +33,7 @@ type ExpressRouteConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnectionpeerings_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCrossConnectionPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionPeeringsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCrossConnectionPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutecrossconnections_client.go
@@ -33,7 +33,7 @@ type ExpressRouteCrossConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteCrossConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteCrossConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteCrossConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutegateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutegateways_client.go
@@ -33,7 +33,7 @@ type ExpressRouteGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressroutelinks_client.go
@@ -33,7 +33,7 @@ type ExpressRouteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteLinksClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportauthorizations_client.go
@@ -33,7 +33,7 @@ type ExpressRoutePortAuthorizationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortAuthorizationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortAuthorizationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRoutePortAuthorizationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteports_client.go
@@ -33,7 +33,7 @@ type ExpressRoutePortsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRoutePortsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteportslocations_client.go
@@ -33,7 +33,7 @@ type ExpressRoutePortsLocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRoutePortsLocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRoutePortsLocationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRoutePortsLocationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteproviderportslocation_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteproviderportslocation_client.go
@@ -33,7 +33,7 @@ type ExpressRouteProviderPortsLocationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteProviderPortsLocationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteProviderPortsLocationClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteProviderPortsLocationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_expressrouteserviceproviders_client.go
@@ -33,7 +33,7 @@ type ExpressRouteServiceProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewExpressRouteServiceProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ExpressRouteServiceProvidersClient, error) {
-	cl, err := arm.NewClient(moduleName+".ExpressRouteServiceProvidersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicies_client.go
@@ -33,7 +33,7 @@ type FirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPoliciesClient, error) {
-	cl, err := arm.NewClient(moduleName+".FirewallPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignatures_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignatures_client.go
@@ -33,7 +33,7 @@ type FirewallPolicyIdpsSignaturesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesClient, error) {
-	cl, err := arm.NewClient(moduleName+".FirewallPolicyIdpsSignaturesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesfiltervalues_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesfiltervalues_client.go
@@ -33,7 +33,7 @@ type FirewallPolicyIdpsSignaturesFilterValuesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesFilterValuesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesFilterValuesClient, error) {
-	cl, err := arm.NewClient(moduleName+".FirewallPolicyIdpsSignaturesFilterValuesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesoverrides_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyidpssignaturesoverrides_client.go
@@ -33,7 +33,7 @@ type FirewallPolicyIdpsSignaturesOverridesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPolicyIdpsSignaturesOverridesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyIdpsSignaturesOverridesClient, error) {
-	cl, err := arm.NewClient(moduleName+".FirewallPolicyIdpsSignaturesOverridesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_firewallpolicyrulecollectiongroups_client.go
@@ -33,7 +33,7 @@ type FirewallPolicyRuleCollectionGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFirewallPolicyRuleCollectionGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FirewallPolicyRuleCollectionGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".FirewallPolicyRuleCollectionGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_flowlogs_client.go
@@ -33,7 +33,7 @@ type FlowLogsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewFlowLogsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*FlowLogsClient, error) {
-	cl, err := arm.NewClient(moduleName+".FlowLogsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_groups_client.go
@@ -34,7 +34,7 @@ type GroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*GroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".GroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubroutetables_client.go
@@ -33,7 +33,7 @@ type HubRouteTablesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewHubRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubRouteTablesClient, error) {
-	cl, err := arm.NewClient(moduleName+".HubRouteTablesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_hubvirtualnetworkconnections_client.go
@@ -33,7 +33,7 @@ type HubVirtualNetworkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewHubVirtualNetworkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*HubVirtualNetworkConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".HubVirtualNetworkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_inboundnatrules_client.go
@@ -33,7 +33,7 @@ type InboundNatRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInboundNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundNatRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".InboundNatRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_inboundsecurityrule_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_inboundsecurityrule_client.go
@@ -33,7 +33,7 @@ type InboundSecurityRuleClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInboundSecurityRuleClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InboundSecurityRuleClient, error) {
-	cl, err := arm.NewClient(moduleName+".InboundSecurityRuleClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceipconfigurations_client.go
@@ -33,7 +33,7 @@ type InterfaceIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceIPConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".InterfaceIPConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaceloadbalancers_client.go
@@ -33,7 +33,7 @@ type InterfaceLoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceLoadBalancersClient, error) {
-	cl, err := arm.NewClient(moduleName+".InterfaceLoadBalancersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfaces_client.go
@@ -33,7 +33,7 @@ type InterfacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfacesClient, error) {
-	cl, err := arm.NewClient(moduleName+".InterfacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_interfacetapconfigurations_client.go
@@ -33,7 +33,7 @@ type InterfaceTapConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewInterfaceTapConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*InterfaceTapConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".InterfaceTapConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipallocations_client.go
@@ -33,7 +33,7 @@ type IPAllocationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPAllocationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPAllocationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".IPAllocationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_ipgroups_client.go
@@ -33,7 +33,7 @@ type IPGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewIPGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*IPGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".IPGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerbackendaddresspools_client.go
@@ -33,7 +33,7 @@ type LoadBalancerBackendAddressPoolsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerBackendAddressPoolsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerBackendAddressPoolsClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerBackendAddressPoolsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerfrontendipconfigurations_client.go
@@ -33,7 +33,7 @@ type LoadBalancerFrontendIPConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerFrontendIPConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerFrontendIPConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerFrontendIPConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerloadbalancingrules_client.go
@@ -33,7 +33,7 @@ type LoadBalancerLoadBalancingRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerLoadBalancingRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerLoadBalancingRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerLoadBalancingRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancernetworkinterfaces_client.go
@@ -33,7 +33,7 @@ type LoadBalancerNetworkInterfacesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerNetworkInterfacesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerNetworkInterfacesClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerNetworkInterfacesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalanceroutboundrules_client.go
@@ -33,7 +33,7 @@ type LoadBalancerOutboundRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerOutboundRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerOutboundRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerOutboundRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancerprobes_client.go
@@ -33,7 +33,7 @@ type LoadBalancerProbesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancerProbesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancerProbesClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancerProbesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_loadbalancers_client.go
@@ -33,7 +33,7 @@ type LoadBalancersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLoadBalancersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LoadBalancersClient, error) {
-	cl, err := arm.NewClient(moduleName+".LoadBalancersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_localnetworkgateways_client.go
@@ -33,7 +33,7 @@ type LocalNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewLocalNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*LocalNetworkGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".LocalNetworkGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_management_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_management_client.go
@@ -34,7 +34,7 @@ type ManagementClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagementClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementClient, error) {
-	cl, err := arm.NewClient(moduleName+".ManagementClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managementgroupnetworkmanagerconnections_client.go
@@ -31,7 +31,7 @@ type ManagementGroupNetworkManagerConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagementGroupNetworkManagerConnectionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagementGroupNetworkManagerConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ManagementGroupNetworkManagerConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_managercommits_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managercommits_client.go
@@ -33,7 +33,7 @@ type ManagerCommitsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagerCommitsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagerCommitsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ManagerCommitsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_managerdeploymentstatus_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managerdeploymentstatus_client.go
@@ -34,7 +34,7 @@ type ManagerDeploymentStatusClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagerDeploymentStatusClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagerDeploymentStatusClient, error) {
-	cl, err := arm.NewClient(moduleName+".ManagerDeploymentStatusClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_managers_client.go
@@ -34,7 +34,7 @@ type ManagersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewManagersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ManagersClient, error) {
-	cl, err := arm.NewClient(moduleName+".ManagersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natgateways_client.go
@@ -33,7 +33,7 @@ type NatGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNatGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".NatGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_natrules_client.go
@@ -33,7 +33,7 @@ type NatRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*NatRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".NatRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_operations_client.go
@@ -27,7 +27,7 @@ type OperationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".OperationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_p2svpngateways_client.go
@@ -33,7 +33,7 @@ type P2SVPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewP2SVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*P2SVPNGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".P2SVPNGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_packetcaptures_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_packetcaptures_client.go
@@ -33,7 +33,7 @@ type PacketCapturesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPacketCapturesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PacketCapturesClient, error) {
-	cl, err := arm.NewClient(moduleName+".PacketCapturesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_peerexpressroutecircuitconnections_client.go
@@ -33,7 +33,7 @@ type PeerExpressRouteCircuitConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPeerExpressRouteCircuitConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PeerExpressRouteCircuitConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".PeerExpressRouteCircuitConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatednszonegroups_client.go
@@ -33,7 +33,7 @@ type PrivateDNSZoneGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateDNSZoneGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateDNSZoneGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".PrivateDNSZoneGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privateendpoints_client.go
@@ -33,7 +33,7 @@ type PrivateEndpointsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateEndpointsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateEndpointsClient, error) {
-	cl, err := arm.NewClient(moduleName+".PrivateEndpointsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_privatelinkservices_client.go
@@ -33,7 +33,7 @@ type PrivateLinkServicesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPrivateLinkServicesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PrivateLinkServicesClient, error) {
-	cl, err := arm.NewClient(moduleName+".PrivateLinkServicesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_profiles_client.go
@@ -33,7 +33,7 @@ type ProfilesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewProfilesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ProfilesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ProfilesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipaddresses_client.go
@@ -33,7 +33,7 @@ type PublicIPAddressesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPAddressesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPAddressesClient, error) {
-	cl, err := arm.NewClient(moduleName+".PublicIPAddressesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_publicipprefixes_client.go
@@ -33,7 +33,7 @@ type PublicIPPrefixesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewPublicIPPrefixesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*PublicIPPrefixesClient, error) {
-	cl, err := arm.NewClient(moduleName+".PublicIPPrefixesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_resourcenavigationlinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_resourcenavigationlinks_client.go
@@ -33,7 +33,7 @@ type ResourceNavigationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewResourceNavigationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ResourceNavigationLinksClient, error) {
-	cl, err := arm.NewClient(moduleName+".ResourceNavigationLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilterrules_client.go
@@ -33,7 +33,7 @@ type RouteFilterRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFilterRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFilterRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".RouteFilterRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routefilters_client.go
@@ -33,7 +33,7 @@ type RouteFiltersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteFiltersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteFiltersClient, error) {
-	cl, err := arm.NewClient(moduleName+".RouteFiltersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routemaps_client.go
@@ -33,7 +33,7 @@ type RouteMapsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteMapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteMapsClient, error) {
-	cl, err := arm.NewClient(moduleName+".RouteMapsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routes_client.go
@@ -33,7 +33,7 @@ type RoutesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRoutesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutesClient, error) {
-	cl, err := arm.NewClient(moduleName+".RoutesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routetables_client.go
@@ -33,7 +33,7 @@ type RouteTablesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRouteTablesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RouteTablesClient, error) {
-	cl, err := arm.NewClient(moduleName+".RouteTablesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_routingintent_client.go
@@ -33,7 +33,7 @@ type RoutingIntentClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewRoutingIntentClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*RoutingIntentClient, error) {
-	cl, err := arm.NewClient(moduleName+".RoutingIntentClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_scopeconnections_client.go
@@ -34,7 +34,7 @@ type ScopeConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewScopeConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ScopeConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ScopeConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityadminconfigurations_client.go
@@ -34,7 +34,7 @@ type SecurityAdminConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityAdminConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityAdminConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SecurityAdminConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitygroups_client.go
@@ -33,7 +33,7 @@ type SecurityGroupsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityGroupsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityGroupsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SecurityGroupsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securitypartnerproviders_client.go
@@ -33,7 +33,7 @@ type SecurityPartnerProvidersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityPartnerProvidersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityPartnerProvidersClient, error) {
-	cl, err := arm.NewClient(moduleName+".SecurityPartnerProvidersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_securityrules_client.go
@@ -33,7 +33,7 @@ type SecurityRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSecurityRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SecurityRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".SecurityRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceassociationlinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceassociationlinks_client.go
@@ -33,7 +33,7 @@ type ServiceAssociationLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceAssociationLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceAssociationLinksClient, error) {
-	cl, err := arm.NewClient(moduleName+".ServiceAssociationLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicies_client.go
@@ -33,7 +33,7 @@ type ServiceEndpointPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPoliciesClient, error) {
-	cl, err := arm.NewClient(moduleName+".ServiceEndpointPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_serviceendpointpolicydefinitions_client.go
@@ -33,7 +33,7 @@ type ServiceEndpointPolicyDefinitionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceEndpointPolicyDefinitionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceEndpointPolicyDefinitionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ServiceEndpointPolicyDefinitionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_servicetaginformation_client.go
@@ -34,7 +34,7 @@ type ServiceTagInformationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceTagInformationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagInformationClient, error) {
-	cl, err := arm.NewClient(moduleName+".ServiceTagInformationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_servicetags_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_servicetags_client.go
@@ -33,7 +33,7 @@ type ServiceTagsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewServiceTagsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*ServiceTagsClient, error) {
-	cl, err := arm.NewClient(moduleName+".ServiceTagsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_staticmembers_client.go
@@ -34,7 +34,7 @@ type StaticMembersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewStaticMembersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*StaticMembersClient, error) {
-	cl, err := arm.NewClient(moduleName+".StaticMembersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subnets_client.go
@@ -33,7 +33,7 @@ type SubnetsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSubnetsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubnetsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SubnetsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_subscriptionnetworkmanagerconnections_client.go
@@ -34,7 +34,7 @@ type SubscriptionNetworkManagerConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewSubscriptionNetworkManagerConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*SubscriptionNetworkManagerConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".SubscriptionNetworkManagerConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_usages_client.go
@@ -33,7 +33,7 @@ type UsagesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewUsagesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*UsagesClient, error) {
-	cl, err := arm.NewClient(moduleName+".UsagesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vipswap_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vipswap_client.go
@@ -33,7 +33,7 @@ type VipSwapClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVipSwapClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VipSwapClient, error) {
-	cl, err := arm.NewClient(moduleName+".VipSwapClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliances_client.go
@@ -33,7 +33,7 @@ type VirtualAppliancesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualAppliancesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualAppliancesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualAppliancesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualappliancesites_client.go
@@ -33,7 +33,7 @@ type VirtualApplianceSitesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualApplianceSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualApplianceSitesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualApplianceSitesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualapplianceskus_client.go
@@ -33,7 +33,7 @@ type VirtualApplianceSKUsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualApplianceSKUsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualApplianceSKUsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualApplianceSKUsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnection_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnection_client.go
@@ -33,7 +33,7 @@ type VirtualHubBgpConnectionClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubBgpConnectionClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubBgpConnectionClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualHubBgpConnectionClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubbgpconnections_client.go
@@ -33,7 +33,7 @@ type VirtualHubBgpConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubBgpConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubBgpConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualHubBgpConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubipconfiguration_client.go
@@ -33,7 +33,7 @@ type VirtualHubIPConfigurationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubIPConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubIPConfigurationClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualHubIPConfigurationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubroutetablev2s_client.go
@@ -33,7 +33,7 @@ type VirtualHubRouteTableV2SClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubRouteTableV2SClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubRouteTableV2SClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualHubRouteTableV2SClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualhubs_client.go
@@ -33,7 +33,7 @@ type VirtualHubsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualHubsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualHubsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualHubsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewayconnections_client.go
@@ -33,7 +33,7 @@ type VirtualNetworkGatewayConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewayConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworkGatewayConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgatewaynatrules_client.go
@@ -33,7 +33,7 @@ type VirtualNetworkGatewayNatRulesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewayNatRulesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewayNatRulesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworkGatewayNatRulesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkgateways_client.go
@@ -33,7 +33,7 @@ type VirtualNetworkGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworkGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworkpeerings_client.go
@@ -33,7 +33,7 @@ type VirtualNetworkPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkPeeringsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworkPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworks_client.go
@@ -34,7 +34,7 @@ type VirtualNetworksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworksClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualnetworktaps_client.go
@@ -33,7 +33,7 @@ type VirtualNetworkTapsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualNetworkTapsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualNetworkTapsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualNetworkTapsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouterpeerings_client.go
@@ -33,7 +33,7 @@ type VirtualRouterPeeringsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRouterPeeringsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRouterPeeringsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualRouterPeeringsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualrouters_client.go
@@ -33,7 +33,7 @@ type VirtualRoutersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualRoutersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualRoutersClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualRoutersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_virtualwans_client.go
@@ -33,7 +33,7 @@ type VirtualWansClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVirtualWansClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VirtualWansClient, error) {
-	cl, err := arm.NewClient(moduleName+".VirtualWansClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnconnections_client.go
@@ -33,7 +33,7 @@ type VPNConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpngateways_client.go
@@ -33,7 +33,7 @@ type VPNGatewaysClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNGatewaysClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNGatewaysClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNGatewaysClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnlinkconnections_client.go
@@ -33,7 +33,7 @@ type VPNLinkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNLinkConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNLinkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurations_client.go
@@ -33,7 +33,7 @@ type VPNServerConfigurationsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNServerConfigurationsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnserverconfigurationsassociatedwithvirtualwan_client.go
@@ -33,7 +33,7 @@ type VPNServerConfigurationsAssociatedWithVirtualWanClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNServerConfigurationsAssociatedWithVirtualWanClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNServerConfigurationsAssociatedWithVirtualWanClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNServerConfigurationsAssociatedWithVirtualWanClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinkconnections_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinkconnections_client.go
@@ -33,7 +33,7 @@ type VPNSiteLinkConnectionsClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinkConnectionsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinkConnectionsClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNSiteLinkConnectionsClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitelinks_client.go
@@ -33,7 +33,7 @@ type VPNSiteLinksClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSiteLinksClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSiteLinksClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNSiteLinksClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsites_client.go
@@ -33,7 +33,7 @@ type VPNSitesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNSitesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_vpnsitesconfiguration_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_vpnsitesconfiguration_client.go
@@ -33,7 +33,7 @@ type VPNSitesConfigurationClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewVPNSitesConfigurationClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*VPNSitesConfigurationClient, error) {
-	cl, err := arm.NewClient(moduleName+".VPNSitesConfigurationClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_watchers_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_watchers_client.go
@@ -33,7 +33,7 @@ type WatchersClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WatchersClient, error) {
-	cl, err := arm.NewClient(moduleName+".WatchersClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webapplicationfirewallpolicies_client.go
@@ -33,7 +33,7 @@ type WebApplicationFirewallPoliciesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWebApplicationFirewallPoliciesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebApplicationFirewallPoliciesClient, error) {
-	cl, err := arm.NewClient(moduleName+".WebApplicationFirewallPoliciesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_webcategories_client.go
@@ -33,7 +33,7 @@ type WebCategoriesClient struct {
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
 func NewWebCategoriesClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*WebCategoriesClient, error) {
-	cl, err := arm.NewClient(moduleName+".WebCategoriesClient", moduleVersion, credential, options)
+	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In azcore@v1.9.0 the client constructor parameter is now just the module name, no client suffix required.