### PR TITLE
Support XML additional properties with empty values

### DIFF
--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.60",
+  "version": "4.0.0-preview.61",
   "description": "AutoRest Go Generator",
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",

--- a/packages/autorest.go/src/generator/xmlAdditionalProps.ts
+++ b/packages/autorest.go/src/generator/xmlAdditionalProps.ts
@@ -36,9 +36,6 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if tokName == "" {
 				continue
 			}
-			if *ap == nil {
-				*ap = additionalProperties{}
-			}
 			tokValue = string(tt)
 		case xml.EndElement:
 			if tokName == "" {

--- a/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
@@ -5,6 +5,7 @@ package xmlgroup
 
 import (
 	"context"
+	"encoding/xml"
 	"generatortests"
 	"testing"
 	"time"
@@ -637,4 +638,29 @@ func TestPutWrappedLists(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.Zero(t, result)
+}
+
+func TestMetadataWithEmptyValue(t *testing.T) {
+	const data1 = `<Container><Metadata><key1 /><key2>value2</key2></Metadata></Container>`
+	c := Container{}
+	err := xml.Unmarshal([]byte(data1), &c)
+	require.NoError(t, err)
+	require.Len(t, c.Metadata, 2)
+	require.Empty(t, *c.Metadata["key1"])
+	require.EqualValues(t, "value2", *c.Metadata["key2"])
+
+	const data2 = `<Container><Metadata><key2>value2</key2><key1 /></Metadata></Container>`
+	c = Container{}
+	err = xml.Unmarshal([]byte(data2), &c)
+	require.NoError(t, err)
+	require.Len(t, c.Metadata, 2)
+	require.Empty(t, *c.Metadata["key1"])
+	require.EqualValues(t, "value2", *c.Metadata["key2"])
+
+	const data3 = `<Container><Metadata><key1 /></Metadata></Container>`
+	c = Container{}
+	err = xml.Unmarshal([]byte(data3), &c)
+	require.NoError(t, err)
+	require.Len(t, c.Metadata, 1)
+	require.Empty(t, *c.Metadata["key1"])
 }

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
@@ -29,9 +29,6 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if tokName == "" {
 				continue
 			}
-			if *ap == nil {
-				*ap = additionalProperties{}
-			}
 			tokValue = string(tt)
 		case xml.EndElement:
 			if tokName == "" {

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
@@ -10,6 +10,7 @@ package xmlgroup
 
 import (
 	"encoding/xml"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"strings"
 )
 
@@ -18,11 +19,12 @@ type additionalProperties map[string]*string
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tokName := ""
+	tokValue := ""
 	for t, err := d.Token(); err == nil; t, err = d.Token() {
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = strings.ToLower(tt.Name.Local)
-			break
+			tokValue = ""
 		case xml.CharData:
 			if tokName == "" {
 				continue
@@ -30,10 +32,16 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if *ap == nil {
 				*ap = additionalProperties{}
 			}
-			s := string(tt)
-			(*ap)[tokName] = &s
+			tokValue = string(tt)
+		case xml.EndElement:
+			if tokName == "" {
+				continue
+			}
+			if *ap == nil {
+				*ap = additionalProperties{}
+			}
+			(*ap)[tokName] = to.Ptr(tokValue)
 			tokName = ""
-			break
 		}
 	}
 	return nil

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_xml_helper.go
@@ -10,7 +10,9 @@ package xmlgroup
 
 import (
 	"encoding/xml"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"io"
 	"strings"
 )
 
@@ -20,7 +22,13 @@ type additionalProperties map[string]*string
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tokName := ""
 	tokValue := ""
-	for t, err := d.Token(); err == nil; t, err = d.Token() {
+	for {
+		t, err := d.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = strings.ToLower(tt.Name.Local)

--- a/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
+++ b/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
@@ -29,9 +29,6 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if tokName == "" {
 				continue
 			}
-			if *ap == nil {
-				*ap = additionalProperties{}
-			}
 			tokValue = string(tt)
 		case xml.EndElement:
 			if tokName == "" {

--- a/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
+++ b/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
@@ -10,7 +10,9 @@ package azblob
 
 import (
 	"encoding/xml"
+	"errors"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"io"
 	"strings"
 )
 
@@ -20,7 +22,13 @@ type additionalProperties map[string]*string
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tokName := ""
 	tokValue := ""
-	for t, err := d.Token(); err == nil; t, err = d.Token() {
+	for {
+		t, err := d.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return err
+		}
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = strings.ToLower(tt.Name.Local)

--- a/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
+++ b/packages/autorest.go/test/storage/azblob/zz_xml_helper.go
@@ -10,6 +10,7 @@ package azblob
 
 import (
 	"encoding/xml"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"strings"
 )
 
@@ -18,11 +19,12 @@ type additionalProperties map[string]*string
 // UnmarshalXML implements the xml.Unmarshaler interface for additionalProperties.
 func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	tokName := ""
+	tokValue := ""
 	for t, err := d.Token(); err == nil; t, err = d.Token() {
 		switch tt := t.(type) {
 		case xml.StartElement:
 			tokName = strings.ToLower(tt.Name.Local)
-			break
+			tokValue = ""
 		case xml.CharData:
 			if tokName == "" {
 				continue
@@ -30,10 +32,16 @@ func (ap *additionalProperties) UnmarshalXML(d *xml.Decoder, start xml.StartElem
 			if *ap == nil {
 				*ap = additionalProperties{}
 			}
-			s := string(tt)
-			(*ap)[tokName] = &s
+			tokValue = string(tt)
+		case xml.EndElement:
+			if tokName == "" {
+				continue
+			}
+			if *ap == nil {
+				*ap = additionalProperties{}
+			}
+			(*ap)[tokName] = to.Ptr(tokValue)
 			tokName = ""
-			break
 		}
 	}
 	return nil


### PR DESCRIPTION
Use the empty string (not nil) if the key has no value.

Codegen fix for https://github.com/Azure/azure-sdk-for-go/issues/21887