### PR TITLE
Add coverage for tsp bodyoptionalitygroup

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -221,8 +221,8 @@ importers:
         specifier: '>=0.37.2 <1.0.0'
         version: 0.37.2(@typespec/compiler@0.52.0-dev.18)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)
       '@azure-tools/typespec-client-generator-core':
-        specifier: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz
-        version: '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%25252525252525252Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz(@typespec/compiler@0.52.0-dev.18)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)'
+        specifier: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz
+        version: '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%252Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz(@typespec/compiler@0.52.0-dev.18)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)'
       '@typespec/compiler':
         specifier: '>=0.52.0-dev.18 <1.0.0'
         version: 0.52.0-dev.18
@@ -8923,17 +8923,17 @@ packages:
       commander: 9.5.0
     dev: false
 
-  '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%25252525252525252Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz(@typespec/compiler@0.52.0-dev.18)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)':
-    resolution: {tarball: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz}
-    id: '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%25252525252525252Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz'
+  '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%252Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz(@typespec/compiler@0.52.0-dev.18)(@typespec/http@0.51.0)(@typespec/rest@0.51.0)(@typespec/versioning@0.51.0)':
+    resolution: {tarball: https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz}
+    id: '@artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%252Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz'
     name: '@azure-tools/typespec-client-generator-core'
-    version: 0.38.0-pr-6.20240116.7
+    version: 0.39.0-pr-6.20240126.10
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.51.0
-      '@typespec/http': ~0.51.0
-      '@typespec/rest': ~0.51.0
-      '@typespec/versioning': ~0.51.0
+      '@typespec/compiler': ~0.52.0
+      '@typespec/http': ~0.52.0
+      '@typespec/rest': ~0.52.0
+      '@typespec/versioning': ~0.52.0
     dependencies:
       '@typespec/compiler': 0.52.0-dev.18
       '@typespec/http': 0.51.0(@typespec/compiler@0.52.0-dev.18)

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -34,7 +34,7 @@ const cadlRanch = {
   'bytesgroup': ['encode/bytes'],
   'datetimegroup': ['encode/datetime', 'slice-elements-byval=true'],
   'durationgroup': ['encode/duration'],
-  'bodyoptionalgroup': ['parameters/body-optionality'],   // missing tests
+  'bodyoptionalgroup': ['parameters/body-optionality'],
   'collectionfmtgroup': ['parameters/collection-format'], // missing tests
   //'spreadgroup': ['parameters/spread'], // needs more investigation
   //'contentneggroup': ['payload/content-negotiation'], // https://github.com/Azure/typespec-azure/issues/107

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -65,7 +65,7 @@
     "@azure-tools/naming.go": "workspace:*",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/typespec-azure-core": ">=0.37.2 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQxMDI3MS9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.38.0-pr-6.20240116.7.tgz",
+    "@azure-tools/typespec-client-generator-core": "https://artprodcus3.artifacts.visualstudio.com/A0fb41ef4-5012-48a9-bf39-4ee3de03ee35/29ec6040-b234-4e31-b139-33dc4287b756/_apis/artifact/cGlwZWxpbmVhcnRpZmFjdDovL2F6dXJlLXNkay9wcm9qZWN0SWQvMjllYzYwNDAtYjIzNC00ZTMxLWIxMzktMzNkYzQyODdiNzU2L2J1aWxkSWQvMzQ0NDU5Ny9hcnRpZmFjdE5hbWUvcGFja2FnZXM1/content?format=file&subPath=%2Fazure-tools-typespec-client-generator-core-0.39.0-pr-6.20240126.10.tgz",
     "@typespec/compiler": ">=0.52.0-dev.18 <1.0.0",
     "@typespec/http": ">=0.51.0 <1.0.0",
     "@typespec/rest": ">=0.51.0 <1.0.0",

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -76,9 +76,9 @@ export class clientAdapter {
       method = new go.Method(methodName, goClient, sdkMethod.operation.path, sdkMethod.operation.verb, getStatusCodes(sdkMethod.operation), naming);
     } else if (sdkMethod.kind === 'paging') {
       method = new go.PageableMethod(methodName, goClient, sdkMethod.operation.path, sdkMethod.operation.verb, getStatusCodes(sdkMethod.operation), naming);
-      if (sdkMethod.nextLinkLogicalPath) {
-        // TODO: this assumes that nextLink is the first element. and what does it mean to have more than one entry?
-        (<go.PageableMethod>method).nextLinkName = capitalize(ensureNameCase(sdkMethod.nextLinkLogicalPath[0]));
+      if (sdkMethod.nextLinkPath) {
+        // TODO: handle nested next link
+        (<go.PageableMethod>method).nextLinkName = capitalize(ensureNameCase(sdkMethod.nextLinkPath));
       }
     } else {
       throw new Error(`method kind ${sdkMethod.kind} NYI`);

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_options.go
@@ -84,7 +84,7 @@ type ResponseBodyClientBase64URLOptions struct {
 }
 
 type ResponseBodyClientCustomContentTypeOptions struct {
-	Accept *string
+	// placeholder for future optional parameters
 }
 
 type ResponseBodyClientDefaultOptions struct {
@@ -92,5 +92,5 @@ type ResponseBodyClientDefaultOptions struct {
 }
 
 type ResponseBodyClientOctetStreamOptions struct {
-	Accept *string
+	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
@@ -122,11 +122,7 @@ func (client *ResponseBodyClient) customContentTypeCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	acceptDefault := "image/png"
-	if options != nil && options.Accept != nil {
-		acceptDefault = *options.Accept
-	}
-	req.Raw().Header["Accept"] = []string{acceptDefault}
+	req.Raw().Header["Accept"] = []string{"image/png"}
 	return req, nil
 }
 
@@ -202,11 +198,7 @@ func (client *ResponseBodyClient) octetStreamCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	acceptDefault := "application/octet-stream"
-	if options != nil && options.Accept != nil {
-		acceptDefault = *options.Accept
-	}
-	req.Raw().Header["Accept"] = []string{acceptDefault}
+	req.Raw().Header["Accept"] = []string{"application/octet-stream"}
 	return req, nil
 }
 

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/bodyoptionality_client_test.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/bodyoptionality_client_test.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package bodyoptionalgroup_test
+
+import (
+	"bodyoptionalgroup"
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodyOptionalityClient_RequiredExplicit(t *testing.T) {
+	client, err := bodyoptionalgroup.NewBodyOptionalityClient(nil)
+	require.NoError(t, err)
+	resp, err := client.RequiredExplicit(context.Background(), bodyoptionalgroup.BodyModel{
+		Name: to.Ptr("foo"),
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestBodyOptionalityClient_RequiredImplicit(t *testing.T) {
+	client, err := bodyoptionalgroup.NewBodyOptionalityClient(nil)
+	require.NoError(t, err)
+	resp, err := client.RequiredImplicit(context.Background(), bodyoptionalgroup.BodyModel{
+		Name: to.Ptr("foo"),
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/custom_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/custom_client.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package bodyoptionalgroup
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewBodyOptionalityClient(options *azcore.ClientOptions) (*BodyOptionalityClient, error) {
+	internal, err := newClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &BodyOptionalityClient{
+		internal: internal,
+	}, nil
+}
+
+func NewOptionalExplicitClient(options *azcore.ClientOptions) (*OptionalExplicitClient, error) {
+	internal, err := newClient(options)
+	if err != nil {
+		return nil, err
+	}
+	return &OptionalExplicitClient{
+		internal: internal,
+	}, nil
+}
+
+func newClient(options *azcore.ClientOptions) (*azcore.Client, error) {
+	return azcore.NewClient("bodyoptionalgroup", "v0.1.0", runtime.PipelineOptions{}, options)
+}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/go.mod
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/go.mod
@@ -2,10 +2,16 @@ module bodyoptionalgroup
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.0
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/go.sum
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/go.sum
@@ -3,10 +3,16 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.0/go.mod h1:uReU2sSxZExRPBAg3q
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.0 h1:d81/ng9rET2YqdVkVwkb6EXeRrLJIwyGnJcAlAWKwhs=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.0/go.mod h1:s4kgfzA0covAXNicZHDMN58jExvcng2mC/DepXiF1EI=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
 golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/optionalexplicit_client_test.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/optionalexplicit_client_test.go
@@ -1,0 +1,36 @@
+//go:build go1.18
+// +build go1.18
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package bodyoptionalgroup_test
+
+import (
+	"bodyoptionalgroup"
+	"context"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionalExplicitClient_Omit(t *testing.T) {
+	client, err := bodyoptionalgroup.NewOptionalExplicitClient(nil)
+	require.NoError(t, err)
+	resp, err := client.Omit(context.Background(), nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestOptionalExplicitClient_Set(t *testing.T) {
+	client, err := bodyoptionalgroup.NewOptionalExplicitClient(nil)
+	require.NoError(t, err)
+	resp, err := client.Set(context.Background(), &bodyoptionalgroup.OptionalExplicitClientSetOptions{
+		Body: &bodyoptionalgroup.BodyModel{
+			Name: to.Ptr("foo"),
+		},
+	})
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_optionalexplicit_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_optionalexplicit_client.go
@@ -21,9 +21,9 @@ type OptionalExplicitClient struct {
 	internal *azcore.Client
 }
 
-func (client *OptionalExplicitClient) Omit(ctx context.Context, body BodyModel, options *OptionalExplicitClientOmitOptions) (OptionalExplicitClientOmitResponse, error) {
+func (client *OptionalExplicitClient) Omit(ctx context.Context, options *OptionalExplicitClientOmitOptions) (OptionalExplicitClientOmitResponse, error) {
 	var err error
-	req, err := client.omitCreateRequest(ctx, body, options)
+	req, err := client.omitCreateRequest(ctx, options)
 	if err != nil {
 		return OptionalExplicitClientOmitResponse{}, err
 	}
@@ -39,22 +39,25 @@ func (client *OptionalExplicitClient) Omit(ctx context.Context, body BodyModel, 
 }
 
 // omitCreateRequest creates the Omit request.
-func (client *OptionalExplicitClient) omitCreateRequest(ctx context.Context, body BodyModel, options *OptionalExplicitClientOmitOptions) (*policy.Request, error) {
+func (client *OptionalExplicitClient) omitCreateRequest(ctx context.Context, options *OptionalExplicitClientOmitOptions) (*policy.Request, error) {
 	urlPath := "/parameters/body-optionality/optional-explicit/omit"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
-		return nil, err
+	if options != nil && options.Body != nil {
+		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }
 
-func (client *OptionalExplicitClient) Set(ctx context.Context, body BodyModel, options *OptionalExplicitClientSetOptions) (OptionalExplicitClientSetResponse, error) {
+func (client *OptionalExplicitClient) Set(ctx context.Context, options *OptionalExplicitClientSetOptions) (OptionalExplicitClientSetResponse, error) {
 	var err error
-	req, err := client.setCreateRequest(ctx, body, options)
+	req, err := client.setCreateRequest(ctx, options)
 	if err != nil {
 		return OptionalExplicitClientSetResponse{}, err
 	}
@@ -70,15 +73,18 @@ func (client *OptionalExplicitClient) Set(ctx context.Context, body BodyModel, o
 }
 
 // setCreateRequest creates the Set request.
-func (client *OptionalExplicitClient) setCreateRequest(ctx context.Context, body BodyModel, options *OptionalExplicitClientSetOptions) (*policy.Request, error) {
+func (client *OptionalExplicitClient) setCreateRequest(ctx context.Context, options *OptionalExplicitClientSetOptions) (*policy.Request, error) {
 	urlPath := "/parameters/body-optionality/optional-explicit/set"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"application/json"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
-		return nil, err
+	if options != nil && options.Body != nil {
+		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
+			return nil, err
+		}
+		return req, nil
 	}
 	return req, nil
 }

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
@@ -16,9 +16,9 @@ type BodyOptionalityClientRequiredImplicitOptions struct {
 }
 
 type OptionalExplicitClientOmitOptions struct {
-	// placeholder for future optional parameters
+	Body *BodyModel
 }
 
 type OptionalExplicitClientSetOptions struct {
-	// placeholder for future optional parameters
+	Body *BodyModel
 }


### PR DESCRIPTION
Update to latest TCGC which fixed an issue with optional bodies and constant accept header params.