### PR TITLE
Consolidate module name and version into Module type

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/adapter.ts
+++ b/packages/autorest.go/src/m4togocodemodel/adapter.ts
@@ -57,12 +57,11 @@ export async function m4ToGoCodeModel(host: AutorestExtensionHost) {
     if (session.model.language.go!.needsXMLDictionaryUnmarshalling) {
       codeModel.marshallingRequirements.generateXMLDictionaryUnmarshallingHelper = true;
     }
-    if (session.model.language.go!.moduleVersion !== '') {
-      codeModel.options.moduleVersion = session.model.language.go!.moduleVersion;
-    }
-    if (session.model.language.go!.module !== 'none') {
-      codeModel.options.module = session.model.language.go!.module;
-    } else if (session.model.language.go!.containingModule !== 'none') {
+    if (session.model.language.go!.module && session.model.language.go!.moduleVersion) {
+      codeModel.options.module = new go.Module(session.model.language.go!.module, session.model.language.go!.moduleVersion);
+    } else if (session.model.language.go!.module || session.model.language.go!.moduleVersion) {
+      throw new Error('--module and --module-version must both or neither be set');
+    } else if (session.model.language.go!.containingModule !== '') {
       codeModel.options.containingModule = session.model.language.go!.containingModule;
     }
     adaptConstantTypes(session.model, codeModel);

--- a/packages/autorest.go/src/transform/namer.ts
+++ b/packages/autorest.go/src/transform/namer.ts
@@ -78,32 +78,24 @@ export async function namer(session: Session<CodeModel>) {
   model.language.go!.rawJSONAsBytes = rawJSONAsBytes;
   const sliceElementsByValue = await session.getValue('slice-elements-byval', false);
   model.language.go!.sliceElementsByValue = sliceElementsByValue;
-  const moduleVersion = await session.getValue('module-version', '');
-  if (moduleVersion !== '' && !moduleVersion.match(/^(\d+\.\d+\.\d+(?:-beta\.\d+)?)?$/)) {
-    throw new Error(`module version ${moduleVersion} must in the format major.minor.patch[-beta.N]`);
-  }
-  model.language.go!.moduleVersion = moduleVersion;
 
-  let module = await session.getValue('module', 'none');
-  if (module !== 'none') {
-    if (module.match(/\/v\d+$/)) {
-      throw new Error('module name must not contain major version suffix');
-    }
-    if (moduleVersion !== '') {
-      // if the modules major version is greater than one, add a major version suffix to the module name
-      const majorVersion = moduleVersion.substring(0, moduleVersion.indexOf('.'));
-      if (Number(majorVersion) > 1) {
-        module += '/v' + majorVersion;
-      }
-    }
+  const moduleVersion = await session.getValue('module-version', '');
+  if (moduleVersion !== '') {
+    model.language.go!.moduleVersion = moduleVersion;
+  }
+
+  const module = await session.getValue('module', '');
+  if (module !== '') {
+    model.language.go!.module = module;
   }
   model.language.go!.module = module;
 
-  const containingModule = await session.getValue('containing-module', 'none');
-  if (containingModule !== 'none' && module !== 'none') {
+  const containingModule = await session.getValue('containing-module', '');
+  if (containingModule !== '' && module !== '') {
     throw new Error('--module and --containing-module are mutually exclusive');
   }
   model.language.go!.containingModule = containingModule;
+
   const singleClient = await session.getValue('single-client', false);
   model.language.go!.singleClient = singleClient;
 

--- a/packages/codegen.go/src/constants.ts
+++ b/packages/codegen.go/src/constants.ts
@@ -20,13 +20,13 @@ export async function generateConstants(codeModel: go.CodeModel): Promise<string
   }
   // data-plane clients must manage their own constants for these values
   if (codeModel.type === 'azure-arm') {
-    if (!codeModel.options.moduleVersion) {
-      throw new Error('--module-version is a required parameter when --azure-arm is set');
+    if (!codeModel.options.module) {
+      throw new Error('--module and --module-version are required parameters when --azure-arm is set');
     }
     text += 'const (\n';
     // strip off any major version suffix
-    text += `\tmoduleName = "${codeModel.options.module?.replace(/\/v\d+$/, '')}"\n`;
-    text += `\tmoduleVersion = "v${codeModel.options.moduleVersion}"\n`;
+    text += `\tmoduleName = "${codeModel.options.module.name.replace(/\/v\d+$/, '')}"\n`;
+    text += `\tmoduleVersion = "v${codeModel.options.module.version}"\n`;
     text += ')\n\n';
   }
   for (const enm of values(codeModel.constants)) {

--- a/packages/codegen.go/src/gomod.ts
+++ b/packages/codegen.go/src/gomod.ts
@@ -9,13 +9,13 @@ import { lt, toSemver } from '@azure-tools/codegen';
 // Creates the content in go.mod if the --module switch was specified.
 // if there's a preexisting go.mod file, update its specified version of azcore as needed.
 export async function generateGoModFile(codeModel: go.CodeModel, existingGoMod?: string): Promise<string> {
-  const modName = codeModel.options.module;
-  if (!modName) {
+  if (!codeModel.options.module) {
     if (!existingGoMod) {
       return '';
     }
-    throw new Error('--module is required when go.mod exists');
+    throw new Error('--module and --module-version are required when go.mod exists');
   }
+  const modName = codeModel.options.module.name;
 
   // here we specify the minimum version of azcore as required by the code generator.
   // the version can be overwritten by passing the --azcore-version switch during generation.

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -553,7 +553,7 @@ export function formatCommentAsBulletItem(description: string): string {
 export function getParentImport(codeModel: go.CodeModel): string {
   const clientPkg = codeModel.packageName;
   if (codeModel.options.module) {
-    return codeModel.options.module;
+    return codeModel.options.module.name;
   } else if (codeModel.options.containingModule) {
     return codeModel.options.containingModule + '/' + clientPkg;
   } else {

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -968,7 +968,7 @@ export class Module implements Module {
       throw new Error('module name must not contain major version suffix');
     }
     if (!version.match(/^(\d+\.\d+\.\d+(?:-beta\.\d+)?)?$/)) {
-      throw new Error(`module version ${version} must in the format major.minor.patch[-beta.N]`);
+      throw new Error(`module version ${version} must be in the format major.minor.patch[-beta.N]`);
     }
     // if the module's major version is greater than one, add a major version suffix to the module name
     const majorVersion = version.substring(0, version.indexOf('.'));

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -147,6 +147,7 @@ function generate(moduleName, input, outputDir, additionalArgs) {
     try {
       const options = [];
       options.push(`--option="@azure-tools/typespec-go.module=${moduleName}"`);
+      options.push(`--option="@azure-tools/typespec-go.module-version=0.1.0"`);
       options.push(`--option="@azure-tools/typespec-go.emitter-output-dir=${fullOutputDir}"`);
       options.push(`--option="@azure-tools/typespec-go.file-prefix=zz_"`);
       if (switches.includes('--debugger')) {

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -23,11 +23,10 @@ export function tcgcToGoCodeModel(context: EmitContext<GoEmitterOptions>): go.Co
   }
 
   const codeModel = new go.CodeModel(info, 'data-plane', packageNameFromOutputFolder(context.emitterOutputDir), options);
-  if (context.options.module) {
-    codeModel.options.module = context.options.module;
-  }
-  if (context.options['module-version']) {
-    codeModel.options.moduleVersion = context.options['module-version'];
+  if (context.options.module && context.options['module-version']) {
+    codeModel.options.module = new go.Module(context.options.module, context.options['module-version']);
+  } else if (context.options.module || context.options['module-version']) {
+    throw new Error('--module and --module-version must both or neither be set');
   }
   if (context.options['rawjson-as-bytes']) {
     codeModel.options.rawJSONAsBytes = true;


### PR DESCRIPTION
Since the two must be set together or not at all, this reflects that requirement in the code model.
Moved module name and version validation to Module's constructor so it can be used by both code generators.
Move ARM constructor generation to its own function.