### PR TITLE
Omit major version suffix for moduleName

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.59",
+  "version": "4.0.0-preview.60",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/constants.ts
+++ b/packages/autorest.go/src/generator/constants.ts
@@ -24,7 +24,8 @@ export async function generateConstants(codeModel: GoCodeModel): Promise<string>
       throw new Error('--module-version is a required parameter when --azure-arm is set');
     }
     text += 'const (\n';
-    text += `\tmoduleName = "${codeModel.options.module}"\n`;
+    // strip off any major version suffix
+    text += `\tmoduleName = "${codeModel.options.module?.replace(/\/v\d+$/, '')}"\n`;
     text += `\tmoduleVersion = "v${codeModel.options.moduleVersion}"\n`;
     text += ')\n\n';
   }

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_constants.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_constants.go
@@ -9,7 +9,7 @@
 package armdataboxedge
 
 const (
-	moduleName    = "armdataboxedge/v2"
+	moduleName    = "armdataboxedge"
 	moduleVersion = "v2.0.0"
 )
 


### PR DESCRIPTION
This prevents changing the telemetry string across major versions. In addition, the module version is included so it's redundant.