### PR TITLE
Add client accessor method name to ClientAccessor type

### DIFF
--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -258,6 +258,10 @@ export interface Client {
 
 // ClientAccessor is a client method that returns a sub-client instance.
 export interface ClientAccessor {
+  // the name of the client accessor method
+  accessorName: string;
+
+  // the client returned by the accessor method
   subClient: Client;
 }
 
@@ -1041,7 +1045,7 @@ export class CodeModel implements CodeModel {
     this.clients.sort((a: Client, b: Client) => { return sortAscending(a.clientName, b.clientName); });
     for (const client of this.clients) {
       client.methods.sort((a: Method, b: Method) => { return sortAscending(a.methodName, b.methodName); });
-      client.clientAccessors.sort((a: ClientAccessor, b: ClientAccessor) => { return sortAscending(a.subClient.clientName, b.subClient.clientName); });
+      client.clientAccessors.sort((a: ClientAccessor, b: ClientAccessor) => { return sortAscending(a.accessorName, b.accessorName); });
     }
   }
 }
@@ -1060,7 +1064,8 @@ export class Client implements Client {
 }
 
 export class ClientAccessor implements ClientAccessor {
-  constructor(subClient: Client) {
+  constructor(accessorName: string, subClient: Client) {
+    this.accessorName = accessorName;
     this.subClient = subClient;
   }
 }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -112,7 +112,7 @@ export class clientAdapter {
     for (const sdkMethod of sdkClient.methods) {
       if (sdkMethod.kind === 'clientaccessor') {
         const subClient = this.recursiveAdaptClient(sdkMethod.response, goClient);
-        goClient.clientAccessors.push(new go.ClientAccessor(subClient));
+        goClient.clientAccessors.push(new go.ClientAccessor(`New${subClient.clientName}`, subClient));
       } else {
         this.adaptMethod(sdkMethod, goClient);
       }


### PR DESCRIPTION
Relying on Client.ctorName is a bit of a hack and that field will be going away in a future change for generating client constructors.