### PR TITLE
Update CI to latest versions of Go and golangci-lint

### DIFF
--- a/eng/pipelines/ci-go.yml
+++ b/eng/pipelines/ci-go.yml
@@ -28,9 +28,9 @@ jobs:
 
     strategy:
       matrix:
-        Linux_Go120:
+        Linux_Go121:
           vm.image: "ubuntu-22.04"
-          go.version: "1.20.3"
+          go.version: "1.21.4"
 
     pool:
       vmImage: "$(vm.image)"

--- a/eng/pipelines/ci-gotest.yml
+++ b/eng/pipelines/ci-gotest.yml
@@ -8,6 +8,8 @@ trigger:
   paths:
     exclude:
       - packages/autorest.go
+      - packages/codegen.go
+      - packages/codemodel.go
       - packages/typespec-go
 
 pr:
@@ -20,6 +22,8 @@ pr:
   paths:
     exclude:
       - packages/autorest.go
+      - packages/codegen.go
+      - packages/codemodel.go
       - packages/typespec-go
 
 jobs:
@@ -28,9 +32,9 @@ jobs:
 
     strategy:
       matrix:
-        Linux_Go120:
+        Linux_Go121:
           vm.image: "ubuntu-22.04"
-          go.version: "1.20.3"
+          go.version: "1.21.4"
 
     pool:
       vmImage: "$(vm.image)"

--- a/eng/pipelines/ci-typespec.yml
+++ b/eng/pipelines/ci-typespec.yml
@@ -30,9 +30,9 @@ jobs:
 
     strategy:
       matrix:
-        Linux_Go120:
+        Linux_Go121:
           vm.image: "ubuntu-22.04"
-          go.version: "1.20.3"
+          go.version: "1.21.4
 
     pool:
       vmImage: "$(vm.image)"

--- a/eng/pipelines/ci-typespec.yml
+++ b/eng/pipelines/ci-typespec.yml
@@ -43,4 +43,4 @@ jobs:
           NodeVersion: "18.x"
           GoVersion: "$(go.version)"
 
-      - template: ../steps/build-test-gotest.yaml
+      - template: ../steps/build-test-typespec.yaml

--- a/eng/pipelines/publish-dev-release-go.yml
+++ b/eng/pipelines/publish-dev-release-go.yml
@@ -8,7 +8,7 @@ steps:
   - template: ../steps/set-env.yaml
     parameters:
       NodeVersion: "18.x"
-      GoVersion: "1.20.3"
+      GoVersion: "1.21.4"
 
   - template: ../steps/build-test-go.yaml
 

--- a/eng/pipelines/publish-release-go.yml
+++ b/eng/pipelines/publish-release-go.yml
@@ -8,7 +8,7 @@ steps:
   - template: ../steps/set-env.yaml
     parameters:
       NodeVersion: "18.x"
-      GoVersion: "1.20.3"
+      GoVersion: "1.21.4"
 
   - template: ../steps/build-test-go.yaml
 

--- a/eng/pipelines/publish-release-gotest.yml
+++ b/eng/pipelines/publish-release-gotest.yml
@@ -8,7 +8,7 @@ steps:
   - template: ../steps/set-env.yaml
     parameters:
       NodeVersion: "18.x"
-      GoVersion: "1.20.3"
+      GoVersion: "1.21.4"
 
   - template: ../steps/build-test-gotest.yaml
 

--- a/eng/steps/build-test-go.yaml
+++ b/eng/steps/build-test-go.yaml
@@ -26,7 +26,7 @@ steps:
       go version
       go install github.com/jstemmer/go-junit-report@v1.0.0
       go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@latest
-      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1
+      curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
       ~/go/bin/golangci-lint --version
     displayName: "Install Dependencies"
     workingDirectory: "${{ parameters.GoTestPath }}"

--- a/eng/steps/set-env.yaml
+++ b/eng/steps/set-env.yaml
@@ -1,6 +1,6 @@
 parameters:
   NodeVersion: "18.x"
-  GoVersion: "1.20.3"
+  GoVersion: "1.21.4"
 
 steps:
   - task: NodeTool@0


### PR DESCRIPTION
Add codegen.go and codemodel.go to the exclusions list for gotest as it doesn't rely on them at present.