### PR TITLE
Various emitter cleanup

### DIFF
--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -766,7 +766,7 @@ export interface HeaderMapResponse {
   collectionPrefix: string;
 }
 
-export type PrimitiveTypeName = 'any' | 'bool' | 'byte' | 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64' | 'rune' | 'string';
+export type PrimitiveTypeName = 'any' | 'bool' | 'byte' | 'float32' | 'float64' | 'int8' | 'int16' | 'int32' | 'int64' | 'rune' | 'string' | 'uint8' | 'uint16' | 'uint32' | 'uint64';
 
 export type BytesEncoding = 'Std' | 'URL';
 

--- a/packages/typespec-go/src/emitter.ts
+++ b/packages/typespec-go/src/emitter.ts
@@ -15,22 +15,13 @@ import { generatePolymorphicHelpers } from '../../codegen.go/src/polymorphics.js
 import { generateResponses } from '../../codegen.go/src/responses.js';
 import { generateTimeHelpers } from '../../codegen.go/src/time.js';
 import { generateServers } from '../../codegen.go/src/fake/servers.js';
-import { generateServerFactory } from '../../codegen.go/src/fake/factory.js';
+//import { generateServerFactory } from '../../codegen.go/src/fake/factory.js';
 import { existsSync } from 'fs';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { EmitContext } from '@typespec/compiler';
-import { waitForDebugger } from 'inspector';
 import 'source-map-support/register.js';
 
 export async function $onEmit(context: EmitContext<GoEmitterOptions>) {
-  // TODO: get debugger pause integrated
-  /*if (context.program.getOption('debugger')) {
-    console.warn('got debugger');
-    waitForDebugger();
-  } else {
-    console.warn('no debugger!');
-  }*/
-
   const codeModel = tcgcToGoCodeModel(context);
   await mkdir(context.emitterOutputDir, {recursive: true});
 

--- a/packages/typespec-go/src/emitter.ts
+++ b/packages/typespec-go/src/emitter.ts
@@ -113,7 +113,7 @@ export async function $onEmit(context: EmitContext<GoEmitterOptions>) {
       writeFile(`${fakesDir}/${filePrefix}${fileName}.go`, op.content);
     }
 
-    // skip server factory for now as we don't generate it (yet)
+    // TODO: skip server factory for now as we don't generate it (yet)
     /*const serverFactory = generateServerFactory(codeModel);
     if (serverFactory !== '') {
       writeFile(`${fakesDir}/${filePrefix}server_factory.go`, serverFactory);

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -8,7 +8,6 @@ import { GoEmitterOptions } from '../lib.js';
 import { isTypePassedByValue, typeAdapter } from './types.js';
 import * as go from '../../../codemodel.go/src/gocodemodel.js';
 import * as tcgc from '@azure-tools/typespec-client-generator-core';
-import { values } from '@azure-tools/linq';
 
 // used to convert SDK clients and their methods to Go code model types
 export class clientAdapter {
@@ -19,13 +18,11 @@ export class clientAdapter {
   // as not every option might contain them, and parameter groups can be shared
   // across multiple operations
   private clientParams: Map<string, go.Parameter>;
-  private paramGroups: Map<string, go.ParameterGroup>;
 
   constructor(ta: typeAdapter, opts: GoEmitterOptions) {
     this.ta = ta;
     this.opts = opts;
     this.clientParams = new Map<string, go.Parameter>();
-    this.paramGroups = new Map<string, go.ParameterGroup>();
   }
 
   // converts all clients and their methods to Go code model types.
@@ -188,10 +185,6 @@ export class clientAdapter {
     }
   
     this.adaptMethodParameters(sdkMethod, method);
-  
-    /*for (const apiver of values(op.apiVersions)) {
-      method.apiVersions.push(apiver.version);
-    }*/
 
     // we must do this after adapting method params as it can add optional params
     this.ta.codeModel.paramGroups.push(this.adaptParameterGroup(method.optionalParamsGroup));
@@ -255,7 +248,6 @@ export class clientAdapter {
     };
     if (param.onClient) {
       // check if we've already adapted this client parameter
-      // TODO: grouped client params
       const clientParam = this.clientParams.get(getClientParamsKey(param));
       if (clientParam) {
         return clientParam;

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -291,7 +291,7 @@ export class typeAdapter {
           return decimalType;
         }
         decimalType = new go.PrimitiveType(decimalKey);
-        this. types.set(decimalKey, decimalType);
+        this.types.set(decimalKey, decimalType);
         return decimalType;
       }
       case 'eTag': {
@@ -610,7 +610,7 @@ export class typeAdapter {
           return <go.LiteralValue>literalDecimal;
         }
         literalDecimal = new go.LiteralValue(new go.PrimitiveType('float64'), constType.value);
-        this. types.set(keyName, literalDecimal);
+        this.types.set(keyName, literalDecimal);
         return literalDecimal;
       }
       /*case 'date':

--- a/packages/typespec-go/tsconfig.json
+++ b/packages/typespec-go/tsconfig.json
@@ -16,7 +16,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
     "outDir": "dist",
     "skipLibCheck": true,


### PR DESCRIPTION
Added support for unsigned int types.
Removed some commented out and dead code. This includes the commented out code for client-side default values in models as tsp doesn't support that scenario.
Consolidated some type adaptation.
Removed some now-handled TODOs.
No more unused locals.