### PR TITLE
Rename StandardType to QualifiedType

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -119,7 +119,7 @@ function populateMethod(op: m4.Operation, method: go.Method | go.NextPageMethod,
 function adaptHeaderType(schema: m4.Schema, forParam: boolean): go.HeaderType {
   // for header params, we never pass the element type by pointer
   const type = adaptPossibleType(schema, forParam);
-  if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isStandardType(type)) {
+  if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
     throw new Error(`unexpected header parameter type ${schema.type}`);
   }
   return type;
@@ -127,7 +127,7 @@ function adaptHeaderType(schema: m4.Schema, forParam: boolean): go.HeaderType {
 
 function adaptPathParameterType(schema: m4.Schema): go.PathParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isStandardType(type)) {
+  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected path parameter type ${schema.type}`);
   }
   return type;
@@ -135,7 +135,7 @@ function adaptPathParameterType(schema: m4.Schema): go.PathParameterType {
 
 function adaptQueryParameterType(schema: m4.Schema): go.QueryParameterType {
   const type = adaptPossibleType(schema);
-  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isStandardType(type)) {
+  if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
     throw new Error(`unexpected query parameter type ${schema.type}`);
   } else if (go.isSliceType(type)) {
     type.elementTypeByValue = true;
@@ -232,7 +232,7 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     respEnv.result = new go.HeadAsBooleanResult(resultProp.language.go!.name);
   } else if (!resultProp.language.go!.embeddedType) {
     const resultType = adaptPossibleType(resultProp.schema);
-    if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isStandardType(resultType)) {
+    if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
       throw new Error(`invalid monomorphic result type ${resultType}`);
     }
     respEnv.result = new go.MonomorphicResult(resultProp.language.go!.name, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol), resultType, resultProp.language.go!.byValue);

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -343,7 +343,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (binaryType) {
         return binaryType;
       }
-      binaryType = new go.StandardType('io.ReadSeekCloser', 'io');
+      binaryType = new go.QualifiedType('ReadSeekCloser', 'io');
       types.set(m4.SchemaType.Binary, binaryType);
       return binaryType;
     }

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -325,14 +325,14 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
         content += '\t\t\tcontent, err = io.ReadAll(part)\n';
         content += '\t\t\tif err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n';
         let assignedValue: string;
-        if (go.isStandardType(param.type) && param.type.typeName === 'io.ReadSeekCloser') {
+        if (go.isQualifiedType(param.type) && param.type.typeName === 'ReadSeekCloser') {
           imports.add('bytes');
           imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
           assignedValue = 'streaming.NopCloser(bytes.NewReader(content))';
         } else if (go.isConstantType(param.type) || (go.isPrimitiveType(param.type) && param.type.typeName === 'string')) {
           assignedValue = 'string(content)';
         } else if (go.isSliceType(param.type)) {
-          if (go.isStandardType(param.type.elementType) && param.type.elementType.typeName === 'io.ReadSeekCloser') {
+          if (go.isQualifiedType(param.type.elementType) && param.type.elementType.typeName === 'ReadSeekCloser') {
             imports.add('bytes');
             imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
             assignedValue = `append(${param.paramName}, streaming.NopCloser(bytes.NewReader(content)))`;

--- a/packages/codegen.go/src/imports.ts
+++ b/packages/codegen.go/src/imports.ts
@@ -55,7 +55,7 @@ export class ImportManager {
       this.addImportForType(type.valueType);
     } else if (go.isSliceType(type)) {
       this.addImportForType(type.elementType);
-    } else if (go.isStandardType(type)) {
+    } else if (go.isQualifiedType(type)) {
       this.add(type.packageName);
     } else if (go.isTimeType(type)) {
       this.add('time');

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -233,7 +233,7 @@ export class clientAdapter {
       respEnv.result.description = bodyResponses[0].description;
     } else {
       const resultType = this.ta.getPossibleType(bodyResponses[0], false, false);
-      if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isStandardType(resultType)) {
+      if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
         throw new Error(`invalid monomorphic result type ${go.getTypeDeclaration(resultType)}`);
       }
       respEnv.result = new go.MonomorphicResult('Value', 'JSON', resultType, isTypePassedByValue(bodyResponses[0]));
@@ -265,7 +265,7 @@ export class clientAdapter {
   private adaptHeaderType(sdkType: tcgc.SdkType, forParam: boolean): go.HeaderType {
     // for header params, we never pass the element type by pointer
     const type = this.ta.getPossibleType(sdkType, forParam, false);
-    if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isStandardType(type)) {
+    if (go.isInterfaceType(type) || go.isMapType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type) || go.isQualifiedType(type)) {
       throw new Error(`unexpected header parameter type ${sdkType.kind}`);
     }
     return type;
@@ -273,7 +273,7 @@ export class clientAdapter {
   
   private adaptPathParameterType(sdkType: tcgc.SdkType): go.PathParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isStandardType(type)) {
+    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
       throw new Error(`unexpected path parameter type ${sdkType.kind}`);
     }
     return type;
@@ -281,7 +281,7 @@ export class clientAdapter {
   
   private adaptQueryParameterType(sdkType: tcgc.SdkType): go.QueryParameterType {
     const type = this.ta.getPossibleType(sdkType, false, false);
-    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isStandardType(type)) {
+    if (go.isMapType(type) || go.isInterfaceType(type) || go.isModelType(type) || go.isPolymorphicType(type) || go.isSliceType(type)  || go.isQualifiedType(type)) {
       throw new Error(`unexpected query parameter type ${sdkType.kind}`);
     } else if (go.isSliceType(type)) {
       type.elementTypeByValue = true;


### PR DESCRIPTION
Expand usage beyond the standard library, e.g. ETag from azcore. Remove the need to duplicate the package name in the type name. It will be extracted in calls to getTypeDeclaration().