### PR TITLE
Canonicalize Content-Type header

### DIFF
--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -703,6 +703,10 @@ function createProtocolRequest(client: go.Client, method: go.Method | go.NextPag
     }
   }
   for (const param of headerParams.sort((a: go.HeaderParameter, b: go.HeaderParameter) => { return helpers.sortAscending(a.headerName, b.headerName);})) {
+    if (param.headerName.match(/^content-type$/)) {
+      // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
+      param.headerName = 'Content-Type';
+    }
     if (helpers.isRequiredParameter(param) || helpers.isLiteralParameter(param) || go.isClientSideDefault(param.paramType)) {
       text += emitHeaderSet(param, '\t');
     } else if (param.location === 'client' && !param.group) {

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
@@ -108,7 +108,7 @@ func (client *RequestBodyClient) customContentTypeCreateRequest(ctx context.Cont
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"image/png"}
+	req.Raw().Header["Content-Type"] = []string{"image/png"}
 	if err := runtime.MarshalAsByteArray(req, value, runtime.Base64StdFormat); err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func (client *RequestBodyClient) octetStreamCreateRequest(ctx context.Context, v
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"application/octet-stream"}
+	req.Raw().Header["Content-Type"] = []string{"application/octet-stream"}
 	if err := runtime.MarshalAsByteArray(req, value, runtime.Base64StdFormat); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -92,7 +92,7 @@ func (client *JsonMergePatchClient) updateOptionalResourceCreateRequest(ctx cont
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	req.Raw().Header["content-type"] = []string{"application/merge-patch+json"}
+	req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
 	if options != nil && options.Body != nil {
 		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
 			return nil, err
@@ -140,7 +140,7 @@ func (client *JsonMergePatchClient) updateResourceCreateRequest(ctx context.Cont
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	req.Raw().Header["content-type"] = []string{"application/merge-patch+json"}
+	req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_stringbody_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_stringbody_client.go
@@ -121,7 +121,7 @@ func (client *StringBodyClient) sendAsJSONCreateRequest(ctx context.Context, tex
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"application/json"}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, textParam); err != nil {
 		return nil, err
 	}
@@ -153,7 +153,7 @@ func (client *StringBodyClient) sendAsTextCreateRequest(ctx context.Context, tex
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"text/plain"}
+	req.Raw().Header["Content-Type"] = []string{"text/plain"}
 	if err := runtime.MarshalAsJSON(req, textParam); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_formdata_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_formdata_client.go
@@ -44,7 +44,7 @@ func (client *FormDataClient) basicCreateRequest(ctx context.Context, body Multi
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (client *FormDataClient) binaryArrayPartsCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (client *FormDataClient) checkFileNameAndContentTypeCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (client *FormDataClient) complexCreateRequest(ctx context.Context, body Com
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (client *FormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, b
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (client *FormDataClient) jsonPartCreateRequest(ctx context.Context, body JS
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func (client *FormDataClient) multiBinaryPartsCreateRequest(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["content-type"] = []string{"multipart/form-data"}
+	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Request.SetBody will preserve an existing Content-Type header value but the check is done on the canonicalized header name.