### PR TITLE
Don't error on empty time values

### DIFF
--- a/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/acr/azacr/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/fake/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/arraygroup/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc1123.go
@@ -37,6 +37,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc1123.go
@@ -37,6 +37,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/complexgroup/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/fake/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/datetimegroup/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/datetimerfc1123group/fake/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/datetimerfc1123group/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/datetimerfc1123group/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/fake/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/dictionarygroup/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/fake/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/xmlgroup_test.go
@@ -686,3 +686,15 @@ func TestDateTimeWithSpace(t *testing.T) {
 	require.NotNil(t, dst.Expiry)
 	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.Expiry, 0)
 }
+
+func TestEmptyTimeRFC1123(t *testing.T) {
+	dst := BlobProperties{}
+	require.NoError(t, xml.Unmarshal([]byte(`<BlobProperties><CopyCompletionTime/></BlobProperties>`), &dst))
+	require.Nil(t, dst.CopyCompletionTime)
+}
+
+func TestEmptyTimeRFC3339(t *testing.T) {
+	dst := AccessPolicy{}
+	require.NoError(t, xml.Unmarshal([]byte(`<AccessPolicy><Expiry/></AccessPolicy>`), &dst))
+	require.Nil(t, dst.Expiry)
+}

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_models_serde.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_models_serde.go
@@ -43,8 +43,12 @@ func (a *AccessPolicy) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	a.Expiry = (*time.Time)(aux.Expiry)
-	a.Start = (*time.Time)(aux.Start)
+	if aux.Expiry != nil && !(*time.Time)(aux.Expiry).IsZero() {
+		a.Expiry = (*time.Time)(aux.Expiry)
+	}
+	if aux.Start != nil && !(*time.Time)(aux.Start).IsZero() {
+		a.Start = (*time.Time)(aux.Start)
+	}
 	return nil
 }
 
@@ -93,7 +97,9 @@ func (b *Banana) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	b.Expiration = (*time.Time)(aux.Expiration)
+	if aux.Expiration != nil && !(*time.Time)(aux.Expiration).IsZero() {
+		b.Expiration = (*time.Time)(aux.Expiration)
+	}
 	return nil
 }
 
@@ -144,9 +150,15 @@ func (b *BlobProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	b.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
-	b.DeletedTime = (*time.Time)(aux.DeletedTime)
-	b.LastModified = (*time.Time)(aux.LastModified)
+	if aux.CopyCompletionTime != nil && !(*time.Time)(aux.CopyCompletionTime).IsZero() {
+		b.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
+	}
+	if aux.DeletedTime != nil && !(*time.Time)(aux.DeletedTime).IsZero() {
+		b.DeletedTime = (*time.Time)(aux.DeletedTime)
+	}
+	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
+		b.LastModified = (*time.Time)(aux.LastModified)
+	}
 	return nil
 }
 
@@ -210,7 +222,9 @@ func (c *ContainerProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElem
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.LastModified = (*time.Time)(aux.LastModified)
+	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
+		c.LastModified = (*time.Time)(aux.LastModified)
+	}
 	return nil
 }
 

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/autorest/xmlgroup/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/compute/armcompute/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/consumption/armconsumption/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/databoxedge/armdataboxedge/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/machinelearning/armmachinelearning/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string
@@ -133,6 +136,9 @@ func (t *timeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *timeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	layout := utcTime
 	if tzOffsetRegex.Match(data) {
 		layout = timeFormat

--- a/packages/autorest.go/test/maps/azalias/models_test.go
+++ b/packages/autorest.go/test/maps/azalias/models_test.go
@@ -100,3 +100,11 @@ func TestDateTimeWithSpace(t *testing.T) {
 	require.NotNil(t, dst.StartTime)
 	require.WithinDuration(t, time.Date(2024, 1, 18, 14, 18, 54, 123000000, time.UTC), *dst.StartTime, 0)
 }
+
+func TestEmptyAndNullTime(t *testing.T) {
+	dst := TypeWithSliceOfTimes{}
+	require.NoError(t, json.Unmarshal([]byte("{}"), &dst))
+	require.Nil(t, dst.Interval)
+	require.NoError(t, json.Unmarshal([]byte(`{"interval": null}`), &dst))
+	require.Nil(t, dst.Interval)
+}

--- a/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/maps/azalias/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string
@@ -133,6 +136,9 @@ func (t *timeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *timeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	layout := utcTime
 	if tzOffsetRegex.Match(data) {
 		layout = timeFormat

--- a/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/fake/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/network/armnetwork/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/storage/azblob/zz_models_serde.go
+++ b/packages/autorest.go/test/storage/azblob/zz_models_serde.go
@@ -117,8 +117,12 @@ func (c *ContainerProperties) UnmarshalXML(dec *xml.Decoder, start xml.StartElem
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	c.DeletedTime = (*time.Time)(aux.DeletedTime)
-	c.LastModified = (*time.Time)(aux.LastModified)
+	if aux.DeletedTime != nil && !(*time.Time)(aux.DeletedTime).IsZero() {
+		c.DeletedTime = (*time.Time)(aux.DeletedTime)
+	}
+	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
+		c.LastModified = (*time.Time)(aux.LastModified)
+	}
 	return nil
 }
 
@@ -177,7 +181,9 @@ func (g *GeoReplication) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
+	if aux.LastSyncTime != nil && !(*time.Time)(aux.LastSyncTime).IsZero() {
+		g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
+	}
 	return nil
 }
 
@@ -286,19 +292,35 @@ func (p *PropertiesInternal) UnmarshalXML(dec *xml.Decoder, start xml.StartEleme
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	p.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
+	if aux.AccessTierChangeTime != nil && !(*time.Time)(aux.AccessTierChangeTime).IsZero() {
+		p.AccessTierChangeTime = (*time.Time)(aux.AccessTierChangeTime)
+	}
 	if aux.ContentMD5 != nil {
 		if err := runtime.DecodeByteArray(*aux.ContentMD5, &p.ContentMD5, runtime.Base64StdFormat); err != nil {
 			return err
 		}
 	}
-	p.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
-	p.CreationTime = (*time.Time)(aux.CreationTime)
-	p.DeletedTime = (*time.Time)(aux.DeletedTime)
-	p.ExpiresOn = (*time.Time)(aux.ExpiresOn)
-	p.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
-	p.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
-	p.LastModified = (*time.Time)(aux.LastModified)
+	if aux.CopyCompletionTime != nil && !(*time.Time)(aux.CopyCompletionTime).IsZero() {
+		p.CopyCompletionTime = (*time.Time)(aux.CopyCompletionTime)
+	}
+	if aux.CreationTime != nil && !(*time.Time)(aux.CreationTime).IsZero() {
+		p.CreationTime = (*time.Time)(aux.CreationTime)
+	}
+	if aux.DeletedTime != nil && !(*time.Time)(aux.DeletedTime).IsZero() {
+		p.DeletedTime = (*time.Time)(aux.DeletedTime)
+	}
+	if aux.ExpiresOn != nil && !(*time.Time)(aux.ExpiresOn).IsZero() {
+		p.ExpiresOn = (*time.Time)(aux.ExpiresOn)
+	}
+	if aux.ImmutabilityPolicyExpiresOn != nil && !(*time.Time)(aux.ImmutabilityPolicyExpiresOn).IsZero() {
+		p.ImmutabilityPolicyExpiresOn = (*time.Time)(aux.ImmutabilityPolicyExpiresOn)
+	}
+	if aux.LastAccessedOn != nil && !(*time.Time)(aux.LastAccessedOn).IsZero() {
+		p.LastAccessedOn = (*time.Time)(aux.LastAccessedOn)
+	}
+	if aux.LastModified != nil && !(*time.Time)(aux.LastModified).IsZero() {
+		p.LastModified = (*time.Time)(aux.LastModified)
+	}
 	return nil
 }
 
@@ -400,8 +422,12 @@ func (u *UserDelegationKey) UnmarshalXML(dec *xml.Decoder, start xml.StartElemen
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	u.SignedExpiry = (*time.Time)(aux.SignedExpiry)
-	u.SignedStart = (*time.Time)(aux.SignedStart)
+	if aux.SignedExpiry != nil && !(*time.Time)(aux.SignedExpiry).IsZero() {
+		u.SignedExpiry = (*time.Time)(aux.SignedExpiry)
+	}
+	if aux.SignedStart != nil && !(*time.Time)(aux.SignedStart).IsZero() {
+		u.SignedStart = (*time.Time)(aux.SignedStart)
+	}
 	return nil
 }
 

--- a/packages/autorest.go/test/storage/azblob/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/storage/azblob/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/storage/azblob/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azartifacts/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/synapse/azspark/zz_time_rfc3339.go
@@ -57,6 +57,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/autorest.go/test/tables/aztables/zz_models_serde.go
+++ b/packages/autorest.go/test/tables/aztables/zz_models_serde.go
@@ -42,8 +42,12 @@ func (a *AccessPolicy) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) er
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	a.Expiry = (*time.Time)(aux.Expiry)
-	a.Start = (*time.Time)(aux.Start)
+	if aux.Expiry != nil && !(*time.Time)(aux.Expiry).IsZero() {
+		a.Expiry = (*time.Time)(aux.Expiry)
+	}
+	if aux.Start != nil && !(*time.Time)(aux.Start).IsZero() {
+		a.Start = (*time.Time)(aux.Start)
+	}
 	return nil
 }
 
@@ -103,7 +107,9 @@ func (g *GeoReplication) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 	if err := dec.DecodeElement(aux, &start); err != nil {
 		return err
 	}
-	g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
+	if aux.LastSyncTime != nil && !(*time.Time)(aux.LastSyncTime).IsZero() {
+		g.LastSyncTime = (*time.Time)(aux.LastSyncTime)
+	}
 	return nil
 }
 

--- a/packages/autorest.go/test/tables/aztables/zz_time_rfc1123.go
+++ b/packages/autorest.go/test/tables/aztables/zz_time_rfc1123.go
@@ -33,6 +33,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
+++ b/packages/autorest.go/test/tables/aztables/zz_time_rfc3339.go
@@ -53,6 +53,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/codegen.go/src/models.ts
+++ b/packages/codegen.go/src/models.ts
@@ -615,7 +615,8 @@ function generateXMLUnmarshaller(modelType: go.ModelType, modelDef: ModelDef, im
   text += '\t}\n';
   for (const field of values(modelDef.Fields)) {
     if (go.isTimeType(field.type)) {
-      text += `\t${receiver}.${field.fieldName} = (*time.Time)(aux.${field.fieldName})\n`;
+      text += `\tif aux.${field.fieldName} != nil && !(*time.Time)(aux.${field.fieldName}).IsZero() {\n`;
+      text += `\t\t${receiver}.${field.fieldName} = (*time.Time)(aux.${field.fieldName})\n\t}\n`;
     } else if (field.annotations.isAdditionalProperties || go.isMapType(field.type)) {
       text += `\t${receiver}.${field.fieldName} = (map[string]*string)(aux.${field.fieldName})\n`;
     } else if (go.isBytesType(field.type)) {

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -99,6 +99,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err
@@ -200,7 +203,10 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 	return t.Parse(layout, string(data))
 }
 
-func (t *dateTimeRFC3339) UnmarshalText(data []byte) (error) {
+func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string
@@ -286,6 +292,9 @@ func (t *timeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *timeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	layout := utcTime
 	if tzOffsetRegex.Match(data) {
 		layout = timeFormat

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc1123.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc1123.go
@@ -36,6 +36,9 @@ func (t *dateTimeRFC1123) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC1123) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	p, err := time.Parse(time.RFC1123, string(data))
 	*t = dateTimeRFC1123(p)
 	return err

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_time_rfc3339.go
@@ -56,6 +56,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_time_rfc3339.go
@@ -52,6 +52,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_time_rfc3339.go
@@ -52,6 +52,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_time_rfc3339.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_time_rfc3339.go
@@ -56,6 +56,9 @@ func (t *dateTimeRFC3339) UnmarshalJSON(data []byte) error {
 }
 
 func (t *dateTimeRFC3339) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
 	tzOffset := tzOffsetRegex.Match(data)
 	hasT := strings.Contains(string(data), "T") || strings.Contains(string(data), "t")
 	var layout string


### PR DESCRIPTION
This mostly impacts XML unmarshalers which can have an empty element when there's no time value. Parsing will fail on the empty string, so just skip it instead.
Don't set *time.Time fields to a zero-value time.Time. This is another artifact of how the XML unmarshaler works.