### PR TITLE
Add single-client option for code generation

### DIFF
--- a/packages/autorest.go/.scripts/regeneration.js
+++ b/packages/autorest.go/.scripts/regeneration.js
@@ -128,7 +128,7 @@ generate("azacr", acr, 'test/acr/azacr', '--module="azacr" --module-version=0.1.
 const machineLearning = './swagger/specification/machinelearningservices/resource-manager';
 generateFromReadme("armmachinelearning", machineLearning, 'package-2022-02-01-preview', 'test/machinelearning/armmachinelearning', '--module=armmachinelearning --module-version=1.0.0 --azure-arm=true --generate-fakes=false --inject-spans=false --remove-unreferenced-types');
 
-generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --slice-elements-byval --disallow-unknown-fields');
+generate("azalias", 'packages/autorest.go/test/swagger/alias.json', 'test/maps/azalias', '--security=AzureKey --module="azalias" --module-version=0.1.0 --openapi-type="data-plane" --generate-fakes --inject-spans --slice-elements-byval --disallow-unknown-fields --single-client');
 
 function should_generate(name) {
   if (filter !== undefined) {

--- a/packages/autorest.go/README.md
+++ b/packages/autorest.go/README.md
@@ -120,4 +120,7 @@ help-content:
         description: Enables generation of fake servers. The default value is set to the value of --azure-arm.
       - key: inject-spans
         description: Enables generation of spans for distributed tracing. The default value is set to the value of --azure-arm.
+      - key: single-client
+        type: boolean
+        description: Indicates package has a single client. This will omit the Client prefix from options and response types. If multiple clients are detected, an error is returned.
 ```

--- a/packages/autorest.go/src/transform/namer.ts
+++ b/packages/autorest.go/src/transform/namer.ts
@@ -104,6 +104,8 @@ export async function namer(session: Session<CodeModel>) {
     throw new Error('--module and --containing-module are mutually exclusive');
   }
   model.language.go!.containingModule = containingModule;
+  const singleClient = await session.getValue('single-client', false);
+  model.language.go!.singleClient = singleClient;
 
   // fix up type names
   const structNames = new Set<string>();

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -27,31 +27,31 @@ import (
 type Server struct {
 	// Create is the fake for method Client.Create
 	// HTTP status codes to indicate success: http.StatusCreated
-	Create func(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum azalias.BooleanEnum, unixTimeQuery time.Time, headerEnum azalias.SomeEnum, queryEnum azalias.SomeEnum, options *azalias.ClientCreateOptions) (resp azfake.Responder[azalias.ClientCreateResponse], errResp azfake.ErrorResponder)
+	Create func(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum azalias.BooleanEnum, unixTimeQuery time.Time, headerEnum azalias.SomeEnum, queryEnum azalias.SomeEnum, options *azalias.CreateOptions) (resp azfake.Responder[azalias.CreateResponse], errResp azfake.ErrorResponder)
 
 	// GetScript is the fake for method Client.GetScript
 	// HTTP status codes to indicate success: http.StatusOK
-	GetScript func(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props azalias.GeoJSONObjectNamedCollection, someGroup azalias.SomeGroup, explodedGroup azalias.ExplodedGroup, options *azalias.ClientGetScriptOptions) (resp azfake.Responder[azalias.ClientGetScriptResponse], errResp azfake.ErrorResponder)
+	GetScript func(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props azalias.GeoJSONObjectNamedCollection, someGroup azalias.SomeGroup, explodedGroup azalias.ExplodedGroup, options *azalias.GetScriptOptions) (resp azfake.Responder[azalias.GetScriptResponse], errResp azfake.ErrorResponder)
 
 	// NewListPager is the fake for method Client.NewListPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListPager func(headerEnums []azalias.IntEnum, queryEnum azalias.IntEnum, options *azalias.ClientListOptions) (resp azfake.PagerResponder[azalias.ClientListResponse])
+	NewListPager func(headerEnums []azalias.IntEnum, queryEnum azalias.IntEnum, options *azalias.ListOptions) (resp azfake.PagerResponder[azalias.ListResponseEnvelope])
 
 	// BeginListLRO is the fake for method Client.BeginListLRO
 	// HTTP status codes to indicate success: http.StatusAccepted
-	BeginListLRO func(ctx context.Context, options *azalias.ClientBeginListLROOptions) (resp azfake.PollerResponder[azfake.PagerResponder[azalias.ClientListLROResponse]], errResp azfake.ErrorResponder)
+	BeginListLRO func(ctx context.Context, options *azalias.BeginListLROOptions) (resp azfake.PollerResponder[azfake.PagerResponder[azalias.ListLROResponse]], errResp azfake.ErrorResponder)
 
 	// NewListWithSharedNextOnePager is the fake for method Client.NewListWithSharedNextOnePager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListWithSharedNextOnePager func(options *azalias.ClientListWithSharedNextOneOptions) (resp azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse])
+	NewListWithSharedNextOnePager func(options *azalias.ListWithSharedNextOneOptions) (resp azfake.PagerResponder[azalias.ListWithSharedNextOneResponse])
 
 	// NewListWithSharedNextTwoPager is the fake for method Client.NewListWithSharedNextTwoPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListWithSharedNextTwoPager func(options *azalias.ClientListWithSharedNextTwoOptions) (resp azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse])
+	NewListWithSharedNextTwoPager func(options *azalias.ListWithSharedNextTwoOptions) (resp azfake.PagerResponder[azalias.ListWithSharedNextTwoResponse])
 
 	// PolicyAssignment is the fake for method Client.PolicyAssignment
 	// HTTP status codes to indicate success: http.StatusOK
-	PolicyAssignment func(ctx context.Context, things []azalias.Things, polymorphicParam azalias.GeoJSONObjectClassification, options *azalias.ClientPolicyAssignmentOptions) (resp azfake.Responder[azalias.ClientPolicyAssignmentResponse], errResp azfake.ErrorResponder)
+	PolicyAssignment func(ctx context.Context, things []azalias.Things, polymorphicParam azalias.GeoJSONObjectClassification, options *azalias.PolicyAssignmentOptions) (resp azfake.Responder[azalias.PolicyAssignmentResponse], errResp azfake.ErrorResponder)
 }
 
 // NewServerTransport creates a new instance of ServerTransport with the provided implementation.
@@ -60,10 +60,10 @@ type Server struct {
 func NewServerTransport(srv *Server) *ServerTransport {
 	return &ServerTransport{
 		srv:                           srv,
-		newListPager:                  newTracker[azfake.PagerResponder[azalias.ClientListResponse]](),
-		beginListLRO:                  newTracker[azfake.PollerResponder[azfake.PagerResponder[azalias.ClientListLROResponse]]](),
-		newListWithSharedNextOnePager: newTracker[azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse]](),
-		newListWithSharedNextTwoPager: newTracker[azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse]](),
+		newListPager:                  newTracker[azfake.PagerResponder[azalias.ListResponseEnvelope]](),
+		beginListLRO:                  newTracker[azfake.PollerResponder[azfake.PagerResponder[azalias.ListLROResponse]]](),
+		newListWithSharedNextOnePager: newTracker[azfake.PagerResponder[azalias.ListWithSharedNextOneResponse]](),
+		newListWithSharedNextTwoPager: newTracker[azfake.PagerResponder[azalias.ListWithSharedNextTwoResponse]](),
 	}
 }
 
@@ -71,10 +71,10 @@ func NewServerTransport(srv *Server) *ServerTransport {
 // Don't use this type directly, use NewServerTransport instead.
 type ServerTransport struct {
 	srv                           *Server
-	newListPager                  *tracker[azfake.PagerResponder[azalias.ClientListResponse]]
-	beginListLRO                  *tracker[azfake.PollerResponder[azfake.PagerResponder[azalias.ClientListLROResponse]]]
-	newListWithSharedNextOnePager *tracker[azfake.PagerResponder[azalias.ClientListWithSharedNextOneResponse]]
-	newListWithSharedNextTwoPager *tracker[azfake.PagerResponder[azalias.ClientListWithSharedNextTwoResponse]]
+	newListPager                  *tracker[azfake.PagerResponder[azalias.ListResponseEnvelope]]
+	beginListLRO                  *tracker[azfake.PollerResponder[azfake.PagerResponder[azalias.ListLROResponse]]]
+	newListWithSharedNextOnePager *tracker[azfake.PagerResponder[azalias.ListWithSharedNextOneResponse]]
+	newListWithSharedNextTwoPager *tracker[azfake.PagerResponder[azalias.ListWithSharedNextTwoResponse]]
 }
 
 // Do implements the policy.Transporter interface for ServerTransport.
@@ -231,9 +231,9 @@ func (s *ServerTransport) dispatchCreate(req *http.Request) (*http.Response, err
 	if err != nil {
 		return nil, err
 	}
-	var options *azalias.ClientCreateOptions
+	var options *azalias.CreateOptions
 	if creatorIDParam != nil || assignedIDParam != nil || boolHeaderEnum1Param != nil || optionalUnixTimeParam != nil || len(groupByParam) > 0 {
-		options = &azalias.ClientCreateOptions{
+		options = &azalias.CreateOptions{
 			CreatorID:        creatorIDParam,
 			AssignedID:       assignedIDParam,
 			BoolHeaderEnum1:  boolHeaderEnum1Param,
@@ -345,9 +345,9 @@ func (s *ServerTransport) dispatchGetScript(req *http.Request) (*http.Response, 
 	explodedGroup := azalias.ExplodedGroup{
 		ExplodedStuff: explodedStuffParam,
 	}
-	var options *azalias.ClientGetScriptOptions
+	var options *azalias.GetScriptOptions
 	if len(optionalExplodedStuffParam) > 0 {
-		options = &azalias.ClientGetScriptOptions{
+		options = &azalias.GetScriptOptions{
 			OptionalExplodedStuff: optionalExplodedStuffParam,
 		}
 	}
@@ -436,9 +436,9 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 		for i := 0; i < len(groupByUnescaped); i++ {
 			groupByParam[i] = azalias.LogMetricsGroupBy(groupByUnescaped[i])
 		}
-		var options *azalias.ClientListOptions
+		var options *azalias.ListOptions
 		if len(queryEnumsParam) > 0 || headerEnumParam != nil || len(groupByParam) > 0 {
-			options = &azalias.ClientListOptions{
+			options = &azalias.ListOptions{
 				QueryEnums: queryEnumsParam,
 				HeaderEnum: headerEnumParam,
 				GroupBy:    groupByParam,
@@ -447,7 +447,7 @@ func (s *ServerTransport) dispatchNewListPager(req *http.Request) (*http.Respons
 		resp := s.srv.NewListPager(headerEnumsParam, queryEnumParam, options)
 		newListPager = &resp
 		s.newListPager.add(req, newListPager)
-		server.PagerResponderInjectNextLinks(newListPager, req, func(page *azalias.ClientListResponse, createLink func() string) {
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *azalias.ListResponseEnvelope, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
@@ -504,7 +504,7 @@ func (s *ServerTransport) dispatchNewListWithSharedNextOnePager(req *http.Reques
 		resp := s.srv.NewListWithSharedNextOnePager(nil)
 		newListWithSharedNextOnePager = &resp
 		s.newListWithSharedNextOnePager.add(req, newListWithSharedNextOnePager)
-		server.PagerResponderInjectNextLinks(newListWithSharedNextOnePager, req, func(page *azalias.ClientListWithSharedNextOneResponse, createLink func() string) {
+		server.PagerResponderInjectNextLinks(newListWithSharedNextOnePager, req, func(page *azalias.ListWithSharedNextOneResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
@@ -531,7 +531,7 @@ func (s *ServerTransport) dispatchNewListWithSharedNextTwoPager(req *http.Reques
 		resp := s.srv.NewListWithSharedNextTwoPager(nil)
 		newListWithSharedNextTwoPager = &resp
 		s.newListWithSharedNextTwoPager.add(req, newListWithSharedNextTwoPager)
-		server.PagerResponderInjectNextLinks(newListWithSharedNextTwoPager, req, func(page *azalias.ClientListWithSharedNextTwoResponse, createLink func() string) {
+		server.PagerResponderInjectNextLinks(newListWithSharedNextTwoPager, req, func(page *azalias.ListWithSharedNextTwoResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}
@@ -581,9 +581,9 @@ func (s *ServerTransport) dispatchPolicyAssignment(req *http.Request) (*http.Res
 		return nil, err
 	}
 	uniqueParam := getOptional(uniqueUnescaped)
-	var options *azalias.ClientPolicyAssignmentOptions
+	var options *azalias.PolicyAssignmentOptions
 	if intervalParam != nil || uniqueParam != nil {
-		options = &azalias.ClientPolicyAssignmentOptions{
+		options = &azalias.PolicyAssignmentOptions{
 			Interval: intervalParam,
 			Unique:   uniqueParam,
 		}

--- a/packages/autorest.go/test/maps/azalias/fakes_test.go
+++ b/packages/autorest.go/test/maps/azalias/fakes_test.go
@@ -26,7 +26,7 @@ func TestFakeCreate(t *testing.T) {
 	queryEnumContent := azalias.SomeEnumThree
 	BoolHeaderEnum1Content := azalias.BooleanEnumDisabled
 	server := fake.Server{
-		Create: func(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum azalias.BooleanEnum, unixTimeQuery time.Time, headerEnum azalias.SomeEnum, queryEnum azalias.SomeEnum, options *azalias.ClientCreateOptions) (resp azfake.Responder[azalias.ClientCreateResponse], errResp azfake.ErrorResponder) {
+		Create: func(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum azalias.BooleanEnum, unixTimeQuery time.Time, headerEnum azalias.SomeEnum, queryEnum azalias.SomeEnum, options *azalias.CreateOptions) (resp azfake.Responder[azalias.CreateResponse], errResp azfake.ErrorResponder) {
 			require.EqualValues(t, headerBoolsContent, headerBools)
 			require.EqualValues(t, stringQueryContent, stringQuery)
 			require.EqualValues(t, boolHeaderEnumContent, boolHeaderEnum)
@@ -36,7 +36,7 @@ func TestFakeCreate(t *testing.T) {
 			require.NotNil(t, options)
 			require.NotNil(t, options.BoolHeaderEnum1)
 			require.EqualValues(t, BoolHeaderEnum1Content, *options.BoolHeaderEnum1)
-			resp.SetResponse(http.StatusCreated, azalias.ClientCreateResponse{}, nil)
+			resp.SetResponse(http.StatusCreated, azalias.CreateResponse{}, nil)
 			return
 		},
 	}
@@ -44,7 +44,7 @@ func TestFakeCreate(t *testing.T) {
 		Transport: fake.NewServerTransport(&server),
 	})
 	require.NoError(t, err)
-	_, err = client.Create(context.Background(), headerBoolsContent, stringQueryContent, boolHeaderEnumContent, unixTimeQueryContent, headerEnumContent, queryEnumContent, &azalias.ClientCreateOptions{
+	_, err = client.Create(context.Background(), headerBoolsContent, stringQueryContent, boolHeaderEnumContent, unixTimeQueryContent, headerEnumContent, queryEnumContent, &azalias.CreateOptions{
 		BoolHeaderEnum1: to.Ptr(BoolHeaderEnum1Content),
 	})
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestFakeGetScript(t *testing.T) {
 	headerStrings := []string{"bing", "bing"}
 	require.NoError(t, err)
 	server := fake.Server{
-		GetScript: func(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props azalias.GeoJSONObjectNamedCollection, someGroup azalias.SomeGroup, explodedGroup azalias.ExplodedGroup, options *azalias.ClientGetScriptOptions) (resp azfake.Responder[azalias.ClientGetScriptResponse], errResp azfake.ErrorResponder) {
+		GetScript: func(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props azalias.GeoJSONObjectNamedCollection, someGroup azalias.SomeGroup, explodedGroup azalias.ExplodedGroup, options *azalias.GetScriptOptions) (resp azfake.Responder[azalias.GetScriptResponse], errResp azfake.ErrorResponder) {
 			require.EqualValues(t, headerContent, headerCounts)
 			require.EqualValues(t, queryContent, queryCounts)
 			require.EqualValues(t, explodedStringStuff, explodedStrings)
@@ -68,7 +68,7 @@ func TestFakeGetScript(t *testing.T) {
 			require.EqualValues(t, explodedContent, explodedGroup.ExplodedStuff)
 			require.EqualValues(t, timeContent, headerTime)
 			require.EqualValues(t, headerStrings, someGroup.HeaderStrings)
-			resp.SetResponse(http.StatusOK, azalias.ClientGetScriptResponse{}, nil)
+			resp.SetResponse(http.StatusOK, azalias.GetScriptResponse{}, nil)
 			return
 		},
 	}

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -50,8 +50,8 @@ type Client struct {
 //   - stringQuery - The unique id that references the assigned data item to be aliased.
 //   - boolHeaderEnum - Some enums that are boolean values.
 //   - unixTimeQuery - Required unix time passed via query param.
-//   - options - ClientCreateOptions contains the optional parameters for the Client.Create method.
-func (client *Client) Create(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum BooleanEnum, unixTimeQuery time.Time, headerEnum SomeEnum, queryEnum SomeEnum, options *ClientCreateOptions) (ClientCreateResponse, error) {
+//   - options - CreateOptions contains the optional parameters for the Client.Create method.
+func (client *Client) Create(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum BooleanEnum, unixTimeQuery time.Time, headerEnum SomeEnum, queryEnum SomeEnum, options *CreateOptions) (CreateResponse, error) {
 	var err error
 	const operationName = "Client.Create"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -59,22 +59,22 @@ func (client *Client) Create(ctx context.Context, headerBools []bool, stringQuer
 	defer func() { endSpan(err) }()
 	req, err := client.createCreateRequest(ctx, headerBools, stringQuery, boolHeaderEnum, unixTimeQuery, headerEnum, queryEnum, options)
 	if err != nil {
-		return ClientCreateResponse{}, err
+		return CreateResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientCreateResponse{}, err
+		return CreateResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusCreated) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientCreateResponse{}, err
+		return CreateResponse{}, err
 	}
 	resp, err := client.createHandleResponse(httpResp)
 	return resp, err
 }
 
 // createCreateRequest creates the Create request.
-func (client *Client) createCreateRequest(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum BooleanEnum, unixTimeQuery time.Time, headerEnum SomeEnum, queryEnum SomeEnum, options *ClientCreateOptions) (*policy.Request, error) {
+func (client *Client) createCreateRequest(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum BooleanEnum, unixTimeQuery time.Time, headerEnum SomeEnum, queryEnum SomeEnum, options *CreateOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -116,13 +116,13 @@ func (client *Client) createCreateRequest(ctx context.Context, headerBools []boo
 }
 
 // createHandleResponse handles the Create response.
-func (client *Client) createHandleResponse(resp *http.Response) (ClientCreateResponse, error) {
-	result := ClientCreateResponse{}
+func (client *Client) createHandleResponse(resp *http.Response) (CreateResponse, error) {
+	result := CreateResponse{}
 	if val := resp.Header.Get("Access-Control-Expose-Headers"); val != "" {
 		result.AccessControlExposeHeaders = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.AliasesCreateResponse); err != nil {
-		return ClientCreateResponse{}, err
+		return CreateResponse{}, err
 	}
 	return result, nil
 }
@@ -133,8 +133,8 @@ func (client *Client) createHandleResponse(resp *http.Response) (ClientCreateRes
 // Generated from API version 2.0
 //   - SomeGroup - SomeGroup contains a group of parameters for the Client.GetScript method.
 //   - ExplodedGroup - ExplodedGroup contains a group of parameters for the Client.GetScript method.
-//   - options - ClientGetScriptOptions contains the optional parameters for the Client.GetScript method.
-func (client *Client) GetScript(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props GeoJSONObjectNamedCollection, someGroup SomeGroup, explodedGroup ExplodedGroup, options *ClientGetScriptOptions) (ClientGetScriptResponse, error) {
+//   - options - GetScriptOptions contains the optional parameters for the Client.GetScript method.
+func (client *Client) GetScript(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props GeoJSONObjectNamedCollection, someGroup SomeGroup, explodedGroup ExplodedGroup, options *GetScriptOptions) (GetScriptResponse, error) {
 	var err error
 	const operationName = "Client.GetScript"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -142,22 +142,22 @@ func (client *Client) GetScript(ctx context.Context, headerCounts []int32, query
 	defer func() { endSpan(err) }()
 	req, err := client.getScriptCreateRequest(ctx, headerCounts, queryCounts, explodedStringStuff, numericHeader, headerTime, props, someGroup, explodedGroup, options)
 	if err != nil {
-		return ClientGetScriptResponse{}, err
+		return GetScriptResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientGetScriptResponse{}, err
+		return GetScriptResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientGetScriptResponse{}, err
+		return GetScriptResponse{}, err
 	}
 	resp, err := client.getScriptHandleResponse(httpResp)
 	return resp, err
 }
 
 // getScriptCreateRequest creates the GetScript request.
-func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props GeoJSONObjectNamedCollection, someGroup SomeGroup, explodedGroup ExplodedGroup, options *ClientGetScriptOptions) (*policy.Request, error) {
+func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props GeoJSONObjectNamedCollection, someGroup SomeGroup, explodedGroup ExplodedGroup, options *GetScriptOptions) (*policy.Request, error) {
 	urlPath := "/scripts"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -189,11 +189,11 @@ func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts [
 }
 
 // getScriptHandleResponse handles the GetScript response.
-func (client *Client) getScriptHandleResponse(resp *http.Response) (ClientGetScriptResponse, error) {
-	result := ClientGetScriptResponse{}
+func (client *Client) getScriptHandleResponse(resp *http.Response) (GetScriptResponse, error) {
+	result := GetScriptResponse{}
 	body, err := runtime.Payload(resp)
 	if err != nil {
-		return ClientGetScriptResponse{}, err
+		return GetScriptResponse{}, err
 	}
 	txt := string(body)
 	result.Value = &txt
@@ -220,13 +220,13 @@ func (client *Client) getScriptHandleResponse(resp *http.Response) (ClientGetScr
 // "2020-02-18T19:53:33.123Z" } ] }
 //
 // Generated from API version 2.0
-//   - options - ClientListOptions contains the optional parameters for the Client.NewListPager method.
-func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, options *ClientListOptions) *runtime.Pager[ClientListResponse] {
-	return runtime.NewPager(runtime.PagingHandler[ClientListResponse]{
-		More: func(page ClientListResponse) bool {
+//   - options - ListOptions contains the optional parameters for the Client.NewListPager method.
+func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, options *ListOptions) *runtime.Pager[ListResponseEnvelope] {
+	return runtime.NewPager(runtime.PagingHandler[ListResponseEnvelope]{
+		More: func(page ListResponseEnvelope) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ClientListResponse) (ClientListResponse, error) {
+		Fetcher: func(ctx context.Context, page *ListResponseEnvelope) (ListResponseEnvelope, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListPager")
 			nextLink := ""
 			if page != nil {
@@ -236,7 +236,7 @@ func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, opt
 				return client.listCreateRequest(ctx, headerEnums, queryEnum, options)
 			}, nil)
 			if err != nil {
-				return ClientListResponse{}, err
+				return ListResponseEnvelope{}, err
 			}
 			return client.listHandleResponse(resp)
 		},
@@ -245,7 +245,7 @@ func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, opt
 }
 
 // listCreateRequest creates the List request.
-func (client *Client) listCreateRequest(ctx context.Context, headerEnums []IntEnum, queryEnum IntEnum, options *ClientListOptions) (*policy.Request, error) {
+func (client *Client) listCreateRequest(ctx context.Context, headerEnums []IntEnum, queryEnum IntEnum, options *ListOptions) (*policy.Request, error) {
 	urlPath := "/aliases"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -274,10 +274,10 @@ func (client *Client) listCreateRequest(ctx context.Context, headerEnums []IntEn
 }
 
 // listHandleResponse handles the List response.
-func (client *Client) listHandleResponse(resp *http.Response) (ClientListResponse, error) {
-	result := ClientListResponse{}
+func (client *Client) listHandleResponse(resp *http.Response) (ListResponseEnvelope, error) {
+	result := ListResponseEnvelope{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
-		return ClientListResponse{}, err
+		return ListResponseEnvelope{}, err
 	}
 	return result, nil
 }
@@ -285,13 +285,13 @@ func (client *Client) listHandleResponse(resp *http.Response) (ClientListRespons
 // BeginListLRO - A long-running paged operation that uses a next link operation
 //
 // Generated from API version 2.0
-//   - options - ClientBeginListLROOptions contains the optional parameters for the Client.BeginListLRO method.
-func (client *Client) BeginListLRO(ctx context.Context, options *ClientBeginListLROOptions) (*runtime.Poller[*runtime.Pager[ClientListLROResponse]], error) {
-	pager := runtime.NewPager(runtime.PagingHandler[ClientListLROResponse]{
-		More: func(page ClientListLROResponse) bool {
+//   - options - BeginListLROOptions contains the optional parameters for the Client.BeginListLRO method.
+func (client *Client) BeginListLRO(ctx context.Context, options *BeginListLROOptions) (*runtime.Poller[*runtime.Pager[ListLROResponse]], error) {
+	pager := runtime.NewPager(runtime.PagingHandler[ListLROResponse]{
+		More: func(page ListLROResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ClientListLROResponse) (ClientListLROResponse, error) {
+		Fetcher: func(ctx context.Context, page *ListLROResponse) (ListLROResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.BeginListLRO")
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), *page.NextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listLROCreateRequest(ctx, options)
@@ -301,7 +301,7 @@ func (client *Client) BeginListLRO(ctx context.Context, options *ClientBeginList
 				},
 			})
 			if err != nil {
-				return ClientListLROResponse{}, err
+				return ListLROResponse{}, err
 			}
 			return client.listLROHandleResponse(resp)
 		},
@@ -312,13 +312,13 @@ func (client *Client) BeginListLRO(ctx context.Context, options *ClientBeginList
 		if err != nil {
 			return nil, err
 		}
-		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[*runtime.Pager[ClientListLROResponse]]{
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[*runtime.Pager[ListLROResponse]]{
 			Response: &pager,
 			Tracer:   client.internal.Tracer(),
 		})
 		return poller, err
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ClientListLROResponse]]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[*runtime.Pager[ListLROResponse]]{
 			Response: &pager,
 			Tracer:   client.internal.Tracer(),
 		})
@@ -328,7 +328,7 @@ func (client *Client) BeginListLRO(ctx context.Context, options *ClientBeginList
 // ListLRO - A long-running paged operation that uses a next link operation
 //
 // Generated from API version 2.0
-func (client *Client) listLRO(ctx context.Context, options *ClientBeginListLROOptions) (*http.Response, error) {
+func (client *Client) listLRO(ctx context.Context, options *BeginListLROOptions) (*http.Response, error) {
 	var err error
 	const operationName = "Client.BeginListLRO"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -350,7 +350,7 @@ func (client *Client) listLRO(ctx context.Context, options *ClientBeginListLROOp
 }
 
 // listLROCreateRequest creates the ListLRO request.
-func (client *Client) listLROCreateRequest(ctx context.Context, options *ClientBeginListLROOptions) (*policy.Request, error) {
+func (client *Client) listLROCreateRequest(ctx context.Context, options *BeginListLROOptions) (*policy.Request, error) {
 	urlPath := "/paged"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -361,22 +361,21 @@ func (client *Client) listLROCreateRequest(ctx context.Context, options *ClientB
 }
 
 // listLROHandleResponse handles the ListLRO response.
-func (client *Client) listLROHandleResponse(resp *http.Response) (ClientListLROResponse, error) {
-	result := ClientListLROResponse{}
+func (client *Client) listLROHandleResponse(resp *http.Response) (ListLROResponse, error) {
+	result := ListLROResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PagesOfThings); err != nil {
-		return ClientListLROResponse{}, err
+		return ListLROResponse{}, err
 	}
 	return result, nil
 }
 
-//   - options - ClientListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager
-//     method.
-func (client *Client) NewListWithSharedNextOnePager(options *ClientListWithSharedNextOneOptions) *runtime.Pager[ClientListWithSharedNextOneResponse] {
-	return runtime.NewPager(runtime.PagingHandler[ClientListWithSharedNextOneResponse]{
-		More: func(page ClientListWithSharedNextOneResponse) bool {
+// - options - ListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
+func (client *Client) NewListWithSharedNextOnePager(options *ListWithSharedNextOneOptions) *runtime.Pager[ListWithSharedNextOneResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ListWithSharedNextOneResponse]{
+		More: func(page ListWithSharedNextOneResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ClientListWithSharedNextOneResponse) (ClientListWithSharedNextOneResponse, error) {
+		Fetcher: func(ctx context.Context, page *ListWithSharedNextOneResponse) (ListWithSharedNextOneResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextOnePager")
 			nextLink := ""
 			if page != nil {
@@ -390,7 +389,7 @@ func (client *Client) NewListWithSharedNextOnePager(options *ClientListWithShare
 				},
 			})
 			if err != nil {
-				return ClientListWithSharedNextOneResponse{}, err
+				return ListWithSharedNextOneResponse{}, err
 			}
 			return client.listWithSharedNextOneHandleResponse(resp)
 		},
@@ -399,7 +398,7 @@ func (client *Client) NewListWithSharedNextOnePager(options *ClientListWithShare
 }
 
 // listWithSharedNextOneCreateRequest creates the ListWithSharedNextOne request.
-func (client *Client) listWithSharedNextOneCreateRequest(ctx context.Context, options *ClientListWithSharedNextOneOptions) (*policy.Request, error) {
+func (client *Client) listWithSharedNextOneCreateRequest(ctx context.Context, options *ListWithSharedNextOneOptions) (*policy.Request, error) {
 	urlPath := "/listWithSharedNextOne"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -410,22 +409,21 @@ func (client *Client) listWithSharedNextOneCreateRequest(ctx context.Context, op
 }
 
 // listWithSharedNextOneHandleResponse handles the ListWithSharedNextOne response.
-func (client *Client) listWithSharedNextOneHandleResponse(resp *http.Response) (ClientListWithSharedNextOneResponse, error) {
-	result := ClientListWithSharedNextOneResponse{}
+func (client *Client) listWithSharedNextOneHandleResponse(resp *http.Response) (ListWithSharedNextOneResponse, error) {
+	result := ListWithSharedNextOneResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
-		return ClientListWithSharedNextOneResponse{}, err
+		return ListWithSharedNextOneResponse{}, err
 	}
 	return result, nil
 }
 
-//   - options - ClientListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager
-//     method.
-func (client *Client) NewListWithSharedNextTwoPager(options *ClientListWithSharedNextTwoOptions) *runtime.Pager[ClientListWithSharedNextTwoResponse] {
-	return runtime.NewPager(runtime.PagingHandler[ClientListWithSharedNextTwoResponse]{
-		More: func(page ClientListWithSharedNextTwoResponse) bool {
+// - options - ListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
+func (client *Client) NewListWithSharedNextTwoPager(options *ListWithSharedNextTwoOptions) *runtime.Pager[ListWithSharedNextTwoResponse] {
+	return runtime.NewPager(runtime.PagingHandler[ListWithSharedNextTwoResponse]{
+		More: func(page ListWithSharedNextTwoResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ClientListWithSharedNextTwoResponse) (ClientListWithSharedNextTwoResponse, error) {
+		Fetcher: func(ctx context.Context, page *ListWithSharedNextTwoResponse) (ListWithSharedNextTwoResponse, error) {
 			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "Client.NewListWithSharedNextTwoPager")
 			nextLink := ""
 			if page != nil {
@@ -439,7 +437,7 @@ func (client *Client) NewListWithSharedNextTwoPager(options *ClientListWithShare
 				},
 			})
 			if err != nil {
-				return ClientListWithSharedNextTwoResponse{}, err
+				return ListWithSharedNextTwoResponse{}, err
 			}
 			return client.listWithSharedNextTwoHandleResponse(resp)
 		},
@@ -448,7 +446,7 @@ func (client *Client) NewListWithSharedNextTwoPager(options *ClientListWithShare
 }
 
 // listWithSharedNextTwoCreateRequest creates the ListWithSharedNextTwo request.
-func (client *Client) listWithSharedNextTwoCreateRequest(ctx context.Context, options *ClientListWithSharedNextTwoOptions) (*policy.Request, error) {
+func (client *Client) listWithSharedNextTwoCreateRequest(ctx context.Context, options *ListWithSharedNextTwoOptions) (*policy.Request, error) {
 	urlPath := "/listWithSharedNextTwo"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -459,10 +457,10 @@ func (client *Client) listWithSharedNextTwoCreateRequest(ctx context.Context, op
 }
 
 // listWithSharedNextTwoHandleResponse handles the ListWithSharedNextTwo response.
-func (client *Client) listWithSharedNextTwoHandleResponse(resp *http.Response) (ClientListWithSharedNextTwoResponse, error) {
-	result := ClientListWithSharedNextTwoResponse{}
+func (client *Client) listWithSharedNextTwoHandleResponse(resp *http.Response) (ListWithSharedNextTwoResponse, error) {
+	result := ListWithSharedNextTwoResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.ListResponse); err != nil {
-		return ClientListWithSharedNextTwoResponse{}, err
+		return ListWithSharedNextTwoResponse{}, err
 	}
 	return result, nil
 }
@@ -471,8 +469,8 @@ func (client *Client) listWithSharedNextTwoHandleResponse(resp *http.Response) (
 // If the operation fails it returns an *azcore.ResponseError type.
 //
 // Generated from API version 2.0
-//   - options - ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
-func (client *Client) PolicyAssignment(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *ClientPolicyAssignmentOptions) (ClientPolicyAssignmentResponse, error) {
+//   - options - PolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
+func (client *Client) PolicyAssignment(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *PolicyAssignmentOptions) (PolicyAssignmentResponse, error) {
 	var err error
 	const operationName = "Client.PolicyAssignment"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -480,22 +478,22 @@ func (client *Client) PolicyAssignment(ctx context.Context, things []Things, pol
 	defer func() { endSpan(err) }()
 	req, err := client.policyAssignmentCreateRequest(ctx, things, polymorphicParam, options)
 	if err != nil {
-		return ClientPolicyAssignmentResponse{}, err
+		return PolicyAssignmentResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientPolicyAssignmentResponse{}, err
+		return PolicyAssignmentResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientPolicyAssignmentResponse{}, err
+		return PolicyAssignmentResponse{}, err
 	}
 	resp, err := client.policyAssignmentHandleResponse(httpResp)
 	return resp, err
 }
 
 // policyAssignmentCreateRequest creates the PolicyAssignment request.
-func (client *Client) policyAssignmentCreateRequest(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *ClientPolicyAssignmentOptions) (*policy.Request, error) {
+func (client *Client) policyAssignmentCreateRequest(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *PolicyAssignmentOptions) (*policy.Request, error) {
 	urlPath := "/policy"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
 	if err != nil {
@@ -527,10 +525,10 @@ func (client *Client) policyAssignmentCreateRequest(ctx context.Context, things 
 }
 
 // policyAssignmentHandleResponse handles the PolicyAssignment response.
-func (client *Client) policyAssignmentHandleResponse(resp *http.Response) (ClientPolicyAssignmentResponse, error) {
-	result := ClientPolicyAssignmentResponse{}
+func (client *Client) policyAssignmentHandleResponse(resp *http.Response) (PolicyAssignmentResponse, error) {
+	result := PolicyAssignmentResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.PolicyAssignmentProperties); err != nil {
-		return ClientPolicyAssignmentResponse{}, err
+		return PolicyAssignmentResponse{}, err
 	}
 	return result, nil
 }

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -10,14 +10,32 @@ package azalias
 
 import "time"
 
-// ClientBeginListLROOptions contains the optional parameters for the Client.BeginListLRO method.
-type ClientBeginListLROOptions struct {
+// BeginListLROOptions contains the optional parameters for the Client.BeginListLRO method.
+type BeginListLROOptions struct {
 	// Resumes the LRO from the provided token.
 	ResumeToken string
 }
 
-// ClientCreateOptions contains the optional parameters for the Client.Create method.
-type ClientCreateOptions struct {
+// ClientGroup contains a group of parameters for the Client client.
+type ClientGroup struct {
+	// Index number of Azure Maps API.
+	ClientIndex int32
+
+	// Version number of Azure Maps API.
+	ClientVersion string
+}
+
+// ClientOptionalGroup contains a group of parameters for the Client client.
+type ClientOptionalGroup struct {
+	// Index number of Azure Maps API.
+	OptionalIndex *int32
+
+	// Version number of Azure Maps API.
+	OptionalVersion *string
+}
+
+// CreateOptions contains the optional parameters for the Client.Create method.
+type CreateOptions struct {
 	// Some enums that are boolean values.
 	BoolHeaderEnum1 *BooleanEnum
 	GroupBy         []SomethingCount
@@ -32,55 +50,37 @@ type ClientCreateOptions struct {
 	CreatorID *int32
 }
 
-// ClientGetScriptOptions contains the optional parameters for the Client.GetScript method.
-type ClientGetScriptOptions struct {
+// ExplodedGroup contains a group of parameters for the Client.GetScript method.
+type ExplodedGroup struct {
+	ExplodedStuff []int64
+}
+
+// GetScriptOptions contains the optional parameters for the Client.GetScript method.
+type GetScriptOptions struct {
 	OptionalExplodedStuff []string
 }
 
-// ClientGroup contains a group of parameters for the Client client.
-type ClientGroup struct {
-	// Index number of Azure Maps API.
-	ClientIndex int32
-
-	// Version number of Azure Maps API.
-	ClientVersion string
-}
-
-// ClientListOptions contains the optional parameters for the Client.NewListPager method.
-type ClientListOptions struct {
+// ListOptions contains the optional parameters for the Client.NewListPager method.
+type ListOptions struct {
 	GroupBy    []LogMetricsGroupBy
 	HeaderEnum *IntEnum
 	QueryEnums []IntEnum
 }
 
-// ClientListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
-type ClientListWithSharedNextOneOptions struct {
+// ListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
+type ListWithSharedNextOneOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ClientListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
-type ClientListWithSharedNextTwoOptions struct {
+// ListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
+type ListWithSharedNextTwoOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ClientOptionalGroup contains a group of parameters for the Client client.
-type ClientOptionalGroup struct {
-	// Index number of Azure Maps API.
-	OptionalIndex *int32
-
-	// Version number of Azure Maps API.
-	OptionalVersion *string
-}
-
-// ClientPolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
-type ClientPolicyAssignmentOptions struct {
+// PolicyAssignmentOptions contains the optional parameters for the Client.PolicyAssignment method.
+type PolicyAssignmentOptions struct {
 	Interval *string
 	Unique   *string
-}
-
-// ExplodedGroup contains a group of parameters for the Client.GetScript method.
-type ExplodedGroup struct {
-	ExplodedStuff []int64
 }
 
 // SomeGroup contains a group of parameters for the Client.GetScript method.

--- a/packages/autorest.go/test/maps/azalias/zz_responses.go
+++ b/packages/autorest.go/test/maps/azalias/zz_responses.go
@@ -8,8 +8,8 @@
 
 package azalias
 
-// ClientCreateResponse contains the response from method Client.Create.
-type ClientCreateResponse struct {
+// CreateResponse contains the response from method Client.Create.
+type CreateResponse struct {
 	// The response model for the Alias Create API for the case when the alias was successfully created.
 	AliasesCreateResponse
 
@@ -17,35 +17,35 @@ type ClientCreateResponse struct {
 	AccessControlExposeHeaders *string
 }
 
-// ClientGetScriptResponse contains the response from method Client.GetScript.
-type ClientGetScriptResponse struct {
+// GetScriptResponse contains the response from method Client.GetScript.
+type GetScriptResponse struct {
 	Value *string
 }
 
-// ClientListLROResponse contains the response from method Client.BeginListLRO.
-type ClientListLROResponse struct {
+// ListLROResponse contains the response from method Client.BeginListLRO.
+type ListLROResponse struct {
 	PagesOfThings
 }
 
-// ClientListResponse contains the response from method Client.NewListPager.
-type ClientListResponse struct {
+// ListResponseEnvelope contains the response from method Client.NewListPager.
+type ListResponseEnvelope struct {
 	// The response model for the List API. Returns a list of all the previously created aliases.
 	ListResponse
 }
 
-// ClientListWithSharedNextOneResponse contains the response from method Client.NewListWithSharedNextOnePager.
-type ClientListWithSharedNextOneResponse struct {
+// ListWithSharedNextOneResponse contains the response from method Client.NewListWithSharedNextOnePager.
+type ListWithSharedNextOneResponse struct {
 	// The response model for the List API. Returns a list of all the previously created aliases.
 	ListResponse
 }
 
-// ClientListWithSharedNextTwoResponse contains the response from method Client.NewListWithSharedNextTwoPager.
-type ClientListWithSharedNextTwoResponse struct {
+// ListWithSharedNextTwoResponse contains the response from method Client.NewListWithSharedNextTwoPager.
+type ListWithSharedNextTwoResponse struct {
 	// The response model for the List API. Returns a list of all the previously created aliases.
 	ListResponse
 }
 
-// ClientPolicyAssignmentResponse contains the response from method Client.PolicyAssignment.
-type ClientPolicyAssignmentResponse struct {
+// PolicyAssignmentResponse contains the response from method Client.PolicyAssignment.
+type PolicyAssignmentResponse struct {
 	PolicyAssignmentProperties
 }

--- a/packages/naming.go/src/naming.ts
+++ b/packages/naming.go/src/naming.ts
@@ -118,3 +118,11 @@ export function uncapitalize(str: string): string {
 export function createPolymorphicInterfaceName(base: string): string {
   return base + 'Classification';
 }
+
+export function createOptionsTypeDescription(typeName: string, methodName: string): string {
+  return `${typeName} contains the optional parameters for the ${methodName} method.`;
+}
+
+export function createResponseEnvelopeDescription(typeName: string, methodName: string): string {
+  return `${typeName} contains the response from method ${methodName}.`
+}

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -51,7 +51,7 @@ const cadlRanch = {
   'dictionarygroup': ['type/dictionary'],
   'extensiblegroup': ['type/enum/extensible'],
   'fixedgroup': ['type/enum/fixed'],
-  'emptygroup': ['type/model/empty'],
+  'emptygroup': ['type/model/empty', 'single-client=true'],
   'enumdiscgroup': ['type/model/inheritance/enum-discriminator'],
   //'nesteddiscgroup': ['type/model/inheritance/nested-discriminator'], // not a real scenario
   'nodiscgroup': ['type/model/inheritance/not-discriminated'],

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -16,6 +16,7 @@ export interface GoEmitterOptions {
   'package-name'?: string;
   'rawjson-as-bytes'?: boolean;
   'slice-elements-byval'?: boolean;
+  'single-client'?: boolean;
 }
 
 const EmitterOptionsSchema: JSONSchemaType<GoEmitterOptions> = {
@@ -31,7 +32,8 @@ const EmitterOptionsSchema: JSONSchemaType<GoEmitterOptions> = {
     'module-version': { type: 'string', nullable: true },
     'package-name': { type: 'string', nullable: true },
     'rawjson-as-bytes': { type: 'boolean', nullable: true },
-    'slice-elements-byval': { type: 'boolean', nullable: true }
+    'slice-elements-byval': { type: 'boolean', nullable: true },
+    'single-client': { type: 'boolean', nullable: true }
   },
   required: [],
 };

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -40,7 +40,7 @@ export function tcgcToGoCodeModel(context: EmitContext<GoEmitterOptions>): go.Co
   const ta = new typeAdapter(codeModel);
   ta.adaptTypes(sdkContext);
 
-  const ca = new clientAdapter(ta);
+  const ca = new clientAdapter(ta, context.options);
   ca.adaptClients(sdkContext.sdkPackage);
   codeModel.sortContent();
   return codeModel;

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
@@ -22,6 +22,7 @@ type ApiKeyClient struct {
 }
 
 // Invalid - Check whether client is authenticated.
+//   - options - ApiKeyClientInvalidOptions contains the optional parameters for the ApiKeyClient.Invalid method.
 func (client *ApiKeyClient) Invalid(ctx context.Context, options *ApiKeyClientInvalidOptions) (ApiKeyClientInvalidResponse, error) {
 	var err error
 	req, err := client.invalidCreateRequest(ctx, options)
@@ -51,6 +52,7 @@ func (client *ApiKeyClient) invalidCreateRequest(ctx context.Context, options *A
 }
 
 // Valid - Check whether client is authenticated
+//   - options - ApiKeyClientValidOptions contains the optional parameters for the ApiKeyClient.Valid method.
 func (client *ApiKeyClient) Valid(ctx context.Context, options *ApiKeyClientValidOptions) (ApiKeyClientValidResponse, error) {
 	var err error
 	req, err := client.validCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_options.go
@@ -7,10 +7,12 @@
 
 package apikeygroup
 
+// ApiKeyClientInvalidOptions contains the optional parameters for the ApiKeyClient.Invalid method.
 type ApiKeyClientInvalidOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ApiKeyClientValidOptions contains the optional parameters for the ApiKeyClient.Valid method.
 type ApiKeyClientValidOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_custom_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_custom_client.go
@@ -22,6 +22,7 @@ type CustomClient struct {
 }
 
 // Invalid - Check whether client is authenticated.
+//   - options - CustomClientInvalidOptions contains the optional parameters for the CustomClient.Invalid method.
 func (client *CustomClient) Invalid(ctx context.Context, options *CustomClientInvalidOptions) (CustomClientInvalidResponse, error) {
 	var err error
 	req, err := client.invalidCreateRequest(ctx, options)
@@ -51,6 +52,7 @@ func (client *CustomClient) invalidCreateRequest(ctx context.Context, options *C
 }
 
 // Valid - Check whether client is authenticated
+//   - options - CustomClientValidOptions contains the optional parameters for the CustomClient.Valid method.
 func (client *CustomClient) Valid(ctx context.Context, options *CustomClientValidOptions) (CustomClientValidResponse, error) {
 	var err error
 	req, err := client.validCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_options.go
@@ -7,10 +7,12 @@
 
 package customgroup
 
+// CustomClientInvalidOptions contains the optional parameters for the CustomClient.Invalid method.
 type CustomClientInvalidOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CustomClientValidOptions contains the optional parameters for the CustomClient.Valid method.
 type CustomClientValidOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_oauth2_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_oauth2_client.go
@@ -22,6 +22,7 @@ type OAuth2Client struct {
 }
 
 // Invalid - Check whether client is authenticated. Will return an invalid bearer error.
+//   - options - OAuth2ClientInvalidOptions contains the optional parameters for the OAuth2Client.Invalid method.
 func (client *OAuth2Client) Invalid(ctx context.Context, options *OAuth2ClientInvalidOptions) (OAuth2ClientInvalidResponse, error) {
 	var err error
 	req, err := client.invalidCreateRequest(ctx, options)
@@ -51,6 +52,7 @@ func (client *OAuth2Client) invalidCreateRequest(ctx context.Context, options *O
 }
 
 // Valid - Check whether client is authenticated
+//   - options - OAuth2ClientValidOptions contains the optional parameters for the OAuth2Client.Valid method.
 func (client *OAuth2Client) Valid(ctx context.Context, options *OAuth2ClientValidOptions) (OAuth2ClientValidResponse, error) {
 	var err error
 	req, err := client.validCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_options.go
@@ -7,10 +7,12 @@
 
 package oauth2group
 
+// OAuth2ClientInvalidOptions contains the optional parameters for the OAuth2Client.Invalid method.
 type OAuth2ClientInvalidOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OAuth2ClientValidOptions contains the optional parameters for the OAuth2Client.Valid method.
 type OAuth2ClientValidOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_options.go
@@ -7,10 +7,12 @@
 
 package unionauthgroup
 
+// UnionClientValidKeyOptions contains the optional parameters for the UnionClient.ValidKey method.
 type UnionClientValidKeyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnionClientValidTokenOptions contains the optional parameters for the UnionClient.ValidToken method.
 type UnionClientValidTokenOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_union_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_union_client.go
@@ -22,6 +22,7 @@ type UnionClient struct {
 }
 
 // ValidKey - Check whether client is authenticated
+//   - options - UnionClientValidKeyOptions contains the optional parameters for the UnionClient.ValidKey method.
 func (client *UnionClient) ValidKey(ctx context.Context, options *UnionClientValidKeyOptions) (UnionClientValidKeyResponse, error) {
 	var err error
 	req, err := client.validKeyCreateRequest(ctx, options)
@@ -50,6 +51,7 @@ func (client *UnionClient) validKeyCreateRequest(ctx context.Context, options *U
 }
 
 // ValidToken - Check whether client is authenticated
+//   - options - UnionClientValidTokenOptions contains the optional parameters for the UnionClient.ValidToken method.
 func (client *UnionClient) ValidToken(ctx context.Context, options *UnionClientValidTokenOptions) (UnionClientValidTokenResponse, error) {
 	var err error
 	req, err := client.validTokenCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_internaloperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_internaloperation_client.go
@@ -21,6 +21,8 @@ type InternalOperationClient struct {
 	internal *azcore.Client
 }
 
+//   - options - InternalOperationClientInternalDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.InternalDecoratorInInternal
+//     method.
 func (client *InternalOperationClient) InternalDecoratorInInternal(ctx context.Context, name string, options *InternalOperationClientInternalDecoratorInInternalOptions) (InternalOperationClientInternalDecoratorInInternalResponse, error) {
 	var err error
 	req, err := client.internalDecoratorInInternalCreateRequest(ctx, name, options)
@@ -62,6 +64,8 @@ func (client *InternalOperationClient) internalDecoratorInInternalHandleResponse
 	return result, nil
 }
 
+//   - options - InternalOperationClientNoDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.NoDecoratorInInternal
+//     method.
 func (client *InternalOperationClient) NoDecoratorInInternal(ctx context.Context, name string, options *InternalOperationClientNoDecoratorInInternalOptions) (InternalOperationClientNoDecoratorInInternalResponse, error) {
 	var err error
 	req, err := client.noDecoratorInInternalCreateRequest(ctx, name, options)
@@ -103,6 +107,8 @@ func (client *InternalOperationClient) noDecoratorInInternalHandleResponse(resp 
 	return result, nil
 }
 
+//   - options - InternalOperationClientPublicDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.PublicDecoratorInInternal
+//     method.
 func (client *InternalOperationClient) PublicDecoratorInInternal(ctx context.Context, name string, options *InternalOperationClientPublicDecoratorInInternalOptions) (InternalOperationClientPublicDecoratorInInternalResponse, error) {
 	var err error
 	req, err := client.publicDecoratorInInternalCreateRequest(ctx, name, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_options.go
@@ -7,38 +7,56 @@
 
 package accessgroup
 
+// InternalOperationClientInternalDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.InternalDecoratorInInternal
+// method.
 type InternalOperationClientInternalDecoratorInInternalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// InternalOperationClientNoDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.NoDecoratorInInternal
+// method.
 type InternalOperationClientNoDecoratorInInternalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// InternalOperationClientPublicDecoratorInInternalOptions contains the optional parameters for the InternalOperationClient.PublicDecoratorInInternal
+// method.
 type InternalOperationClientPublicDecoratorInInternalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PublicOperationClientNoDecoratorInPublicOptions contains the optional parameters for the PublicOperationClient.NoDecoratorInPublic
+// method.
 type PublicOperationClientNoDecoratorInPublicOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PublicOperationClientPublicDecoratorInPublicOptions contains the optional parameters for the PublicOperationClient.PublicDecoratorInPublic
+// method.
 type PublicOperationClientPublicDecoratorInPublicOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RelativeModelInOperationClientDiscriminatorOptions contains the optional parameters for the RelativeModelInOperationClient.Discriminator
+// method.
 type RelativeModelInOperationClientDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RelativeModelInOperationClientOperationOptions contains the optional parameters for the RelativeModelInOperationClient.Operation
+// method.
 type RelativeModelInOperationClientOperationOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SharedModelInOperationClientInternalOptions contains the optional parameters for the SharedModelInOperationClient.Internal
+// method.
 type SharedModelInOperationClientInternalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SharedModelInOperationClientPublicOptions contains the optional parameters for the SharedModelInOperationClient.Public
+// method.
 type SharedModelInOperationClientPublicOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_publicoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_publicoperation_client.go
@@ -21,6 +21,8 @@ type PublicOperationClient struct {
 	internal *azcore.Client
 }
 
+//   - options - PublicOperationClientNoDecoratorInPublicOptions contains the optional parameters for the PublicOperationClient.NoDecoratorInPublic
+//     method.
 func (client *PublicOperationClient) NoDecoratorInPublic(ctx context.Context, name string, options *PublicOperationClientNoDecoratorInPublicOptions) (PublicOperationClientNoDecoratorInPublicResponse, error) {
 	var err error
 	req, err := client.noDecoratorInPublicCreateRequest(ctx, name, options)
@@ -62,6 +64,8 @@ func (client *PublicOperationClient) noDecoratorInPublicHandleResponse(resp *htt
 	return result, nil
 }
 
+//   - options - PublicOperationClientPublicDecoratorInPublicOptions contains the optional parameters for the PublicOperationClient.PublicDecoratorInPublic
+//     method.
 func (client *PublicOperationClient) PublicDecoratorInPublic(ctx context.Context, name string, options *PublicOperationClientPublicDecoratorInPublicOptions) (PublicOperationClientPublicDecoratorInPublicResponse, error) {
 	var err error
 	req, err := client.publicDecoratorInPublicCreateRequest(ctx, name, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_relativemodelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_relativemodelinoperation_client.go
@@ -29,6 +29,8 @@ type RelativeModelInOperationClient struct {
 // "kind": "real"
 // }
 // ```
+//   - options - RelativeModelInOperationClientDiscriminatorOptions contains the optional parameters for the RelativeModelInOperationClient.Discriminator
+//     method.
 func (client *RelativeModelInOperationClient) Discriminator(ctx context.Context, kind string, options *RelativeModelInOperationClientDiscriminatorOptions) (RelativeModelInOperationClientDiscriminatorResponse, error) {
 	var err error
 	req, err := client.discriminatorCreateRequest(ctx, kind, options)
@@ -81,6 +83,8 @@ func (client *RelativeModelInOperationClient) discriminatorHandleResponse(resp *
 // }
 // }
 // ```
+//   - options - RelativeModelInOperationClientOperationOptions contains the optional parameters for the RelativeModelInOperationClient.Operation
+//     method.
 func (client *RelativeModelInOperationClient) Operation(ctx context.Context, name string, options *RelativeModelInOperationClientOperationOptions) (RelativeModelInOperationClientOperationResponse, error) {
 	var err error
 	req, err := client.operationCreateRequest(ctx, name, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_sharedmodelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_sharedmodelinoperation_client.go
@@ -21,6 +21,8 @@ type SharedModelInOperationClient struct {
 	internal *azcore.Client
 }
 
+//   - options - SharedModelInOperationClientInternalOptions contains the optional parameters for the SharedModelInOperationClient.Internal
+//     method.
 func (client *SharedModelInOperationClient) Internal(ctx context.Context, name string, options *SharedModelInOperationClientInternalOptions) (SharedModelInOperationClientInternalResponse, error) {
 	var err error
 	req, err := client.internalCreateRequest(ctx, name, options)
@@ -62,6 +64,8 @@ func (client *SharedModelInOperationClient) internalHandleResponse(resp *http.Re
 	return result, nil
 }
 
+//   - options - SharedModelInOperationClientPublicOptions contains the optional parameters for the SharedModelInOperationClient.Public
+//     method.
 func (client *SharedModelInOperationClient) Public(ctx context.Context, name string, options *SharedModelInOperationClientPublicOptions) (SharedModelInOperationClientPublicResponse, error) {
 	var err error
 	req, err := client.publicCreateRequest(ctx, name, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_modelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_modelinoperation_client.go
@@ -27,6 +27,8 @@ type ModelInOperationClient struct {
 // "name": <any string>
 // }
 // ```
+//   - options - ModelInOperationClientInputToInputOutputOptions contains the optional parameters for the ModelInOperationClient.InputToInputOutput
+//     method.
 func (client *ModelInOperationClient) InputToInputOutput(ctx context.Context, body InputModel, options *ModelInOperationClientInputToInputOutputOptions) (ModelInOperationClientInputToInputOutputResponse, error) {
 	var err error
 	req, err := client.inputToInputOutputCreateRequest(ctx, body, options)
@@ -64,6 +66,8 @@ func (client *ModelInOperationClient) inputToInputOutputCreateRequest(ctx contex
 // "name": <any string>
 // }
 // ```
+//   - options - ModelInOperationClientOutputToInputOutputOptions contains the optional parameters for the ModelInOperationClient.OutputToInputOutput
+//     method.
 func (client *ModelInOperationClient) OutputToInputOutput(ctx context.Context, options *ModelInOperationClientOutputToInputOutputOptions) (ModelInOperationClientOutputToInputOutputResponse, error) {
 	var err error
 	req, err := client.outputToInputOutputCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_options.go
@@ -7,10 +7,14 @@
 
 package coreusagegroup
 
+// ModelInOperationClientInputToInputOutputOptions contains the optional parameters for the ModelInOperationClient.InputToInputOutput
+// method.
 type ModelInOperationClientInputToInputOutputOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelInOperationClientOutputToInputOutputOptions contains the optional parameters for the ModelInOperationClient.OutputToInputOutput
+// method.
 type ModelInOperationClientOutputToInputOutputOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basic_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basic_client.go
@@ -28,6 +28,7 @@ type BasicClient struct {
 // CreateOrReplace - Adds a user or replaces a user's fields.
 //   - resource - The resource instance.
 //   - id - The user's id.
+//   - options - BasicClientCreateOrReplaceOptions contains the optional parameters for the BasicClient.CreateOrReplace method.
 func (client *BasicClient) CreateOrReplace(ctx context.Context, resource User, id int32, options *BasicClientCreateOrReplaceOptions) (BasicClientCreateOrReplaceResponse, error) {
 	var err error
 	req, err := client.createOrReplaceCreateRequest(ctx, resource, id, options)
@@ -77,6 +78,7 @@ func (client *BasicClient) createOrReplaceHandleResponse(resp *http.Response) (B
 // CreateOrUpdate - Adds a user or updates a user's fields.
 //   - resource - The resource instance.
 //   - id - The user's id.
+//   - options - BasicClientCreateOrUpdateOptions contains the optional parameters for the BasicClient.CreateOrUpdate method.
 func (client *BasicClient) CreateOrUpdate(ctx context.Context, resource User, id int32, options *BasicClientCreateOrUpdateOptions) (BasicClientCreateOrUpdateResponse, error) {
 	var err error
 	req, err := client.createOrUpdateCreateRequest(ctx, resource, id, options)
@@ -125,6 +127,7 @@ func (client *BasicClient) createOrUpdateHandleResponse(resp *http.Response) (Ba
 
 // Delete - Deletes a user.
 //   - id - The user's id.
+//   - options - BasicClientDeleteOptions contains the optional parameters for the BasicClient.Delete method.
 func (client *BasicClient) Delete(ctx context.Context, id int32, options *BasicClientDeleteOptions) (BasicClientDeleteResponse, error) {
 	var err error
 	req, err := client.deleteCreateRequest(ctx, id, options)
@@ -160,6 +163,7 @@ func (client *BasicClient) deleteCreateRequest(ctx context.Context, id int32, op
 // Export - Exports a user.
 //   - id - The user's id.
 //   - formatParam - The format of the data.
+//   - options - BasicClientExportOptions contains the optional parameters for the BasicClient.Export method.
 func (client *BasicClient) Export(ctx context.Context, id int32, formatParam string, options *BasicClientExportOptions) (BasicClientExportResponse, error) {
 	var err error
 	req, err := client.exportCreateRequest(ctx, id, formatParam, options)
@@ -205,6 +209,7 @@ func (client *BasicClient) exportHandleResponse(resp *http.Response) (BasicClien
 
 // Get - Gets a user.
 //   - id - The user's id.
+//   - options - BasicClientGetOptions contains the optional parameters for the BasicClient.Get method.
 func (client *BasicClient) Get(ctx context.Context, id int32, options *BasicClientGetOptions) (BasicClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, id, options)
@@ -248,6 +253,7 @@ func (client *BasicClient) getHandleResponse(resp *http.Response) (BasicClientGe
 }
 
 // NewListPager - Lists all users.
+//   - options - BasicClientListOptions contains the optional parameters for the BasicClient.NewListPager method.
 func (client *BasicClient) NewListPager(options *BasicClientListOptions) *runtime.Pager[BasicClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListResponse]{
 		More: func(page BasicClientListResponse) bool {
@@ -320,6 +326,8 @@ func (client *BasicClient) listHandleResponse(resp *http.Response) (BasicClientL
 }
 
 // NewListWithCustomPageModelPager - List with custom page model.
+//   - options - BasicClientListWithCustomPageModelOptions contains the optional parameters for the BasicClient.NewListWithCustomPageModelPager
+//     method.
 func (client *BasicClient) NewListWithCustomPageModelPager(options *BasicClientListWithCustomPageModelOptions) *runtime.Pager[BasicClientListWithCustomPageModelResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListWithCustomPageModelResponse]{
 		More: func(page BasicClientListWithCustomPageModelResponse) bool {
@@ -365,6 +373,7 @@ func (client *BasicClient) listWithCustomPageModelHandleResponse(resp *http.Resp
 }
 
 // NewListWithPagePager - List with Azure.Core.Page<>.
+//   - options - BasicClientListWithPageOptions contains the optional parameters for the BasicClient.NewListWithPagePager method.
 func (client *BasicClient) NewListWithPagePager(options *BasicClientListWithPageOptions) *runtime.Pager[BasicClientListWithPageResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListWithPageResponse]{
 		More: func(page BasicClientListWithPageResponse) bool {
@@ -411,6 +420,8 @@ func (client *BasicClient) listWithPageHandleResponse(resp *http.Response) (Basi
 
 // NewListWithParametersPager - List with extensible enum parameter Azure.Core.Page<>.
 //   - bodyInput - The body of the input.
+//   - options - BasicClientListWithParametersOptions contains the optional parameters for the BasicClient.NewListWithParametersPager
+//     method.
 func (client *BasicClient) NewListWithParametersPager(bodyInput ListItemInputBody, options *BasicClientListWithParametersOptions) *runtime.Pager[BasicClientListWithParametersResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListWithParametersResponse]{
 		More: func(page BasicClientListWithParametersResponse) bool {

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package basicgroup
 
+// BasicClientCreateOrReplaceOptions contains the optional parameters for the BasicClient.CreateOrReplace method.
 type BasicClientCreateOrReplaceOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientCreateOrUpdateOptions contains the optional parameters for the BasicClient.CreateOrUpdate method.
 type BasicClientCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientDeleteOptions contains the optional parameters for the BasicClient.Delete method.
 type BasicClientDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientExportOptions contains the optional parameters for the BasicClient.Export method.
 type BasicClientExportOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientGetOptions contains the optional parameters for the BasicClient.Get method.
 type BasicClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientListOptions contains the optional parameters for the BasicClient.NewListPager method.
 type BasicClientListOptions struct {
 	// Expand the indicated resources into the response.
 	Expand []string
@@ -50,23 +56,31 @@ type BasicClientListOptions struct {
 	Top *int32
 }
 
+// BasicClientListWithCustomPageModelOptions contains the optional parameters for the BasicClient.NewListWithCustomPageModelPager
+// method.
 type BasicClientListWithCustomPageModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientListWithPageOptions contains the optional parameters for the BasicClient.NewListWithPagePager method.
 type BasicClientListWithPageOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BasicClientListWithParametersOptions contains the optional parameters for the BasicClient.NewListWithParametersPager method.
 type BasicClientListWithParametersOptions struct {
 	// Another query parameter.
 	Another *ListItemInputExtensibleEnum
 }
 
+// TwoModelsAsPageItemClientListFirstItemOptions contains the optional parameters for the TwoModelsAsPageItemClient.NewListFirstItemPager
+// method.
 type TwoModelsAsPageItemClientListFirstItemOptions struct {
 	// placeholder for future optional parameters
 }
 
+// TwoModelsAsPageItemClientListSecondItemOptions contains the optional parameters for the TwoModelsAsPageItemClient.NewListSecondItemPager
+// method.
 type TwoModelsAsPageItemClientListSecondItemOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_responses.go
@@ -36,36 +36,36 @@ type BasicClientGetResponse struct {
 	User
 }
 
-// BasicClientListResponse contains the response from method BasicClient.List.
+// BasicClientListResponse contains the response from method BasicClient.NewListPager.
 type BasicClientListResponse struct {
 	// Paged collection of User items
 	PagedUser
 }
 
-// BasicClientListWithCustomPageModelResponse contains the response from method BasicClient.ListWithCustomPageModel.
+// BasicClientListWithCustomPageModelResponse contains the response from method BasicClient.NewListWithCustomPageModelPager.
 type BasicClientListWithCustomPageModelResponse struct {
 	UserListResults
 }
 
-// BasicClientListWithPageResponse contains the response from method BasicClient.ListWithPage.
+// BasicClientListWithPageResponse contains the response from method BasicClient.NewListWithPagePager.
 type BasicClientListWithPageResponse struct {
 	// Paged collection of User items
 	PagedUser
 }
 
-// BasicClientListWithParametersResponse contains the response from method BasicClient.ListWithParameters.
+// BasicClientListWithParametersResponse contains the response from method BasicClient.NewListWithParametersPager.
 type BasicClientListWithParametersResponse struct {
 	// Paged collection of User items
 	PagedUser
 }
 
-// TwoModelsAsPageItemClientListFirstItemResponse contains the response from method TwoModelsAsPageItemClient.ListFirstItem.
+// TwoModelsAsPageItemClientListFirstItemResponse contains the response from method TwoModelsAsPageItemClient.NewListFirstItemPager.
 type TwoModelsAsPageItemClientListFirstItemResponse struct {
 	// Paged collection of FirstItem items
 	PagedFirstItem
 }
 
-// TwoModelsAsPageItemClientListSecondItemResponse contains the response from method TwoModelsAsPageItemClient.ListSecondItem.
+// TwoModelsAsPageItemClientListSecondItemResponse contains the response from method TwoModelsAsPageItemClient.NewListSecondItemPager.
 type TwoModelsAsPageItemClientListSecondItemResponse struct {
 	// Paged collection of SecondItem items
 	PagedSecondItem

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_twomodelsaspageitem_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_twomodelsaspageitem_client.go
@@ -24,6 +24,8 @@ type TwoModelsAsPageItemClient struct {
 
 // NewListFirstItemPager - Two operations with two different page item types should be successfully generated. Should generate
 // model for FirstItem.
+//   - options - TwoModelsAsPageItemClientListFirstItemOptions contains the optional parameters for the TwoModelsAsPageItemClient.NewListFirstItemPager
+//     method.
 func (client *TwoModelsAsPageItemClient) NewListFirstItemPager(options *TwoModelsAsPageItemClientListFirstItemOptions) *runtime.Pager[TwoModelsAsPageItemClientListFirstItemResponse] {
 	return runtime.NewPager(runtime.PagingHandler[TwoModelsAsPageItemClientListFirstItemResponse]{
 		More: func(page TwoModelsAsPageItemClientListFirstItemResponse) bool {
@@ -70,6 +72,8 @@ func (client *TwoModelsAsPageItemClient) listFirstItemHandleResponse(resp *http.
 
 // NewListSecondItemPager - Two operations with two different page item types should be successfully generated. Should generate
 // model for SecondItem.
+//   - options - TwoModelsAsPageItemClientListSecondItemOptions contains the optional parameters for the TwoModelsAsPageItemClient.NewListSecondItemPager
+//     method.
 func (client *TwoModelsAsPageItemClient) NewListSecondItemPager(options *TwoModelsAsPageItemClientListSecondItemOptions) *runtime.Pager[TwoModelsAsPageItemClientListSecondItemResponse] {
 	return runtime.NewPager(runtime.PagingHandler[TwoModelsAsPageItemClientListSecondItemResponse]{
 		More: func(page TwoModelsAsPageItemClientListSecondItemResponse) bool {

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_bar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_bar_client.go
@@ -21,6 +21,7 @@ type BarClient struct {
 	internal *azcore.Client
 }
 
+// - options - BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 func (client *BarClient) Five(ctx context.Context, options *BarClientFiveOptions) (BarClientFiveResponse, error) {
 	var err error
 	req, err := client.fiveCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *BarClient) fiveCreateRequest(ctx context.Context, options *BarClie
 	return req, nil
 }
 
+// - options - BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 func (client *BarClient) Six(ctx context.Context, options *BarClientSixOptions) (BarClientSixResponse, error) {
 	var err error
 	req, err := client.sixCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_foo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_foo_client.go
@@ -21,6 +21,7 @@ type FooClient struct {
 	internal *azcore.Client
 }
 
+// - options - FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 func (client *FooClient) Four(ctx context.Context, options *FooClientFourOptions) (FooClientFourResponse, error) {
 	var err error
 	req, err := client.fourCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *FooClient) fourCreateRequest(ctx context.Context, options *FooClie
 	return req, nil
 }
 
+// - options - FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 func (client *FooClient) Three(ctx context.Context, options *FooClientThreeOptions) (FooClientThreeResponse, error) {
 	var err error
 	req, err := client.threeCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package defaultgroup
 
+// BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 type BarClientFiveOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 type BarClientSixOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 type FooClientFourOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 type FooClientThreeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 type ServiceClientOneOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 type ServiceClientTwoOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_service_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_service_client.go
@@ -21,6 +21,7 @@ type ServiceClient struct {
 	internal *azcore.Client
 }
 
+// - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneOptions) (ServiceClientOneResponse, error) {
 	var err error
 	req, err := client.oneCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *ServiceClient) oneCreateRequest(ctx context.Context, options *Serv
 	return req, nil
 }
 
+// - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoOptions) (ServiceClientTwoResponse, error) {
 	var err error
 	req, err := client.twoCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_bar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_bar_client.go
@@ -21,6 +21,7 @@ type BarClient struct {
 	internal *azcore.Client
 }
 
+// - options - BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 func (client *BarClient) Five(ctx context.Context, options *BarClientFiveOptions) (BarClientFiveResponse, error) {
 	var err error
 	req, err := client.fiveCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *BarClient) fiveCreateRequest(ctx context.Context, options *BarClie
 	return req, nil
 }
 
+// - options - BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 func (client *BarClient) Six(ctx context.Context, options *BarClientSixOptions) (BarClientSixResponse, error) {
 	var err error
 	req, err := client.sixCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_foo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_foo_client.go
@@ -21,6 +21,7 @@ type FooClient struct {
 	internal *azcore.Client
 }
 
+// - options - FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 func (client *FooClient) Four(ctx context.Context, options *FooClientFourOptions) (FooClientFourResponse, error) {
 	var err error
 	req, err := client.fourCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *FooClient) fourCreateRequest(ctx context.Context, options *FooClie
 	return req, nil
 }
 
+// - options - FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 func (client *FooClient) Three(ctx context.Context, options *FooClientThreeOptions) (FooClientThreeResponse, error) {
 	var err error
 	req, err := client.threeCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package multiclientgroup
 
+// BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 type BarClientFiveOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 type BarClientSixOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 type FooClientFourOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 type FooClientThreeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 type ServiceClientOneOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 type ServiceClientTwoOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_service_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_service_client.go
@@ -21,6 +21,7 @@ type ServiceClient struct {
 	internal *azcore.Client
 }
 
+// - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneOptions) (ServiceClientOneResponse, error) {
 	var err error
 	req, err := client.oneCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *ServiceClient) oneCreateRequest(ctx context.Context, options *Serv
 	return req, nil
 }
 
+// - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoOptions) (ServiceClientTwoResponse, error) {
 	var err error
 	req, err := client.twoCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_bar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_bar_client.go
@@ -21,6 +21,7 @@ type BarClient struct {
 	internal *azcore.Client
 }
 
+// - options - BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 func (client *BarClient) Five(ctx context.Context, options *BarClientFiveOptions) (BarClientFiveResponse, error) {
 	var err error
 	req, err := client.fiveCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *BarClient) fiveCreateRequest(ctx context.Context, options *BarClie
 	return req, nil
 }
 
+// - options - BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 func (client *BarClient) Six(ctx context.Context, options *BarClientSixOptions) (BarClientSixResponse, error) {
 	var err error
 	req, err := client.sixCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_foo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_foo_client.go
@@ -21,6 +21,7 @@ type FooClient struct {
 	internal *azcore.Client
 }
 
+// - options - FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 func (client *FooClient) Four(ctx context.Context, options *FooClientFourOptions) (FooClientFourResponse, error) {
 	var err error
 	req, err := client.fourCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *FooClient) fourCreateRequest(ctx context.Context, options *FooClie
 	return req, nil
 }
 
+// - options - FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 func (client *FooClient) Three(ctx context.Context, options *FooClientThreeOptions) (FooClientThreeResponse, error) {
 	var err error
 	req, err := client.threeCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package renamedopgroup
 
+// BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 type BarClientFiveOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 type BarClientSixOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 type FooClientFourOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 type FooClientThreeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 type ServiceClientOneOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 type ServiceClientTwoOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_service_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_service_client.go
@@ -21,6 +21,7 @@ type ServiceClient struct {
 	internal *azcore.Client
 }
 
+// - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneOptions) (ServiceClientOneResponse, error) {
 	var err error
 	req, err := client.oneCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *ServiceClient) oneCreateRequest(ctx context.Context, options *Serv
 	return req, nil
 }
 
+// - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoOptions) (ServiceClientTwoResponse, error) {
 	var err error
 	req, err := client.twoCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_bar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_bar_client.go
@@ -21,6 +21,7 @@ type BarClient struct {
 	internal *azcore.Client
 }
 
+// - options - BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 func (client *BarClient) Five(ctx context.Context, options *BarClientFiveOptions) (BarClientFiveResponse, error) {
 	var err error
 	req, err := client.fiveCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *BarClient) fiveCreateRequest(ctx context.Context, options *BarClie
 	return req, nil
 }
 
+// - options - BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 func (client *BarClient) Six(ctx context.Context, options *BarClientSixOptions) (BarClientSixResponse, error) {
 	var err error
 	req, err := client.sixCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_foo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_foo_client.go
@@ -21,6 +21,7 @@ type FooClient struct {
 	internal *azcore.Client
 }
 
+// - options - FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 func (client *FooClient) Four(ctx context.Context, options *FooClientFourOptions) (FooClientFourResponse, error) {
 	var err error
 	req, err := client.fourCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *FooClient) fourCreateRequest(ctx context.Context, options *FooClie
 	return req, nil
 }
 
+// - options - FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 func (client *FooClient) Three(ctx context.Context, options *FooClientThreeOptions) (FooClientThreeResponse, error) {
 	var err error
 	req, err := client.threeCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package twoopgroup
 
+// BarClientFiveOptions contains the optional parameters for the BarClient.Five method.
 type BarClientFiveOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BarClientSixOptions contains the optional parameters for the BarClient.Six method.
 type BarClientSixOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientFourOptions contains the optional parameters for the FooClient.Four method.
 type FooClientFourOptions struct {
 	// placeholder for future optional parameters
 }
 
+// FooClientThreeOptions contains the optional parameters for the FooClient.Three method.
 type FooClientThreeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 type ServiceClientOneOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 type ServiceClientTwoOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_service_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_service_client.go
@@ -21,6 +21,7 @@ type ServiceClient struct {
 	internal *azcore.Client
 }
 
+// - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneOptions) (ServiceClientOneResponse, error) {
 	var err error
 	req, err := client.oneCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *ServiceClient) oneCreateRequest(ctx context.Context, options *Serv
 	return req, nil
 }
 
+// - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoOptions) (ServiceClientTwoResponse, error) {
 	var err error
 	req, err := client.twoCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_header_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_header_client.go
@@ -23,6 +23,7 @@ type HeaderClient struct {
 	internal *azcore.Client
 }
 
+// - options - HeaderClientBase64Options contains the optional parameters for the HeaderClient.Base64 method.
 func (client *HeaderClient) Base64(ctx context.Context, value []byte, options *HeaderClientBase64Options) (HeaderClientBase64Response, error) {
 	var err error
 	req, err := client.base64CreateRequest(ctx, value, options)
@@ -51,6 +52,7 @@ func (client *HeaderClient) base64CreateRequest(ctx context.Context, value []byt
 	return req, nil
 }
 
+// - options - HeaderClientBase64URLOptions contains the optional parameters for the HeaderClient.Base64URL method.
 func (client *HeaderClient) Base64URL(ctx context.Context, value []byte, options *HeaderClientBase64URLOptions) (HeaderClientBase64URLResponse, error) {
 	var err error
 	req, err := client.base64URLCreateRequest(ctx, value, options)
@@ -79,6 +81,7 @@ func (client *HeaderClient) base64URLCreateRequest(ctx context.Context, value []
 	return req, nil
 }
 
+// - options - HeaderClientBase64URLArrayOptions contains the optional parameters for the HeaderClient.Base64URLArray method.
 func (client *HeaderClient) Base64URLArray(ctx context.Context, value [][]byte, options *HeaderClientBase64URLArrayOptions) (HeaderClientBase64URLArrayResponse, error) {
 	var err error
 	req, err := client.base64URLArrayCreateRequest(ctx, value, options)
@@ -113,6 +116,7 @@ func (client *HeaderClient) base64URLArrayCreateRequest(ctx context.Context, val
 	return req, nil
 }
 
+// - options - HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 func (client *HeaderClient) Default(ctx context.Context, value []byte, options *HeaderClientDefaultOptions) (HeaderClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, value, options)

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_options.go
@@ -7,90 +7,114 @@
 
 package bytesgroup
 
+// HeaderClientBase64Options contains the optional parameters for the HeaderClient.Base64 method.
 type HeaderClientBase64Options struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientBase64URLArrayOptions contains the optional parameters for the HeaderClient.Base64URLArray method.
 type HeaderClientBase64URLArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientBase64URLOptions contains the optional parameters for the HeaderClient.Base64URL method.
 type HeaderClientBase64URLOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 type HeaderClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientBase64Options contains the optional parameters for the PropertyClient.Base64 method.
 type PropertyClientBase64Options struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientBase64URLArrayOptions contains the optional parameters for the PropertyClient.Base64URLArray method.
 type PropertyClientBase64URLArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientBase64URLOptions contains the optional parameters for the PropertyClient.Base64URL method.
 type PropertyClientBase64URLOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 type PropertyClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientBase64Options contains the optional parameters for the QueryClient.Base64 method.
 type QueryClientBase64Options struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientBase64URLArrayOptions contains the optional parameters for the QueryClient.Base64URLArray method.
 type QueryClientBase64URLArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientBase64URLOptions contains the optional parameters for the QueryClient.Base64URL method.
 type QueryClientBase64URLOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 type QueryClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RequestBodyClientBase64Options contains the optional parameters for the RequestBodyClient.Base64 method.
 type RequestBodyClientBase64Options struct {
 	// placeholder for future optional parameters
 }
 
+// RequestBodyClientBase64URLOptions contains the optional parameters for the RequestBodyClient.Base64URL method.
 type RequestBodyClientBase64URLOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RequestBodyClientCustomContentTypeOptions contains the optional parameters for the RequestBodyClient.CustomContentType
+// method.
 type RequestBodyClientCustomContentTypeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RequestBodyClientDefaultOptions contains the optional parameters for the RequestBodyClient.Default method.
 type RequestBodyClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RequestBodyClientOctetStreamOptions contains the optional parameters for the RequestBodyClient.OctetStream method.
 type RequestBodyClientOctetStreamOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseBodyClientBase64Options contains the optional parameters for the ResponseBodyClient.Base64 method.
 type ResponseBodyClientBase64Options struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseBodyClientBase64URLOptions contains the optional parameters for the ResponseBodyClient.Base64URL method.
 type ResponseBodyClientBase64URLOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseBodyClientCustomContentTypeOptions contains the optional parameters for the ResponseBodyClient.CustomContentType
+// method.
 type ResponseBodyClientCustomContentTypeOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseBodyClientDefaultOptions contains the optional parameters for the ResponseBodyClient.Default method.
 type ResponseBodyClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseBodyClientOctetStreamOptions contains the optional parameters for the ResponseBodyClient.OctetStream method.
 type ResponseBodyClientOctetStreamOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_property_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_property_client.go
@@ -21,6 +21,7 @@ type PropertyClient struct {
 	internal *azcore.Client
 }
 
+// - options - PropertyClientBase64Options contains the optional parameters for the PropertyClient.Base64 method.
 func (client *PropertyClient) Base64(ctx context.Context, body Base64BytesProperty, options *PropertyClientBase64Options) (PropertyClientBase64Response, error) {
 	var err error
 	req, err := client.base64CreateRequest(ctx, body, options)
@@ -63,6 +64,7 @@ func (client *PropertyClient) base64HandleResponse(resp *http.Response) (Propert
 	return result, nil
 }
 
+// - options - PropertyClientBase64URLOptions contains the optional parameters for the PropertyClient.Base64URL method.
 func (client *PropertyClient) Base64URL(ctx context.Context, body Base64URLBytesProperty, options *PropertyClientBase64URLOptions) (PropertyClientBase64URLResponse, error) {
 	var err error
 	req, err := client.base64URLCreateRequest(ctx, body, options)
@@ -105,6 +107,7 @@ func (client *PropertyClient) base64URLHandleResponse(resp *http.Response) (Prop
 	return result, nil
 }
 
+// - options - PropertyClientBase64URLArrayOptions contains the optional parameters for the PropertyClient.Base64URLArray method.
 func (client *PropertyClient) Base64URLArray(ctx context.Context, body Base64URLArrayBytesProperty, options *PropertyClientBase64URLArrayOptions) (PropertyClientBase64URLArrayResponse, error) {
 	var err error
 	req, err := client.base64URLArrayCreateRequest(ctx, body, options)
@@ -147,6 +150,7 @@ func (client *PropertyClient) base64URLArrayHandleResponse(resp *http.Response) 
 	return result, nil
 }
 
+// - options - PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 func (client *PropertyClient) Default(ctx context.Context, body DefaultBytesProperty, options *PropertyClientDefaultOptions) (PropertyClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_query_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_query_client.go
@@ -23,6 +23,7 @@ type QueryClient struct {
 	internal *azcore.Client
 }
 
+// - options - QueryClientBase64Options contains the optional parameters for the QueryClient.Base64 method.
 func (client *QueryClient) Base64(ctx context.Context, value []byte, options *QueryClientBase64Options) (QueryClientBase64Response, error) {
 	var err error
 	req, err := client.base64CreateRequest(ctx, value, options)
@@ -53,6 +54,7 @@ func (client *QueryClient) base64CreateRequest(ctx context.Context, value []byte
 	return req, nil
 }
 
+// - options - QueryClientBase64URLOptions contains the optional parameters for the QueryClient.Base64URL method.
 func (client *QueryClient) Base64URL(ctx context.Context, value []byte, options *QueryClientBase64URLOptions) (QueryClientBase64URLResponse, error) {
 	var err error
 	req, err := client.base64URLCreateRequest(ctx, value, options)
@@ -83,6 +85,7 @@ func (client *QueryClient) base64URLCreateRequest(ctx context.Context, value []b
 	return req, nil
 }
 
+// - options - QueryClientBase64URLArrayOptions contains the optional parameters for the QueryClient.Base64URLArray method.
 func (client *QueryClient) Base64URLArray(ctx context.Context, value [][]byte, options *QueryClientBase64URLArrayOptions) (QueryClientBase64URLArrayResponse, error) {
 	var err error
 	req, err := client.base64URLArrayCreateRequest(ctx, value, options)
@@ -119,6 +122,7 @@ func (client *QueryClient) base64URLArrayCreateRequest(ctx context.Context, valu
 	return req, nil
 }
 
+// - options - QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 func (client *QueryClient) Default(ctx context.Context, value []byte, options *QueryClientDefaultOptions) (QueryClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, value, options)

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
@@ -21,6 +21,7 @@ type RequestBodyClient struct {
 	internal *azcore.Client
 }
 
+// - options - RequestBodyClientBase64Options contains the optional parameters for the RequestBodyClient.Base64 method.
 func (client *RequestBodyClient) Base64(ctx context.Context, value []byte, options *RequestBodyClientBase64Options) (RequestBodyClientBase64Response, error) {
 	var err error
 	req, err := client.base64CreateRequest(ctx, value, options)
@@ -52,6 +53,7 @@ func (client *RequestBodyClient) base64CreateRequest(ctx context.Context, value 
 	return req, nil
 }
 
+// - options - RequestBodyClientBase64URLOptions contains the optional parameters for the RequestBodyClient.Base64URL method.
 func (client *RequestBodyClient) Base64URL(ctx context.Context, value []byte, options *RequestBodyClientBase64URLOptions) (RequestBodyClientBase64URLResponse, error) {
 	var err error
 	req, err := client.base64URLCreateRequest(ctx, value, options)
@@ -83,6 +85,8 @@ func (client *RequestBodyClient) base64URLCreateRequest(ctx context.Context, val
 	return req, nil
 }
 
+//   - options - RequestBodyClientCustomContentTypeOptions contains the optional parameters for the RequestBodyClient.CustomContentType
+//     method.
 func (client *RequestBodyClient) CustomContentType(ctx context.Context, value []byte, options *RequestBodyClientCustomContentTypeOptions) (RequestBodyClientCustomContentTypeResponse, error) {
 	var err error
 	req, err := client.customContentTypeCreateRequest(ctx, value, options)
@@ -114,6 +118,7 @@ func (client *RequestBodyClient) customContentTypeCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// - options - RequestBodyClientDefaultOptions contains the optional parameters for the RequestBodyClient.Default method.
 func (client *RequestBodyClient) Default(ctx context.Context, value []byte, options *RequestBodyClientDefaultOptions) (RequestBodyClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, value, options)
@@ -145,6 +150,7 @@ func (client *RequestBodyClient) defaultCreateRequest(ctx context.Context, value
 	return req, nil
 }
 
+// - options - RequestBodyClientOctetStreamOptions contains the optional parameters for the RequestBodyClient.OctetStream method.
 func (client *RequestBodyClient) OctetStream(ctx context.Context, value []byte, options *RequestBodyClientOctetStreamOptions) (RequestBodyClientOctetStreamResponse, error) {
 	var err error
 	req, err := client.octetStreamCreateRequest(ctx, value, options)

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
@@ -21,6 +21,7 @@ type ResponseBodyClient struct {
 	internal *azcore.Client
 }
 
+// - options - ResponseBodyClientBase64Options contains the optional parameters for the ResponseBodyClient.Base64 method.
 func (client *ResponseBodyClient) Base64(ctx context.Context, options *ResponseBodyClientBase64Options) (ResponseBodyClientBase64Response, error) {
 	var err error
 	req, err := client.base64CreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *ResponseBodyClient) base64HandleResponse(resp *http.Response) (Res
 	return result, nil
 }
 
+// - options - ResponseBodyClientBase64URLOptions contains the optional parameters for the ResponseBodyClient.Base64URL method.
 func (client *ResponseBodyClient) Base64URL(ctx context.Context, options *ResponseBodyClientBase64URLOptions) (ResponseBodyClientBase64URLResponse, error) {
 	var err error
 	req, err := client.base64URLCreateRequest(ctx, options)
@@ -97,6 +99,8 @@ func (client *ResponseBodyClient) base64URLHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+//   - options - ResponseBodyClientCustomContentTypeOptions contains the optional parameters for the ResponseBodyClient.CustomContentType
+//     method.
 func (client *ResponseBodyClient) CustomContentType(ctx context.Context, options *ResponseBodyClientCustomContentTypeOptions) (ResponseBodyClientCustomContentTypeResponse, error) {
 	var err error
 	req, err := client.customContentTypeCreateRequest(ctx, options)
@@ -135,6 +139,7 @@ func (client *ResponseBodyClient) customContentTypeHandleResponse(resp *http.Res
 	return result, nil
 }
 
+// - options - ResponseBodyClientDefaultOptions contains the optional parameters for the ResponseBodyClient.Default method.
 func (client *ResponseBodyClient) Default(ctx context.Context, options *ResponseBodyClientDefaultOptions) (ResponseBodyClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, options)
@@ -173,6 +178,8 @@ func (client *ResponseBodyClient) defaultHandleResponse(resp *http.Response) (Re
 	return result, nil
 }
 
+//   - options - ResponseBodyClientOctetStreamOptions contains the optional parameters for the ResponseBodyClient.OctetStream
+//     method.
 func (client *ResponseBodyClient) OctetStream(ctx context.Context, options *ResponseBodyClientOctetStreamOptions) (ResponseBodyClientOctetStreamResponse, error) {
 	var err error
 	req, err := client.octetStreamCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_header_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_header_client.go
@@ -23,6 +23,7 @@ type HeaderClient struct {
 	internal *azcore.Client
 }
 
+// - options - HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 func (client *HeaderClient) Default(ctx context.Context, value time.Time, options *HeaderClientDefaultOptions) (HeaderClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, value, options)
@@ -51,6 +52,7 @@ func (client *HeaderClient) defaultCreateRequest(ctx context.Context, value time
 	return req, nil
 }
 
+// - options - HeaderClientRFC3339Options contains the optional parameters for the HeaderClient.RFC3339 method.
 func (client *HeaderClient) RFC3339(ctx context.Context, value time.Time, options *HeaderClientRFC3339Options) (HeaderClientRFC3339Response, error) {
 	var err error
 	req, err := client.rfc3339CreateRequest(ctx, value, options)
@@ -79,6 +81,7 @@ func (client *HeaderClient) rfc3339CreateRequest(ctx context.Context, value time
 	return req, nil
 }
 
+// - options - HeaderClientRFC7231Options contains the optional parameters for the HeaderClient.RFC7231 method.
 func (client *HeaderClient) RFC7231(ctx context.Context, value time.Time, options *HeaderClientRFC7231Options) (HeaderClientRFC7231Response, error) {
 	var err error
 	req, err := client.rfc7231CreateRequest(ctx, value, options)
@@ -107,6 +110,7 @@ func (client *HeaderClient) rfc7231CreateRequest(ctx context.Context, value time
 	return req, nil
 }
 
+// - options - HeaderClientUnixTimestampOptions contains the optional parameters for the HeaderClient.UnixTimestamp method.
 func (client *HeaderClient) UnixTimestamp(ctx context.Context, value time.Time, options *HeaderClientUnixTimestampOptions) (HeaderClientUnixTimestampResponse, error) {
 	var err error
 	req, err := client.unixTimestampCreateRequest(ctx, value, options)
@@ -135,6 +139,8 @@ func (client *HeaderClient) unixTimestampCreateRequest(ctx context.Context, valu
 	return req, nil
 }
 
+//   - options - HeaderClientUnixTimestampArrayOptions contains the optional parameters for the HeaderClient.UnixTimestampArray
+//     method.
 func (client *HeaderClient) UnixTimestampArray(ctx context.Context, value []time.Time, options *HeaderClientUnixTimestampArrayOptions) (HeaderClientUnixTimestampArrayResponse, error) {
 	var err error
 	req, err := client.unixTimestampArrayCreateRequest(ctx, value, options)

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_options.go
@@ -7,78 +7,97 @@
 
 package datetimegroup
 
+// HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 type HeaderClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientRFC3339Options contains the optional parameters for the HeaderClient.RFC3339 method.
 type HeaderClientRFC3339Options struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientRFC7231Options contains the optional parameters for the HeaderClient.RFC7231 method.
 type HeaderClientRFC7231Options struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientUnixTimestampArrayOptions contains the optional parameters for the HeaderClient.UnixTimestampArray method.
 type HeaderClientUnixTimestampArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientUnixTimestampOptions contains the optional parameters for the HeaderClient.UnixTimestamp method.
 type HeaderClientUnixTimestampOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 type PropertyClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientRFC3339Options contains the optional parameters for the PropertyClient.RFC3339 method.
 type PropertyClientRFC3339Options struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientRFC7231Options contains the optional parameters for the PropertyClient.RFC7231 method.
 type PropertyClientRFC7231Options struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientUnixTimestampArrayOptions contains the optional parameters for the PropertyClient.UnixTimestampArray method.
 type PropertyClientUnixTimestampArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientUnixTimestampOptions contains the optional parameters for the PropertyClient.UnixTimestamp method.
 type PropertyClientUnixTimestampOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 type QueryClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientRFC3339Options contains the optional parameters for the QueryClient.RFC3339 method.
 type QueryClientRFC3339Options struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientRFC7231Options contains the optional parameters for the QueryClient.RFC7231 method.
 type QueryClientRFC7231Options struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientUnixTimestampArrayOptions contains the optional parameters for the QueryClient.UnixTimestampArray method.
 type QueryClientUnixTimestampArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientUnixTimestampOptions contains the optional parameters for the QueryClient.UnixTimestamp method.
 type QueryClientUnixTimestampOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseHeaderClientDefaultOptions contains the optional parameters for the ResponseHeaderClient.Default method.
 type ResponseHeaderClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseHeaderClientRFC3339Options contains the optional parameters for the ResponseHeaderClient.RFC3339 method.
 type ResponseHeaderClientRFC3339Options struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseHeaderClientRFC7231Options contains the optional parameters for the ResponseHeaderClient.RFC7231 method.
 type ResponseHeaderClientRFC7231Options struct {
 	// placeholder for future optional parameters
 }
 
+// ResponseHeaderClientUnixTimestampOptions contains the optional parameters for the ResponseHeaderClient.UnixTimestamp method.
 type ResponseHeaderClientUnixTimestampOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_property_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_property_client.go
@@ -21,6 +21,7 @@ type PropertyClient struct {
 	internal *azcore.Client
 }
 
+// - options - PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 func (client *PropertyClient) Default(ctx context.Context, body DefaultDatetimeProperty, options *PropertyClientDefaultOptions) (PropertyClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, body, options)
@@ -63,6 +64,7 @@ func (client *PropertyClient) defaultHandleResponse(resp *http.Response) (Proper
 	return result, nil
 }
 
+// - options - PropertyClientRFC3339Options contains the optional parameters for the PropertyClient.RFC3339 method.
 func (client *PropertyClient) RFC3339(ctx context.Context, body RFC3339DatetimeProperty, options *PropertyClientRFC3339Options) (PropertyClientRFC3339Response, error) {
 	var err error
 	req, err := client.rfc3339CreateRequest(ctx, body, options)
@@ -105,6 +107,7 @@ func (client *PropertyClient) rfc3339HandleResponse(resp *http.Response) (Proper
 	return result, nil
 }
 
+// - options - PropertyClientRFC7231Options contains the optional parameters for the PropertyClient.RFC7231 method.
 func (client *PropertyClient) RFC7231(ctx context.Context, body RFC7231DatetimeProperty, options *PropertyClientRFC7231Options) (PropertyClientRFC7231Response, error) {
 	var err error
 	req, err := client.rfc7231CreateRequest(ctx, body, options)
@@ -147,6 +150,7 @@ func (client *PropertyClient) rfc7231HandleResponse(resp *http.Response) (Proper
 	return result, nil
 }
 
+// - options - PropertyClientUnixTimestampOptions contains the optional parameters for the PropertyClient.UnixTimestamp method.
 func (client *PropertyClient) UnixTimestamp(ctx context.Context, body UnixTimestampDatetimeProperty, options *PropertyClientUnixTimestampOptions) (PropertyClientUnixTimestampResponse, error) {
 	var err error
 	req, err := client.unixTimestampCreateRequest(ctx, body, options)
@@ -189,6 +193,8 @@ func (client *PropertyClient) unixTimestampHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+//   - options - PropertyClientUnixTimestampArrayOptions contains the optional parameters for the PropertyClient.UnixTimestampArray
+//     method.
 func (client *PropertyClient) UnixTimestampArray(ctx context.Context, body UnixTimestampArrayDatetimeProperty, options *PropertyClientUnixTimestampArrayOptions) (PropertyClientUnixTimestampArrayResponse, error) {
 	var err error
 	req, err := client.unixTimestampArrayCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_query_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_query_client.go
@@ -23,6 +23,7 @@ type QueryClient struct {
 	internal *azcore.Client
 }
 
+// - options - QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 func (client *QueryClient) Default(ctx context.Context, value time.Time, options *QueryClientDefaultOptions) (QueryClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, value, options)
@@ -53,6 +54,7 @@ func (client *QueryClient) defaultCreateRequest(ctx context.Context, value time.
 	return req, nil
 }
 
+// - options - QueryClientRFC3339Options contains the optional parameters for the QueryClient.RFC3339 method.
 func (client *QueryClient) RFC3339(ctx context.Context, value time.Time, options *QueryClientRFC3339Options) (QueryClientRFC3339Response, error) {
 	var err error
 	req, err := client.rfc3339CreateRequest(ctx, value, options)
@@ -83,6 +85,7 @@ func (client *QueryClient) rfc3339CreateRequest(ctx context.Context, value time.
 	return req, nil
 }
 
+// - options - QueryClientRFC7231Options contains the optional parameters for the QueryClient.RFC7231 method.
 func (client *QueryClient) RFC7231(ctx context.Context, value time.Time, options *QueryClientRFC7231Options) (QueryClientRFC7231Response, error) {
 	var err error
 	req, err := client.rfc7231CreateRequest(ctx, value, options)
@@ -113,6 +116,7 @@ func (client *QueryClient) rfc7231CreateRequest(ctx context.Context, value time.
 	return req, nil
 }
 
+// - options - QueryClientUnixTimestampOptions contains the optional parameters for the QueryClient.UnixTimestamp method.
 func (client *QueryClient) UnixTimestamp(ctx context.Context, value time.Time, options *QueryClientUnixTimestampOptions) (QueryClientUnixTimestampResponse, error) {
 	var err error
 	req, err := client.unixTimestampCreateRequest(ctx, value, options)
@@ -143,6 +147,8 @@ func (client *QueryClient) unixTimestampCreateRequest(ctx context.Context, value
 	return req, nil
 }
 
+//   - options - QueryClientUnixTimestampArrayOptions contains the optional parameters for the QueryClient.UnixTimestampArray
+//     method.
 func (client *QueryClient) UnixTimestampArray(ctx context.Context, value []time.Time, options *QueryClientUnixTimestampArrayOptions) (QueryClientUnixTimestampArrayResponse, error) {
 	var err error
 	req, err := client.unixTimestampArrayCreateRequest(ctx, value, options)

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_responseheader_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_responseheader_client.go
@@ -24,6 +24,7 @@ type ResponseHeaderClient struct {
 	internal *azcore.Client
 }
 
+// - options - ResponseHeaderClientDefaultOptions contains the optional parameters for the ResponseHeaderClient.Default method.
 func (client *ResponseHeaderClient) Default(ctx context.Context, options *ResponseHeaderClientDefaultOptions) (ResponseHeaderClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, options)
@@ -65,6 +66,7 @@ func (client *ResponseHeaderClient) defaultHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+// - options - ResponseHeaderClientRFC3339Options contains the optional parameters for the ResponseHeaderClient.RFC3339 method.
 func (client *ResponseHeaderClient) RFC3339(ctx context.Context, options *ResponseHeaderClientRFC3339Options) (ResponseHeaderClientRFC3339Response, error) {
 	var err error
 	req, err := client.rfc3339CreateRequest(ctx, options)
@@ -106,6 +108,7 @@ func (client *ResponseHeaderClient) rfc3339HandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+// - options - ResponseHeaderClientRFC7231Options contains the optional parameters for the ResponseHeaderClient.RFC7231 method.
 func (client *ResponseHeaderClient) RFC7231(ctx context.Context, options *ResponseHeaderClientRFC7231Options) (ResponseHeaderClientRFC7231Response, error) {
 	var err error
 	req, err := client.rfc7231CreateRequest(ctx, options)
@@ -147,6 +150,8 @@ func (client *ResponseHeaderClient) rfc7231HandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+//   - options - ResponseHeaderClientUnixTimestampOptions contains the optional parameters for the ResponseHeaderClient.UnixTimestamp
+//     method.
 func (client *ResponseHeaderClient) UnixTimestamp(ctx context.Context, options *ResponseHeaderClientUnixTimestampOptions) (ResponseHeaderClientUnixTimestampResponse, error) {
 	var err error
 	req, err := client.unixTimestampCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_header_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_header_client.go
@@ -23,6 +23,7 @@ type HeaderClient struct {
 	internal *azcore.Client
 }
 
+// - options - HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 func (client *HeaderClient) Default(ctx context.Context, duration string, options *HeaderClientDefaultOptions) (HeaderClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, duration, options)
@@ -51,6 +52,7 @@ func (client *HeaderClient) defaultCreateRequest(ctx context.Context, duration s
 	return req, nil
 }
 
+// - options - HeaderClientFloatSecondsOptions contains the optional parameters for the HeaderClient.FloatSeconds method.
 func (client *HeaderClient) FloatSeconds(ctx context.Context, duration float32, options *HeaderClientFloatSecondsOptions) (HeaderClientFloatSecondsResponse, error) {
 	var err error
 	req, err := client.floatSecondsCreateRequest(ctx, duration, options)
@@ -79,6 +81,7 @@ func (client *HeaderClient) floatSecondsCreateRequest(ctx context.Context, durat
 	return req, nil
 }
 
+// - options - HeaderClientISO8601Options contains the optional parameters for the HeaderClient.ISO8601 method.
 func (client *HeaderClient) ISO8601(ctx context.Context, duration string, options *HeaderClientISO8601Options) (HeaderClientISO8601Response, error) {
 	var err error
 	req, err := client.iso8601CreateRequest(ctx, duration, options)
@@ -107,6 +110,7 @@ func (client *HeaderClient) iso8601CreateRequest(ctx context.Context, duration s
 	return req, nil
 }
 
+// - options - HeaderClientISO8601ArrayOptions contains the optional parameters for the HeaderClient.ISO8601Array method.
 func (client *HeaderClient) ISO8601Array(ctx context.Context, duration []string, options *HeaderClientISO8601ArrayOptions) (HeaderClientISO8601ArrayResponse, error) {
 	var err error
 	req, err := client.iso8601ArrayCreateRequest(ctx, duration, options)
@@ -135,6 +139,7 @@ func (client *HeaderClient) iso8601ArrayCreateRequest(ctx context.Context, durat
 	return req, nil
 }
 
+// - options - HeaderClientInt32SecondsOptions contains the optional parameters for the HeaderClient.Int32Seconds method.
 func (client *HeaderClient) Int32Seconds(ctx context.Context, duration int32, options *HeaderClientInt32SecondsOptions) (HeaderClientInt32SecondsResponse, error) {
 	var err error
 	req, err := client.int32SecondsCreateRequest(ctx, duration, options)

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_options.go
@@ -7,62 +7,77 @@
 
 package durationgroup
 
+// HeaderClientDefaultOptions contains the optional parameters for the HeaderClient.Default method.
 type HeaderClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientFloatSecondsOptions contains the optional parameters for the HeaderClient.FloatSeconds method.
 type HeaderClientFloatSecondsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientISO8601ArrayOptions contains the optional parameters for the HeaderClient.ISO8601Array method.
 type HeaderClientISO8601ArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientISO8601Options contains the optional parameters for the HeaderClient.ISO8601 method.
 type HeaderClientISO8601Options struct {
 	// placeholder for future optional parameters
 }
 
+// HeaderClientInt32SecondsOptions contains the optional parameters for the HeaderClient.Int32Seconds method.
 type HeaderClientInt32SecondsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 type PropertyClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientFloatSecondsArrayOptions contains the optional parameters for the PropertyClient.FloatSecondsArray method.
 type PropertyClientFloatSecondsArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientFloatSecondsOptions contains the optional parameters for the PropertyClient.FloatSeconds method.
 type PropertyClientFloatSecondsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientISO8601Options contains the optional parameters for the PropertyClient.ISO8601 method.
 type PropertyClientISO8601Options struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientInt32SecondsOptions contains the optional parameters for the PropertyClient.Int32Seconds method.
 type PropertyClientInt32SecondsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 type QueryClientDefaultOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientFloatSecondsOptions contains the optional parameters for the QueryClient.FloatSeconds method.
 type QueryClientFloatSecondsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientISO8601Options contains the optional parameters for the QueryClient.ISO8601 method.
 type QueryClientISO8601Options struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientInt32SecondsArrayOptions contains the optional parameters for the QueryClient.Int32SecondsArray method.
 type QueryClientInt32SecondsArrayOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientInt32SecondsOptions contains the optional parameters for the QueryClient.Int32Seconds method.
 type QueryClientInt32SecondsOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_property_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_property_client.go
@@ -21,6 +21,7 @@ type PropertyClient struct {
 	internal *azcore.Client
 }
 
+// - options - PropertyClientDefaultOptions contains the optional parameters for the PropertyClient.Default method.
 func (client *PropertyClient) Default(ctx context.Context, body DefaultDurationProperty, options *PropertyClientDefaultOptions) (PropertyClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, body, options)
@@ -63,6 +64,7 @@ func (client *PropertyClient) defaultHandleResponse(resp *http.Response) (Proper
 	return result, nil
 }
 
+// - options - PropertyClientFloatSecondsOptions contains the optional parameters for the PropertyClient.FloatSeconds method.
 func (client *PropertyClient) FloatSeconds(ctx context.Context, body FloatSecondsDurationProperty, options *PropertyClientFloatSecondsOptions) (PropertyClientFloatSecondsResponse, error) {
 	var err error
 	req, err := client.floatSecondsCreateRequest(ctx, body, options)
@@ -105,6 +107,8 @@ func (client *PropertyClient) floatSecondsHandleResponse(resp *http.Response) (P
 	return result, nil
 }
 
+//   - options - PropertyClientFloatSecondsArrayOptions contains the optional parameters for the PropertyClient.FloatSecondsArray
+//     method.
 func (client *PropertyClient) FloatSecondsArray(ctx context.Context, body FloatSecondsDurationArrayProperty, options *PropertyClientFloatSecondsArrayOptions) (PropertyClientFloatSecondsArrayResponse, error) {
 	var err error
 	req, err := client.floatSecondsArrayCreateRequest(ctx, body, options)
@@ -147,6 +151,7 @@ func (client *PropertyClient) floatSecondsArrayHandleResponse(resp *http.Respons
 	return result, nil
 }
 
+// - options - PropertyClientISO8601Options contains the optional parameters for the PropertyClient.ISO8601 method.
 func (client *PropertyClient) ISO8601(ctx context.Context, body ISO8601DurationProperty, options *PropertyClientISO8601Options) (PropertyClientISO8601Response, error) {
 	var err error
 	req, err := client.iso8601CreateRequest(ctx, body, options)
@@ -189,6 +194,7 @@ func (client *PropertyClient) iso8601HandleResponse(resp *http.Response) (Proper
 	return result, nil
 }
 
+// - options - PropertyClientInt32SecondsOptions contains the optional parameters for the PropertyClient.Int32Seconds method.
 func (client *PropertyClient) Int32Seconds(ctx context.Context, body Int32SecondsDurationProperty, options *PropertyClientInt32SecondsOptions) (PropertyClientInt32SecondsResponse, error) {
 	var err error
 	req, err := client.int32SecondsCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_query_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_query_client.go
@@ -24,6 +24,7 @@ type QueryClient struct {
 	internal *azcore.Client
 }
 
+// - options - QueryClientDefaultOptions contains the optional parameters for the QueryClient.Default method.
 func (client *QueryClient) Default(ctx context.Context, input string, options *QueryClientDefaultOptions) (QueryClientDefaultResponse, error) {
 	var err error
 	req, err := client.defaultCreateRequest(ctx, input, options)
@@ -54,6 +55,7 @@ func (client *QueryClient) defaultCreateRequest(ctx context.Context, input strin
 	return req, nil
 }
 
+// - options - QueryClientFloatSecondsOptions contains the optional parameters for the QueryClient.FloatSeconds method.
 func (client *QueryClient) FloatSeconds(ctx context.Context, input float32, options *QueryClientFloatSecondsOptions) (QueryClientFloatSecondsResponse, error) {
 	var err error
 	req, err := client.floatSecondsCreateRequest(ctx, input, options)
@@ -84,6 +86,7 @@ func (client *QueryClient) floatSecondsCreateRequest(ctx context.Context, input 
 	return req, nil
 }
 
+// - options - QueryClientISO8601Options contains the optional parameters for the QueryClient.ISO8601 method.
 func (client *QueryClient) ISO8601(ctx context.Context, input string, options *QueryClientISO8601Options) (QueryClientISO8601Response, error) {
 	var err error
 	req, err := client.iso8601CreateRequest(ctx, input, options)
@@ -114,6 +117,7 @@ func (client *QueryClient) iso8601CreateRequest(ctx context.Context, input strin
 	return req, nil
 }
 
+// - options - QueryClientInt32SecondsOptions contains the optional parameters for the QueryClient.Int32Seconds method.
 func (client *QueryClient) Int32Seconds(ctx context.Context, input int32, options *QueryClientInt32SecondsOptions) (QueryClientInt32SecondsResponse, error) {
 	var err error
 	req, err := client.int32SecondsCreateRequest(ctx, input, options)
@@ -144,6 +148,7 @@ func (client *QueryClient) int32SecondsCreateRequest(ctx context.Context, input 
 	return req, nil
 }
 
+// - options - QueryClientInt32SecondsArrayOptions contains the optional parameters for the QueryClient.Int32SecondsArray method.
 func (client *QueryClient) Int32SecondsArray(ctx context.Context, input []int32, options *QueryClientInt32SecondsArrayOptions) (QueryClientInt32SecondsArrayResponse, error) {
 	var err error
 	req, err := client.int32SecondsArrayCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
@@ -21,6 +21,8 @@ type BodyOptionalityClient struct {
 	internal *azcore.Client
 }
 
+//   - options - BodyOptionalityClientRequiredExplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredExplicit
+//     method.
 func (client *BodyOptionalityClient) RequiredExplicit(ctx context.Context, body BodyModel, options *BodyOptionalityClientRequiredExplicitOptions) (BodyOptionalityClientRequiredExplicitResponse, error) {
 	var err error
 	req, err := client.requiredExplicitCreateRequest(ctx, body, options)
@@ -52,6 +54,8 @@ func (client *BodyOptionalityClient) requiredExplicitCreateRequest(ctx context.C
 	return req, nil
 }
 
+//   - options - BodyOptionalityClientRequiredImplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredImplicit
+//     method.
 func (client *BodyOptionalityClient) RequiredImplicit(ctx context.Context, body BodyModel, options *BodyOptionalityClientRequiredImplicitOptions) (BodyOptionalityClientRequiredImplicitResponse, error) {
 	var err error
 	req, err := client.requiredImplicitCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_optionalexplicit_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_optionalexplicit_client.go
@@ -21,6 +21,7 @@ type OptionalExplicitClient struct {
 	internal *azcore.Client
 }
 
+// - options - OptionalExplicitClientOmitOptions contains the optional parameters for the OptionalExplicitClient.Omit method.
 func (client *OptionalExplicitClient) Omit(ctx context.Context, options *OptionalExplicitClientOmitOptions) (OptionalExplicitClientOmitResponse, error) {
 	var err error
 	req, err := client.omitCreateRequest(ctx, options)
@@ -55,6 +56,7 @@ func (client *OptionalExplicitClient) omitCreateRequest(ctx context.Context, opt
 	return req, nil
 }
 
+// - options - OptionalExplicitClientSetOptions contains the optional parameters for the OptionalExplicitClient.Set method.
 func (client *OptionalExplicitClient) Set(ctx context.Context, options *OptionalExplicitClientSetOptions) (OptionalExplicitClientSetResponse, error) {
 	var err error
 	req, err := client.setCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
@@ -7,18 +7,24 @@
 
 package bodyoptionalgroup
 
+// BodyOptionalityClientRequiredExplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredExplicit
+// method.
 type BodyOptionalityClientRequiredExplicitOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BodyOptionalityClientRequiredImplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredImplicit
+// method.
 type BodyOptionalityClientRequiredImplicitOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OptionalExplicitClientOmitOptions contains the optional parameters for the OptionalExplicitClient.Omit method.
 type OptionalExplicitClientOmitOptions struct {
 	Body *BodyModel
 }
 
+// OptionalExplicitClientSetOptions contains the optional parameters for the OptionalExplicitClient.Set method.
 type OptionalExplicitClientSetOptions struct {
 	Body *BodyModel
 }

--- a/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_header_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_header_client.go
@@ -23,6 +23,7 @@ type HeaderClient struct {
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - HeaderClientCSVOptions contains the optional parameters for the HeaderClient.CSV method.
 func (client *HeaderClient) CSV(ctx context.Context, colors []string, options *HeaderClientCSVOptions) (HeaderClientCSVResponse, error) {
 	var err error
 	req, err := client.csvCreateRequest(ctx, colors, options)

--- a/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package collectionfmtgroup
 
+// HeaderClientCSVOptions contains the optional parameters for the HeaderClient.CSV method.
 type HeaderClientCSVOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientCSVOptions contains the optional parameters for the QueryClient.CSV method.
 type QueryClientCSVOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientMultiOptions contains the optional parameters for the QueryClient.Multi method.
 type QueryClientMultiOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientPipesOptions contains the optional parameters for the QueryClient.Pipes method.
 type QueryClientPipesOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientSsvOptions contains the optional parameters for the QueryClient.Ssv method.
 type QueryClientSsvOptions struct {
 	// placeholder for future optional parameters
 }
 
+// QueryClientTsvOptions contains the optional parameters for the QueryClient.Tsv method.
 type QueryClientTsvOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_query_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_query_client.go
@@ -23,6 +23,7 @@ type QueryClient struct {
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - QueryClientCSVOptions contains the optional parameters for the QueryClient.CSV method.
 func (client *QueryClient) CSV(ctx context.Context, colors []string, options *QueryClientCSVOptions) (QueryClientCSVResponse, error) {
 	var err error
 	req, err := client.csvCreateRequest(ctx, colors, options)
@@ -54,6 +55,7 @@ func (client *QueryClient) csvCreateRequest(ctx context.Context, colors []string
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - QueryClientMultiOptions contains the optional parameters for the QueryClient.Multi method.
 func (client *QueryClient) Multi(ctx context.Context, colors []string, options *QueryClientMultiOptions) (QueryClientMultiResponse, error) {
 	var err error
 	req, err := client.multiCreateRequest(ctx, colors, options)
@@ -87,6 +89,7 @@ func (client *QueryClient) multiCreateRequest(ctx context.Context, colors []stri
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - QueryClientPipesOptions contains the optional parameters for the QueryClient.Pipes method.
 func (client *QueryClient) Pipes(ctx context.Context, colors []string, options *QueryClientPipesOptions) (QueryClientPipesResponse, error) {
 	var err error
 	req, err := client.pipesCreateRequest(ctx, colors, options)
@@ -118,6 +121,7 @@ func (client *QueryClient) pipesCreateRequest(ctx context.Context, colors []stri
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - QueryClientSsvOptions contains the optional parameters for the QueryClient.Ssv method.
 func (client *QueryClient) Ssv(ctx context.Context, colors []string, options *QueryClientSsvOptions) (QueryClientSsvResponse, error) {
 	var err error
 	req, err := client.ssvCreateRequest(ctx, colors, options)
@@ -149,6 +153,7 @@ func (client *QueryClient) ssvCreateRequest(ctx context.Context, colors []string
 }
 
 // - colors - Possible values for colors are [blue,red,green]
+// - options - QueryClientTsvOptions contains the optional parameters for the QueryClient.Tsv method.
 func (client *QueryClient) Tsv(ctx context.Context, colors []string, options *QueryClientTsvOptions) (QueryClientTsvResponse, error) {
 	var err error
 	req, err := client.tsvCreateRequest(ctx, colors, options)

--- a/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_options.go
@@ -7,6 +7,7 @@
 
 package pageablegroup
 
+// PageableClientListOptions contains the optional parameters for the PageableClient.NewListPager method.
 type PageableClientListOptions struct {
 	// The maximum number of result items per page.
 	Maxpagesize *int32

--- a/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_pageable_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_pageable_client.go
@@ -23,6 +23,7 @@ type PageableClient struct {
 }
 
 // NewListPager - List users
+//   - options - PageableClientListOptions contains the optional parameters for the PageableClient.NewListPager method.
 func (client *PageableClient) NewListPager(options *PageableClientListOptions) *runtime.Pager[PageableClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[PageableClientListResponse]{
 		More: func(page PageableClientListResponse) bool {

--- a/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_responses.go
@@ -7,7 +7,7 @@
 
 package pageablegroup
 
-// PageableClientListResponse contains the response from method PageableClient.List.
+// PageableClientListResponse contains the response from method PageableClient.NewListPager.
 type PageableClientListResponse struct {
 	// Paged collection of User items
 	PagedUser

--- a/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package projectednamegroup
 
+// ProjectedNameClientClientNameOptions contains the optional parameters for the ProjectedNameClient.ClientName method.
 type ProjectedNameClientClientNameOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ProjectedNameClientParameterOptions contains the optional parameters for the ProjectedNameClient.Parameter method.
 type ProjectedNameClientParameterOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientClientOptions contains the optional parameters for the PropertyClient.Client method.
 type PropertyClientClientOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientJSONAndClientOptions contains the optional parameters for the PropertyClient.JSONAndClient method.
 type PropertyClientJSONAndClientOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientJSONOptions contains the optional parameters for the PropertyClient.JSON method.
 type PropertyClientJSONOptions struct {
 	// placeholder for future optional parameters
 }
 
+// PropertyClientLanguageOptions contains the optional parameters for the PropertyClient.Language method.
 type PropertyClientLanguageOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_projectedname_client.go
+++ b/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_projectedname_client.go
@@ -21,6 +21,8 @@ type ProjectedNameClient struct {
 	internal *azcore.Client
 }
 
+//   - options - ProjectedNameClientClientNameOptions contains the optional parameters for the ProjectedNameClient.ClientName
+//     method.
 func (client *ProjectedNameClient) ClientName(ctx context.Context, options *ProjectedNameClientClientNameOptions) (ProjectedNameClientClientNameResponse, error) {
 	var err error
 	req, err := client.clientNameCreateRequest(ctx, options)
@@ -48,6 +50,7 @@ func (client *ProjectedNameClient) clientNameCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
+// - options - ProjectedNameClientParameterOptions contains the optional parameters for the ProjectedNameClient.Parameter method.
 func (client *ProjectedNameClient) Parameter(ctx context.Context, clientName string, options *ProjectedNameClientParameterOptions) (ProjectedNameClientParameterResponse, error) {
 	var err error
 	req, err := client.parameterCreateRequest(ctx, clientName, options)

--- a/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_property_client.go
+++ b/packages/typespec-go/test/cadlranch/projection/projectednamegroup/zz_property_client.go
@@ -21,6 +21,7 @@ type PropertyClient struct {
 	internal *azcore.Client
 }
 
+// - options - PropertyClientClientOptions contains the optional parameters for the PropertyClient.Client method.
 func (client *PropertyClient) Client(ctx context.Context, body ClientProjectedNameModel, options *PropertyClientClientOptions) (PropertyClientClientResponse, error) {
 	var err error
 	req, err := client.clientCreateRequest(ctx, body, options)
@@ -52,6 +53,7 @@ func (client *PropertyClient) clientCreateRequest(ctx context.Context, body Clie
 	return req, nil
 }
 
+// - options - PropertyClientJSONOptions contains the optional parameters for the PropertyClient.JSON method.
 func (client *PropertyClient) JSON(ctx context.Context, body JSONProjectedNameModel, options *PropertyClientJSONOptions) (PropertyClientJSONResponse, error) {
 	var err error
 	req, err := client.jsonCreateRequest(ctx, body, options)
@@ -83,6 +85,7 @@ func (client *PropertyClient) jsonCreateRequest(ctx context.Context, body JSONPr
 	return req, nil
 }
 
+// - options - PropertyClientJSONAndClientOptions contains the optional parameters for the PropertyClient.JSONAndClient method.
 func (client *PropertyClient) JSONAndClient(ctx context.Context, body JSONAndClientProjectedNameModel, options *PropertyClientJSONAndClientOptions) (PropertyClientJSONAndClientResponse, error) {
 	var err error
 	req, err := client.jsonAndClientCreateRequest(ctx, body, options)
@@ -114,6 +117,7 @@ func (client *PropertyClient) jsonAndClientCreateRequest(ctx context.Context, bo
 	return req, nil
 }
 
+// - options - PropertyClientLanguageOptions contains the optional parameters for the PropertyClient.Language method.
 func (client *PropertyClient) Language(ctx context.Context, body LanguageProjectedNameModel, options *PropertyClientLanguageOptions) (PropertyClientLanguageResponse, error) {
 	var err error
 	req, err := client.languageCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivengroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivengroup/zz_options.go
@@ -7,15 +7,21 @@
 
 package srvdrivengroup
 
+// ResiliencyServiceDrivenClientAddOperationOptions contains the optional parameters for the ResiliencyServiceDrivenClient.AddOperation
+// method.
 type ResiliencyServiceDrivenClientAddOperationOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ResiliencyServiceDrivenClientFromNoneOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromNone
+// method.
 type ResiliencyServiceDrivenClientFromNoneOptions struct {
 	// I'm a new input optional parameter
 	NewParameter *string
 }
 
+// ResiliencyServiceDrivenClientFromOneOptionalOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneOptional
+// method.
 type ResiliencyServiceDrivenClientFromOneOptionalOptions struct {
 	// I'm a new input optional parameter
 	NewParameter *string
@@ -24,6 +30,8 @@ type ResiliencyServiceDrivenClientFromOneOptionalOptions struct {
 	Parameter *string
 }
 
+// ResiliencyServiceDrivenClientFromOneRequiredOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneRequired
+// method.
 type ResiliencyServiceDrivenClientFromOneRequiredOptions struct {
 	// I'm a new input optional parameter
 	NewParameter *string

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivengroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivengroup/zz_resiliencyservicedriven_client.go
@@ -22,6 +22,8 @@ type ResiliencyServiceDrivenClient struct {
 }
 
 // AddOperation - Added operation
+//   - options - ResiliencyServiceDrivenClientAddOperationOptions contains the optional parameters for the ResiliencyServiceDrivenClient.AddOperation
+//     method.
 func (client *ResiliencyServiceDrivenClient) AddOperation(ctx context.Context, options *ResiliencyServiceDrivenClientAddOperationOptions) (ResiliencyServiceDrivenClientAddOperationResponse, error) {
 	var err error
 	req, err := client.addOperationCreateRequest(ctx, options)
@@ -50,6 +52,8 @@ func (client *ResiliencyServiceDrivenClient) addOperationCreateRequest(ctx conte
 }
 
 // FromNone - Test that grew up from accepting no parameters to an optional input parameter
+//   - options - ResiliencyServiceDrivenClientFromNoneOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromNone
+//     method.
 func (client *ResiliencyServiceDrivenClient) FromNone(ctx context.Context, options *ResiliencyServiceDrivenClientFromNoneOptions) (ResiliencyServiceDrivenClientFromNoneResponse, error) {
 	var err error
 	req, err := client.fromNoneCreateRequest(ctx, options)
@@ -84,6 +88,8 @@ func (client *ResiliencyServiceDrivenClient) fromNoneCreateRequest(ctx context.C
 
 // FromOneOptional - Tests that we can grow up an operation from accepting one optional parameter to accepting two optional
 // parameters.
+//   - options - ResiliencyServiceDrivenClientFromOneOptionalOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneOptional
+//     method.
 func (client *ResiliencyServiceDrivenClient) FromOneOptional(ctx context.Context, options *ResiliencyServiceDrivenClientFromOneOptionalOptions) (ResiliencyServiceDrivenClientFromOneOptionalResponse, error) {
 	var err error
 	req, err := client.fromOneOptionalCreateRequest(ctx, options)
@@ -122,6 +128,8 @@ func (client *ResiliencyServiceDrivenClient) fromOneOptionalCreateRequest(ctx co
 // FromOneRequired - Operation that grew up from accepting one required parameter to accepting a required parameter and an
 // optional parameter.
 //   - parameter - I am a required parameter
+//   - options - ResiliencyServiceDrivenClientFromOneRequiredOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneRequired
+//     method.
 func (client *ResiliencyServiceDrivenClient) FromOneRequired(ctx context.Context, parameter string, options *ResiliencyServiceDrivenClientFromOneRequiredOptions) (ResiliencyServiceDrivenClientFromOneRequiredResponse, error) {
 	var err error
 	req, err := client.fromOneRequiredCreateRequest(ctx, parameter, options)

--- a/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_multiple_client.go
+++ b/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_multiple_client.go
@@ -24,6 +24,8 @@ type MultipleClient struct {
 	internal *azcore.Client
 }
 
+//   - options - MultipleClientNoOperationParamsOptions contains the optional parameters for the MultipleClient.NoOperationParams
+//     method.
 func (client *MultipleClient) NoOperationParams(ctx context.Context, options *MultipleClientNoOperationParamsOptions) (MultipleClientNoOperationParamsResponse, error) {
 	var err error
 	req, err := client.noOperationParamsCreateRequest(ctx, options)
@@ -50,6 +52,8 @@ func (client *MultipleClient) noOperationParamsCreateRequest(ctx context.Context
 	return req, nil
 }
 
+//   - options - MultipleClientWithOperationPathParamOptions contains the optional parameters for the MultipleClient.WithOperationPathParam
+//     method.
 func (client *MultipleClient) WithOperationPathParam(ctx context.Context, keyword string, options *MultipleClientWithOperationPathParamOptions) (MultipleClientWithOperationPathParamResponse, error) {
 	var err error
 	req, err := client.withOperationPathParamCreateRequest(ctx, keyword, options)

--- a/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_options.go
@@ -7,10 +7,13 @@
 
 package multiplegroup
 
+// MultipleClientNoOperationParamsOptions contains the optional parameters for the MultipleClient.NoOperationParams method.
 type MultipleClientNoOperationParamsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// MultipleClientWithOperationPathParamOptions contains the optional parameters for the MultipleClient.WithOperationPathParam
+// method.
 type MultipleClientWithOperationPathParamOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_options.go
@@ -7,6 +7,7 @@
 
 package singlegroup
 
+// SingleClientMyOpOptions contains the optional parameters for the SingleClient.MyOp method.
 type SingleClientMyOpOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_single_client.go
+++ b/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_single_client.go
@@ -21,6 +21,7 @@ type SingleClient struct {
 	internal *azcore.Client
 }
 
+// - options - SingleClientMyOpOptions contains the optional parameters for the SingleClient.MyOp method.
 func (client *SingleClient) MyOp(ctx context.Context, options *SingleClientMyOpOptions) (SingleClientMyOpResponse, error) {
 	var err error
 	req, err := client.myOpCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_clientrequestid_client.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_clientrequestid_client.go
@@ -22,6 +22,7 @@ type ClientRequestIdClient struct {
 }
 
 // Get - Get operation with azure client request id header.
+//   - options - ClientRequestIdClientGetOptions contains the optional parameters for the ClientRequestIdClient.Get method.
 func (client *ClientRequestIdClient) Get(ctx context.Context, options *ClientRequestIdClientGetOptions) (ClientRequestIdClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_options.go
@@ -7,6 +7,7 @@
 
 package clientreqidgroup
 
+// ClientRequestIdClientGetOptions contains the optional parameters for the ClientRequestIdClient.Get method.
 type ClientRequestIdClientGetOptions struct {
 	ClientRequestID *string
 }

--- a/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_conditionalrequest_client.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_conditionalrequest_client.go
@@ -22,6 +22,8 @@ type ConditionalRequestClient struct {
 }
 
 // PostIfMatch - Check when only If-Match in header is defined.
+//   - options - ConditionalRequestClientPostIfMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfMatch
+//     method.
 func (client *ConditionalRequestClient) PostIfMatch(ctx context.Context, options *ConditionalRequestClientPostIfMatchOptions) (ConditionalRequestClientPostIfMatchResponse, error) {
 	var err error
 	req, err := client.postIfMatchCreateRequest(ctx, options)
@@ -53,6 +55,8 @@ func (client *ConditionalRequestClient) postIfMatchCreateRequest(ctx context.Con
 }
 
 // PostIfNoneMatch - Check when only If-None-Match in header is defined.
+//   - options - ConditionalRequestClientPostIfNoneMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfNoneMatch
+//     method.
 func (client *ConditionalRequestClient) PostIfNoneMatch(ctx context.Context, options *ConditionalRequestClientPostIfNoneMatchOptions) (ConditionalRequestClientPostIfNoneMatchResponse, error) {
 	var err error
 	req, err := client.postIfNoneMatchCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_options.go
@@ -7,11 +7,15 @@
 
 package condreqgroup
 
+// ConditionalRequestClientPostIfMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfMatch
+// method.
 type ConditionalRequestClientPostIfMatchOptions struct {
 	// The request should only proceed if an entity matches this string.
 	IfMatch *string
 }
 
+// ConditionalRequestClientPostIfNoneMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfNoneMatch
+// method.
 type ConditionalRequestClientPostIfNoneMatchOptions struct {
 	// The request should only proceed if no entity matches this string.
 	IfNoneMatch *string

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_modelproperties_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_modelproperties_client.go
@@ -21,6 +21,8 @@ type ModelPropertiesClient struct {
 	internal *azcore.Client
 }
 
+//   - options - ModelPropertiesClientSameAsModelOptions contains the optional parameters for the ModelPropertiesClient.SameAsModel
+//     method.
 func (client *ModelPropertiesClient) SameAsModel(ctx context.Context, body SameAsModel, options *ModelPropertiesClientSameAsModelOptions) (ModelPropertiesClientSameAsModelResponse, error) {
 	var err error
 	req, err := client.sameAsModelCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_models_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_models_client.go
@@ -21,6 +21,7 @@ type ModelsClient struct {
 	internal *azcore.Client
 }
 
+// - options - ModelsClientWithAndOptions contains the optional parameters for the ModelsClient.WithAnd method.
 func (client *ModelsClient) WithAnd(ctx context.Context, body And, options *ModelsClientWithAndOptions) (ModelsClientWithAndResponse, error) {
 	var err error
 	req, err := client.withAndCreateRequest(ctx, body, options)
@@ -52,6 +53,7 @@ func (client *ModelsClient) withAndCreateRequest(ctx context.Context, body And, 
 	return req, nil
 }
 
+// - options - ModelsClientWithAsOptions contains the optional parameters for the ModelsClient.WithAs method.
 func (client *ModelsClient) WithAs(ctx context.Context, body As, options *ModelsClientWithAsOptions) (ModelsClientWithAsResponse, error) {
 	var err error
 	req, err := client.withAsCreateRequest(ctx, body, options)
@@ -83,6 +85,7 @@ func (client *ModelsClient) withAsCreateRequest(ctx context.Context, body As, op
 	return req, nil
 }
 
+// - options - ModelsClientWithAssertOptions contains the optional parameters for the ModelsClient.WithAssert method.
 func (client *ModelsClient) WithAssert(ctx context.Context, body Assert, options *ModelsClientWithAssertOptions) (ModelsClientWithAssertResponse, error) {
 	var err error
 	req, err := client.withAssertCreateRequest(ctx, body, options)
@@ -114,6 +117,7 @@ func (client *ModelsClient) withAssertCreateRequest(ctx context.Context, body As
 	return req, nil
 }
 
+// - options - ModelsClientWithAsyncOptions contains the optional parameters for the ModelsClient.WithAsync method.
 func (client *ModelsClient) WithAsync(ctx context.Context, body Async, options *ModelsClientWithAsyncOptions) (ModelsClientWithAsyncResponse, error) {
 	var err error
 	req, err := client.withAsyncCreateRequest(ctx, body, options)
@@ -145,6 +149,7 @@ func (client *ModelsClient) withAsyncCreateRequest(ctx context.Context, body Asy
 	return req, nil
 }
 
+// - options - ModelsClientWithAwaitOptions contains the optional parameters for the ModelsClient.WithAwait method.
 func (client *ModelsClient) WithAwait(ctx context.Context, body Await, options *ModelsClientWithAwaitOptions) (ModelsClientWithAwaitResponse, error) {
 	var err error
 	req, err := client.withAwaitCreateRequest(ctx, body, options)
@@ -176,6 +181,7 @@ func (client *ModelsClient) withAwaitCreateRequest(ctx context.Context, body Awa
 	return req, nil
 }
 
+// - options - ModelsClientWithBreakOptions contains the optional parameters for the ModelsClient.WithBreak method.
 func (client *ModelsClient) WithBreak(ctx context.Context, body Break, options *ModelsClientWithBreakOptions) (ModelsClientWithBreakResponse, error) {
 	var err error
 	req, err := client.withBreakCreateRequest(ctx, body, options)
@@ -207,6 +213,7 @@ func (client *ModelsClient) withBreakCreateRequest(ctx context.Context, body Bre
 	return req, nil
 }
 
+// - options - ModelsClientWithClassOptions contains the optional parameters for the ModelsClient.WithClass method.
 func (client *ModelsClient) WithClass(ctx context.Context, body Class, options *ModelsClientWithClassOptions) (ModelsClientWithClassResponse, error) {
 	var err error
 	req, err := client.withClassCreateRequest(ctx, body, options)
@@ -238,6 +245,7 @@ func (client *ModelsClient) withClassCreateRequest(ctx context.Context, body Cla
 	return req, nil
 }
 
+// - options - ModelsClientWithConstructorOptions contains the optional parameters for the ModelsClient.WithConstructor method.
 func (client *ModelsClient) WithConstructor(ctx context.Context, body Constructor, options *ModelsClientWithConstructorOptions) (ModelsClientWithConstructorResponse, error) {
 	var err error
 	req, err := client.withConstructorCreateRequest(ctx, body, options)
@@ -269,6 +277,7 @@ func (client *ModelsClient) withConstructorCreateRequest(ctx context.Context, bo
 	return req, nil
 }
 
+// - options - ModelsClientWithContinueOptions contains the optional parameters for the ModelsClient.WithContinue method.
 func (client *ModelsClient) WithContinue(ctx context.Context, body Continue, options *ModelsClientWithContinueOptions) (ModelsClientWithContinueResponse, error) {
 	var err error
 	req, err := client.withContinueCreateRequest(ctx, body, options)
@@ -300,6 +309,7 @@ func (client *ModelsClient) withContinueCreateRequest(ctx context.Context, body 
 	return req, nil
 }
 
+// - options - ModelsClientWithDefOptions contains the optional parameters for the ModelsClient.WithDef method.
 func (client *ModelsClient) WithDef(ctx context.Context, body Def, options *ModelsClientWithDefOptions) (ModelsClientWithDefResponse, error) {
 	var err error
 	req, err := client.withDefCreateRequest(ctx, body, options)
@@ -331,6 +341,7 @@ func (client *ModelsClient) withDefCreateRequest(ctx context.Context, body Def, 
 	return req, nil
 }
 
+// - options - ModelsClientWithDelOptions contains the optional parameters for the ModelsClient.WithDel method.
 func (client *ModelsClient) WithDel(ctx context.Context, body Del, options *ModelsClientWithDelOptions) (ModelsClientWithDelResponse, error) {
 	var err error
 	req, err := client.withDelCreateRequest(ctx, body, options)
@@ -362,6 +373,7 @@ func (client *ModelsClient) withDelCreateRequest(ctx context.Context, body Del, 
 	return req, nil
 }
 
+// - options - ModelsClientWithElifOptions contains the optional parameters for the ModelsClient.WithElif method.
 func (client *ModelsClient) WithElif(ctx context.Context, body Elif, options *ModelsClientWithElifOptions) (ModelsClientWithElifResponse, error) {
 	var err error
 	req, err := client.withElifCreateRequest(ctx, body, options)
@@ -393,6 +405,7 @@ func (client *ModelsClient) withElifCreateRequest(ctx context.Context, body Elif
 	return req, nil
 }
 
+// - options - ModelsClientWithElseOptions contains the optional parameters for the ModelsClient.WithElse method.
 func (client *ModelsClient) WithElse(ctx context.Context, body Else, options *ModelsClientWithElseOptions) (ModelsClientWithElseResponse, error) {
 	var err error
 	req, err := client.withElseCreateRequest(ctx, body, options)
@@ -424,6 +437,7 @@ func (client *ModelsClient) withElseCreateRequest(ctx context.Context, body Else
 	return req, nil
 }
 
+// - options - ModelsClientWithExceptOptions contains the optional parameters for the ModelsClient.WithExcept method.
 func (client *ModelsClient) WithExcept(ctx context.Context, body Except, options *ModelsClientWithExceptOptions) (ModelsClientWithExceptResponse, error) {
 	var err error
 	req, err := client.withExceptCreateRequest(ctx, body, options)
@@ -455,6 +469,7 @@ func (client *ModelsClient) withExceptCreateRequest(ctx context.Context, body Ex
 	return req, nil
 }
 
+// - options - ModelsClientWithExecOptions contains the optional parameters for the ModelsClient.WithExec method.
 func (client *ModelsClient) WithExec(ctx context.Context, body Exec, options *ModelsClientWithExecOptions) (ModelsClientWithExecResponse, error) {
 	var err error
 	req, err := client.withExecCreateRequest(ctx, body, options)
@@ -486,6 +501,7 @@ func (client *ModelsClient) withExecCreateRequest(ctx context.Context, body Exec
 	return req, nil
 }
 
+// - options - ModelsClientWithFinallyOptions contains the optional parameters for the ModelsClient.WithFinally method.
 func (client *ModelsClient) WithFinally(ctx context.Context, body Finally, options *ModelsClientWithFinallyOptions) (ModelsClientWithFinallyResponse, error) {
 	var err error
 	req, err := client.withFinallyCreateRequest(ctx, body, options)
@@ -517,6 +533,7 @@ func (client *ModelsClient) withFinallyCreateRequest(ctx context.Context, body F
 	return req, nil
 }
 
+// - options - ModelsClientWithForOptions contains the optional parameters for the ModelsClient.WithFor method.
 func (client *ModelsClient) WithFor(ctx context.Context, body For, options *ModelsClientWithForOptions) (ModelsClientWithForResponse, error) {
 	var err error
 	req, err := client.withForCreateRequest(ctx, body, options)
@@ -548,6 +565,7 @@ func (client *ModelsClient) withForCreateRequest(ctx context.Context, body For, 
 	return req, nil
 }
 
+// - options - ModelsClientWithFromOptions contains the optional parameters for the ModelsClient.WithFrom method.
 func (client *ModelsClient) WithFrom(ctx context.Context, body From, options *ModelsClientWithFromOptions) (ModelsClientWithFromResponse, error) {
 	var err error
 	req, err := client.withFromCreateRequest(ctx, body, options)
@@ -579,6 +597,7 @@ func (client *ModelsClient) withFromCreateRequest(ctx context.Context, body From
 	return req, nil
 }
 
+// - options - ModelsClientWithGlobalOptions contains the optional parameters for the ModelsClient.WithGlobal method.
 func (client *ModelsClient) WithGlobal(ctx context.Context, body Global, options *ModelsClientWithGlobalOptions) (ModelsClientWithGlobalResponse, error) {
 	var err error
 	req, err := client.withGlobalCreateRequest(ctx, body, options)
@@ -610,6 +629,7 @@ func (client *ModelsClient) withGlobalCreateRequest(ctx context.Context, body Gl
 	return req, nil
 }
 
+// - options - ModelsClientWithIfOptions contains the optional parameters for the ModelsClient.WithIf method.
 func (client *ModelsClient) WithIf(ctx context.Context, body If, options *ModelsClientWithIfOptions) (ModelsClientWithIfResponse, error) {
 	var err error
 	req, err := client.withIfCreateRequest(ctx, body, options)
@@ -641,6 +661,7 @@ func (client *ModelsClient) withIfCreateRequest(ctx context.Context, body If, op
 	return req, nil
 }
 
+// - options - ModelsClientWithImportOptions contains the optional parameters for the ModelsClient.WithImport method.
 func (client *ModelsClient) WithImport(ctx context.Context, body Import, options *ModelsClientWithImportOptions) (ModelsClientWithImportResponse, error) {
 	var err error
 	req, err := client.withImportCreateRequest(ctx, body, options)
@@ -672,6 +693,7 @@ func (client *ModelsClient) withImportCreateRequest(ctx context.Context, body Im
 	return req, nil
 }
 
+// - options - ModelsClientWithInOptions contains the optional parameters for the ModelsClient.WithIn method.
 func (client *ModelsClient) WithIn(ctx context.Context, body In, options *ModelsClientWithInOptions) (ModelsClientWithInResponse, error) {
 	var err error
 	req, err := client.withInCreateRequest(ctx, body, options)
@@ -703,6 +725,7 @@ func (client *ModelsClient) withInCreateRequest(ctx context.Context, body In, op
 	return req, nil
 }
 
+// - options - ModelsClientWithIsOptions contains the optional parameters for the ModelsClient.WithIs method.
 func (client *ModelsClient) WithIs(ctx context.Context, body Is, options *ModelsClientWithIsOptions) (ModelsClientWithIsResponse, error) {
 	var err error
 	req, err := client.withIsCreateRequest(ctx, body, options)
@@ -734,6 +757,7 @@ func (client *ModelsClient) withIsCreateRequest(ctx context.Context, body Is, op
 	return req, nil
 }
 
+// - options - ModelsClientWithLambdaOptions contains the optional parameters for the ModelsClient.WithLambda method.
 func (client *ModelsClient) WithLambda(ctx context.Context, body Lambda, options *ModelsClientWithLambdaOptions) (ModelsClientWithLambdaResponse, error) {
 	var err error
 	req, err := client.withLambdaCreateRequest(ctx, body, options)
@@ -765,6 +789,7 @@ func (client *ModelsClient) withLambdaCreateRequest(ctx context.Context, body La
 	return req, nil
 }
 
+// - options - ModelsClientWithNotOptions contains the optional parameters for the ModelsClient.WithNot method.
 func (client *ModelsClient) WithNot(ctx context.Context, body Not, options *ModelsClientWithNotOptions) (ModelsClientWithNotResponse, error) {
 	var err error
 	req, err := client.withNotCreateRequest(ctx, body, options)
@@ -796,6 +821,7 @@ func (client *ModelsClient) withNotCreateRequest(ctx context.Context, body Not, 
 	return req, nil
 }
 
+// - options - ModelsClientWithOrOptions contains the optional parameters for the ModelsClient.WithOr method.
 func (client *ModelsClient) WithOr(ctx context.Context, body Or, options *ModelsClientWithOrOptions) (ModelsClientWithOrResponse, error) {
 	var err error
 	req, err := client.withOrCreateRequest(ctx, body, options)
@@ -827,6 +853,7 @@ func (client *ModelsClient) withOrCreateRequest(ctx context.Context, body Or, op
 	return req, nil
 }
 
+// - options - ModelsClientWithPassOptions contains the optional parameters for the ModelsClient.WithPass method.
 func (client *ModelsClient) WithPass(ctx context.Context, body Pass, options *ModelsClientWithPassOptions) (ModelsClientWithPassResponse, error) {
 	var err error
 	req, err := client.withPassCreateRequest(ctx, body, options)
@@ -858,6 +885,7 @@ func (client *ModelsClient) withPassCreateRequest(ctx context.Context, body Pass
 	return req, nil
 }
 
+// - options - ModelsClientWithRaiseOptions contains the optional parameters for the ModelsClient.WithRaise method.
 func (client *ModelsClient) WithRaise(ctx context.Context, body Raise, options *ModelsClientWithRaiseOptions) (ModelsClientWithRaiseResponse, error) {
 	var err error
 	req, err := client.withRaiseCreateRequest(ctx, body, options)
@@ -889,6 +917,7 @@ func (client *ModelsClient) withRaiseCreateRequest(ctx context.Context, body Rai
 	return req, nil
 }
 
+// - options - ModelsClientWithReturnOptions contains the optional parameters for the ModelsClient.WithReturn method.
 func (client *ModelsClient) WithReturn(ctx context.Context, body Return, options *ModelsClientWithReturnOptions) (ModelsClientWithReturnResponse, error) {
 	var err error
 	req, err := client.withReturnCreateRequest(ctx, body, options)
@@ -920,6 +949,7 @@ func (client *ModelsClient) withReturnCreateRequest(ctx context.Context, body Re
 	return req, nil
 }
 
+// - options - ModelsClientWithTryOptions contains the optional parameters for the ModelsClient.WithTry method.
 func (client *ModelsClient) WithTry(ctx context.Context, body Try, options *ModelsClientWithTryOptions) (ModelsClientWithTryResponse, error) {
 	var err error
 	req, err := client.withTryCreateRequest(ctx, body, options)
@@ -951,6 +981,7 @@ func (client *ModelsClient) withTryCreateRequest(ctx context.Context, body Try, 
 	return req, nil
 }
 
+// - options - ModelsClientWithWhileOptions contains the optional parameters for the ModelsClient.WithWhile method.
 func (client *ModelsClient) WithWhile(ctx context.Context, body While, options *ModelsClientWithWhileOptions) (ModelsClientWithWhileResponse, error) {
 	var err error
 	req, err := client.withWhileCreateRequest(ctx, body, options)
@@ -982,6 +1013,7 @@ func (client *ModelsClient) withWhileCreateRequest(ctx context.Context, body Whi
 	return req, nil
 }
 
+// - options - ModelsClientWithWithOptions contains the optional parameters for the ModelsClient.WithWith method.
 func (client *ModelsClient) WithWith(ctx context.Context, body With, options *ModelsClientWithWithOptions) (ModelsClientWithWithResponse, error) {
 	var err error
 	req, err := client.withWithCreateRequest(ctx, body, options)
@@ -1013,6 +1045,7 @@ func (client *ModelsClient) withWithCreateRequest(ctx context.Context, body With
 	return req, nil
 }
 
+// - options - ModelsClientWithYieldOptions contains the optional parameters for the ModelsClient.WithYield method.
 func (client *ModelsClient) WithYield(ctx context.Context, body Yield, options *ModelsClientWithYieldOptions) (ModelsClientWithYieldResponse, error) {
 	var err error
 	req, err := client.withYieldCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_operations_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_operations_client.go
@@ -21,6 +21,7 @@ type OperationsClient struct {
 	internal *azcore.Client
 }
 
+// - options - OperationsClientAndOptions contains the optional parameters for the OperationsClient.And method.
 func (client *OperationsClient) And(ctx context.Context, options *OperationsClientAndOptions) (OperationsClientAndResponse, error) {
 	var err error
 	req, err := client.andCreateRequest(ctx, options)
@@ -48,6 +49,7 @@ func (client *OperationsClient) andCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientAsOptions contains the optional parameters for the OperationsClient.As method.
 func (client *OperationsClient) As(ctx context.Context, options *OperationsClientAsOptions) (OperationsClientAsResponse, error) {
 	var err error
 	req, err := client.asCreateRequest(ctx, options)
@@ -75,6 +77,7 @@ func (client *OperationsClient) asCreateRequest(ctx context.Context, options *Op
 	return req, nil
 }
 
+// - options - OperationsClientAssertOptions contains the optional parameters for the OperationsClient.Assert method.
 func (client *OperationsClient) Assert(ctx context.Context, options *OperationsClientAssertOptions) (OperationsClientAssertResponse, error) {
 	var err error
 	req, err := client.assertCreateRequest(ctx, options)
@@ -102,6 +105,7 @@ func (client *OperationsClient) assertCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientAsyncOptions contains the optional parameters for the OperationsClient.Async method.
 func (client *OperationsClient) Async(ctx context.Context, options *OperationsClientAsyncOptions) (OperationsClientAsyncResponse, error) {
 	var err error
 	req, err := client.asyncCreateRequest(ctx, options)
@@ -129,6 +133,7 @@ func (client *OperationsClient) asyncCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientAwaitOptions contains the optional parameters for the OperationsClient.Await method.
 func (client *OperationsClient) Await(ctx context.Context, options *OperationsClientAwaitOptions) (OperationsClientAwaitResponse, error) {
 	var err error
 	req, err := client.awaitCreateRequest(ctx, options)
@@ -156,6 +161,7 @@ func (client *OperationsClient) awaitCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientBreakOptions contains the optional parameters for the OperationsClient.Break method.
 func (client *OperationsClient) Break(ctx context.Context, options *OperationsClientBreakOptions) (OperationsClientBreakResponse, error) {
 	var err error
 	req, err := client.breakCreateRequest(ctx, options)
@@ -183,6 +189,7 @@ func (client *OperationsClient) breakCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientClassOptions contains the optional parameters for the OperationsClient.Class method.
 func (client *OperationsClient) Class(ctx context.Context, options *OperationsClientClassOptions) (OperationsClientClassResponse, error) {
 	var err error
 	req, err := client.classCreateRequest(ctx, options)
@@ -210,6 +217,7 @@ func (client *OperationsClient) classCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientConstructorOptions contains the optional parameters for the OperationsClient.Constructor method.
 func (client *OperationsClient) Constructor(ctx context.Context, options *OperationsClientConstructorOptions) (OperationsClientConstructorResponse, error) {
 	var err error
 	req, err := client.constructorCreateRequest(ctx, options)
@@ -237,6 +245,7 @@ func (client *OperationsClient) constructorCreateRequest(ctx context.Context, op
 	return req, nil
 }
 
+// - options - OperationsClientContinueOptions contains the optional parameters for the OperationsClient.Continue method.
 func (client *OperationsClient) Continue(ctx context.Context, options *OperationsClientContinueOptions) (OperationsClientContinueResponse, error) {
 	var err error
 	req, err := client.continueCreateRequest(ctx, options)
@@ -264,6 +273,7 @@ func (client *OperationsClient) continueCreateRequest(ctx context.Context, optio
 	return req, nil
 }
 
+// - options - OperationsClientDefOptions contains the optional parameters for the OperationsClient.Def method.
 func (client *OperationsClient) Def(ctx context.Context, options *OperationsClientDefOptions) (OperationsClientDefResponse, error) {
 	var err error
 	req, err := client.defCreateRequest(ctx, options)
@@ -291,6 +301,7 @@ func (client *OperationsClient) defCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientDelOptions contains the optional parameters for the OperationsClient.Del method.
 func (client *OperationsClient) Del(ctx context.Context, options *OperationsClientDelOptions) (OperationsClientDelResponse, error) {
 	var err error
 	req, err := client.delCreateRequest(ctx, options)
@@ -318,6 +329,7 @@ func (client *OperationsClient) delCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientElifOptions contains the optional parameters for the OperationsClient.Elif method.
 func (client *OperationsClient) Elif(ctx context.Context, options *OperationsClientElifOptions) (OperationsClientElifResponse, error) {
 	var err error
 	req, err := client.elifCreateRequest(ctx, options)
@@ -345,6 +357,7 @@ func (client *OperationsClient) elifCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientElseOptions contains the optional parameters for the OperationsClient.Else method.
 func (client *OperationsClient) Else(ctx context.Context, options *OperationsClientElseOptions) (OperationsClientElseResponse, error) {
 	var err error
 	req, err := client.elseCreateRequest(ctx, options)
@@ -372,6 +385,7 @@ func (client *OperationsClient) elseCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientExceptOptions contains the optional parameters for the OperationsClient.Except method.
 func (client *OperationsClient) Except(ctx context.Context, options *OperationsClientExceptOptions) (OperationsClientExceptResponse, error) {
 	var err error
 	req, err := client.exceptCreateRequest(ctx, options)
@@ -399,6 +413,7 @@ func (client *OperationsClient) exceptCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientExecOptions contains the optional parameters for the OperationsClient.Exec method.
 func (client *OperationsClient) Exec(ctx context.Context, options *OperationsClientExecOptions) (OperationsClientExecResponse, error) {
 	var err error
 	req, err := client.execCreateRequest(ctx, options)
@@ -426,6 +441,7 @@ func (client *OperationsClient) execCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientFinallyOptions contains the optional parameters for the OperationsClient.Finally method.
 func (client *OperationsClient) Finally(ctx context.Context, options *OperationsClientFinallyOptions) (OperationsClientFinallyResponse, error) {
 	var err error
 	req, err := client.finallyCreateRequest(ctx, options)
@@ -453,6 +469,7 @@ func (client *OperationsClient) finallyCreateRequest(ctx context.Context, option
 	return req, nil
 }
 
+// - options - OperationsClientForOptions contains the optional parameters for the OperationsClient.For method.
 func (client *OperationsClient) For(ctx context.Context, options *OperationsClientForOptions) (OperationsClientForResponse, error) {
 	var err error
 	req, err := client.forCreateRequest(ctx, options)
@@ -480,6 +497,7 @@ func (client *OperationsClient) forCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientFromOptions contains the optional parameters for the OperationsClient.From method.
 func (client *OperationsClient) From(ctx context.Context, options *OperationsClientFromOptions) (OperationsClientFromResponse, error) {
 	var err error
 	req, err := client.fromCreateRequest(ctx, options)
@@ -507,6 +525,7 @@ func (client *OperationsClient) fromCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientGlobalOptions contains the optional parameters for the OperationsClient.Global method.
 func (client *OperationsClient) Global(ctx context.Context, options *OperationsClientGlobalOptions) (OperationsClientGlobalResponse, error) {
 	var err error
 	req, err := client.globalCreateRequest(ctx, options)
@@ -534,6 +553,7 @@ func (client *OperationsClient) globalCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientIfOptions contains the optional parameters for the OperationsClient.If method.
 func (client *OperationsClient) If(ctx context.Context, options *OperationsClientIfOptions) (OperationsClientIfResponse, error) {
 	var err error
 	req, err := client.ifCreateRequest(ctx, options)
@@ -561,6 +581,7 @@ func (client *OperationsClient) ifCreateRequest(ctx context.Context, options *Op
 	return req, nil
 }
 
+// - options - OperationsClientImportOptions contains the optional parameters for the OperationsClient.Import method.
 func (client *OperationsClient) Import(ctx context.Context, options *OperationsClientImportOptions) (OperationsClientImportResponse, error) {
 	var err error
 	req, err := client.importCreateRequest(ctx, options)
@@ -588,6 +609,7 @@ func (client *OperationsClient) importCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientInOptions contains the optional parameters for the OperationsClient.In method.
 func (client *OperationsClient) In(ctx context.Context, options *OperationsClientInOptions) (OperationsClientInResponse, error) {
 	var err error
 	req, err := client.inCreateRequest(ctx, options)
@@ -615,6 +637,7 @@ func (client *OperationsClient) inCreateRequest(ctx context.Context, options *Op
 	return req, nil
 }
 
+// - options - OperationsClientIsOptions contains the optional parameters for the OperationsClient.Is method.
 func (client *OperationsClient) Is(ctx context.Context, options *OperationsClientIsOptions) (OperationsClientIsResponse, error) {
 	var err error
 	req, err := client.isCreateRequest(ctx, options)
@@ -642,6 +665,7 @@ func (client *OperationsClient) isCreateRequest(ctx context.Context, options *Op
 	return req, nil
 }
 
+// - options - OperationsClientLambdaOptions contains the optional parameters for the OperationsClient.Lambda method.
 func (client *OperationsClient) Lambda(ctx context.Context, options *OperationsClientLambdaOptions) (OperationsClientLambdaResponse, error) {
 	var err error
 	req, err := client.lambdaCreateRequest(ctx, options)
@@ -669,6 +693,7 @@ func (client *OperationsClient) lambdaCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientNotOptions contains the optional parameters for the OperationsClient.Not method.
 func (client *OperationsClient) Not(ctx context.Context, options *OperationsClientNotOptions) (OperationsClientNotResponse, error) {
 	var err error
 	req, err := client.notCreateRequest(ctx, options)
@@ -696,6 +721,7 @@ func (client *OperationsClient) notCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientOrOptions contains the optional parameters for the OperationsClient.Or method.
 func (client *OperationsClient) Or(ctx context.Context, options *OperationsClientOrOptions) (OperationsClientOrResponse, error) {
 	var err error
 	req, err := client.orCreateRequest(ctx, options)
@@ -723,6 +749,7 @@ func (client *OperationsClient) orCreateRequest(ctx context.Context, options *Op
 	return req, nil
 }
 
+// - options - OperationsClientPassOptions contains the optional parameters for the OperationsClient.Pass method.
 func (client *OperationsClient) Pass(ctx context.Context, options *OperationsClientPassOptions) (OperationsClientPassResponse, error) {
 	var err error
 	req, err := client.passCreateRequest(ctx, options)
@@ -750,6 +777,7 @@ func (client *OperationsClient) passCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientRaiseOptions contains the optional parameters for the OperationsClient.Raise method.
 func (client *OperationsClient) Raise(ctx context.Context, options *OperationsClientRaiseOptions) (OperationsClientRaiseResponse, error) {
 	var err error
 	req, err := client.raiseCreateRequest(ctx, options)
@@ -777,6 +805,7 @@ func (client *OperationsClient) raiseCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientReturnOptions contains the optional parameters for the OperationsClient.Return method.
 func (client *OperationsClient) Return(ctx context.Context, options *OperationsClientReturnOptions) (OperationsClientReturnResponse, error) {
 	var err error
 	req, err := client.returnCreateRequest(ctx, options)
@@ -804,6 +833,7 @@ func (client *OperationsClient) returnCreateRequest(ctx context.Context, options
 	return req, nil
 }
 
+// - options - OperationsClientTryOptions contains the optional parameters for the OperationsClient.Try method.
 func (client *OperationsClient) Try(ctx context.Context, options *OperationsClientTryOptions) (OperationsClientTryResponse, error) {
 	var err error
 	req, err := client.tryCreateRequest(ctx, options)
@@ -831,6 +861,7 @@ func (client *OperationsClient) tryCreateRequest(ctx context.Context, options *O
 	return req, nil
 }
 
+// - options - OperationsClientWhileOptions contains the optional parameters for the OperationsClient.While method.
 func (client *OperationsClient) While(ctx context.Context, options *OperationsClientWhileOptions) (OperationsClientWhileResponse, error) {
 	var err error
 	req, err := client.whileCreateRequest(ctx, options)
@@ -858,6 +889,7 @@ func (client *OperationsClient) whileCreateRequest(ctx context.Context, options 
 	return req, nil
 }
 
+// - options - OperationsClientWithOptions contains the optional parameters for the OperationsClient.With method.
 func (client *OperationsClient) With(ctx context.Context, options *OperationsClientWithOptions) (OperationsClientWithResponse, error) {
 	var err error
 	req, err := client.withCreateRequest(ctx, options)
@@ -885,6 +917,7 @@ func (client *OperationsClient) withCreateRequest(ctx context.Context, options *
 	return req, nil
 }
 
+// - options - OperationsClientYieldOptions contains the optional parameters for the OperationsClient.Yield method.
 func (client *OperationsClient) Yield(ctx context.Context, options *OperationsClientYieldOptions) (OperationsClientYieldResponse, error) {
 	var err error
 	req, err := client.yieldCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_options.go
@@ -7,406 +7,508 @@
 
 package specialwordsgroup
 
+// ModelPropertiesClientSameAsModelOptions contains the optional parameters for the ModelPropertiesClient.SameAsModel method.
 type ModelPropertiesClientSameAsModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithAndOptions contains the optional parameters for the ModelsClient.WithAnd method.
 type ModelsClientWithAndOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithAsOptions contains the optional parameters for the ModelsClient.WithAs method.
 type ModelsClientWithAsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithAssertOptions contains the optional parameters for the ModelsClient.WithAssert method.
 type ModelsClientWithAssertOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithAsyncOptions contains the optional parameters for the ModelsClient.WithAsync method.
 type ModelsClientWithAsyncOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithAwaitOptions contains the optional parameters for the ModelsClient.WithAwait method.
 type ModelsClientWithAwaitOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithBreakOptions contains the optional parameters for the ModelsClient.WithBreak method.
 type ModelsClientWithBreakOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithClassOptions contains the optional parameters for the ModelsClient.WithClass method.
 type ModelsClientWithClassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithConstructorOptions contains the optional parameters for the ModelsClient.WithConstructor method.
 type ModelsClientWithConstructorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithContinueOptions contains the optional parameters for the ModelsClient.WithContinue method.
 type ModelsClientWithContinueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithDefOptions contains the optional parameters for the ModelsClient.WithDef method.
 type ModelsClientWithDefOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithDelOptions contains the optional parameters for the ModelsClient.WithDel method.
 type ModelsClientWithDelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithElifOptions contains the optional parameters for the ModelsClient.WithElif method.
 type ModelsClientWithElifOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithElseOptions contains the optional parameters for the ModelsClient.WithElse method.
 type ModelsClientWithElseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithExceptOptions contains the optional parameters for the ModelsClient.WithExcept method.
 type ModelsClientWithExceptOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithExecOptions contains the optional parameters for the ModelsClient.WithExec method.
 type ModelsClientWithExecOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithFinallyOptions contains the optional parameters for the ModelsClient.WithFinally method.
 type ModelsClientWithFinallyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithForOptions contains the optional parameters for the ModelsClient.WithFor method.
 type ModelsClientWithForOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithFromOptions contains the optional parameters for the ModelsClient.WithFrom method.
 type ModelsClientWithFromOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithGlobalOptions contains the optional parameters for the ModelsClient.WithGlobal method.
 type ModelsClientWithGlobalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithIfOptions contains the optional parameters for the ModelsClient.WithIf method.
 type ModelsClientWithIfOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithImportOptions contains the optional parameters for the ModelsClient.WithImport method.
 type ModelsClientWithImportOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithInOptions contains the optional parameters for the ModelsClient.WithIn method.
 type ModelsClientWithInOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithIsOptions contains the optional parameters for the ModelsClient.WithIs method.
 type ModelsClientWithIsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithLambdaOptions contains the optional parameters for the ModelsClient.WithLambda method.
 type ModelsClientWithLambdaOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithNotOptions contains the optional parameters for the ModelsClient.WithNot method.
 type ModelsClientWithNotOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithOrOptions contains the optional parameters for the ModelsClient.WithOr method.
 type ModelsClientWithOrOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithPassOptions contains the optional parameters for the ModelsClient.WithPass method.
 type ModelsClientWithPassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithRaiseOptions contains the optional parameters for the ModelsClient.WithRaise method.
 type ModelsClientWithRaiseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithReturnOptions contains the optional parameters for the ModelsClient.WithReturn method.
 type ModelsClientWithReturnOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithTryOptions contains the optional parameters for the ModelsClient.WithTry method.
 type ModelsClientWithTryOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithWhileOptions contains the optional parameters for the ModelsClient.WithWhile method.
 type ModelsClientWithWhileOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithWithOptions contains the optional parameters for the ModelsClient.WithWith method.
 type ModelsClientWithWithOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelsClientWithYieldOptions contains the optional parameters for the ModelsClient.WithYield method.
 type ModelsClientWithYieldOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientAndOptions contains the optional parameters for the OperationsClient.And method.
 type OperationsClientAndOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientAsOptions contains the optional parameters for the OperationsClient.As method.
 type OperationsClientAsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientAssertOptions contains the optional parameters for the OperationsClient.Assert method.
 type OperationsClientAssertOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientAsyncOptions contains the optional parameters for the OperationsClient.Async method.
 type OperationsClientAsyncOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientAwaitOptions contains the optional parameters for the OperationsClient.Await method.
 type OperationsClientAwaitOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientBreakOptions contains the optional parameters for the OperationsClient.Break method.
 type OperationsClientBreakOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientClassOptions contains the optional parameters for the OperationsClient.Class method.
 type OperationsClientClassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientConstructorOptions contains the optional parameters for the OperationsClient.Constructor method.
 type OperationsClientConstructorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientContinueOptions contains the optional parameters for the OperationsClient.Continue method.
 type OperationsClientContinueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientDefOptions contains the optional parameters for the OperationsClient.Def method.
 type OperationsClientDefOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientDelOptions contains the optional parameters for the OperationsClient.Del method.
 type OperationsClientDelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientElifOptions contains the optional parameters for the OperationsClient.Elif method.
 type OperationsClientElifOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientElseOptions contains the optional parameters for the OperationsClient.Else method.
 type OperationsClientElseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientExceptOptions contains the optional parameters for the OperationsClient.Except method.
 type OperationsClientExceptOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientExecOptions contains the optional parameters for the OperationsClient.Exec method.
 type OperationsClientExecOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientFinallyOptions contains the optional parameters for the OperationsClient.Finally method.
 type OperationsClientFinallyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientForOptions contains the optional parameters for the OperationsClient.For method.
 type OperationsClientForOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientFromOptions contains the optional parameters for the OperationsClient.From method.
 type OperationsClientFromOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientGlobalOptions contains the optional parameters for the OperationsClient.Global method.
 type OperationsClientGlobalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientIfOptions contains the optional parameters for the OperationsClient.If method.
 type OperationsClientIfOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientImportOptions contains the optional parameters for the OperationsClient.Import method.
 type OperationsClientImportOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientInOptions contains the optional parameters for the OperationsClient.In method.
 type OperationsClientInOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientIsOptions contains the optional parameters for the OperationsClient.Is method.
 type OperationsClientIsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientLambdaOptions contains the optional parameters for the OperationsClient.Lambda method.
 type OperationsClientLambdaOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientNotOptions contains the optional parameters for the OperationsClient.Not method.
 type OperationsClientNotOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientOrOptions contains the optional parameters for the OperationsClient.Or method.
 type OperationsClientOrOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientPassOptions contains the optional parameters for the OperationsClient.Pass method.
 type OperationsClientPassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientRaiseOptions contains the optional parameters for the OperationsClient.Raise method.
 type OperationsClientRaiseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientReturnOptions contains the optional parameters for the OperationsClient.Return method.
 type OperationsClientReturnOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientTryOptions contains the optional parameters for the OperationsClient.Try method.
 type OperationsClientTryOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientWhileOptions contains the optional parameters for the OperationsClient.While method.
 type OperationsClientWhileOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientWithOptions contains the optional parameters for the OperationsClient.With method.
 type OperationsClientWithOptions struct {
 	// placeholder for future optional parameters
 }
 
+// OperationsClientYieldOptions contains the optional parameters for the OperationsClient.Yield method.
 type OperationsClientYieldOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithAndOptions contains the optional parameters for the ParametersClient.WithAnd method.
 type ParametersClientWithAndOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithAsOptions contains the optional parameters for the ParametersClient.WithAs method.
 type ParametersClientWithAsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithAssertOptions contains the optional parameters for the ParametersClient.WithAssert method.
 type ParametersClientWithAssertOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithAsyncOptions contains the optional parameters for the ParametersClient.WithAsync method.
 type ParametersClientWithAsyncOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithAwaitOptions contains the optional parameters for the ParametersClient.WithAwait method.
 type ParametersClientWithAwaitOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithBreakOptions contains the optional parameters for the ParametersClient.WithBreak method.
 type ParametersClientWithBreakOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithCancellationTokenOptions contains the optional parameters for the ParametersClient.WithCancellationToken
+// method.
 type ParametersClientWithCancellationTokenOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithClassOptions contains the optional parameters for the ParametersClient.WithClass method.
 type ParametersClientWithClassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithConstructorOptions contains the optional parameters for the ParametersClient.WithConstructor method.
 type ParametersClientWithConstructorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithContinueOptions contains the optional parameters for the ParametersClient.WithContinue method.
 type ParametersClientWithContinueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithDefOptions contains the optional parameters for the ParametersClient.WithDef method.
 type ParametersClientWithDefOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithDelOptions contains the optional parameters for the ParametersClient.WithDel method.
 type ParametersClientWithDelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithElifOptions contains the optional parameters for the ParametersClient.WithElif method.
 type ParametersClientWithElifOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithElseOptions contains the optional parameters for the ParametersClient.WithElse method.
 type ParametersClientWithElseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithExceptOptions contains the optional parameters for the ParametersClient.WithExcept method.
 type ParametersClientWithExceptOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithExecOptions contains the optional parameters for the ParametersClient.WithExec method.
 type ParametersClientWithExecOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithFinallyOptions contains the optional parameters for the ParametersClient.WithFinally method.
 type ParametersClientWithFinallyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithForOptions contains the optional parameters for the ParametersClient.WithFor method.
 type ParametersClientWithForOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithFromOptions contains the optional parameters for the ParametersClient.WithFrom method.
 type ParametersClientWithFromOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithGlobalOptions contains the optional parameters for the ParametersClient.WithGlobal method.
 type ParametersClientWithGlobalOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithIfOptions contains the optional parameters for the ParametersClient.WithIf method.
 type ParametersClientWithIfOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithImportOptions contains the optional parameters for the ParametersClient.WithImport method.
 type ParametersClientWithImportOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithInOptions contains the optional parameters for the ParametersClient.WithIn method.
 type ParametersClientWithInOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithIsOptions contains the optional parameters for the ParametersClient.WithIs method.
 type ParametersClientWithIsOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithLambdaOptions contains the optional parameters for the ParametersClient.WithLambda method.
 type ParametersClientWithLambdaOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithNotOptions contains the optional parameters for the ParametersClient.WithNot method.
 type ParametersClientWithNotOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithOrOptions contains the optional parameters for the ParametersClient.WithOr method.
 type ParametersClientWithOrOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithPassOptions contains the optional parameters for the ParametersClient.WithPass method.
 type ParametersClientWithPassOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithRaiseOptions contains the optional parameters for the ParametersClient.WithRaise method.
 type ParametersClientWithRaiseOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithReturnOptions contains the optional parameters for the ParametersClient.WithReturn method.
 type ParametersClientWithReturnOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithTryOptions contains the optional parameters for the ParametersClient.WithTry method.
 type ParametersClientWithTryOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithWhileOptions contains the optional parameters for the ParametersClient.WithWhile method.
 type ParametersClientWithWhileOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithWithOptions contains the optional parameters for the ParametersClient.WithWith method.
 type ParametersClientWithWithOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ParametersClientWithYieldOptions contains the optional parameters for the ParametersClient.WithYield method.
 type ParametersClientWithYieldOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_parameters_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_parameters_client.go
@@ -21,6 +21,7 @@ type ParametersClient struct {
 	internal *azcore.Client
 }
 
+// - options - ParametersClientWithAndOptions contains the optional parameters for the ParametersClient.WithAnd method.
 func (client *ParametersClient) WithAnd(ctx context.Context, and string, options *ParametersClientWithAndOptions) (ParametersClientWithAndResponse, error) {
 	var err error
 	req, err := client.withAndCreateRequest(ctx, and, options)
@@ -51,6 +52,7 @@ func (client *ParametersClient) withAndCreateRequest(ctx context.Context, and st
 	return req, nil
 }
 
+// - options - ParametersClientWithAsOptions contains the optional parameters for the ParametersClient.WithAs method.
 func (client *ParametersClient) WithAs(ctx context.Context, as string, options *ParametersClientWithAsOptions) (ParametersClientWithAsResponse, error) {
 	var err error
 	req, err := client.withAsCreateRequest(ctx, as, options)
@@ -81,6 +83,7 @@ func (client *ParametersClient) withAsCreateRequest(ctx context.Context, as stri
 	return req, nil
 }
 
+// - options - ParametersClientWithAssertOptions contains the optional parameters for the ParametersClient.WithAssert method.
 func (client *ParametersClient) WithAssert(ctx context.Context, assert string, options *ParametersClientWithAssertOptions) (ParametersClientWithAssertResponse, error) {
 	var err error
 	req, err := client.withAssertCreateRequest(ctx, assert, options)
@@ -111,6 +114,7 @@ func (client *ParametersClient) withAssertCreateRequest(ctx context.Context, ass
 	return req, nil
 }
 
+// - options - ParametersClientWithAsyncOptions contains the optional parameters for the ParametersClient.WithAsync method.
 func (client *ParametersClient) WithAsync(ctx context.Context, async string, options *ParametersClientWithAsyncOptions) (ParametersClientWithAsyncResponse, error) {
 	var err error
 	req, err := client.withAsyncCreateRequest(ctx, async, options)
@@ -141,6 +145,7 @@ func (client *ParametersClient) withAsyncCreateRequest(ctx context.Context, asyn
 	return req, nil
 }
 
+// - options - ParametersClientWithAwaitOptions contains the optional parameters for the ParametersClient.WithAwait method.
 func (client *ParametersClient) WithAwait(ctx context.Context, await string, options *ParametersClientWithAwaitOptions) (ParametersClientWithAwaitResponse, error) {
 	var err error
 	req, err := client.withAwaitCreateRequest(ctx, await, options)
@@ -171,6 +176,7 @@ func (client *ParametersClient) withAwaitCreateRequest(ctx context.Context, awai
 	return req, nil
 }
 
+// - options - ParametersClientWithBreakOptions contains the optional parameters for the ParametersClient.WithBreak method.
 func (client *ParametersClient) WithBreak(ctx context.Context, breakParam string, options *ParametersClientWithBreakOptions) (ParametersClientWithBreakResponse, error) {
 	var err error
 	req, err := client.withBreakCreateRequest(ctx, breakParam, options)
@@ -201,6 +207,8 @@ func (client *ParametersClient) withBreakCreateRequest(ctx context.Context, brea
 	return req, nil
 }
 
+//   - options - ParametersClientWithCancellationTokenOptions contains the optional parameters for the ParametersClient.WithCancellationToken
+//     method.
 func (client *ParametersClient) WithCancellationToken(ctx context.Context, cancellationToken string, options *ParametersClientWithCancellationTokenOptions) (ParametersClientWithCancellationTokenResponse, error) {
 	var err error
 	req, err := client.withCancellationTokenCreateRequest(ctx, cancellationToken, options)
@@ -231,6 +239,7 @@ func (client *ParametersClient) withCancellationTokenCreateRequest(ctx context.C
 	return req, nil
 }
 
+// - options - ParametersClientWithClassOptions contains the optional parameters for the ParametersClient.WithClass method.
 func (client *ParametersClient) WithClass(ctx context.Context, class string, options *ParametersClientWithClassOptions) (ParametersClientWithClassResponse, error) {
 	var err error
 	req, err := client.withClassCreateRequest(ctx, class, options)
@@ -261,6 +270,8 @@ func (client *ParametersClient) withClassCreateRequest(ctx context.Context, clas
 	return req, nil
 }
 
+//   - options - ParametersClientWithConstructorOptions contains the optional parameters for the ParametersClient.WithConstructor
+//     method.
 func (client *ParametersClient) WithConstructor(ctx context.Context, constructor string, options *ParametersClientWithConstructorOptions) (ParametersClientWithConstructorResponse, error) {
 	var err error
 	req, err := client.withConstructorCreateRequest(ctx, constructor, options)
@@ -291,6 +302,7 @@ func (client *ParametersClient) withConstructorCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// - options - ParametersClientWithContinueOptions contains the optional parameters for the ParametersClient.WithContinue method.
 func (client *ParametersClient) WithContinue(ctx context.Context, continueParam string, options *ParametersClientWithContinueOptions) (ParametersClientWithContinueResponse, error) {
 	var err error
 	req, err := client.withContinueCreateRequest(ctx, continueParam, options)
@@ -321,6 +333,7 @@ func (client *ParametersClient) withContinueCreateRequest(ctx context.Context, c
 	return req, nil
 }
 
+// - options - ParametersClientWithDefOptions contains the optional parameters for the ParametersClient.WithDef method.
 func (client *ParametersClient) WithDef(ctx context.Context, def string, options *ParametersClientWithDefOptions) (ParametersClientWithDefResponse, error) {
 	var err error
 	req, err := client.withDefCreateRequest(ctx, def, options)
@@ -351,6 +364,7 @@ func (client *ParametersClient) withDefCreateRequest(ctx context.Context, def st
 	return req, nil
 }
 
+// - options - ParametersClientWithDelOptions contains the optional parameters for the ParametersClient.WithDel method.
 func (client *ParametersClient) WithDel(ctx context.Context, del string, options *ParametersClientWithDelOptions) (ParametersClientWithDelResponse, error) {
 	var err error
 	req, err := client.withDelCreateRequest(ctx, del, options)
@@ -381,6 +395,7 @@ func (client *ParametersClient) withDelCreateRequest(ctx context.Context, del st
 	return req, nil
 }
 
+// - options - ParametersClientWithElifOptions contains the optional parameters for the ParametersClient.WithElif method.
 func (client *ParametersClient) WithElif(ctx context.Context, elif string, options *ParametersClientWithElifOptions) (ParametersClientWithElifResponse, error) {
 	var err error
 	req, err := client.withElifCreateRequest(ctx, elif, options)
@@ -411,6 +426,7 @@ func (client *ParametersClient) withElifCreateRequest(ctx context.Context, elif 
 	return req, nil
 }
 
+// - options - ParametersClientWithElseOptions contains the optional parameters for the ParametersClient.WithElse method.
 func (client *ParametersClient) WithElse(ctx context.Context, elseParam string, options *ParametersClientWithElseOptions) (ParametersClientWithElseResponse, error) {
 	var err error
 	req, err := client.withElseCreateRequest(ctx, elseParam, options)
@@ -441,6 +457,7 @@ func (client *ParametersClient) withElseCreateRequest(ctx context.Context, elseP
 	return req, nil
 }
 
+// - options - ParametersClientWithExceptOptions contains the optional parameters for the ParametersClient.WithExcept method.
 func (client *ParametersClient) WithExcept(ctx context.Context, except string, options *ParametersClientWithExceptOptions) (ParametersClientWithExceptResponse, error) {
 	var err error
 	req, err := client.withExceptCreateRequest(ctx, except, options)
@@ -471,6 +488,7 @@ func (client *ParametersClient) withExceptCreateRequest(ctx context.Context, exc
 	return req, nil
 }
 
+// - options - ParametersClientWithExecOptions contains the optional parameters for the ParametersClient.WithExec method.
 func (client *ParametersClient) WithExec(ctx context.Context, execParam string, options *ParametersClientWithExecOptions) (ParametersClientWithExecResponse, error) {
 	var err error
 	req, err := client.withExecCreateRequest(ctx, execParam, options)
@@ -501,6 +519,7 @@ func (client *ParametersClient) withExecCreateRequest(ctx context.Context, execP
 	return req, nil
 }
 
+// - options - ParametersClientWithFinallyOptions contains the optional parameters for the ParametersClient.WithFinally method.
 func (client *ParametersClient) WithFinally(ctx context.Context, finally string, options *ParametersClientWithFinallyOptions) (ParametersClientWithFinallyResponse, error) {
 	var err error
 	req, err := client.withFinallyCreateRequest(ctx, finally, options)
@@ -531,6 +550,7 @@ func (client *ParametersClient) withFinallyCreateRequest(ctx context.Context, fi
 	return req, nil
 }
 
+// - options - ParametersClientWithForOptions contains the optional parameters for the ParametersClient.WithFor method.
 func (client *ParametersClient) WithFor(ctx context.Context, forParam string, options *ParametersClientWithForOptions) (ParametersClientWithForResponse, error) {
 	var err error
 	req, err := client.withForCreateRequest(ctx, forParam, options)
@@ -561,6 +581,7 @@ func (client *ParametersClient) withForCreateRequest(ctx context.Context, forPar
 	return req, nil
 }
 
+// - options - ParametersClientWithFromOptions contains the optional parameters for the ParametersClient.WithFrom method.
 func (client *ParametersClient) WithFrom(ctx context.Context, from string, options *ParametersClientWithFromOptions) (ParametersClientWithFromResponse, error) {
 	var err error
 	req, err := client.withFromCreateRequest(ctx, from, options)
@@ -591,6 +612,7 @@ func (client *ParametersClient) withFromCreateRequest(ctx context.Context, from 
 	return req, nil
 }
 
+// - options - ParametersClientWithGlobalOptions contains the optional parameters for the ParametersClient.WithGlobal method.
 func (client *ParametersClient) WithGlobal(ctx context.Context, global string, options *ParametersClientWithGlobalOptions) (ParametersClientWithGlobalResponse, error) {
 	var err error
 	req, err := client.withGlobalCreateRequest(ctx, global, options)
@@ -621,6 +643,7 @@ func (client *ParametersClient) withGlobalCreateRequest(ctx context.Context, glo
 	return req, nil
 }
 
+// - options - ParametersClientWithIfOptions contains the optional parameters for the ParametersClient.WithIf method.
 func (client *ParametersClient) WithIf(ctx context.Context, ifParam string, options *ParametersClientWithIfOptions) (ParametersClientWithIfResponse, error) {
 	var err error
 	req, err := client.withIfCreateRequest(ctx, ifParam, options)
@@ -651,6 +674,7 @@ func (client *ParametersClient) withIfCreateRequest(ctx context.Context, ifParam
 	return req, nil
 }
 
+// - options - ParametersClientWithImportOptions contains the optional parameters for the ParametersClient.WithImport method.
 func (client *ParametersClient) WithImport(ctx context.Context, importParam string, options *ParametersClientWithImportOptions) (ParametersClientWithImportResponse, error) {
 	var err error
 	req, err := client.withImportCreateRequest(ctx, importParam, options)
@@ -681,6 +705,7 @@ func (client *ParametersClient) withImportCreateRequest(ctx context.Context, imp
 	return req, nil
 }
 
+// - options - ParametersClientWithInOptions contains the optional parameters for the ParametersClient.WithIn method.
 func (client *ParametersClient) WithIn(ctx context.Context, in string, options *ParametersClientWithInOptions) (ParametersClientWithInResponse, error) {
 	var err error
 	req, err := client.withInCreateRequest(ctx, in, options)
@@ -711,6 +736,7 @@ func (client *ParametersClient) withInCreateRequest(ctx context.Context, in stri
 	return req, nil
 }
 
+// - options - ParametersClientWithIsOptions contains the optional parameters for the ParametersClient.WithIs method.
 func (client *ParametersClient) WithIs(ctx context.Context, is string, options *ParametersClientWithIsOptions) (ParametersClientWithIsResponse, error) {
 	var err error
 	req, err := client.withIsCreateRequest(ctx, is, options)
@@ -741,6 +767,7 @@ func (client *ParametersClient) withIsCreateRequest(ctx context.Context, is stri
 	return req, nil
 }
 
+// - options - ParametersClientWithLambdaOptions contains the optional parameters for the ParametersClient.WithLambda method.
 func (client *ParametersClient) WithLambda(ctx context.Context, lambda string, options *ParametersClientWithLambdaOptions) (ParametersClientWithLambdaResponse, error) {
 	var err error
 	req, err := client.withLambdaCreateRequest(ctx, lambda, options)
@@ -771,6 +798,7 @@ func (client *ParametersClient) withLambdaCreateRequest(ctx context.Context, lam
 	return req, nil
 }
 
+// - options - ParametersClientWithNotOptions contains the optional parameters for the ParametersClient.WithNot method.
 func (client *ParametersClient) WithNot(ctx context.Context, not string, options *ParametersClientWithNotOptions) (ParametersClientWithNotResponse, error) {
 	var err error
 	req, err := client.withNotCreateRequest(ctx, not, options)
@@ -801,6 +829,7 @@ func (client *ParametersClient) withNotCreateRequest(ctx context.Context, not st
 	return req, nil
 }
 
+// - options - ParametersClientWithOrOptions contains the optional parameters for the ParametersClient.WithOr method.
 func (client *ParametersClient) WithOr(ctx context.Context, or string, options *ParametersClientWithOrOptions) (ParametersClientWithOrResponse, error) {
 	var err error
 	req, err := client.withOrCreateRequest(ctx, or, options)
@@ -831,6 +860,7 @@ func (client *ParametersClient) withOrCreateRequest(ctx context.Context, or stri
 	return req, nil
 }
 
+// - options - ParametersClientWithPassOptions contains the optional parameters for the ParametersClient.WithPass method.
 func (client *ParametersClient) WithPass(ctx context.Context, pass string, options *ParametersClientWithPassOptions) (ParametersClientWithPassResponse, error) {
 	var err error
 	req, err := client.withPassCreateRequest(ctx, pass, options)
@@ -861,6 +891,7 @@ func (client *ParametersClient) withPassCreateRequest(ctx context.Context, pass 
 	return req, nil
 }
 
+// - options - ParametersClientWithRaiseOptions contains the optional parameters for the ParametersClient.WithRaise method.
 func (client *ParametersClient) WithRaise(ctx context.Context, raise string, options *ParametersClientWithRaiseOptions) (ParametersClientWithRaiseResponse, error) {
 	var err error
 	req, err := client.withRaiseCreateRequest(ctx, raise, options)
@@ -891,6 +922,7 @@ func (client *ParametersClient) withRaiseCreateRequest(ctx context.Context, rais
 	return req, nil
 }
 
+// - options - ParametersClientWithReturnOptions contains the optional parameters for the ParametersClient.WithReturn method.
 func (client *ParametersClient) WithReturn(ctx context.Context, returnParam string, options *ParametersClientWithReturnOptions) (ParametersClientWithReturnResponse, error) {
 	var err error
 	req, err := client.withReturnCreateRequest(ctx, returnParam, options)
@@ -921,6 +953,7 @@ func (client *ParametersClient) withReturnCreateRequest(ctx context.Context, ret
 	return req, nil
 }
 
+// - options - ParametersClientWithTryOptions contains the optional parameters for the ParametersClient.WithTry method.
 func (client *ParametersClient) WithTry(ctx context.Context, try string, options *ParametersClientWithTryOptions) (ParametersClientWithTryResponse, error) {
 	var err error
 	req, err := client.withTryCreateRequest(ctx, try, options)
@@ -951,6 +984,7 @@ func (client *ParametersClient) withTryCreateRequest(ctx context.Context, try st
 	return req, nil
 }
 
+// - options - ParametersClientWithWhileOptions contains the optional parameters for the ParametersClient.WithWhile method.
 func (client *ParametersClient) WithWhile(ctx context.Context, while string, options *ParametersClientWithWhileOptions) (ParametersClientWithWhileResponse, error) {
 	var err error
 	req, err := client.withWhileCreateRequest(ctx, while, options)
@@ -981,6 +1015,7 @@ func (client *ParametersClient) withWhileCreateRequest(ctx context.Context, whil
 	return req, nil
 }
 
+// - options - ParametersClientWithWithOptions contains the optional parameters for the ParametersClient.WithWith method.
 func (client *ParametersClient) WithWith(ctx context.Context, with string, options *ParametersClientWithWithOptions) (ParametersClientWithWithResponse, error) {
 	var err error
 	req, err := client.withWithCreateRequest(ctx, with, options)
@@ -1011,6 +1046,7 @@ func (client *ParametersClient) withWithCreateRequest(ctx context.Context, with 
 	return req, nil
 }
 
+// - options - ParametersClientWithYieldOptions contains the optional parameters for the ParametersClient.WithYield method.
 func (client *ParametersClient) WithYield(ctx context.Context, yield string, options *ParametersClientWithYieldOptions) (ParametersClientWithYieldResponse, error) {
 	var err error
 	req, err := client.withYieldCreateRequest(ctx, yield, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_booleanvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_booleanvalue_client.go
@@ -21,6 +21,7 @@ type BooleanValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - BooleanValueClientGetOptions contains the optional parameters for the BooleanValueClient.Get method.
 func (client *BooleanValueClient) Get(ctx context.Context, options *BooleanValueClientGetOptions) (BooleanValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *BooleanValueClient) getHandleResponse(resp *http.Response) (Boolea
 	return result, nil
 }
 
+// - options - BooleanValueClientPutOptions contains the optional parameters for the BooleanValueClient.Put method.
 func (client *BooleanValueClient) Put(ctx context.Context, body []bool, options *BooleanValueClientPutOptions) (BooleanValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_datetimevalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_datetimevalue_client.go
@@ -22,6 +22,7 @@ type DatetimeValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - DatetimeValueClientGetOptions contains the optional parameters for the DatetimeValueClient.Get method.
 func (client *DatetimeValueClient) Get(ctx context.Context, options *DatetimeValueClientGetOptions) (DatetimeValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -66,6 +67,7 @@ func (client *DatetimeValueClient) getHandleResponse(resp *http.Response) (Datet
 	return result, nil
 }
 
+// - options - DatetimeValueClientPutOptions contains the optional parameters for the DatetimeValueClient.Put method.
 func (client *DatetimeValueClient) Put(ctx context.Context, body []time.Time, options *DatetimeValueClientPutOptions) (DatetimeValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_durationvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_durationvalue_client.go
@@ -21,6 +21,7 @@ type DurationValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - DurationValueClientGetOptions contains the optional parameters for the DurationValueClient.Get method.
 func (client *DurationValueClient) Get(ctx context.Context, options *DurationValueClientGetOptions) (DurationValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *DurationValueClient) getHandleResponse(resp *http.Response) (Durat
 	return result, nil
 }
 
+// - options - DurationValueClientPutOptions contains the optional parameters for the DurationValueClient.Put method.
 func (client *DurationValueClient) Put(ctx context.Context, body []string, options *DurationValueClientPutOptions) (DurationValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_float32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_float32value_client.go
@@ -21,6 +21,7 @@ type Float32ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Float32ValueClientGetOptions contains the optional parameters for the Float32ValueClient.Get method.
 func (client *Float32ValueClient) Get(ctx context.Context, options *Float32ValueClientGetOptions) (Float32ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Float32ValueClient) getHandleResponse(resp *http.Response) (Float3
 	return result, nil
 }
 
+// - options - Float32ValueClientPutOptions contains the optional parameters for the Float32ValueClient.Put method.
 func (client *Float32ValueClient) Put(ctx context.Context, body []float32, options *Float32ValueClientPutOptions) (Float32ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_int32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_int32value_client.go
@@ -21,6 +21,7 @@ type Int32ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Int32ValueClientGetOptions contains the optional parameters for the Int32ValueClient.Get method.
 func (client *Int32ValueClient) Get(ctx context.Context, options *Int32ValueClientGetOptions) (Int32ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Int32ValueClient) getHandleResponse(resp *http.Response) (Int32Val
 	return result, nil
 }
 
+// - options - Int32ValueClientPutOptions contains the optional parameters for the Int32ValueClient.Put method.
 func (client *Int32ValueClient) Put(ctx context.Context, body []int32, options *Int32ValueClientPutOptions) (Int32ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_int64value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_int64value_client.go
@@ -21,6 +21,7 @@ type Int64ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Int64ValueClientGetOptions contains the optional parameters for the Int64ValueClient.Get method.
 func (client *Int64ValueClient) Get(ctx context.Context, options *Int64ValueClientGetOptions) (Int64ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Int64ValueClient) getHandleResponse(resp *http.Response) (Int64Val
 	return result, nil
 }
 
+// - options - Int64ValueClientPutOptions contains the optional parameters for the Int64ValueClient.Put method.
 func (client *Int64ValueClient) Put(ctx context.Context, body []int64, options *Int64ValueClientPutOptions) (Int64ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_modelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_modelvalue_client.go
@@ -21,6 +21,7 @@ type ModelValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - ModelValueClientGetOptions contains the optional parameters for the ModelValueClient.Get method.
 func (client *ModelValueClient) Get(ctx context.Context, options *ModelValueClientGetOptions) (ModelValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *ModelValueClient) getHandleResponse(resp *http.Response) (ModelVal
 	return result, nil
 }
 
+// - options - ModelValueClientPutOptions contains the optional parameters for the ModelValueClient.Put method.
 func (client *ModelValueClient) Put(ctx context.Context, body []InnerModel, options *ModelValueClientPutOptions) (ModelValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_nullablefloatvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_nullablefloatvalue_client.go
@@ -21,6 +21,7 @@ type NullableFloatValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - NullableFloatValueClientGetOptions contains the optional parameters for the NullableFloatValueClient.Get method.
 func (client *NullableFloatValueClient) Get(ctx context.Context, options *NullableFloatValueClientGetOptions) (NullableFloatValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *NullableFloatValueClient) getHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+// - options - NullableFloatValueClientPutOptions contains the optional parameters for the NullableFloatValueClient.Put method.
 func (client *NullableFloatValueClient) Put(ctx context.Context, body []*float32, options *NullableFloatValueClientPutOptions) (NullableFloatValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_options.go
@@ -7,82 +7,102 @@
 
 package arraygroup
 
+// BooleanValueClientGetOptions contains the optional parameters for the BooleanValueClient.Get method.
 type BooleanValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BooleanValueClientPutOptions contains the optional parameters for the BooleanValueClient.Put method.
 type BooleanValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeValueClientGetOptions contains the optional parameters for the DatetimeValueClient.Get method.
 type DatetimeValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeValueClientPutOptions contains the optional parameters for the DatetimeValueClient.Put method.
 type DatetimeValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationValueClientGetOptions contains the optional parameters for the DurationValueClient.Get method.
 type DurationValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationValueClientPutOptions contains the optional parameters for the DurationValueClient.Put method.
 type DurationValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Float32ValueClientGetOptions contains the optional parameters for the Float32ValueClient.Get method.
 type Float32ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Float32ValueClientPutOptions contains the optional parameters for the Float32ValueClient.Put method.
 type Float32ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int32ValueClientGetOptions contains the optional parameters for the Int32ValueClient.Get method.
 type Int32ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int32ValueClientPutOptions contains the optional parameters for the Int32ValueClient.Put method.
 type Int32ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int64ValueClientGetOptions contains the optional parameters for the Int64ValueClient.Get method.
 type Int64ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int64ValueClientPutOptions contains the optional parameters for the Int64ValueClient.Put method.
 type Int64ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelValueClientGetOptions contains the optional parameters for the ModelValueClient.Get method.
 type ModelValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelValueClientPutOptions contains the optional parameters for the ModelValueClient.Put method.
 type ModelValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NullableFloatValueClientGetOptions contains the optional parameters for the NullableFloatValueClient.Get method.
 type NullableFloatValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NullableFloatValueClientPutOptions contains the optional parameters for the NullableFloatValueClient.Put method.
 type NullableFloatValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringValueClientGetOptions contains the optional parameters for the StringValueClient.Get method.
 type StringValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringValueClientPutOptions contains the optional parameters for the StringValueClient.Put method.
 type StringValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownValueClientGetOptions contains the optional parameters for the UnknownValueClient.Get method.
 type UnknownValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownValueClientPutOptions contains the optional parameters for the UnknownValueClient.Put method.
 type UnknownValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_stringvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_stringvalue_client.go
@@ -21,6 +21,7 @@ type StringValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - StringValueClientGetOptions contains the optional parameters for the StringValueClient.Get method.
 func (client *StringValueClient) Get(ctx context.Context, options *StringValueClientGetOptions) (StringValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *StringValueClient) getHandleResponse(resp *http.Response) (StringV
 	return result, nil
 }
 
+// - options - StringValueClientPutOptions contains the optional parameters for the StringValueClient.Put method.
 func (client *StringValueClient) Put(ctx context.Context, body []string, options *StringValueClientPutOptions) (StringValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_unknownvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_unknownvalue_client.go
@@ -21,6 +21,7 @@ type UnknownValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - UnknownValueClientGetOptions contains the optional parameters for the UnknownValueClient.Get method.
 func (client *UnknownValueClient) Get(ctx context.Context, options *UnknownValueClientGetOptions) (UnknownValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *UnknownValueClient) getHandleResponse(resp *http.Response) (Unknow
 	return result, nil
 }
 
+// - options - UnknownValueClientPutOptions contains the optional parameters for the UnknownValueClient.Put method.
 func (client *UnknownValueClient) Put(ctx context.Context, body []any, options *UnknownValueClientPutOptions) (UnknownValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_booleanvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_booleanvalue_client.go
@@ -21,6 +21,7 @@ type BooleanValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - BooleanValueClientGetOptions contains the optional parameters for the BooleanValueClient.Get method.
 func (client *BooleanValueClient) Get(ctx context.Context, options *BooleanValueClientGetOptions) (BooleanValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *BooleanValueClient) getHandleResponse(resp *http.Response) (Boolea
 	return result, nil
 }
 
+// - options - BooleanValueClientPutOptions contains the optional parameters for the BooleanValueClient.Put method.
 func (client *BooleanValueClient) Put(ctx context.Context, body map[string]*bool, options *BooleanValueClientPutOptions) (BooleanValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_datetimevalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_datetimevalue_client.go
@@ -22,6 +22,7 @@ type DatetimeValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - DatetimeValueClientGetOptions contains the optional parameters for the DatetimeValueClient.Get method.
 func (client *DatetimeValueClient) Get(ctx context.Context, options *DatetimeValueClientGetOptions) (DatetimeValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -66,6 +67,7 @@ func (client *DatetimeValueClient) getHandleResponse(resp *http.Response) (Datet
 	return result, nil
 }
 
+// - options - DatetimeValueClientPutOptions contains the optional parameters for the DatetimeValueClient.Put method.
 func (client *DatetimeValueClient) Put(ctx context.Context, body map[string]*time.Time, options *DatetimeValueClientPutOptions) (DatetimeValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_durationvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_durationvalue_client.go
@@ -21,6 +21,7 @@ type DurationValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - DurationValueClientGetOptions contains the optional parameters for the DurationValueClient.Get method.
 func (client *DurationValueClient) Get(ctx context.Context, options *DurationValueClientGetOptions) (DurationValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *DurationValueClient) getHandleResponse(resp *http.Response) (Durat
 	return result, nil
 }
 
+// - options - DurationValueClientPutOptions contains the optional parameters for the DurationValueClient.Put method.
 func (client *DurationValueClient) Put(ctx context.Context, body map[string]*string, options *DurationValueClientPutOptions) (DurationValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_float32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_float32value_client.go
@@ -21,6 +21,7 @@ type Float32ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Float32ValueClientGetOptions contains the optional parameters for the Float32ValueClient.Get method.
 func (client *Float32ValueClient) Get(ctx context.Context, options *Float32ValueClientGetOptions) (Float32ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Float32ValueClient) getHandleResponse(resp *http.Response) (Float3
 	return result, nil
 }
 
+// - options - Float32ValueClientPutOptions contains the optional parameters for the Float32ValueClient.Put method.
 func (client *Float32ValueClient) Put(ctx context.Context, body map[string]*float32, options *Float32ValueClientPutOptions) (Float32ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_int32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_int32value_client.go
@@ -21,6 +21,7 @@ type Int32ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Int32ValueClientGetOptions contains the optional parameters for the Int32ValueClient.Get method.
 func (client *Int32ValueClient) Get(ctx context.Context, options *Int32ValueClientGetOptions) (Int32ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Int32ValueClient) getHandleResponse(resp *http.Response) (Int32Val
 	return result, nil
 }
 
+// - options - Int32ValueClientPutOptions contains the optional parameters for the Int32ValueClient.Put method.
 func (client *Int32ValueClient) Put(ctx context.Context, body map[string]*int32, options *Int32ValueClientPutOptions) (Int32ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_int64value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_int64value_client.go
@@ -21,6 +21,7 @@ type Int64ValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - Int64ValueClientGetOptions contains the optional parameters for the Int64ValueClient.Get method.
 func (client *Int64ValueClient) Get(ctx context.Context, options *Int64ValueClientGetOptions) (Int64ValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *Int64ValueClient) getHandleResponse(resp *http.Response) (Int64Val
 	return result, nil
 }
 
+// - options - Int64ValueClientPutOptions contains the optional parameters for the Int64ValueClient.Put method.
 func (client *Int64ValueClient) Put(ctx context.Context, body map[string]*int64, options *Int64ValueClientPutOptions) (Int64ValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_modelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_modelvalue_client.go
@@ -21,6 +21,7 @@ type ModelValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - ModelValueClientGetOptions contains the optional parameters for the ModelValueClient.Get method.
 func (client *ModelValueClient) Get(ctx context.Context, options *ModelValueClientGetOptions) (ModelValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *ModelValueClient) getHandleResponse(resp *http.Response) (ModelVal
 	return result, nil
 }
 
+// - options - ModelValueClientPutOptions contains the optional parameters for the ModelValueClient.Put method.
 func (client *ModelValueClient) Put(ctx context.Context, body map[string]*InnerModel, options *ModelValueClientPutOptions) (ModelValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_nullablefloatvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_nullablefloatvalue_client.go
@@ -21,6 +21,7 @@ type NullableFloatValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - NullableFloatValueClientGetOptions contains the optional parameters for the NullableFloatValueClient.Get method.
 func (client *NullableFloatValueClient) Get(ctx context.Context, options *NullableFloatValueClientGetOptions) (NullableFloatValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *NullableFloatValueClient) getHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+// - options - NullableFloatValueClientPutOptions contains the optional parameters for the NullableFloatValueClient.Put method.
 func (client *NullableFloatValueClient) Put(ctx context.Context, body map[string]*float32, options *NullableFloatValueClientPutOptions) (NullableFloatValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_options.go
@@ -7,90 +7,112 @@
 
 package dictionarygroup
 
+// BooleanValueClientGetOptions contains the optional parameters for the BooleanValueClient.Get method.
 type BooleanValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BooleanValueClientPutOptions contains the optional parameters for the BooleanValueClient.Put method.
 type BooleanValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeValueClientGetOptions contains the optional parameters for the DatetimeValueClient.Get method.
 type DatetimeValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeValueClientPutOptions contains the optional parameters for the DatetimeValueClient.Put method.
 type DatetimeValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationValueClientGetOptions contains the optional parameters for the DurationValueClient.Get method.
 type DurationValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationValueClientPutOptions contains the optional parameters for the DurationValueClient.Put method.
 type DurationValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Float32ValueClientGetOptions contains the optional parameters for the Float32ValueClient.Get method.
 type Float32ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Float32ValueClientPutOptions contains the optional parameters for the Float32ValueClient.Put method.
 type Float32ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int32ValueClientGetOptions contains the optional parameters for the Int32ValueClient.Get method.
 type Int32ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int32ValueClientPutOptions contains the optional parameters for the Int32ValueClient.Put method.
 type Int32ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int64ValueClientGetOptions contains the optional parameters for the Int64ValueClient.Get method.
 type Int64ValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Int64ValueClientPutOptions contains the optional parameters for the Int64ValueClient.Put method.
 type Int64ValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelValueClientGetOptions contains the optional parameters for the ModelValueClient.Get method.
 type ModelValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ModelValueClientPutOptions contains the optional parameters for the ModelValueClient.Put method.
 type ModelValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NullableFloatValueClientGetOptions contains the optional parameters for the NullableFloatValueClient.Get method.
 type NullableFloatValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NullableFloatValueClientPutOptions contains the optional parameters for the NullableFloatValueClient.Put method.
 type NullableFloatValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RecursiveModelValueClientGetOptions contains the optional parameters for the RecursiveModelValueClient.Get method.
 type RecursiveModelValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RecursiveModelValueClientPutOptions contains the optional parameters for the RecursiveModelValueClient.Put method.
 type RecursiveModelValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringValueClientGetOptions contains the optional parameters for the StringValueClient.Get method.
 type StringValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringValueClientPutOptions contains the optional parameters for the StringValueClient.Put method.
 type StringValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownValueClientGetOptions contains the optional parameters for the UnknownValueClient.Get method.
 type UnknownValueClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownValueClientPutOptions contains the optional parameters for the UnknownValueClient.Put method.
 type UnknownValueClientPutOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_recursivemodelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_recursivemodelvalue_client.go
@@ -21,6 +21,7 @@ type RecursiveModelValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - RecursiveModelValueClientGetOptions contains the optional parameters for the RecursiveModelValueClient.Get method.
 func (client *RecursiveModelValueClient) Get(ctx context.Context, options *RecursiveModelValueClientGetOptions) (RecursiveModelValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *RecursiveModelValueClient) getHandleResponse(resp *http.Response) 
 	return result, nil
 }
 
+// - options - RecursiveModelValueClientPutOptions contains the optional parameters for the RecursiveModelValueClient.Put method.
 func (client *RecursiveModelValueClient) Put(ctx context.Context, body map[string]*InnerModel, options *RecursiveModelValueClientPutOptions) (RecursiveModelValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_stringvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_stringvalue_client.go
@@ -21,6 +21,7 @@ type StringValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - StringValueClientGetOptions contains the optional parameters for the StringValueClient.Get method.
 func (client *StringValueClient) Get(ctx context.Context, options *StringValueClientGetOptions) (StringValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *StringValueClient) getHandleResponse(resp *http.Response) (StringV
 	return result, nil
 }
 
+// - options - StringValueClientPutOptions contains the optional parameters for the StringValueClient.Put method.
 func (client *StringValueClient) Put(ctx context.Context, body map[string]*string, options *StringValueClientPutOptions) (StringValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_unknownvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_unknownvalue_client.go
@@ -21,6 +21,7 @@ type UnknownValueClient struct {
 	internal *azcore.Client
 }
 
+// - options - UnknownValueClientGetOptions contains the optional parameters for the UnknownValueClient.Get method.
 func (client *UnknownValueClient) Get(ctx context.Context, options *UnknownValueClientGetOptions) (UnknownValueClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *UnknownValueClient) getHandleResponse(resp *http.Response) (Unknow
 	return result, nil
 }
 
+// - options - UnknownValueClientPutOptions contains the optional parameters for the UnknownValueClient.Put method.
 func (client *UnknownValueClient) Put(ctx context.Context, body map[string]any, options *UnknownValueClientPutOptions) (UnknownValueClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_options.go
@@ -7,18 +7,22 @@
 
 package extensiblegroup
 
+// StringClientGetKnownValueOptions contains the optional parameters for the StringClient.GetKnownValue method.
 type StringClientGetKnownValueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientGetUnknownValueOptions contains the optional parameters for the StringClient.GetUnknownValue method.
 type StringClientGetUnknownValueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPutKnownValueOptions contains the optional parameters for the StringClient.PutKnownValue method.
 type StringClientPutKnownValueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPutUnknownValueOptions contains the optional parameters for the StringClient.PutUnknownValue method.
 type StringClientPutUnknownValueOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_string_client.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_string_client.go
@@ -21,6 +21,7 @@ type StringClient struct {
 	internal *azcore.Client
 }
 
+// - options - StringClientGetKnownValueOptions contains the optional parameters for the StringClient.GetKnownValue method.
 func (client *StringClient) GetKnownValue(ctx context.Context, options *StringClientGetKnownValueOptions) (StringClientGetKnownValueResponse, error) {
 	var err error
 	req, err := client.getKnownValueCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *StringClient) getKnownValueHandleResponse(resp *http.Response) (St
 	return result, nil
 }
 
+// - options - StringClientGetUnknownValueOptions contains the optional parameters for the StringClient.GetUnknownValue method.
 func (client *StringClient) GetUnknownValue(ctx context.Context, options *StringClientGetUnknownValueOptions) (StringClientGetUnknownValueResponse, error) {
 	var err error
 	req, err := client.getUnknownValueCreateRequest(ctx, options)
@@ -97,6 +99,7 @@ func (client *StringClient) getUnknownValueHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
+// - options - StringClientPutKnownValueOptions contains the optional parameters for the StringClient.PutKnownValue method.
 func (client *StringClient) PutKnownValue(ctx context.Context, body DaysOfWeekExtensibleEnum, options *StringClientPutKnownValueOptions) (StringClientPutKnownValueResponse, error) {
 	var err error
 	req, err := client.putKnownValueCreateRequest(ctx, body, options)
@@ -128,6 +131,7 @@ func (client *StringClient) putKnownValueCreateRequest(ctx context.Context, body
 	return req, nil
 }
 
+// - options - StringClientPutUnknownValueOptions contains the optional parameters for the StringClient.PutUnknownValue method.
 func (client *StringClient) PutUnknownValue(ctx context.Context, body DaysOfWeekExtensibleEnum, options *StringClientPutUnknownValueOptions) (StringClientPutUnknownValueResponse, error) {
 	var err error
 	req, err := client.putUnknownValueCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_options.go
@@ -7,14 +7,17 @@
 
 package fixedgroup
 
+// StringClientGetKnownValueOptions contains the optional parameters for the StringClient.GetKnownValue method.
 type StringClientGetKnownValueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPutKnownValueOptions contains the optional parameters for the StringClient.PutKnownValue method.
 type StringClientPutKnownValueOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPutUnknownValueOptions contains the optional parameters for the StringClient.PutUnknownValue method.
 type StringClientPutUnknownValueOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_string_client.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_string_client.go
@@ -22,6 +22,7 @@ type StringClient struct {
 }
 
 // GetKnownValue - getKnownValue
+//   - options - StringClientGetKnownValueOptions contains the optional parameters for the StringClient.GetKnownValue method.
 func (client *StringClient) GetKnownValue(ctx context.Context, options *StringClientGetKnownValueOptions) (StringClientGetKnownValueResponse, error) {
 	var err error
 	req, err := client.getKnownValueCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *StringClient) getKnownValueHandleResponse(resp *http.Response) (St
 
 // PutKnownValue - putKnownValue
 //   - body - _
+//   - options - StringClientPutKnownValueOptions contains the optional parameters for the StringClient.PutKnownValue method.
 func (client *StringClient) PutKnownValue(ctx context.Context, body DaysOfWeekEnum, options *StringClientPutKnownValueOptions) (StringClientPutKnownValueResponse, error) {
 	var err error
 	req, err := client.putKnownValueCreateRequest(ctx, body, options)
@@ -95,6 +97,7 @@ func (client *StringClient) putKnownValueCreateRequest(ctx context.Context, body
 
 // PutUnknownValue - putUnknownValue
 //   - body - _
+//   - options - StringClientPutUnknownValueOptions contains the optional parameters for the StringClient.PutUnknownValue method.
 func (client *StringClient) PutUnknownValue(ctx context.Context, body DaysOfWeekEnum, options *StringClientPutUnknownValueOptions) (StringClientPutUnknownValueResponse, error) {
 	var err error
 	req, err := client.putUnknownValueCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_empty_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_empty_client.go
@@ -21,26 +21,27 @@ type EmptyClient struct {
 	internal *azcore.Client
 }
 
-func (client *EmptyClient) GetEmpty(ctx context.Context, options *EmptyClientGetEmptyOptions) (EmptyClientGetEmptyResponse, error) {
+// - options - GetEmptyOptions contains the optional parameters for the EmptyClient.GetEmpty method.
+func (client *EmptyClient) GetEmpty(ctx context.Context, options *GetEmptyOptions) (GetEmptyResponse, error) {
 	var err error
 	req, err := client.getEmptyCreateRequest(ctx, options)
 	if err != nil {
-		return EmptyClientGetEmptyResponse{}, err
+		return GetEmptyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return EmptyClientGetEmptyResponse{}, err
+		return GetEmptyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return EmptyClientGetEmptyResponse{}, err
+		return GetEmptyResponse{}, err
 	}
 	resp, err := client.getEmptyHandleResponse(httpResp)
 	return resp, err
 }
 
 // getEmptyCreateRequest creates the GetEmpty request.
-func (client *EmptyClient) getEmptyCreateRequest(ctx context.Context, options *EmptyClientGetEmptyOptions) (*policy.Request, error) {
+func (client *EmptyClient) getEmptyCreateRequest(ctx context.Context, options *GetEmptyOptions) (*policy.Request, error) {
 	urlPath := "/type/model/empty/alone"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -51,34 +52,35 @@ func (client *EmptyClient) getEmptyCreateRequest(ctx context.Context, options *E
 }
 
 // getEmptyHandleResponse handles the GetEmpty response.
-func (client *EmptyClient) getEmptyHandleResponse(resp *http.Response) (EmptyClientGetEmptyResponse, error) {
-	result := EmptyClientGetEmptyResponse{}
+func (client *EmptyClient) getEmptyHandleResponse(resp *http.Response) (GetEmptyResponse, error) {
+	result := GetEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EmptyOutput); err != nil {
-		return EmptyClientGetEmptyResponse{}, err
+		return GetEmptyResponse{}, err
 	}
 	return result, nil
 }
 
-func (client *EmptyClient) PostRoundTripEmpty(ctx context.Context, body EmptyInputOutput, options *EmptyClientPostRoundTripEmptyOptions) (EmptyClientPostRoundTripEmptyResponse, error) {
+// - options - PostRoundTripEmptyOptions contains the optional parameters for the EmptyClient.PostRoundTripEmpty method.
+func (client *EmptyClient) PostRoundTripEmpty(ctx context.Context, body EmptyInputOutput, options *PostRoundTripEmptyOptions) (PostRoundTripEmptyResponse, error) {
 	var err error
 	req, err := client.postRoundTripEmptyCreateRequest(ctx, body, options)
 	if err != nil {
-		return EmptyClientPostRoundTripEmptyResponse{}, err
+		return PostRoundTripEmptyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return EmptyClientPostRoundTripEmptyResponse{}, err
+		return PostRoundTripEmptyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return EmptyClientPostRoundTripEmptyResponse{}, err
+		return PostRoundTripEmptyResponse{}, err
 	}
 	resp, err := client.postRoundTripEmptyHandleResponse(httpResp)
 	return resp, err
 }
 
 // postRoundTripEmptyCreateRequest creates the PostRoundTripEmpty request.
-func (client *EmptyClient) postRoundTripEmptyCreateRequest(ctx context.Context, body EmptyInputOutput, options *EmptyClientPostRoundTripEmptyOptions) (*policy.Request, error) {
+func (client *EmptyClient) postRoundTripEmptyCreateRequest(ctx context.Context, body EmptyInputOutput, options *PostRoundTripEmptyOptions) (*policy.Request, error) {
 	urlPath := "/type/model/empty/round-trip"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -93,33 +95,34 @@ func (client *EmptyClient) postRoundTripEmptyCreateRequest(ctx context.Context, 
 }
 
 // postRoundTripEmptyHandleResponse handles the PostRoundTripEmpty response.
-func (client *EmptyClient) postRoundTripEmptyHandleResponse(resp *http.Response) (EmptyClientPostRoundTripEmptyResponse, error) {
-	result := EmptyClientPostRoundTripEmptyResponse{}
+func (client *EmptyClient) postRoundTripEmptyHandleResponse(resp *http.Response) (PostRoundTripEmptyResponse, error) {
+	result := PostRoundTripEmptyResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.EmptyInputOutput); err != nil {
-		return EmptyClientPostRoundTripEmptyResponse{}, err
+		return PostRoundTripEmptyResponse{}, err
 	}
 	return result, nil
 }
 
-func (client *EmptyClient) PutEmpty(ctx context.Context, input EmptyInput, options *EmptyClientPutEmptyOptions) (EmptyClientPutEmptyResponse, error) {
+// - options - PutEmptyOptions contains the optional parameters for the EmptyClient.PutEmpty method.
+func (client *EmptyClient) PutEmpty(ctx context.Context, input EmptyInput, options *PutEmptyOptions) (PutEmptyResponse, error) {
 	var err error
 	req, err := client.putEmptyCreateRequest(ctx, input, options)
 	if err != nil {
-		return EmptyClientPutEmptyResponse{}, err
+		return PutEmptyResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return EmptyClientPutEmptyResponse{}, err
+		return PutEmptyResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return EmptyClientPutEmptyResponse{}, err
+		return PutEmptyResponse{}, err
 	}
-	return EmptyClientPutEmptyResponse{}, nil
+	return PutEmptyResponse{}, nil
 }
 
 // putEmptyCreateRequest creates the PutEmpty request.
-func (client *EmptyClient) putEmptyCreateRequest(ctx context.Context, input EmptyInput, options *EmptyClientPutEmptyOptions) (*policy.Request, error) {
+func (client *EmptyClient) putEmptyCreateRequest(ctx context.Context, input EmptyInput, options *PutEmptyOptions) (*policy.Request, error) {
 	urlPath := "/type/model/empty/alone"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_options.go
@@ -7,14 +7,17 @@
 
 package emptygroup
 
-type EmptyClientGetEmptyOptions struct {
+// GetEmptyOptions contains the optional parameters for the EmptyClient.GetEmpty method.
+type GetEmptyOptions struct {
 	// placeholder for future optional parameters
 }
 
-type EmptyClientPostRoundTripEmptyOptions struct {
+// PostRoundTripEmptyOptions contains the optional parameters for the EmptyClient.PostRoundTripEmpty method.
+type PostRoundTripEmptyOptions struct {
 	// placeholder for future optional parameters
 }
 
-type EmptyClientPutEmptyOptions struct {
+// PutEmptyOptions contains the optional parameters for the EmptyClient.PutEmpty method.
+type PutEmptyOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_responses.go
@@ -7,19 +7,19 @@
 
 package emptygroup
 
-// EmptyClientGetEmptyResponse contains the response from method EmptyClient.GetEmpty.
-type EmptyClientGetEmptyResponse struct {
+// GetEmptyResponse contains the response from method EmptyClient.GetEmpty.
+type GetEmptyResponse struct {
 	// Empty model used in operation return type
 	EmptyOutput
 }
 
-// EmptyClientPostRoundTripEmptyResponse contains the response from method EmptyClient.PostRoundTripEmpty.
-type EmptyClientPostRoundTripEmptyResponse struct {
+// PostRoundTripEmptyResponse contains the response from method EmptyClient.PostRoundTripEmpty.
+type PostRoundTripEmptyResponse struct {
 	// Empty model used in both parameter and return type
 	EmptyInputOutput
 }
 
-// EmptyClientPutEmptyResponse contains the response from method EmptyClient.PutEmpty.
-type EmptyClientPutEmptyResponse struct {
+// PutEmptyResponse contains the response from method EmptyClient.PutEmpty.
+type PutEmptyResponse struct {
 	// placeholder for future response values
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
@@ -22,6 +22,8 @@ type EnumDiscriminatorClient struct {
 }
 
 // GetExtensibleModel - Receive model with extensible enum discriminator type.
+//   - options - EnumDiscriminatorClientGetExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModel
+//     method.
 func (client *EnumDiscriminatorClient) GetExtensibleModel(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelOptions) (EnumDiscriminatorClientGetExtensibleModelResponse, error) {
 	var err error
 	req, err := client.getExtensibleModelCreateRequest(ctx, options)
@@ -61,6 +63,8 @@ func (client *EnumDiscriminatorClient) getExtensibleModelHandleResponse(resp *ht
 }
 
 // GetExtensibleModelMissingDiscriminator - Get a model omitting the discriminator.
+//   - options - EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions contains the optional parameters for the
+//     EnumDiscriminatorClient.GetExtensibleModelMissingDiscriminator method.
 func (client *EnumDiscriminatorClient) GetExtensibleModelMissingDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions) (EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getExtensibleModelMissingDiscriminatorCreateRequest(ctx, options)
@@ -100,6 +104,8 @@ func (client *EnumDiscriminatorClient) getExtensibleModelMissingDiscriminatorHan
 }
 
 // GetExtensibleModelWrongDiscriminator - Get a model containing discriminator value never defined.
+//   - options - EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModelWrongDiscriminator
+//     method.
 func (client *EnumDiscriminatorClient) GetExtensibleModelWrongDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions) (EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getExtensibleModelWrongDiscriminatorCreateRequest(ctx, options)
@@ -139,6 +145,8 @@ func (client *EnumDiscriminatorClient) getExtensibleModelWrongDiscriminatorHandl
 }
 
 // GetFixedModel - Receive model with fixed enum discriminator type.
+//   - options - EnumDiscriminatorClientGetFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModel
+//     method.
 func (client *EnumDiscriminatorClient) GetFixedModel(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelOptions) (EnumDiscriminatorClientGetFixedModelResponse, error) {
 	var err error
 	req, err := client.getFixedModelCreateRequest(ctx, options)
@@ -178,6 +186,8 @@ func (client *EnumDiscriminatorClient) getFixedModelHandleResponse(resp *http.Re
 }
 
 // GetFixedModelMissingDiscriminator - Get a model omitting the discriminator.
+//   - options - EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelMissingDiscriminator
+//     method.
 func (client *EnumDiscriminatorClient) GetFixedModelMissingDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions) (EnumDiscriminatorClientGetFixedModelMissingDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getFixedModelMissingDiscriminatorCreateRequest(ctx, options)
@@ -217,6 +227,8 @@ func (client *EnumDiscriminatorClient) getFixedModelMissingDiscriminatorHandleRe
 }
 
 // GetFixedModelWrongDiscriminator - Get a model containing discriminator value never defined.
+//   - options - EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelWrongDiscriminator
+//     method.
 func (client *EnumDiscriminatorClient) GetFixedModelWrongDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions) (EnumDiscriminatorClientGetFixedModelWrongDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getFixedModelWrongDiscriminatorCreateRequest(ctx, options)
@@ -257,6 +269,8 @@ func (client *EnumDiscriminatorClient) getFixedModelWrongDiscriminatorHandleResp
 
 // PutExtensibleModel - Send model with extensible enum discriminator type.
 //   - input - Dog to create
+//   - options - EnumDiscriminatorClientPutExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutExtensibleModel
+//     method.
 func (client *EnumDiscriminatorClient) PutExtensibleModel(ctx context.Context, input DogClassification, options *EnumDiscriminatorClientPutExtensibleModelOptions) (EnumDiscriminatorClientPutExtensibleModelResponse, error) {
 	var err error
 	req, err := client.putExtensibleModelCreateRequest(ctx, input, options)
@@ -290,6 +304,8 @@ func (client *EnumDiscriminatorClient) putExtensibleModelCreateRequest(ctx conte
 
 // PutFixedModel - Send model with fixed enum discriminator type.
 //   - input - Snake to create
+//   - options - EnumDiscriminatorClientPutFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutFixedModel
+//     method.
 func (client *EnumDiscriminatorClient) PutFixedModel(ctx context.Context, input SnakeClassification, options *EnumDiscriminatorClientPutFixedModelOptions) (EnumDiscriminatorClientPutFixedModelResponse, error) {
 	var err error
 	req, err := client.putFixedModelCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_options.go
@@ -7,34 +7,50 @@
 
 package enumdiscgroup
 
+// EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModelMissingDiscriminator
+// method.
 type EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientGetExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModel
+// method.
 type EnumDiscriminatorClientGetExtensibleModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModelWrongDiscriminator
+// method.
 type EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelMissingDiscriminator
+// method.
 type EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientGetFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModel
+// method.
 type EnumDiscriminatorClientGetFixedModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelWrongDiscriminator
+// method.
 type EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientPutExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutExtensibleModel
+// method.
 type EnumDiscriminatorClientPutExtensibleModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// EnumDiscriminatorClientPutFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutFixedModel
+// method.
 type EnumDiscriminatorClientPutFixedModelOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
@@ -21,6 +21,8 @@ type NotDiscriminatedClient struct {
 	internal *azcore.Client
 }
 
+//   - options - NotDiscriminatedClientGetValidOptions contains the optional parameters for the NotDiscriminatedClient.GetValid
+//     method.
 func (client *NotDiscriminatedClient) GetValid(ctx context.Context, options *NotDiscriminatedClientGetValidOptions) (NotDiscriminatedClientGetValidResponse, error) {
 	var err error
 	req, err := client.getValidCreateRequest(ctx, options)
@@ -59,6 +61,8 @@ func (client *NotDiscriminatedClient) getValidHandleResponse(resp *http.Response
 	return result, nil
 }
 
+//   - options - NotDiscriminatedClientPostValidOptions contains the optional parameters for the NotDiscriminatedClient.PostValid
+//     method.
 func (client *NotDiscriminatedClient) PostValid(ctx context.Context, input Siamese, options *NotDiscriminatedClientPostValidOptions) (NotDiscriminatedClientPostValidResponse, error) {
 	var err error
 	req, err := client.postValidCreateRequest(ctx, input, options)
@@ -90,6 +94,8 @@ func (client *NotDiscriminatedClient) postValidCreateRequest(ctx context.Context
 	return req, nil
 }
 
+//   - options - NotDiscriminatedClientPutValidOptions contains the optional parameters for the NotDiscriminatedClient.PutValid
+//     method.
 func (client *NotDiscriminatedClient) PutValid(ctx context.Context, input Siamese, options *NotDiscriminatedClientPutValidOptions) (NotDiscriminatedClientPutValidResponse, error) {
 	var err error
 	req, err := client.putValidCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_options.go
@@ -7,14 +7,17 @@
 
 package nodiscgroup
 
+// NotDiscriminatedClientGetValidOptions contains the optional parameters for the NotDiscriminatedClient.GetValid method.
 type NotDiscriminatedClientGetValidOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NotDiscriminatedClientPostValidOptions contains the optional parameters for the NotDiscriminatedClient.PostValid method.
 type NotDiscriminatedClientPostValidOptions struct {
 	// placeholder for future optional parameters
 }
 
+// NotDiscriminatedClientPutValidOptions contains the optional parameters for the NotDiscriminatedClient.PutValid method.
 type NotDiscriminatedClientPutValidOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_options.go
@@ -7,10 +7,12 @@
 
 package recursivegroup
 
+// RecursiveClientGetOptions contains the optional parameters for the RecursiveClient.Get method.
 type RecursiveClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// RecursiveClientPutOptions contains the optional parameters for the RecursiveClient.Put method.
 type RecursiveClientPutOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_recursive_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_recursive_client.go
@@ -21,6 +21,7 @@ type RecursiveClient struct {
 	internal *azcore.Client
 }
 
+// - options - RecursiveClientGetOptions contains the optional parameters for the RecursiveClient.Get method.
 func (client *RecursiveClient) Get(ctx context.Context, options *RecursiveClientGetOptions) (RecursiveClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -59,6 +60,7 @@ func (client *RecursiveClient) getHandleResponse(resp *http.Response) (Recursive
 	return result, nil
 }
 
+// - options - RecursiveClientPutOptions contains the optional parameters for the RecursiveClient.Put method.
 func (client *RecursiveClient) Put(ctx context.Context, input Extension, options *RecursiveClientPutOptions) (RecursiveClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_options.go
@@ -7,30 +7,42 @@
 
 package singlediscgroup
 
+// SingleDiscriminatorClientGetLegacyModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetLegacyModel
+// method.
 type SingleDiscriminatorClientGetLegacyModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientGetMissingDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetMissingDiscriminator
+// method.
 type SingleDiscriminatorClientGetMissingDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientGetModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetModel method.
 type SingleDiscriminatorClientGetModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientGetRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetRecursiveModel
+// method.
 type SingleDiscriminatorClientGetRecursiveModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientGetWrongDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetWrongDiscriminator
+// method.
 type SingleDiscriminatorClientGetWrongDiscriminatorOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientPutModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutModel method.
 type SingleDiscriminatorClientPutModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// SingleDiscriminatorClientPutRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutRecursiveModel
+// method.
 type SingleDiscriminatorClientPutRecursiveModelOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
@@ -21,6 +21,8 @@ type SingleDiscriminatorClient struct {
 	internal *azcore.Client
 }
 
+//   - options - SingleDiscriminatorClientGetLegacyModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetLegacyModel
+//     method.
 func (client *SingleDiscriminatorClient) GetLegacyModel(ctx context.Context, options *SingleDiscriminatorClientGetLegacyModelOptions) (SingleDiscriminatorClientGetLegacyModelResponse, error) {
 	var err error
 	req, err := client.getLegacyModelCreateRequest(ctx, options)
@@ -59,6 +61,8 @@ func (client *SingleDiscriminatorClient) getLegacyModelHandleResponse(resp *http
 	return result, nil
 }
 
+//   - options - SingleDiscriminatorClientGetMissingDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetMissingDiscriminator
+//     method.
 func (client *SingleDiscriminatorClient) GetMissingDiscriminator(ctx context.Context, options *SingleDiscriminatorClientGetMissingDiscriminatorOptions) (SingleDiscriminatorClientGetMissingDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getMissingDiscriminatorCreateRequest(ctx, options)
@@ -97,6 +101,8 @@ func (client *SingleDiscriminatorClient) getMissingDiscriminatorHandleResponse(r
 	return result, nil
 }
 
+//   - options - SingleDiscriminatorClientGetModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetModel
+//     method.
 func (client *SingleDiscriminatorClient) GetModel(ctx context.Context, options *SingleDiscriminatorClientGetModelOptions) (SingleDiscriminatorClientGetModelResponse, error) {
 	var err error
 	req, err := client.getModelCreateRequest(ctx, options)
@@ -135,6 +141,8 @@ func (client *SingleDiscriminatorClient) getModelHandleResponse(resp *http.Respo
 	return result, nil
 }
 
+//   - options - SingleDiscriminatorClientGetRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetRecursiveModel
+//     method.
 func (client *SingleDiscriminatorClient) GetRecursiveModel(ctx context.Context, options *SingleDiscriminatorClientGetRecursiveModelOptions) (SingleDiscriminatorClientGetRecursiveModelResponse, error) {
 	var err error
 	req, err := client.getRecursiveModelCreateRequest(ctx, options)
@@ -173,6 +181,8 @@ func (client *SingleDiscriminatorClient) getRecursiveModelHandleResponse(resp *h
 	return result, nil
 }
 
+//   - options - SingleDiscriminatorClientGetWrongDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetWrongDiscriminator
+//     method.
 func (client *SingleDiscriminatorClient) GetWrongDiscriminator(ctx context.Context, options *SingleDiscriminatorClientGetWrongDiscriminatorOptions) (SingleDiscriminatorClientGetWrongDiscriminatorResponse, error) {
 	var err error
 	req, err := client.getWrongDiscriminatorCreateRequest(ctx, options)
@@ -211,6 +221,8 @@ func (client *SingleDiscriminatorClient) getWrongDiscriminatorHandleResponse(res
 	return result, nil
 }
 
+//   - options - SingleDiscriminatorClientPutModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutModel
+//     method.
 func (client *SingleDiscriminatorClient) PutModel(ctx context.Context, input BirdClassification, options *SingleDiscriminatorClientPutModelOptions) (SingleDiscriminatorClientPutModelResponse, error) {
 	var err error
 	req, err := client.putModelCreateRequest(ctx, input, options)
@@ -242,6 +254,8 @@ func (client *SingleDiscriminatorClient) putModelCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+//   - options - SingleDiscriminatorClientPutRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutRecursiveModel
+//     method.
 func (client *SingleDiscriminatorClient) PutRecursiveModel(ctx context.Context, input BirdClassification, options *SingleDiscriminatorClientPutRecursiveModelOptions) (SingleDiscriminatorClientPutRecursiveModelResponse, error) {
 	var err error
 	req, err := client.putRecursiveModelCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_options.go
@@ -7,14 +7,17 @@
 
 package usagegroup
 
+// UsageClientInputAndOutputOptions contains the optional parameters for the UsageClient.InputAndOutput method.
 type UsageClientInputAndOutputOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UsageClientInputOptions contains the optional parameters for the UsageClient.Input method.
 type UsageClientInputOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UsageClientOutputOptions contains the optional parameters for the UsageClient.Output method.
 type UsageClientOutputOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_usage_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_usage_client.go
@@ -21,6 +21,7 @@ type UsageClient struct {
 	internal *azcore.Client
 }
 
+// - options - UsageClientInputOptions contains the optional parameters for the UsageClient.Input method.
 func (client *UsageClient) Input(ctx context.Context, input InputRecord, options *UsageClientInputOptions) (UsageClientInputResponse, error) {
 	var err error
 	req, err := client.inputCreateRequest(ctx, input, options)
@@ -52,6 +53,7 @@ func (client *UsageClient) inputCreateRequest(ctx context.Context, input InputRe
 	return req, nil
 }
 
+// - options - UsageClientInputAndOutputOptions contains the optional parameters for the UsageClient.InputAndOutput method.
 func (client *UsageClient) InputAndOutput(ctx context.Context, body InputOutputRecord, options *UsageClientInputAndOutputOptions) (UsageClientInputAndOutputResponse, error) {
 	var err error
 	req, err := client.inputAndOutputCreateRequest(ctx, body, options)
@@ -94,6 +96,7 @@ func (client *UsageClient) inputAndOutputHandleResponse(resp *http.Response) (Us
 	return result, nil
 }
 
+// - options - UsageClientOutputOptions contains the optional parameters for the UsageClient.Output method.
 func (client *UsageClient) Output(ctx context.Context, options *UsageClientOutputOptions) (UsageClientOutputResponse, error) {
 	var err error
 	req, err := client.outputCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_options.go
@@ -7,26 +7,32 @@
 
 package visibilitygroup
 
+// VisibilityClientDeleteModelOptions contains the optional parameters for the VisibilityClient.DeleteModel method.
 type VisibilityClientDeleteModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// VisibilityClientGetModelOptions contains the optional parameters for the VisibilityClient.GetModel method.
 type VisibilityClientGetModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// VisibilityClientHeadModelOptions contains the optional parameters for the VisibilityClient.HeadModel method.
 type VisibilityClientHeadModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// VisibilityClientPatchModelOptions contains the optional parameters for the VisibilityClient.PatchModel method.
 type VisibilityClientPatchModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// VisibilityClientPostModelOptions contains the optional parameters for the VisibilityClient.PostModel method.
 type VisibilityClientPostModelOptions struct {
 	// placeholder for future optional parameters
 }
 
+// VisibilityClientPutModelOptions contains the optional parameters for the VisibilityClient.PutModel method.
 type VisibilityClientPutModelOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
@@ -21,6 +21,7 @@ type VisibilityClient struct {
 	internal *azcore.Client
 }
 
+// - options - VisibilityClientDeleteModelOptions contains the optional parameters for the VisibilityClient.DeleteModel method.
 func (client *VisibilityClient) DeleteModel(ctx context.Context, input VisibilityModel, options *VisibilityClientDeleteModelOptions) (VisibilityClientDeleteModelResponse, error) {
 	var err error
 	req, err := client.deleteModelCreateRequest(ctx, input, options)
@@ -52,6 +53,7 @@ func (client *VisibilityClient) deleteModelCreateRequest(ctx context.Context, in
 	return req, nil
 }
 
+// - options - VisibilityClientGetModelOptions contains the optional parameters for the VisibilityClient.GetModel method.
 func (client *VisibilityClient) GetModel(ctx context.Context, input VisibilityModel, options *VisibilityClientGetModelOptions) (VisibilityClientGetModelResponse, error) {
 	var err error
 	req, err := client.getModelCreateRequest(ctx, input, options)
@@ -94,6 +96,7 @@ func (client *VisibilityClient) getModelHandleResponse(resp *http.Response) (Vis
 	return result, nil
 }
 
+// - options - VisibilityClientHeadModelOptions contains the optional parameters for the VisibilityClient.HeadModel method.
 func (client *VisibilityClient) HeadModel(ctx context.Context, input VisibilityModel, options *VisibilityClientHeadModelOptions) (VisibilityClientHeadModelResponse, error) {
 	var err error
 	req, err := client.headModelCreateRequest(ctx, input, options)
@@ -125,6 +128,7 @@ func (client *VisibilityClient) headModelCreateRequest(ctx context.Context, inpu
 	return req, nil
 }
 
+// - options - VisibilityClientPatchModelOptions contains the optional parameters for the VisibilityClient.PatchModel method.
 func (client *VisibilityClient) PatchModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPatchModelOptions) (VisibilityClientPatchModelResponse, error) {
 	var err error
 	req, err := client.patchModelCreateRequest(ctx, input, options)
@@ -156,6 +160,7 @@ func (client *VisibilityClient) patchModelCreateRequest(ctx context.Context, inp
 	return req, nil
 }
 
+// - options - VisibilityClientPostModelOptions contains the optional parameters for the VisibilityClient.PostModel method.
 func (client *VisibilityClient) PostModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPostModelOptions) (VisibilityClientPostModelResponse, error) {
 	var err error
 	req, err := client.postModelCreateRequest(ctx, input, options)
@@ -187,6 +192,7 @@ func (client *VisibilityClient) postModelCreateRequest(ctx context.Context, inpu
 	return req, nil
 }
 
+// - options - VisibilityClientPutModelOptions contains the optional parameters for the VisibilityClient.PutModel method.
 func (client *VisibilityClient) PutModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPutModelOptions) (VisibilityClientPutModelResponse, error) {
 	var err error
 	req, err := client.putModelCreateRequest(ctx, input, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsfloat_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsfloat_client.go
@@ -22,6 +22,7 @@ type ExtendsFloatClient struct {
 }
 
 // Get - Get call
+//   - options - ExtendsFloatClientGetOptions contains the optional parameters for the ExtendsFloatClient.Get method.
 func (client *ExtendsFloatClient) Get(ctx context.Context, options *ExtendsFloatClientGetOptions) (ExtendsFloatClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *ExtendsFloatClient) getHandleResponse(resp *http.Response) (Extend
 
 // Put - Put operation
 //   - body - body
+//   - options - ExtendsFloatClientPutOptions contains the optional parameters for the ExtendsFloatClient.Put method.
 func (client *ExtendsFloatClient) Put(ctx context.Context, body ExtendsFloatAdditionalProperties, options *ExtendsFloatClientPutOptions) (ExtendsFloatClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsmodel_client.go
@@ -22,6 +22,7 @@ type ExtendsModelClient struct {
 }
 
 // Get - Get call
+//   - options - ExtendsModelClientGetOptions contains the optional parameters for the ExtendsModelClient.Get method.
 func (client *ExtendsModelClient) Get(ctx context.Context, options *ExtendsModelClientGetOptions) (ExtendsModelClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *ExtendsModelClient) getHandleResponse(resp *http.Response) (Extend
 
 // Put - Put operation
 //   - body - body
+//   - options - ExtendsModelClientPutOptions contains the optional parameters for the ExtendsModelClient.Put method.
 func (client *ExtendsModelClient) Put(ctx context.Context, body ExtendsModelAdditionalProperties, options *ExtendsModelClientPutOptions) (ExtendsModelClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsmodelarray_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsmodelarray_client.go
@@ -22,6 +22,7 @@ type ExtendsModelArrayClient struct {
 }
 
 // Get - Get call
+//   - options - ExtendsModelArrayClientGetOptions contains the optional parameters for the ExtendsModelArrayClient.Get method.
 func (client *ExtendsModelArrayClient) Get(ctx context.Context, options *ExtendsModelArrayClientGetOptions) (ExtendsModelArrayClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *ExtendsModelArrayClient) getHandleResponse(resp *http.Response) (E
 
 // Put - Put operation
 //   - body - body
+//   - options - ExtendsModelArrayClientPutOptions contains the optional parameters for the ExtendsModelArrayClient.Put method.
 func (client *ExtendsModelArrayClient) Put(ctx context.Context, body ExtendsModelArrayAdditionalProperties, options *ExtendsModelArrayClientPutOptions) (ExtendsModelArrayClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsstring_client.go
@@ -22,6 +22,7 @@ type ExtendsStringClient struct {
 }
 
 // Get - Get call
+//   - options - ExtendsStringClientGetOptions contains the optional parameters for the ExtendsStringClient.Get method.
 func (client *ExtendsStringClient) Get(ctx context.Context, options *ExtendsStringClientGetOptions) (ExtendsStringClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *ExtendsStringClient) getHandleResponse(resp *http.Response) (Exten
 
 // Put - Put operation
 //   - body - body
+//   - options - ExtendsStringClientPutOptions contains the optional parameters for the ExtendsStringClient.Put method.
 func (client *ExtendsStringClient) Put(ctx context.Context, body ExtendsStringAdditionalProperties, options *ExtendsStringClientPutOptions) (ExtendsStringClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsunknown_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_extendsunknown_client.go
@@ -22,6 +22,7 @@ type ExtendsUnknownClient struct {
 }
 
 // Get - Get call
+//   - options - ExtendsUnknownClientGetOptions contains the optional parameters for the ExtendsUnknownClient.Get method.
 func (client *ExtendsUnknownClient) Get(ctx context.Context, options *ExtendsUnknownClientGetOptions) (ExtendsUnknownClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *ExtendsUnknownClient) getHandleResponse(resp *http.Response) (Exte
 
 // Put - Put operation
 //   - body - body
+//   - options - ExtendsUnknownClientPutOptions contains the optional parameters for the ExtendsUnknownClient.Put method.
 func (client *ExtendsUnknownClient) Put(ctx context.Context, body ExtendsUnknownAdditionalProperties, options *ExtendsUnknownClientPutOptions) (ExtendsUnknownClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isfloat_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isfloat_client.go
@@ -22,6 +22,7 @@ type IsFloatClient struct {
 }
 
 // Get - Get call
+//   - options - IsFloatClientGetOptions contains the optional parameters for the IsFloatClient.Get method.
 func (client *IsFloatClient) Get(ctx context.Context, options *IsFloatClientGetOptions) (IsFloatClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *IsFloatClient) getHandleResponse(resp *http.Response) (IsFloatClie
 
 // Put - Put operation
 //   - body - body
+//   - options - IsFloatClientPutOptions contains the optional parameters for the IsFloatClient.Put method.
 func (client *IsFloatClient) Put(ctx context.Context, body IsFloatAdditionalProperties, options *IsFloatClientPutOptions) (IsFloatClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_ismodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_ismodel_client.go
@@ -22,6 +22,7 @@ type IsModelClient struct {
 }
 
 // Get - Get call
+//   - options - IsModelClientGetOptions contains the optional parameters for the IsModelClient.Get method.
 func (client *IsModelClient) Get(ctx context.Context, options *IsModelClientGetOptions) (IsModelClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *IsModelClient) getHandleResponse(resp *http.Response) (IsModelClie
 
 // Put - Put operation
 //   - body - body
+//   - options - IsModelClientPutOptions contains the optional parameters for the IsModelClient.Put method.
 func (client *IsModelClient) Put(ctx context.Context, body IsModelAdditionalProperties, options *IsModelClientPutOptions) (IsModelClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_ismodelarray_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_ismodelarray_client.go
@@ -22,6 +22,7 @@ type IsModelArrayClient struct {
 }
 
 // Get - Get call
+//   - options - IsModelArrayClientGetOptions contains the optional parameters for the IsModelArrayClient.Get method.
 func (client *IsModelArrayClient) Get(ctx context.Context, options *IsModelArrayClientGetOptions) (IsModelArrayClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *IsModelArrayClient) getHandleResponse(resp *http.Response) (IsMode
 
 // Put - Put operation
 //   - body - body
+//   - options - IsModelArrayClientPutOptions contains the optional parameters for the IsModelArrayClient.Put method.
 func (client *IsModelArrayClient) Put(ctx context.Context, body IsModelArrayAdditionalProperties, options *IsModelArrayClientPutOptions) (IsModelArrayClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isstring_client.go
@@ -22,6 +22,7 @@ type IsStringClient struct {
 }
 
 // Get - Get call
+//   - options - IsStringClientGetOptions contains the optional parameters for the IsStringClient.Get method.
 func (client *IsStringClient) Get(ctx context.Context, options *IsStringClientGetOptions) (IsStringClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *IsStringClient) getHandleResponse(resp *http.Response) (IsStringCl
 
 // Put - Put operation
 //   - body - body
+//   - options - IsStringClientPutOptions contains the optional parameters for the IsStringClient.Put method.
 func (client *IsStringClient) Put(ctx context.Context, body IsStringAdditionalProperties, options *IsStringClientPutOptions) (IsStringClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isunknown_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_isunknown_client.go
@@ -22,6 +22,7 @@ type IsUnknownClient struct {
 }
 
 // Get - Get call
+//   - options - IsUnknownClientGetOptions contains the optional parameters for the IsUnknownClient.Get method.
 func (client *IsUnknownClient) Get(ctx context.Context, options *IsUnknownClientGetOptions) (IsUnknownClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *IsUnknownClient) getHandleResponse(resp *http.Response) (IsUnknown
 
 // Put - Put operation
 //   - body - body
+//   - options - IsUnknownClientPutOptions contains the optional parameters for the IsUnknownClient.Put method.
 func (client *IsUnknownClient) Put(ctx context.Context, body IsUnknownAdditionalProperties, options *IsUnknownClientPutOptions) (IsUnknownClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_options.go
@@ -7,82 +7,102 @@
 
 package addlpropsgroup
 
+// ExtendsFloatClientGetOptions contains the optional parameters for the ExtendsFloatClient.Get method.
 type ExtendsFloatClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsFloatClientPutOptions contains the optional parameters for the ExtendsFloatClient.Put method.
 type ExtendsFloatClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsModelArrayClientGetOptions contains the optional parameters for the ExtendsModelArrayClient.Get method.
 type ExtendsModelArrayClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsModelArrayClientPutOptions contains the optional parameters for the ExtendsModelArrayClient.Put method.
 type ExtendsModelArrayClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsModelClientGetOptions contains the optional parameters for the ExtendsModelClient.Get method.
 type ExtendsModelClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsModelClientPutOptions contains the optional parameters for the ExtendsModelClient.Put method.
 type ExtendsModelClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsStringClientGetOptions contains the optional parameters for the ExtendsStringClient.Get method.
 type ExtendsStringClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsStringClientPutOptions contains the optional parameters for the ExtendsStringClient.Put method.
 type ExtendsStringClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsUnknownClientGetOptions contains the optional parameters for the ExtendsUnknownClient.Get method.
 type ExtendsUnknownClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ExtendsUnknownClientPutOptions contains the optional parameters for the ExtendsUnknownClient.Put method.
 type ExtendsUnknownClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsFloatClientGetOptions contains the optional parameters for the IsFloatClient.Get method.
 type IsFloatClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsFloatClientPutOptions contains the optional parameters for the IsFloatClient.Put method.
 type IsFloatClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsModelArrayClientGetOptions contains the optional parameters for the IsModelArrayClient.Get method.
 type IsModelArrayClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsModelArrayClientPutOptions contains the optional parameters for the IsModelArrayClient.Put method.
 type IsModelArrayClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsModelClientGetOptions contains the optional parameters for the IsModelClient.Get method.
 type IsModelClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsModelClientPutOptions contains the optional parameters for the IsModelClient.Put method.
 type IsModelClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsStringClientGetOptions contains the optional parameters for the IsStringClient.Get method.
 type IsStringClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsStringClientPutOptions contains the optional parameters for the IsStringClient.Put method.
 type IsStringClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsUnknownClientGetOptions contains the optional parameters for the IsUnknownClient.Get method.
 type IsUnknownClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// IsUnknownClientPutOptions contains the optional parameters for the IsUnknownClient.Put method.
 type IsUnknownClientPutOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_bytes_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_bytes_client.go
@@ -22,6 +22,7 @@ type BytesClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - BytesClientGetNonNullOptions contains the optional parameters for the BytesClient.GetNonNull method.
 func (client *BytesClient) GetNonNull(ctx context.Context, options *BytesClientGetNonNullOptions) (BytesClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +62,7 @@ func (client *BytesClient) getNonNullHandleResponse(resp *http.Response) (BytesC
 }
 
 // GetNull - Get models that will return the default object
+//   - options - BytesClientGetNullOptions contains the optional parameters for the BytesClient.GetNull method.
 func (client *BytesClient) GetNull(ctx context.Context, options *BytesClientGetNullOptions) (BytesClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +102,7 @@ func (client *BytesClient) getNullHandleResponse(resp *http.Response) (BytesClie
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - BytesClientPatchNonNullOptions contains the optional parameters for the BytesClient.PatchNonNull method.
 func (client *BytesClient) PatchNonNull(ctx context.Context, body BytesProperty, options *BytesClientPatchNonNullOptions) (BytesClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +135,7 @@ func (client *BytesClient) patchNonNullCreateRequest(ctx context.Context, body B
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - BytesClientPatchNullOptions contains the optional parameters for the BytesClient.PatchNull method.
 func (client *BytesClient) PatchNull(ctx context.Context, body BytesProperty, options *BytesClientPatchNullOptions) (BytesClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_collectionsbyte_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_collectionsbyte_client.go
@@ -22,6 +22,8 @@ type CollectionsByteClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - CollectionsByteClientGetNonNullOptions contains the optional parameters for the CollectionsByteClient.GetNonNull
+//     method.
 func (client *CollectionsByteClient) GetNonNull(ctx context.Context, options *CollectionsByteClientGetNonNullOptions) (CollectionsByteClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +63,7 @@ func (client *CollectionsByteClient) getNonNullHandleResponse(resp *http.Respons
 }
 
 // GetNull - Get models that will return the default object
+//   - options - CollectionsByteClientGetNullOptions contains the optional parameters for the CollectionsByteClient.GetNull method.
 func (client *CollectionsByteClient) GetNull(ctx context.Context, options *CollectionsByteClientGetNullOptions) (CollectionsByteClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +103,8 @@ func (client *CollectionsByteClient) getNullHandleResponse(resp *http.Response) 
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - CollectionsByteClientPatchNonNullOptions contains the optional parameters for the CollectionsByteClient.PatchNonNull
+//     method.
 func (client *CollectionsByteClient) PatchNonNull(ctx context.Context, body CollectionsByteProperty, options *CollectionsByteClientPatchNonNullOptions) (CollectionsByteClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +137,8 @@ func (client *CollectionsByteClient) patchNonNullCreateRequest(ctx context.Conte
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - CollectionsByteClientPatchNullOptions contains the optional parameters for the CollectionsByteClient.PatchNull
+//     method.
 func (client *CollectionsByteClient) PatchNull(ctx context.Context, body CollectionsByteProperty, options *CollectionsByteClientPatchNullOptions) (CollectionsByteClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_collectionsmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_collectionsmodel_client.go
@@ -22,6 +22,8 @@ type CollectionsModelClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - CollectionsModelClientGetNonNullOptions contains the optional parameters for the CollectionsModelClient.GetNonNull
+//     method.
 func (client *CollectionsModelClient) GetNonNull(ctx context.Context, options *CollectionsModelClientGetNonNullOptions) (CollectionsModelClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +63,8 @@ func (client *CollectionsModelClient) getNonNullHandleResponse(resp *http.Respon
 }
 
 // GetNull - Get models that will return the default object
+//   - options - CollectionsModelClientGetNullOptions contains the optional parameters for the CollectionsModelClient.GetNull
+//     method.
 func (client *CollectionsModelClient) GetNull(ctx context.Context, options *CollectionsModelClientGetNullOptions) (CollectionsModelClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +104,8 @@ func (client *CollectionsModelClient) getNullHandleResponse(resp *http.Response)
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - CollectionsModelClientPatchNonNullOptions contains the optional parameters for the CollectionsModelClient.PatchNonNull
+//     method.
 func (client *CollectionsModelClient) PatchNonNull(ctx context.Context, body CollectionsModelProperty, options *CollectionsModelClientPatchNonNullOptions) (CollectionsModelClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +138,8 @@ func (client *CollectionsModelClient) patchNonNullCreateRequest(ctx context.Cont
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - CollectionsModelClientPatchNullOptions contains the optional parameters for the CollectionsModelClient.PatchNull
+//     method.
 func (client *CollectionsModelClient) PatchNull(ctx context.Context, body CollectionsModelProperty, options *CollectionsModelClientPatchNullOptions) (CollectionsModelClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_datetime_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_datetime_client.go
@@ -22,6 +22,7 @@ type DatetimeClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - DatetimeClientGetNonNullOptions contains the optional parameters for the DatetimeClient.GetNonNull method.
 func (client *DatetimeClient) GetNonNull(ctx context.Context, options *DatetimeClientGetNonNullOptions) (DatetimeClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +62,7 @@ func (client *DatetimeClient) getNonNullHandleResponse(resp *http.Response) (Dat
 }
 
 // GetNull - Get models that will return the default object
+//   - options - DatetimeClientGetNullOptions contains the optional parameters for the DatetimeClient.GetNull method.
 func (client *DatetimeClient) GetNull(ctx context.Context, options *DatetimeClientGetNullOptions) (DatetimeClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +102,7 @@ func (client *DatetimeClient) getNullHandleResponse(resp *http.Response) (Dateti
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - DatetimeClientPatchNonNullOptions contains the optional parameters for the DatetimeClient.PatchNonNull method.
 func (client *DatetimeClient) PatchNonNull(ctx context.Context, body DatetimeProperty, options *DatetimeClientPatchNonNullOptions) (DatetimeClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +135,7 @@ func (client *DatetimeClient) patchNonNullCreateRequest(ctx context.Context, bod
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - DatetimeClientPatchNullOptions contains the optional parameters for the DatetimeClient.PatchNull method.
 func (client *DatetimeClient) PatchNull(ctx context.Context, body DatetimeProperty, options *DatetimeClientPatchNullOptions) (DatetimeClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_duration_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_duration_client.go
@@ -22,6 +22,7 @@ type DurationClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - DurationClientGetNonNullOptions contains the optional parameters for the DurationClient.GetNonNull method.
 func (client *DurationClient) GetNonNull(ctx context.Context, options *DurationClientGetNonNullOptions) (DurationClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +62,7 @@ func (client *DurationClient) getNonNullHandleResponse(resp *http.Response) (Dur
 }
 
 // GetNull - Get models that will return the default object
+//   - options - DurationClientGetNullOptions contains the optional parameters for the DurationClient.GetNull method.
 func (client *DurationClient) GetNull(ctx context.Context, options *DurationClientGetNullOptions) (DurationClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +102,7 @@ func (client *DurationClient) getNullHandleResponse(resp *http.Response) (Durati
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - DurationClientPatchNonNullOptions contains the optional parameters for the DurationClient.PatchNonNull method.
 func (client *DurationClient) PatchNonNull(ctx context.Context, body DurationProperty, options *DurationClientPatchNonNullOptions) (DurationClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +135,7 @@ func (client *DurationClient) patchNonNullCreateRequest(ctx context.Context, bod
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - DurationClientPatchNullOptions contains the optional parameters for the DurationClient.PatchNull method.
 func (client *DurationClient) PatchNull(ctx context.Context, body DurationProperty, options *DurationClientPatchNullOptions) (DurationClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_options.go
@@ -7,98 +7,123 @@
 
 package nullablegroup
 
+// BytesClientGetNonNullOptions contains the optional parameters for the BytesClient.GetNonNull method.
 type BytesClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BytesClientGetNullOptions contains the optional parameters for the BytesClient.GetNull method.
 type BytesClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BytesClientPatchNonNullOptions contains the optional parameters for the BytesClient.PatchNonNull method.
 type BytesClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BytesClientPatchNullOptions contains the optional parameters for the BytesClient.PatchNull method.
 type BytesClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsByteClientGetNonNullOptions contains the optional parameters for the CollectionsByteClient.GetNonNull method.
 type CollectionsByteClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsByteClientGetNullOptions contains the optional parameters for the CollectionsByteClient.GetNull method.
 type CollectionsByteClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsByteClientPatchNonNullOptions contains the optional parameters for the CollectionsByteClient.PatchNonNull method.
 type CollectionsByteClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsByteClientPatchNullOptions contains the optional parameters for the CollectionsByteClient.PatchNull method.
 type CollectionsByteClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsModelClientGetNonNullOptions contains the optional parameters for the CollectionsModelClient.GetNonNull method.
 type CollectionsModelClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsModelClientGetNullOptions contains the optional parameters for the CollectionsModelClient.GetNull method.
 type CollectionsModelClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsModelClientPatchNonNullOptions contains the optional parameters for the CollectionsModelClient.PatchNonNull
+// method.
 type CollectionsModelClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// CollectionsModelClientPatchNullOptions contains the optional parameters for the CollectionsModelClient.PatchNull method.
 type CollectionsModelClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeClientGetNonNullOptions contains the optional parameters for the DatetimeClient.GetNonNull method.
 type DatetimeClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeClientGetNullOptions contains the optional parameters for the DatetimeClient.GetNull method.
 type DatetimeClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeClientPatchNonNullOptions contains the optional parameters for the DatetimeClient.PatchNonNull method.
 type DatetimeClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DatetimeClientPatchNullOptions contains the optional parameters for the DatetimeClient.PatchNull method.
 type DatetimeClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationClientGetNonNullOptions contains the optional parameters for the DurationClient.GetNonNull method.
 type DurationClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationClientGetNullOptions contains the optional parameters for the DurationClient.GetNull method.
 type DurationClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationClientPatchNonNullOptions contains the optional parameters for the DurationClient.PatchNonNull method.
 type DurationClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DurationClientPatchNullOptions contains the optional parameters for the DurationClient.PatchNull method.
 type DurationClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientGetNonNullOptions contains the optional parameters for the StringClient.GetNonNull method.
 type StringClientGetNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientGetNullOptions contains the optional parameters for the StringClient.GetNull method.
 type StringClientGetNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPatchNonNullOptions contains the optional parameters for the StringClient.PatchNonNull method.
 type StringClientPatchNonNullOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPatchNullOptions contains the optional parameters for the StringClient.PatchNull method.
 type StringClientPatchNullOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_string_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_string_client.go
@@ -22,6 +22,7 @@ type StringClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+//   - options - StringClientGetNonNullOptions contains the optional parameters for the StringClient.GetNonNull method.
 func (client *StringClient) GetNonNull(ctx context.Context, options *StringClientGetNonNullOptions) (StringClientGetNonNullResponse, error) {
 	var err error
 	req, err := client.getNonNullCreateRequest(ctx, options)
@@ -61,6 +62,7 @@ func (client *StringClient) getNonNullHandleResponse(resp *http.Response) (Strin
 }
 
 // GetNull - Get models that will return the default object
+//   - options - StringClientGetNullOptions contains the optional parameters for the StringClient.GetNull method.
 func (client *StringClient) GetNull(ctx context.Context, options *StringClientGetNullOptions) (StringClientGetNullResponse, error) {
 	var err error
 	req, err := client.getNullCreateRequest(ctx, options)
@@ -100,6 +102,7 @@ func (client *StringClient) getNullHandleResponse(resp *http.Response) (StringCl
 }
 
 // PatchNonNull - Put a body with all properties present.
+//   - options - StringClientPatchNonNullOptions contains the optional parameters for the StringClient.PatchNonNull method.
 func (client *StringClient) PatchNonNull(ctx context.Context, body StringProperty, options *StringClientPatchNonNullOptions) (StringClientPatchNonNullResponse, error) {
 	var err error
 	req, err := client.patchNonNullCreateRequest(ctx, body, options)
@@ -132,6 +135,7 @@ func (client *StringClient) patchNonNullCreateRequest(ctx context.Context, body 
 }
 
 // PatchNull - Put a body with default properties.
+//   - options - StringClientPatchNullOptions contains the optional parameters for the StringClient.PatchNull method.
 func (client *StringClient) PatchNull(ctx context.Context, body StringProperty, options *StringClientPatchNullOptions) (StringClientPatchNullResponse, error) {
 	var err error
 	req, err := client.patchNullCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_boolean_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_boolean_client.go
@@ -22,6 +22,7 @@ type BooleanClient struct {
 }
 
 // Get - get boolean value
+//   - options - BooleanClientGetOptions contains the optional parameters for the BooleanClient.Get method.
 func (client *BooleanClient) Get(ctx context.Context, options *BooleanClientGetOptions) (BooleanClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *BooleanClient) getHandleResponse(resp *http.Response) (BooleanClie
 
 // Put - put boolean value
 //   - body - _
+//   - options - BooleanClientPutOptions contains the optional parameters for the BooleanClient.Put method.
 func (client *BooleanClient) Put(ctx context.Context, body bool, options *BooleanClientPutOptions) (BooleanClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimal128type_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimal128type_client.go
@@ -22,6 +22,8 @@ type Decimal128TypeClient struct {
 	internal *azcore.Client
 }
 
+//   - options - Decimal128TypeClientRequestBodyOptions contains the optional parameters for the Decimal128TypeClient.RequestBody
+//     method.
 func (client *Decimal128TypeClient) RequestBody(ctx context.Context, body float64, options *Decimal128TypeClientRequestBodyOptions) (Decimal128TypeClientRequestBodyResponse, error) {
 	var err error
 	req, err := client.requestBodyCreateRequest(ctx, body, options)
@@ -53,6 +55,8 @@ func (client *Decimal128TypeClient) requestBodyCreateRequest(ctx context.Context
 	return req, nil
 }
 
+//   - options - Decimal128TypeClientRequestParameterOptions contains the optional parameters for the Decimal128TypeClient.RequestParameter
+//     method.
 func (client *Decimal128TypeClient) RequestParameter(ctx context.Context, value float64, options *Decimal128TypeClientRequestParameterOptions) (Decimal128TypeClientRequestParameterResponse, error) {
 	var err error
 	req, err := client.requestParameterCreateRequest(ctx, value, options)
@@ -83,6 +87,8 @@ func (client *Decimal128TypeClient) requestParameterCreateRequest(ctx context.Co
 	return req, nil
 }
 
+//   - options - Decimal128TypeClientResponseBodyOptions contains the optional parameters for the Decimal128TypeClient.ResponseBody
+//     method.
 func (client *Decimal128TypeClient) ResponseBody(ctx context.Context, options *Decimal128TypeClientResponseBodyOptions) (Decimal128TypeClientResponseBodyResponse, error) {
 	var err error
 	req, err := client.responseBodyCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimal128verify_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimal128verify_client.go
@@ -21,6 +21,8 @@ type Decimal128VerifyClient struct {
 	internal *azcore.Client
 }
 
+//   - options - Decimal128VerifyClientPrepareVerifyOptions contains the optional parameters for the Decimal128VerifyClient.PrepareVerify
+//     method.
 func (client *Decimal128VerifyClient) PrepareVerify(ctx context.Context, options *Decimal128VerifyClientPrepareVerifyOptions) (Decimal128VerifyClientPrepareVerifyResponse, error) {
 	var err error
 	req, err := client.prepareVerifyCreateRequest(ctx, options)
@@ -59,6 +61,7 @@ func (client *Decimal128VerifyClient) prepareVerifyHandleResponse(resp *http.Res
 	return result, nil
 }
 
+// - options - Decimal128VerifyClientVerifyOptions contains the optional parameters for the Decimal128VerifyClient.Verify method.
 func (client *Decimal128VerifyClient) Verify(ctx context.Context, body float64, options *Decimal128VerifyClientVerifyOptions) (Decimal128VerifyClientVerifyResponse, error) {
 	var err error
 	req, err := client.verifyCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimaltype_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimaltype_client.go
@@ -22,6 +22,7 @@ type DecimalTypeClient struct {
 	internal *azcore.Client
 }
 
+// - options - DecimalTypeClientRequestBodyOptions contains the optional parameters for the DecimalTypeClient.RequestBody method.
 func (client *DecimalTypeClient) RequestBody(ctx context.Context, body float64, options *DecimalTypeClientRequestBodyOptions) (DecimalTypeClientRequestBodyResponse, error) {
 	var err error
 	req, err := client.requestBodyCreateRequest(ctx, body, options)
@@ -53,6 +54,8 @@ func (client *DecimalTypeClient) requestBodyCreateRequest(ctx context.Context, b
 	return req, nil
 }
 
+//   - options - DecimalTypeClientRequestParameterOptions contains the optional parameters for the DecimalTypeClient.RequestParameter
+//     method.
 func (client *DecimalTypeClient) RequestParameter(ctx context.Context, value float64, options *DecimalTypeClientRequestParameterOptions) (DecimalTypeClientRequestParameterResponse, error) {
 	var err error
 	req, err := client.requestParameterCreateRequest(ctx, value, options)
@@ -83,6 +86,8 @@ func (client *DecimalTypeClient) requestParameterCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+//   - options - DecimalTypeClientResponseBodyOptions contains the optional parameters for the DecimalTypeClient.ResponseBody
+//     method.
 func (client *DecimalTypeClient) ResponseBody(ctx context.Context, options *DecimalTypeClientResponseBodyOptions) (DecimalTypeClientResponseBodyResponse, error) {
 	var err error
 	req, err := client.responseBodyCreateRequest(ctx, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimalverify_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_decimalverify_client.go
@@ -21,6 +21,8 @@ type DecimalVerifyClient struct {
 	internal *azcore.Client
 }
 
+//   - options - DecimalVerifyClientPrepareVerifyOptions contains the optional parameters for the DecimalVerifyClient.PrepareVerify
+//     method.
 func (client *DecimalVerifyClient) PrepareVerify(ctx context.Context, options *DecimalVerifyClientPrepareVerifyOptions) (DecimalVerifyClientPrepareVerifyResponse, error) {
 	var err error
 	req, err := client.prepareVerifyCreateRequest(ctx, options)
@@ -59,6 +61,7 @@ func (client *DecimalVerifyClient) prepareVerifyHandleResponse(resp *http.Respon
 	return result, nil
 }
 
+// - options - DecimalVerifyClientVerifyOptions contains the optional parameters for the DecimalVerifyClient.Verify method.
 func (client *DecimalVerifyClient) Verify(ctx context.Context, body float64, options *DecimalVerifyClientVerifyOptions) (DecimalVerifyClientVerifyResponse, error) {
 	var err error
 	req, err := client.verifyCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_options.go
@@ -7,66 +7,84 @@
 
 package scalargroup
 
+// BooleanClientGetOptions contains the optional parameters for the BooleanClient.Get method.
 type BooleanClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// BooleanClientPutOptions contains the optional parameters for the BooleanClient.Put method.
 type BooleanClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Decimal128TypeClientRequestBodyOptions contains the optional parameters for the Decimal128TypeClient.RequestBody method.
 type Decimal128TypeClientRequestBodyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Decimal128TypeClientRequestParameterOptions contains the optional parameters for the Decimal128TypeClient.RequestParameter
+// method.
 type Decimal128TypeClientRequestParameterOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Decimal128TypeClientResponseBodyOptions contains the optional parameters for the Decimal128TypeClient.ResponseBody method.
 type Decimal128TypeClientResponseBodyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Decimal128VerifyClientPrepareVerifyOptions contains the optional parameters for the Decimal128VerifyClient.PrepareVerify
+// method.
 type Decimal128VerifyClientPrepareVerifyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// Decimal128VerifyClientVerifyOptions contains the optional parameters for the Decimal128VerifyClient.Verify method.
 type Decimal128VerifyClientVerifyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DecimalTypeClientRequestBodyOptions contains the optional parameters for the DecimalTypeClient.RequestBody method.
 type DecimalTypeClientRequestBodyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DecimalTypeClientRequestParameterOptions contains the optional parameters for the DecimalTypeClient.RequestParameter method.
 type DecimalTypeClientRequestParameterOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DecimalTypeClientResponseBodyOptions contains the optional parameters for the DecimalTypeClient.ResponseBody method.
 type DecimalTypeClientResponseBodyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DecimalVerifyClientPrepareVerifyOptions contains the optional parameters for the DecimalVerifyClient.PrepareVerify method.
 type DecimalVerifyClientPrepareVerifyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// DecimalVerifyClientVerifyOptions contains the optional parameters for the DecimalVerifyClient.Verify method.
 type DecimalVerifyClientVerifyOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientGetOptions contains the optional parameters for the StringClient.Get method.
 type StringClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// StringClientPutOptions contains the optional parameters for the StringClient.Put method.
 type StringClientPutOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownClientGetOptions contains the optional parameters for the UnknownClient.Get method.
 type UnknownClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
+// UnknownClientPutOptions contains the optional parameters for the UnknownClient.Put method.
 type UnknownClientPutOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_string_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_string_client.go
@@ -22,6 +22,7 @@ type StringClient struct {
 }
 
 // Get - get string value
+//   - options - StringClientGetOptions contains the optional parameters for the StringClient.Get method.
 func (client *StringClient) Get(ctx context.Context, options *StringClientGetOptions) (StringClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *StringClient) getHandleResponse(resp *http.Response) (StringClient
 
 // Put - put string value
 //   - body - _
+//   - options - StringClientPutOptions contains the optional parameters for the StringClient.Put method.
 func (client *StringClient) Put(ctx context.Context, body string, options *StringClientPutOptions) (StringClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_unknown_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_unknown_client.go
@@ -22,6 +22,7 @@ type UnknownClient struct {
 }
 
 // Get - get unknown value
+//   - options - UnknownClientGetOptions contains the optional parameters for the UnknownClient.Get method.
 func (client *UnknownClient) Get(ctx context.Context, options *UnknownClientGetOptions) (UnknownClientGetResponse, error) {
 	var err error
 	req, err := client.getCreateRequest(ctx, options)
@@ -62,6 +63,7 @@ func (client *UnknownClient) getHandleResponse(resp *http.Response) (UnknownClie
 
 // Put - put unknown value
 //   - body - _
+//   - options - UnknownClientPutOptions contains the optional parameters for the UnknownClient.Put method.
 func (client *UnknownClient) Put(ctx context.Context, body any, options *UnknownClientPutOptions) (UnknownClientPutResponse, error) {
 	var err error
 	req, err := client.putCreateRequest(ctx, body, options)


### PR DESCRIPTION
When enabled, the client name prefix will be omitted from options and response types. If there are multiple clients, an error is returned. Added missing doc comments for options types.
Fixed doc comments for methods that return pagers.

Fixes https://github.com/Azure/autorest.go/issues/1125