### PR TITLE
Add lenient handling of RFC3339 as ISO8601

### DIFF
--- a/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
@@ -664,3 +664,25 @@ func TestMetadataWithEmptyValue(t *testing.T) {
 	require.Len(t, c.Metadata, 1)
 	require.Empty(t, *c.Metadata["key1"])
 }
+
+func TestDateTimeWithSpace(t *testing.T) {
+	dst := AccessPolicy{}
+	require.NoError(t, xml.Unmarshal([]byte(`<AccessPolicy><Expiry>2024-01-18 14:18:54Z</Expiry></AccessPolicy>`), &dst))
+	require.NotNil(t, dst.Expiry)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 0, time.UTC), *dst.Expiry, 0)
+
+	dst = AccessPolicy{}
+	require.NoError(t, xml.Unmarshal([]byte(`<AccessPolicy><Expiry>2024-01-18 14:18:54.123Z</Expiry></AccessPolicy>`), &dst))
+	require.NotNil(t, dst.Expiry)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.Expiry, 0)
+
+	dst = AccessPolicy{}
+	require.NoError(t, xml.Unmarshal([]byte(`<AccessPolicy><Expiry>2024-01-18 14:18:54</Expiry></AccessPolicy>`), &dst))
+	require.NotNil(t, dst.Expiry)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 0, time.UTC), *dst.Expiry, 0)
+
+	dst = AccessPolicy{}
+	require.NoError(t, xml.Unmarshal([]byte(`<AccessPolicy><Expiry>2024-01-18 14:18:54.123</Expiry></AccessPolicy>`), &dst))
+	require.NotNil(t, dst.Expiry)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.Expiry, 0)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/maps/azalias/models_test.go
+++ b/packages/autorest.go/test/maps/azalias/models_test.go
@@ -78,3 +78,25 @@ func TestDisallowedField(t *testing.T) {
 	data := `{"aliasId":"theAlias","unknownField":"value"}`
 	require.Error(t, json.Unmarshal([]byte(data), &resp))
 }
+
+func TestDateTimeWithSpace(t *testing.T) {
+	dst := ScheduleCreateOrUpdateProperties{}
+	require.NoError(t, json.Unmarshal([]byte(`{"startTime":"2024-01-18 14:18:54Z"}`), &dst))
+	require.NotNil(t, dst.StartTime)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 0, time.UTC), *dst.StartTime, 0)
+
+	dst = ScheduleCreateOrUpdateProperties{}
+	require.NoError(t, json.Unmarshal([]byte(`{"startTime":"2024-01-18 14:18:54.123Z"}`), &dst))
+	require.NotNil(t, dst.StartTime)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.StartTime, 0)
+
+	dst = ScheduleCreateOrUpdateProperties{}
+	require.NoError(t, json.Unmarshal([]byte(`{"startTime":"2024-01-18 14:18:54"}`), &dst))
+	require.NotNil(t, dst.StartTime)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 0, time.UTC), *dst.StartTime, 0)
+
+	dst = ScheduleCreateOrUpdateProperties{}
+	require.NoError(t, json.Unmarshal([]byte(`{"startTime":"2024-01-18 14:18:54.123"}`), &dst))
+	require.NotNil(t, dst.StartTime)
+	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.StartTime, 0)
+}

--- a/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
@@ -19,12 +19,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -40,17 +44,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
@@ -15,12 +15,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -36,17 +40,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -156,16 +156,20 @@ function generateRFC3339Helper(preamble: string, dateTime: boolean, time: boolea
 ${imports.text()}
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(\`(Z|z|\\+|-)(\\d+:\\d+)*"*$\`)
+var tzOffsetRegex = regexp.MustCompile(\`(?:Z|z|\\+|-)(?:\\d+:\\d+)*"*$\`)
 `;
 
   if (dateTime) {
     text +=
 `
 const (
-	utcDateTimeJSON = \`"2006-01-02T15:04:05.999999999"\`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON   = \`"\` + time.RFC3339Nano + \`"\`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = \`"\` + utcDateTime + \`"\`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = \`"\` + utcDateTimeNoT + \`"\`
+	dateTimeNoT        = \`2006-01-02 15:04:05.999999999Z07:00\`
+	dateTimeJSON       = \`"\` + time.RFC3339Nano + \`"\`
+	dateTimeJSONNoT    = \`"\` + dateTimeNoT + \`"\`
 )
 
 type dateTimeRFC3339 time.Time
@@ -181,17 +185,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) (error) {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc3339.go
@@ -18,12 +18,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -39,17 +43,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
@@ -14,12 +14,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -35,17 +39,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
@@ -14,12 +14,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -35,17 +39,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_time_rfc3339.go
@@ -18,12 +18,16 @@ import (
 )
 
 // Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
-var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+var tzOffsetRegex = regexp.MustCompile(`(?:Z|z|\+|-)(?:\d+:\d+)*"*$`)
 
 const (
-	utcDateTimeJSON = `"2006-01-02T15:04:05.999999999"`
-	utcDateTime     = "2006-01-02T15:04:05.999999999"
-	dateTimeJSON    = `"` + time.RFC3339Nano + `"`
+	utcDateTime        = "2006-01-02T15:04:05.999999999"
+	utcDateTimeJSON    = `"` + utcDateTime + `"`
+	utcDateTimeNoT     = "2006-01-02 15:04:05.999999999"
+	utcDateTimeJSONNoT = `"` + utcDateTimeNoT + `"`
+	dateTimeNoT        = `2006-01-02 15:04:05.999999999Z07:00`
+	dateTimeJSON       = `"` + time.RFC3339Nano + `"`
+	dateTimeJSONNoT    = `"` + dateTimeNoT + `"`
 )
 
 type dateTimeRFC3339 time.Time
@@ -39,17 +43,33 @@ func (t dateTimeRFC3339) MarshalText() ([]byte, error) {
 }
 
 func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
-	layout := utcDateTimeJSON
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = dateTimeJSON
+	} else if tzOffset {
+		layout = dateTimeJSONNoT
+	} else if hasT {
+		layout = utcDateTimeJSON
+	} else {
+		layout = utcDateTimeJSONNoT
 	}
 	return t.Parse(layout, string(data))
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
-	layout := utcDateTime
-	if tzOffsetRegex.Match(data) {
+	tzOffset := tzOffsetRegex.Match(data)
+	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
+	var layout string
+	if tzOffset && hasT {
 		layout = time.RFC3339Nano
+	} else if tzOffset {
+		layout = dateTimeNoT
+	} else if hasT {
+		layout = utcDateTime
+	} else {
+		layout = utcDateTimeNoT
 	}
 	return t.Parse(layout, string(data))
 }


### PR DESCRIPTION
While RFC3339 requires a 'T' or 't' character separating the date and time, ISO8601 allows a single space character.
Changed the time-zone offset regexp to be non-capturing.

Codegen change for https://github.com/Azure/azure-sdk-for-go/issues/22272