### PR TITLE
Make discriminatorValue a LiteralValue

### DIFF
--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -5,7 +5,7 @@
 
 import * as go from '../../codemodel.go/src/gocodemodel.js';
 import { values } from '@azure-tools/linq';
-import { contentPreamble, getParentImport } from './helpers.js';
+import { contentPreamble, formatLiteralValue, getParentImport } from './helpers.js';
 import { ImportManager } from './imports.js';
 
 // Creates the content in polymorphic_helpers.go
@@ -115,9 +115,9 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
       text += `\tvar b ${prefix}${interfaceType.name}\n`;
       text += `\tswitch m["${interfaceType.discriminatorField}"] {\n`;
       for (const possibleType of interfaceType.possibleTypes) {
-        let disc = possibleType.discriminatorValue;
+        let disc = formatLiteralValue(possibleType.discriminatorValue!);
         // when the discriminator value is an enum, cast the const as a string
-        if (disc![0] !== '"') {
+        if (go.isConstantType(possibleType.discriminatorValue!.type)) {
           disc = `string(${prefix}${disc})`;
         }
         text += `\tcase ${disc}:\n`;

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -135,7 +135,7 @@ export interface PolymorphicType extends StructType {
   // the value in the JSON that indicates what type was sent over the wire (e.g. goblin, salmon, shark)
   // note that for "root" types (Fish), there is no discriminatorValue. however, "sub-root" types (e.g. Salmon)
   // will have this populated.
-  discriminatorValue?: string;
+  discriminatorValue?: LiteralValue;
 }
 
 // PossibleType describes what can be modeled e.g. in an OpenAPI specification
@@ -961,7 +961,7 @@ export class CodeModel implements CodeModel {
   
     this.interfaceTypes.sort((a: InterfaceType, b: InterfaceType) => { return sortAscending(a.name, b.name); });
     for (const iface of this.interfaceTypes) {
-      iface.possibleTypes.sort((a: PolymorphicType, b: PolymorphicType) => { return sortAscending(a.discriminatorValue!, b.discriminatorValue!); });
+      iface.possibleTypes.sort((a: PolymorphicType, b: PolymorphicType) => { return sortAscending(a.discriminatorValue!.literal, b.discriminatorValue!.literal); });
     }
   
     this.models.sort((a: ModelType | PolymorphicType, b: ModelType | PolymorphicType) => { return sortAscending(a.name, b.name); });


### PR DESCRIPTION
Previously, the code model was leaking an implementation detail that was specific to how M4 models the discriminator value. That's now been moved to the M4 adapter.