### PR TITLE
Add String methods to the internal time helpers

### DIFF
--- a/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc1123.go
@@ -45,6 +45,10 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	return err
 }
 
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}
+
 func populateDateTimeRFC1123(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc1123.go
@@ -45,6 +45,10 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	return err
 }
 
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}
+
 func populateDateTimeRFC1123(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/datetimerfc1123group/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/datetimerfc1123group/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/storage/azblob/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/storage/azblob/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
@@ -61,6 +61,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	return err
 }
 
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}
+
 func populateDateTimeRFC3339(m map[string]any, k string, t *time.Time) {
 	if t == nil {
 		return

--- a/packages/autorest.go/test/tables/aztables/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/tables/aztables/zz_time_rfc1123.go
@@ -40,3 +40,7 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}

--- a/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
@@ -56,3 +56,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -269,11 +269,7 @@ function formatHeaderResponseValue(headerResp: go.HeaderResponse | go.HeaderMapR
   } else if (go.isBytesType(headerResp.type)) {
     // ByteArray is a base-64 encoded value in string format
     imports.add('encoding/base64');
-    let byteFormat = 'Std';
-    if (headerResp.type.encoding === 'URL') {
-      byteFormat = 'RawURL';
-    }
-    text += `\t\t${name}, err := base64.${byteFormat}Encoding.DecodeString(val)\n`;
+    text += `\t\t${name}, err := base64.${helpers.formatBytesEncoding(headerResp.type.encoding)}Encoding.DecodeString(val)\n`;
     byRef = '';
   } else if (go.isLiteralValue(headerResp.type)) {
     text += `\t\t${respObj}.${headerResp.fieldName} = &val\n`;

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -103,6 +103,10 @@ func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
 	*t = dateTimeRFC1123(p)
 	return err
 }
+
+func (t dateTimeRFC1123) String() string {
+	return time.Time(t).Format(time.RFC1123)
+}
 `;
   if (needsPopulate) {
     text +=
@@ -196,6 +200,10 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	p, err := time.Parse(layout, strings.ToUpper(value))
 	*t = dateTimeRFC3339(p)
 	return err
+}
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
 }
 `;
     if (needsPopulate) {

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
@@ -55,3 +55,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
@@ -55,3 +55,7 @@ func (t *dateTimeRFC3339) Parse(layout, value string) error {
 	*t = dateTimeRFC3339(p)
 	return err
 }
+
+func (t dateTimeRFC3339) String() string {
+	return time.Time(t).Format(time.RFC3339Nano)
+}


### PR DESCRIPTION
Consolidated some duplicate code for converting Go code model encoding type to the name used in the standard library.
Fix encoding slices of time types used in header/path/query params (will be relevant with upcoming tsp work).