### PR TITLE
Fixes for multipart/form parameters

### DIFF
--- a/packages/autorest.go/test/autorest/formdatagroup/zz_formdata_client.go
+++ b/packages/autorest.go/test/autorest/formdatagroup/zz_formdata_client.go
@@ -57,10 +57,10 @@ func (client *FormdataClient) uploadFileCreateRequest(ctx context.Context, fileC
 	}
 	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"application/octet-stream, application/json"}
-	if err := runtime.SetMultipartFormData(req, map[string]any{
-		"fileContent": fileContent,
-		"fileName":    fileName,
-	}); err != nil {
+	formData := map[string]any{}
+	formData["fileContent"] = fileContent
+	formData["fileName"] = fileName
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -145,9 +145,9 @@ func (client *FormdataClient) uploadFilesCreateRequest(ctx context.Context, file
 	}
 	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"application/octet-stream, application/json"}
-	if err := runtime.SetMultipartFormData(req, map[string]any{
-		"fileContent": fileContent,
-	}); err != nil {
+	formData := map[string]any{}
+	formData["fileContent"] = fileContent
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -530,6 +530,58 @@ func (client *Client) policyAssignmentHandleResponse(resp *http.Response) (Polic
 	return result, nil
 }
 
+// UploadForm -
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2.0
+//   - options - UploadFormOptions contains the optional parameters for the Client.UploadForm method.
+func (client *Client) UploadForm(ctx context.Context, requiredString string, requiredEnum DataSetting, requiredInt int32, options *UploadFormOptions) (UploadFormResponse, error) {
+	var err error
+	const operationName = "Client.UploadForm"
+	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
+	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
+	defer func() { endSpan(err) }()
+	req, err := client.uploadFormCreateRequest(ctx, requiredString, requiredEnum, requiredInt, options)
+	if err != nil {
+		return UploadFormResponse{}, err
+	}
+	httpResp, err := client.internal.Pipeline().Do(req)
+	if err != nil {
+		return UploadFormResponse{}, err
+	}
+	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
+		err = runtime.NewResponseError(httpResp)
+		return UploadFormResponse{}, err
+	}
+	return UploadFormResponse{}, nil
+}
+
+// uploadFormCreateRequest creates the UploadForm request.
+func (client *Client) uploadFormCreateRequest(ctx context.Context, requiredString string, requiredEnum DataSetting, requiredInt int32, options *UploadFormOptions) (*policy.Request, error) {
+	urlPath := "/formdata"
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	if err != nil {
+		return nil, err
+	}
+	formData := map[string]any{}
+	formData["requiredString"] = requiredString
+	if options != nil && options.OptionalString != nil {
+		formData["OptionalString"] = *options.OptionalString
+	}
+	formData["requiredEnum"] = requiredEnum
+	formData["requiredInt"] = requiredInt
+	if options != nil && options.OptionalBool != nil {
+		formData["OptionalBool"] = *options.OptionalBool
+	}
+	if options != nil && options.OptionalIntEnum != nil {
+		formData["OptionalIntEnum"] = *options.OptionalIntEnum
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
 // listLRONextCreateRequest creates the listLRONextCreateRequest request.
 func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
 	urlPath := "/paged"

--- a/packages/autorest.go/test/maps/azalias/zz_models.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models.go
@@ -167,6 +167,22 @@ type ScheduleCreateOrUpdateProperties struct {
 	StartTime *time.Time
 }
 
+type SomeFormData struct {
+	// REQUIRED; test enum with a default
+	RequiredEnum *DataSetting
+
+	// REQUIRED
+	RequiredInt *int32
+
+	// REQUIRED
+	RequiredString *string
+	OptionalBool   *bool
+
+	// List of integer enums
+	OptionalIntEnum *IntEnum
+	OptionalString  *string
+}
+
 type TypeWithRawJSON struct {
 	// any JSON object
 	AnyObject any

--- a/packages/autorest.go/test/maps/azalias/zz_models_serde.go
+++ b/packages/autorest.go/test/maps/azalias/zz_models_serde.go
@@ -563,6 +563,55 @@ func (s *ScheduleCreateOrUpdateProperties) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type SomeFormData.
+func (s SomeFormData) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "optionalBool", s.OptionalBool)
+	populate(objectMap, "optionalIntEnum", s.OptionalIntEnum)
+	populate(objectMap, "optionalString", s.OptionalString)
+	populate(objectMap, "requiredEnum", s.RequiredEnum)
+	populate(objectMap, "requiredInt", s.RequiredInt)
+	populate(objectMap, "requiredString", s.RequiredString)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type SomeFormData.
+func (s *SomeFormData) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", s, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "optionalBool":
+			err = unpopulate(val, "OptionalBool", &s.OptionalBool)
+			delete(rawMsg, key)
+		case "optionalIntEnum":
+			err = unpopulate(val, "OptionalIntEnum", &s.OptionalIntEnum)
+			delete(rawMsg, key)
+		case "optionalString":
+			err = unpopulate(val, "OptionalString", &s.OptionalString)
+			delete(rawMsg, key)
+		case "requiredEnum":
+			err = unpopulate(val, "RequiredEnum", &s.RequiredEnum)
+			delete(rawMsg, key)
+		case "requiredInt":
+			err = unpopulate(val, "RequiredInt", &s.RequiredInt)
+			delete(rawMsg, key)
+		case "requiredString":
+			err = unpopulate(val, "RequiredString", &s.RequiredString)
+			delete(rawMsg, key)
+		default:
+			err = fmt.Errorf("unmarshalling type %T, unknown field %q", s, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", s, err)
+		}
+	}
+	return nil
+}
+
 // MarshalJSON implements the json.Marshaller interface for type TypeWithRawJSON.
 func (t TypeWithRawJSON) MarshalJSON() ([]byte, error) {
 	objectMap := make(map[string]any)

--- a/packages/autorest.go/test/maps/azalias/zz_options.go
+++ b/packages/autorest.go/test/maps/azalias/zz_options.go
@@ -84,3 +84,10 @@ type PolicyAssignmentOptions struct {
 type SomeGroup struct {
 	HeaderStrings []string
 }
+
+// UploadFormOptions contains the optional parameters for the Client.UploadForm method.
+type UploadFormOptions struct {
+	OptionalBool    *bool
+	OptionalIntEnum *IntEnum
+	OptionalString  *string
+}

--- a/packages/autorest.go/test/maps/azalias/zz_responses.go
+++ b/packages/autorest.go/test/maps/azalias/zz_responses.go
@@ -46,3 +46,8 @@ type ListWithSharedNextTwoResponse struct {
 type PolicyAssignmentResponse struct {
 	PolicyAssignmentProperties
 }
+
+// UploadFormResponse contains the response from method Client.UploadForm.
+type UploadFormResponse struct {
+	// placeholder for future response values
+}

--- a/packages/autorest.go/test/swagger/alias.json
+++ b/packages/autorest.go/test/swagger/alias.json
@@ -767,6 +767,28 @@
           }
         }
       }
+    },
+    "/formdata": {
+      "post": {
+        "operationId": "Alias_UploadForm",
+        "consumes": ["multipart/form-data"],
+        "parameters": [
+          {
+            "name": "props",
+            "description": "properties in form data",
+            "required": true,
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/SomeFormData"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "success"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -974,16 +996,7 @@
           "x-ms-client-default": "default-value"
         },
         "setting": {
-          "description": "test enum with a default",
-          "type": "string",
-          "enum": [
-            "one",
-            "two",
-            "three"
-          ],
-          "x-ms-enum": {
-            "name": "DataSetting"
-          },
+          "$ref": "#/definitions/Setting",
           "x-ms-client-default": "two"
         }
       },
@@ -1166,6 +1179,18 @@
       "type": "integer",
       "enum": [200, 403, 405, 406, 429]
     },
+    "Setting": {
+      "description": "test enum with a default",
+      "type": "string",
+      "enum": [
+        "one",
+        "two",
+        "three"
+      ],
+      "x-ms-enum": {
+        "name": "DataSetting"
+      }
+    },
     "PagesOfThings": {
       "type": "object",
       "properties": {
@@ -1179,6 +1204,32 @@
           "type": "string"
         }
       }
+    },
+    "SomeFormData": {
+      "type": "object",
+      "properties": {
+        "requiredString": {
+          "type": "string"
+        },
+        "optionalString": {
+          "type": "string"
+        },
+        "requiredEnum": {
+          "$ref": "#/definitions/Setting"
+        },
+        "requiredInt": {
+          "type": "integer"
+        },
+        "optionalBool": {
+          "type": "boolean"
+        },
+        "optionalIntEnum": {
+          "$ref": "#/definitions/IntEnum"
+        }
+      },
+      "required": [
+        "requiredString", "requiredEnum", "requiredInt"
+      ]
     }
   }
 }

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -560,3 +560,18 @@ export function getParentImport(codeModel: go.CodeModel): string {
     throw new Error('unable to determine containing module for fakes. specify either the module or containing-module switch');
   }
 }
+
+export function getBitSizeForNumber(intSize: 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64'): string {
+  switch (intSize) {
+    case 'int8':
+      return '8';
+    case 'int16':
+      return '16';
+    case 'int32':
+    case 'float32':
+      return '32';
+    case 'int64':
+    case 'float64':
+      return '64';
+  }
+}


### PR DESCRIPTION
Fix bad codegen for optional multipart/form parameters. Handle more primitive types than just string.
Cast to constant type for string-based "enums".