### PR TITLE
Move auto-generated field comments to codegen.go

### DIFF
--- a/packages/autorest.go/src/generator/generator.ts
+++ b/packages/autorest.go/src/generator/generator.ts
@@ -207,7 +207,7 @@ export async function generateCode(host: AutorestExtensionHost) {
     }
   } catch (E) {
     if (debug) {
-      console.error(`${__filename} - FAILURE  ${JSON.stringify(E)} ${(<Error>E).stack}`);
+      console.error(`${import.meta.url} - FAILURE  ${JSON.stringify(E)} ${(<Error>E).stack}`);
     }
     throw E;
   }

--- a/packages/autorest.go/src/transform/helpers.ts
+++ b/packages/autorest.go/src/transform/helpers.ts
@@ -192,11 +192,6 @@ export function formatConstantValue(schema: m4.ConstantSchema): string {
   return schema.value.value;
 }
 
-//  returns true if the object is used for output only
-export function isOutputOnly(obj: m4.ObjectSchema): boolean {
-  return !values(obj.usage).any((u) => { return u === m4.SchemaContext.Input; });
-}
-
 // aggregate the properties from the provided type and its parent types
 export function aggregateProperties(obj: m4.ObjectSchema): Array<m4.Property> {
   const allProps = new Array<m4.Property>();

--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -86,28 +86,9 @@ async function process(session: Session<m4.CodeModel>) {
     }
 
     for (const prop of values(obj.properties)) {
-      const descriptionMods = new Array<string>();
-      if (prop.readOnly) {
-        descriptionMods.push('READ-ONLY');
-      } else if (prop.required && (prop.schema.type !== m4.SchemaType.Constant || helpers.isOutputOnly(obj))) {
-        descriptionMods.push('REQUIRED');
-      } else if (prop.required && prop.schema.type === m4.SchemaType.Constant) {
-        descriptionMods.push('CONSTANT');
-      }
-      if (prop.required && prop.schema.type === m4.SchemaType.Constant && !helpers.isOutputOnly(obj)) {
-        // add a comment with the const value for const properties that are sent over the wire
-        if (prop.language.go!.description) {
-          prop.language.go!.description += '<br/>';
-        }
-        prop.language.go!.description += `Field has constant value ${helpers.formatConstantValue(<m4.ConstantSchema>prop.schema)}, any specified value is ignored.`;
-      }
       if (prop.language.go!.description) {
-        descriptionMods.push(parseComments(prop.language.go!.description));
-      } else if (prop.schema.language.go!.rawJSONAsBytes) {
-        // add a basic description if one isn't available
-        descriptionMods.push('The contents of this field are raw JSON.');
+        prop.language.go!.description = parseComments(prop.language.go!.description);
       }
-      prop.language.go!.description = descriptionMods.join('; ');
       const details = <m4.Language>prop.schema.language.go;
       details.name = `${schemaTypeToGoType(session.model, prop.schema, 'InBody')}`;
       prop.schema = substitueDiscriminator(prop);

--- a/packages/autorest.go/test/synapse/azartifacts/zz_models.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_models.go
@@ -27622,7 +27622,8 @@ type Workspace struct {
 
 // WorkspaceIdentity - Identity properties of the workspace resource.
 type WorkspaceIdentity struct {
-	// REQUIRED; The identity type. Currently the only supported type is 'SystemAssigned'.
+	// CONSTANT; The identity type. Currently the only supported type is 'SystemAssigned'.
+	// Field has constant value "SystemAssigned", any specified value is ignored.
 	Type *string
 
 	// READ-ONLY; The principal id of the identity.

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -309,10 +309,15 @@ export function formatValue(paramName: string, type: go.PossibleType, imports: I
 // returns the clientDefaultValue of the specified param.
 // this is usually the value in quotes (i.e. a string) however
 // it could also be a constant.
-export function formatLiteralValue(value: go.LiteralValue): string {
+// specify withCast: false for doc comments
+export function formatLiteralValue(value: go.LiteralValue, withCast: boolean): string {
   if (go.isConstantType(value.type)) {
     return (<go.ConstantValue>value.literal).valueName;
   } else if (go.isPrimitiveType(value.type)) {
+    // if it's a string, we want the uncasted version to include quotes
+    if (!withCast && value.type.typeName !== 'string') {
+      return `${value.literal}`;
+    }
     switch (value.type.typeName) {
       case 'float32':
         return `float32(${value.literal})`;

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -309,7 +309,6 @@ export function formatValue(paramName: string, type: go.PossibleType, imports: I
 // returns the clientDefaultValue of the specified param.
 // this is usually the value in quotes (i.e. a string) however
 // it could also be a constant.
-// specify withCast: false for doc comments
 export function formatLiteralValue(value: go.LiteralValue, withCast: boolean): string {
   if (go.isConstantType(value.type)) {
     return (<go.ConstantValue>value.literal).valueName;

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -703,7 +703,7 @@ function createProtocolRequest(client: go.Client, method: go.Method | go.NextPag
     let body = helpers.getParamName(bodyParam);
     if (go.isLiteralValue(bodyParam.type)) {
       // if the value is constant, embed it directly
-      body = helpers.formatLiteralValue(bodyParam.type);
+      body = helpers.formatLiteralValue(bodyParam.type, true);
     } else if (bodyParam.bodyFormat === 'XML' && go.isSliceType(bodyParam.type)) {
       // for XML payloads, create a wrapper type if the payload is an array
       imports.add('encoding/xml');
@@ -843,7 +843,7 @@ function createProtocolRequest(client: go.Client, method: go.Method | go.NextPag
 
 function emitClientSideDefault(param: go.HeaderParameter | go.QueryParameter, csd: go.ClientSideDefault, setterFormat: (name: string, val: string) => string, imports: ImportManager): string {
   const defaultVar = uncapitalize(param.paramName) + 'Default';
-  let text = `\t${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue)}\n`;
+  let text = `\t${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
   text += `\tif options != nil && options.${capitalize(param.paramName)} != nil {\n`;
   text += `\t\t${defaultVar} = *options.${capitalize(param.paramName)}\n`;
   text += '}\n';

--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -115,7 +115,7 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
       text += `\tvar b ${prefix}${interfaceType.name}\n`;
       text += `\tswitch m["${interfaceType.discriminatorField}"] {\n`;
       for (const possibleType of interfaceType.possibleTypes) {
-        let disc = formatLiteralValue(possibleType.discriminatorValue!);
+        let disc = formatLiteralValue(possibleType.discriminatorValue!, true);
         // when the discriminator value is an enum, cast the const as a string
         if (go.isConstantType(possibleType.discriminatorValue!.type)) {
           disc = `string(${prefix}${disc})`;

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -114,11 +114,25 @@ export interface ModelType extends StructType {
 
   annotations: ModelAnnotations;
 
+  usage: UsageFlags;
+
   xml?: XMLInfo;
 }
 
 export interface ModelAnnotations {
   omitSerDeMethods: boolean;
+}
+
+// UsageFlags are bit flags indicating how a model/polymorphic type is used
+export enum UsageFlags {
+  // the type is unreferenced
+  None = 0,
+
+  // the type is received over the wire
+  Input = 1,
+
+  // the type is sent over the wire
+  Output = 2
 }
 
 // PolymorphicType is a discriminated type
@@ -128,6 +142,8 @@ export interface PolymorphicType extends StructType {
   format: 'json';
 
   annotations: ModelAnnotations;
+
+  usage: UsageFlags;
 
   // this denotes the polymorphic interface this type implements
   interface: InterfaceType;
@@ -1125,10 +1141,11 @@ export class StructField implements StructField {
 }
 
 export class ModelType implements ModelType {
-  constructor(name: string, format: ModelFormat, annotations: ModelAnnotations) {
+  constructor(name: string, format: ModelFormat, annotations: ModelAnnotations, usage: UsageFlags) {
     this.name = name;
     this.format = format;
     this.annotations = annotations;
+    this.usage = usage;
     this.fields = new Array<ModelField>();
   }
 }
@@ -1159,10 +1176,11 @@ export class ModelFieldAnnotations implements ModelFieldAnnotations {
 }
 
 export class PolymorphicType implements PolymorphicType {
-  constructor(name: string, iface: InterfaceType, annotations: ModelAnnotations) {
+  constructor(name: string, iface: InterfaceType, annotations: ModelAnnotations, usage: UsageFlags) {
     this.name = name;
     this.interface = iface;
     this.annotations = annotations;
+    this.usage = usage;
     this.fields = new Array<ModelField>();
   }
 }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -343,6 +343,13 @@ export class typeAdapter {
       return <go.ModelType | go.PolymorphicType>modelType;
     }
   
+    let usage = go.UsageFlags.None;
+    if (model.usage & tsp.UsageFlags.Input) {
+      usage = go.UsageFlags.Input;
+    }
+    if (model.usage & tsp.UsageFlags.Output) {
+      usage |= go.UsageFlags.Output;
+    }
     // TODO: what's the extension equivalent in TS?
     const annotations = new go.ModelAnnotations(false);
     if (model.discriminatedSubtypes || model.discriminatorValue) {
@@ -375,11 +382,11 @@ export class typeAdapter {
         }
       }
 
-      modelType = new go.PolymorphicType(model.name, iface, annotations);
+      modelType = new go.PolymorphicType(model.name, iface, annotations, usage);
       (<go.PolymorphicType>modelType).discriminatorValue = discriminatorLiteral;
     } else {
       // TODO: hard-coded format
-      modelType = new go.ModelType(model.name, 'json', annotations);
+      modelType = new go.ModelType(model.name, 'json', annotations, usage);
       // polymorphic types don't have XMLInfo
       // TODO: XMLInfo
     }

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_models.go
@@ -9,7 +9,7 @@ package arraygroup
 
 // Array inner model
 type InnerModel struct {
-	// Required string property
+	// REQUIRED; Required string property
 	Property *string
 	Children []InnerModel
 }

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_models.go
@@ -9,7 +9,7 @@ package dictionarygroup
 
 // Dictionary inner model
 type InnerModel struct {
-	// Required string property
+	// REQUIRED; Required string property
 	Property *string
 	Children map[string]*InnerModel
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_models.go
@@ -9,10 +9,11 @@ package enumdiscgroup
 
 // Cobra model
 type Cobra struct {
-	// discriminator property
+	// CONSTANT; discriminator property
+	// Field has constant value SnakeKindCobra, any specified value is ignored.
 	Kind *SnakeKind
 
-	// Length of the snake
+	// REQUIRED; Length of the snake
 	Length *int32
 }
 
@@ -26,10 +27,10 @@ func (c *Cobra) GetSnake() *Snake {
 
 // Test extensible enum type for discriminator
 type Dog struct {
-	// discriminator property
+	// REQUIRED; discriminator property
 	Kind *DogKind
 
-	// Weight of the dog
+	// REQUIRED; Weight of the dog
 	Weight *int32
 }
 
@@ -38,10 +39,11 @@ func (d *Dog) GetDog() *Dog { return d }
 
 // Golden dog model
 type Golden struct {
-	// discriminator property
+	// CONSTANT; discriminator property
+	// Field has constant value DogKindGolden, any specified value is ignored.
 	Kind *DogKind
 
-	// Weight of the dog
+	// REQUIRED; Weight of the dog
 	Weight *int32
 }
 
@@ -55,10 +57,10 @@ func (g *Golden) GetDog() *Dog {
 
 // Test fixed enum type for discriminator
 type Snake struct {
-	// discriminator property
+	// REQUIRED; discriminator property
 	Kind *SnakeKind
 
-	// Length of the snake
+	// REQUIRED; Length of the snake
 	Length *int32
 }
 

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_models.go
@@ -9,18 +9,27 @@ package nodiscgroup
 
 // The second level model in the normal multiple levels inheritance.
 type Cat struct {
-	Age  *int32
+	// REQUIRED
+	Age *int32
+
+	// REQUIRED
 	Name *string
 }
 
 // This is base model for not-discriminated normal multiple levels inheritance.
 type Pet struct {
+	// REQUIRED
 	Name *string
 }
 
 // The third level model in the normal multiple levels inheritance.
 type Siamese struct {
-	Age   *int32
-	Name  *string
+	// REQUIRED
+	Age *int32
+
+	// REQUIRED
+	Name *string
+
+	// REQUIRED
 	Smart *bool
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_models.go
@@ -14,6 +14,7 @@ type Element struct {
 
 // extension
 type Extension struct {
+	// REQUIRED
 	Level     *int32
 	Extension []Extension
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_models.go
@@ -9,7 +9,10 @@ package singlediscgroup
 
 // This is base model for polymorphic single level inheritance with a discriminator.
 type Bird struct {
-	Kind     *string
+	// REQUIRED
+	Kind *string
+
+	// REQUIRED
 	Wingspan *int32
 }
 
@@ -18,7 +21,10 @@ func (b *Bird) GetBird() *Bird { return b }
 
 // Define a base class in the legacy way. Discriminator property is not explicitly defined in the model.
 type Dinosaur struct {
+	// REQUIRED
 	Kind *string
+
+	// REQUIRED
 	Size *int32
 }
 
@@ -27,7 +33,10 @@ func (d *Dinosaur) GetDinosaur() *Dinosaur { return d }
 
 // The second level model in polymorphic single levels inheritance which contains references to other polymorphic instances.
 type Eagle struct {
-	Kind     *string
+	// CONSTANT; undefinedField has constant value "eagle", any specified value is ignored.
+	Kind *string
+
+	// REQUIRED
 	Wingspan *int32
 	Friends  []BirdClassification
 	Hate     map[string]BirdClassification
@@ -44,7 +53,10 @@ func (e *Eagle) GetBird() *Bird {
 
 // The second level model in polymorphic single level inheritance.
 type Goose struct {
-	Kind     *string
+	// CONSTANT; undefinedField has constant value "goose", any specified value is ignored.
+	Kind *string
+
+	// REQUIRED
 	Wingspan *int32
 }
 
@@ -58,7 +70,10 @@ func (g *Goose) GetBird() *Bird {
 
 // The second level model in polymorphic single level inheritance.
 type SeaGull struct {
-	Kind     *string
+	// CONSTANT; undefinedField has constant value "seagull", any specified value is ignored.
+	Kind *string
+
+	// REQUIRED
 	Wingspan *int32
 }
 
@@ -72,7 +87,10 @@ func (s *SeaGull) GetBird() *Bird {
 
 // The second level model in polymorphic single level inheritance.
 type Sparrow struct {
-	Kind     *string
+	// CONSTANT; undefinedField has constant value "sparrow", any specified value is ignored.
+	Kind *string
+
+	// REQUIRED
 	Wingspan *int32
 }
 
@@ -86,7 +104,10 @@ func (s *Sparrow) GetBird() *Bird {
 
 // The second level legacy model in polymorphic single level inheritance.
 type TRex struct {
+	// REQUIRED
 	Kind *string
+
+	// REQUIRED
 	Size *int32
 }
 

--- a/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_models.go
@@ -9,15 +9,18 @@ package usagegroup
 
 // Record used both as operation parameter and return type
 type InputOutputRecord struct {
+	// REQUIRED
 	RequiredProp *string
 }
 
 // Record used in operation parameters
 type InputRecord struct {
+	// REQUIRED
 	RequiredProp *string
 }
 
 // Record used in operation return type
 type OutputRecord struct {
+	// REQUIRED
 	RequiredProp *string
 }

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_models.go
@@ -9,18 +9,18 @@ package visibilitygroup
 
 // Output model with visibility properties.
 type VisibilityModel struct {
-	// Required string[], illustrating a create property.
+	// REQUIRED; Required string[], illustrating a create property.
 	CreateProp []*string
 
-	// Required bool, illustrating a delete property.
+	// REQUIRED; Required bool, illustrating a delete property.
 	DeleteProp *bool
 
-	// Required int32, illustrating a query property.
+	// REQUIRED; Required int32, illustrating a query property.
 	QueryProp *int32
 
-	// Required string, illustrating a readonly property.
+	// REQUIRED; Required string, illustrating a readonly property.
 	ReadProp *string
 
-	// Required int32[], illustrating a update property.
+	// REQUIRED; Required int32[], illustrating a update property.
 	UpdateProp []*int32
 }


### PR DESCRIPTION
This required adding usage flags to the Go code model to describe if a model is input/output/both. This also fixed a corner-case where a field was incorrectly flagged as REQUIRED when it's really CONSTANT. Replaced __filename with the ES module equivalent.