### PR TITLE
Fix handling of content types other than JSON

### DIFF
--- a/packages/autorest.go/test/acr/azacr/fake/zz_containerregistryblob_server.go
+++ b/packages/autorest.go/test/acr/azacr/fake/zz_containerregistryblob_server.go
@@ -303,7 +303,7 @@ func (c *ContainerRegistryBlobServerTransport) dispatchDeleteBlob(req *http.Requ
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -342,7 +342,7 @@ func (c *ContainerRegistryBlobServerTransport) dispatchGetBlob(req *http.Request
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (c *ContainerRegistryBlobServerTransport) dispatchGetChunk(req *http.Reques
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/autorest.go/test/autorest/binarygroup/fake/zz_download_server.go
+++ b/packages/autorest.go/test/autorest/binarygroup/fake/zz_download_server.go
@@ -75,7 +75,7 @@ func (d *DownloadServerTransport) dispatchErrorStream(req *http.Request) (*http.
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/autorest.go/test/autorest/filegroup/fake/zz_files_server.go
+++ b/packages/autorest.go/test/autorest/filegroup/fake/zz_files_server.go
@@ -87,7 +87,7 @@ func (f *FilesServerTransport) dispatchGetEmptyFile(req *http.Request) (*http.Re
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (f *FilesServerTransport) dispatchGetFile(req *http.Request) (*http.Respons
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (f *FilesServerTransport) dispatchGetFileLarge(req *http.Request) (*http.Re
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/autorest.go/test/autorest/formdatagroup/fake/zz_formdata_server.go
+++ b/packages/autorest.go/test/autorest/formdatagroup/fake/zz_formdata_server.go
@@ -125,7 +125,7 @@ func (f *FormdataServerTransport) dispatchUploadFile(req *http.Request) (*http.R
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (f *FormdataServerTransport) dispatchUploadFileViaBody(req *http.Request) (
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ func (f *FormdataServerTransport) dispatchUploadFiles(req *http.Request) (*http.
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroleinstances_server.go
+++ b/packages/autorest.go/test/compute/armcompute/fake/zz_cloudserviceroleinstances_server.go
@@ -284,7 +284,7 @@ func (c *CloudServiceRoleInstancesServerTransport) dispatchGetRemoteDesktopFile(
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -240,7 +240,7 @@ function generateServerTransportMethods(clientPkg: string, serverTransport: stri
       } else if (go.isBinaryResult(method.responseEnvelope.result)) {
         content += '\tresp, err := server.NewResponse(respContent, req, &server.ResponseOptions{\n';
         content += `\t\tBody: server.GetResponse(respr).${getResultFieldName(method.responseEnvelope.result)},\n`;
-        content += '\t\tContentType: "application/octet-stream",\n';
+        content += '\t\tContentType: req.Header.Get("Content-Type"),\n';
         content += '\t})\n';
       } else if (go.isMonomorphicResult(method.responseEnvelope.result)) {
         if (go.isBytesType(method.responseEnvelope.result.monomorphicType)) {

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -42,7 +42,7 @@ const cadlRanch = {
   //'spreadgroup': ['parameters/spread'], // needs more investigation
   //'contentneggroup': ['payload/content-negotiation'], // https://github.com/Azure/typespec-azure/issues/107
   'jmergepatchgroup': ['payload/json-merge-patch'],
-  'mediatypegroup': ['payload/media-type'], // missing tests
+  'mediatypegroup': ['payload/media-type'],
   'multipartgroup': ['payload/multipart'],  // missing tests
   'pageablegroup': ['payload/pageable'],
   'projectednamegroup': ['projection/projected-name'],

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -223,6 +223,20 @@ export class clientAdapter {
     }
   }
 
+  private adaptContentType(contentTypeStr: string): 'binary' | 'JSON' | 'Text' | 'XML' {
+    // we only recognize/support JSON, text, and XML content types, so assume anything else is binary
+    // TODO: this seems goofy but maybe it's ok?
+    let contentType: go.BodyFormat = 'binary';
+    if (contentTypeStr.match(/json/i)) {
+      contentType = 'JSON';
+    } else if (contentTypeStr.match(/text/i)) {
+      contentType = 'Text';
+    } else if (contentTypeStr.match(/xml/i)) {
+      contentType = 'XML';
+    }
+    return contentType;
+  }
+
   private adaptMethodParameter(param: tcgc.SdkBodyParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter, optionalGroup?: go.ParameterGroup): go.Parameter {
     if (param.isApiVersionParam && param.clientDefaultValue) {
       // we emit the api version param inline as a literal, never as a param.
@@ -261,8 +275,14 @@ export class clientAdapter {
     const byVal = isTypePassedByValue(param.type);
 
     if (param.kind === 'body') {
-      // TODO: hard-coded format type
-      adaptedParam = new go.BodyParameter(paramName, 'JSON', param.defaultContentType, this.ta.getPossibleType(param.type, false, true), paramType, byVal);
+      // TODO: form data? (non-multipart)
+      const contentType = this.adaptContentType(param.defaultContentType);
+      let bodyType = this.ta.getPossibleType(param.type, false, true);
+      if (contentType === 'binary') {
+        // tcgc models binary params as 'bytes' but we want an io.ReadSeekCloser
+        bodyType = this.ta.getReadSeekCloser(param.type.kind === 'array');
+      }
+      adaptedParam = new go.BodyParameter(paramName, contentType, `"${param.defaultContentType}"`, bodyType, paramType, byVal);
     } else if (param.kind === 'header') {
       if (param.collectionFormat) {
         if (param.collectionFormat === 'multi') {
@@ -327,17 +347,9 @@ export class clientAdapter {
     const respEnv = new go.ResponseEnvelope(respEnvName, createResponseEnvelopeDescription(respEnvName, this. getMethodNameForDocComment(method)), method);
     this.ta.codeModel.responseEnvelopes.push(respEnv);
 
-    // used to track possible operation response body types
-    const bodyResponses = new Array<tcgc.SdkType>();
-
     // add any headers
     const addedHeaders = new Set<string>();
     for (const httpResp of Object.values(sdkMethod.operation.responses)) { 
-      // for LROs we don't look at the operation response as it contains the polling response type
-      if (!go.isLROMethod(method) && httpResp.type && !bodyResponses.includes(httpResp.type)) {
-        bodyResponses.push(httpResp.type);
-      }
-
       for (const httpHeader of httpResp.headers) {
         if (addedHeaders.has(httpHeader.serializedName)) {
           continue;
@@ -354,25 +366,57 @@ export class clientAdapter {
       }
     }
 
-    let sdkResponse: tcgc.SdkType | undefined;
+    let sdkResponseType = sdkMethod.response.type;
 
-    if (go.isLROMethod(method) && sdkMethod.response.type) {
-      // use the method response for LROs as it contains the "final response" type
-      sdkResponse = sdkMethod.response.type;
-    } else if (bodyResponses.length === 1) {
-      sdkResponse = bodyResponses[0];
-    } else if (bodyResponses.length > 1) {
-      throw new Error('any response NYI');
+    if (!sdkResponseType) {
+      // method doesn't return a type, so we're done
+      return respEnv;
     }
 
-    if (sdkResponse?.kind === 'model') {
-      // workaround until https://github.com/Azure/typespec-azure/issues/124 is fixed
-      if (sdkResponse.name === 'OperationStatus' || sdkResponse.name === 'ResourceOperationStatus') {
-        return respEnv;
+    // workaround until https://github.com/Azure/typespec-azure/issues/124 is fixed
+    if (sdkResponseType.kind === 'model' && (sdkResponseType.name === 'OperationStatus' || sdkResponseType.name === 'ResourceOperationStatus')) {
+      return respEnv;
+    }
+    // end workaround
+
+    // for paged methods, tcgc models the method response type as an Array<T>.
+    // however, we want the synthesized paged response envelope as that's what Go returns.
+    if (sdkMethod.kind === 'paging') {
+      // grab the paged response envelope type from the first response
+      sdkResponseType = Object.values(sdkMethod.operation.responses)[0].type!;
+    }
+
+    // we have a response type, determine the content type
+    let contentType: go.BodyFormat = 'binary';
+    if (sdkMethod.kind === 'lro') {
+      // we can't grovel through the operation responses for LROs as some of them
+      // return only headers, thus have no content type. while it's highly likely
+      // to only ever be JSON, this will be broken for LROs that return text/plain
+      // or a binary response. the former seems unlikely, the latter though...??
+      // TODO: follow up with tcgc team about this
+      contentType = 'JSON';
+    } else {
+      let foundResp = false;
+      for (const httpResp of Object.values(sdkMethod.operation.responses)) {
+        if (!httpResp.type || !httpResp.defaultContentType || httpResp.type.kind !== sdkResponseType.kind) {
+          continue;
+        }
+        contentType = this.adaptContentType(httpResp.defaultContentType);
+        foundResp = true;
+        break;
       }
-      // end workaround
+      if (!foundResp) {
+        throw new Error(`didn't find HTTP response for kind ${sdkResponseType.kind} in method ${method.name}`);
+      }
+    }
+
+    if (contentType === 'binary') {
+      respEnv.result = new go.BinaryResult('Body', 'binary');
+      respEnv.result.description = 'Body contains the streaming response.';
+      return respEnv;
+    } else if (sdkResponseType.kind === 'model') {
       let modelType: go.ModelType | undefined;
-      const modelName = ensureNameCase(sdkResponse.name).toUpperCase();
+      const modelName = ensureNameCase(sdkResponseType.name).toUpperCase();
       for (const model of this.ta.codeModel.models) {
         if (model.name.toUpperCase() === modelName) {
           modelType = model;
@@ -380,22 +424,20 @@ export class clientAdapter {
         }
       }
       if (!modelType) {
-        throw new Error(`didn't find type name ${sdkResponse.name} for response envelope ${respEnv.name}`);
+        throw new Error(`didn't find model type name ${sdkResponseType.name} for response envelope ${respEnv.name}`);
       }
       if (go.isPolymorphicType(modelType)) {
         respEnv.result = new go.PolymorphicResult(modelType.interface);
       } else {
-        // TODO: hard-coded JSON
-        respEnv.result = new go.ModelResult(modelType, 'JSON');
+        respEnv.result = new go.ModelResult(modelType, contentType);
       }
-      respEnv.result.description = sdkResponse.description;
-    } else if (sdkResponse) {
-      const resultType = this.ta.getPossibleType(sdkResponse, false, false);
+      respEnv.result.description = sdkResponseType.description;
+    } else {
+      const resultType = this.ta.getPossibleType(sdkResponseType, false, false);
       if (go.isInterfaceType(resultType) || go.isLiteralValue(resultType) || go.isModelType(resultType) || go.isPolymorphicType(resultType) || go.isQualifiedType(resultType)) {
         throw new Error(`invalid monomorphic result type ${go.getTypeDeclaration(resultType)}`);
       }
-      // TODO: hard-coded JSON
-      respEnv.result = new go.MonomorphicResult('Value', 'JSON', resultType, isTypePassedByValue(sdkResponse));
+      respEnv.result = new go.MonomorphicResult('Value', contentType, resultType, isTypePassedByValue(sdkResponseType));
     }
   
     return respEnv;

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -225,15 +225,15 @@ export class clientAdapter {
 
   private adaptContentType(contentTypeStr: string): 'binary' | 'JSON' | 'Text' | 'XML' {
     // we only recognize/support JSON, text, and XML content types, so assume anything else is binary
-    // TODO: this seems goofy but maybe it's ok?
+    // NOTE: we check XML before text in order to support text/xml
     let contentType: go.BodyFormat = 'binary';
     if (contentTypeStr.match(/json/i)) {
       contentType = 'JSON';
-    } else if (contentTypeStr.match(/text/i)) {
-      contentType = 'Text';
     } else if (contentTypeStr.match(/xml/i)) {
       contentType = 'XML';
-    }
+    } else if (contentTypeStr.match(/text/i)) {
+      contentType = 'Text';
+    } 
     return contentType;
   }
 
@@ -393,7 +393,7 @@ export class clientAdapter {
       // return only headers, thus have no content type. while it's highly likely
       // to only ever be JSON, this will be broken for LROs that return text/plain
       // or a binary response. the former seems unlikely, the latter though...??
-      // TODO: follow up with tcgc team about this
+      // TODO: https://github.com/Azure/typespec-azure/issues/535
       contentType = 'JSON';
     } else {
       let foundResp = false;

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/custom_client_test.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/custom_client_test.go
@@ -9,6 +9,8 @@ package bytesgroup_test
 import (
 	"bytesgroup"
 	"context"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -139,7 +141,14 @@ func TestRequestBodyClientBase64URL(t *testing.T) {
 }
 
 func TestRequestBodyClientCustomContentType(t *testing.T) {
-	t.Skip("https://github.com/Azure/typespec-azure/issues/15")
+	client, err := bytesgroup.NewBytesClient(nil)
+	require.NoError(t, err)
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer pngFile.Close()
+	resp, err := client.NewRequestBodyClient().CustomContentType(context.Background(), pngFile, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
 }
 
 func TestRequestBodyClientDefault(t *testing.T) {
@@ -151,7 +160,14 @@ func TestRequestBodyClientDefault(t *testing.T) {
 }
 
 func TestRequestBodyClientOctetStream(t *testing.T) {
-	t.Skip("https://github.com/Azure/typespec-azure/issues/15")
+	client, err := bytesgroup.NewBytesClient(nil)
+	require.NoError(t, err)
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer pngFile.Close()
+	resp, err := client.NewRequestBodyClient().OctetStream(context.Background(), pngFile, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
 }
 
 func TestResponseBodyClientBase64(t *testing.T) {
@@ -173,7 +189,19 @@ func TestResponseBodyClientBase64URL(t *testing.T) {
 }
 
 func TestResponseBodyClientCustomContent(t *testing.T) {
-	t.Skip("https://github.com/Azure/typespec-azure/issues/15")
+	client, err := bytesgroup.NewBytesClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewResponseBodyClient().CustomContentType(context.Background(), nil)
+	require.NoError(t, err)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	pngBody, err := io.ReadAll(pngFile)
+	require.NoError(t, err)
+	require.NoError(t, pngFile.Close())
+	require.EqualValues(t, pngBody, respBody)
 }
 
 func TestResponseBodyClientDefault(t *testing.T) {
@@ -186,5 +214,17 @@ func TestResponseBodyClientDefault(t *testing.T) {
 }
 
 func TestResponseBodyClientOctetStream(t *testing.T) {
-	t.Skip("https://github.com/Azure/typespec-azure/issues/15")
+	client, err := bytesgroup.NewBytesClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewResponseBodyClient().OctetStream(context.Background(), nil)
+	require.NoError(t, err)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	pngBody, err := io.ReadAll(pngFile)
+	require.NoError(t, err)
+	require.NoError(t, pngFile.Close())
+	require.EqualValues(t, pngBody, respBody)
 }

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/fake/zz_responsebody_server.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/fake/zz_responsebody_server.go
@@ -136,7 +136,7 @@ func (r *ResponseBodyServerTransport) dispatchCustomContentType(req *http.Reques
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (r *ResponseBodyServerTransport) dispatchOctetStream(req *http.Request) (*h
 	}
 	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
 		Body:        server.GetResponse(respr).Body,
-		ContentType: "application/octet-stream",
+		ContentType: req.Header.Get("Content-Type"),
 	})
 	if err != nil {
 		return nil, err

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/fake/zz_responsebody_server.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/fake/zz_responsebody_server.go
@@ -134,7 +134,10 @@ func (r *ResponseBodyServerTransport) dispatchCustomContentType(req *http.Reques
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsByteArray(respContent, server.GetResponse(respr).Value, runtime.Base64StdFormat, req)
+	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
+		Body:        server.GetResponse(respr).Body,
+		ContentType: "application/octet-stream",
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +175,10 @@ func (r *ResponseBodyServerTransport) dispatchOctetStream(req *http.Request) (*h
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsByteArray(respContent, server.GetResponse(respr).Value, runtime.Base64StdFormat, req)
+	resp, err := server.NewResponse(respContent, req, &server.ResponseOptions{
+		Body:        server.GetResponse(respr).Body,
+		ContentType: "application/octet-stream",
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_requestbody_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"io"
 	"net/http"
 )
 
@@ -92,7 +93,7 @@ func (client *RequestBodyClient) base64URLCreateRequest(ctx context.Context, val
 
 //   - options - RequestBodyClientCustomContentTypeOptions contains the optional parameters for the RequestBodyClient.CustomContentType
 //     method.
-func (client *RequestBodyClient) CustomContentType(ctx context.Context, value []byte, options *RequestBodyClientCustomContentTypeOptions) (RequestBodyClientCustomContentTypeResponse, error) {
+func (client *RequestBodyClient) CustomContentType(ctx context.Context, value io.ReadSeekCloser, options *RequestBodyClientCustomContentTypeOptions) (RequestBodyClientCustomContentTypeResponse, error) {
 	var err error
 	const operationName = "RequestBodyClient.CustomContentType"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -114,14 +115,14 @@ func (client *RequestBodyClient) CustomContentType(ctx context.Context, value []
 }
 
 // customContentTypeCreateRequest creates the CustomContentType request.
-func (client *RequestBodyClient) customContentTypeCreateRequest(ctx context.Context, value []byte, options *RequestBodyClientCustomContentTypeOptions) (*policy.Request, error) {
+func (client *RequestBodyClient) customContentTypeCreateRequest(ctx context.Context, value io.ReadSeekCloser, options *RequestBodyClientCustomContentTypeOptions) (*policy.Request, error) {
 	urlPath := "/encode/bytes/body/request/custom-content-type"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"image/png"}
-	if err := runtime.MarshalAsByteArray(req, value, runtime.Base64StdFormat); err != nil {
+	if err := req.SetBody(value, "image/png"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -164,7 +165,7 @@ func (client *RequestBodyClient) defaultCreateRequest(ctx context.Context, value
 }
 
 // - options - RequestBodyClientOctetStreamOptions contains the optional parameters for the RequestBodyClient.OctetStream method.
-func (client *RequestBodyClient) OctetStream(ctx context.Context, value []byte, options *RequestBodyClientOctetStreamOptions) (RequestBodyClientOctetStreamResponse, error) {
+func (client *RequestBodyClient) OctetStream(ctx context.Context, value io.ReadSeekCloser, options *RequestBodyClientOctetStreamOptions) (RequestBodyClientOctetStreamResponse, error) {
 	var err error
 	const operationName = "RequestBodyClient.OctetStream"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -186,14 +187,14 @@ func (client *RequestBodyClient) OctetStream(ctx context.Context, value []byte, 
 }
 
 // octetStreamCreateRequest creates the OctetStream request.
-func (client *RequestBodyClient) octetStreamCreateRequest(ctx context.Context, value []byte, options *RequestBodyClientOctetStreamOptions) (*policy.Request, error) {
+func (client *RequestBodyClient) octetStreamCreateRequest(ctx context.Context, value io.ReadSeekCloser, options *RequestBodyClientOctetStreamOptions) (*policy.Request, error) {
 	urlPath := "/encode/bytes/body/request/octet-stream"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"application/octet-stream"}
-	if err := runtime.MarshalAsByteArray(req, value, runtime.Base64StdFormat); err != nil {
+	if err := req.SetBody(value, "application/octet-stream"); err != nil {
 		return nil, err
 	}
 	return req, nil

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responsebody_client.go
@@ -124,8 +124,7 @@ func (client *ResponseBodyClient) CustomContentType(ctx context.Context, options
 		err = runtime.NewResponseError(httpResp)
 		return ResponseBodyClientCustomContentTypeResponse{}, err
 	}
-	resp, err := client.customContentTypeHandleResponse(httpResp)
-	return resp, err
+	return ResponseBodyClientCustomContentTypeResponse{Body: httpResp.Body}, nil
 }
 
 // customContentTypeCreateRequest creates the CustomContentType request.
@@ -135,17 +134,9 @@ func (client *ResponseBodyClient) customContentTypeCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
+	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"image/png"}
 	return req, nil
-}
-
-// customContentTypeHandleResponse handles the CustomContentType response.
-func (client *ResponseBodyClient) customContentTypeHandleResponse(resp *http.Response) (ResponseBodyClientCustomContentTypeResponse, error) {
-	result := ResponseBodyClientCustomContentTypeResponse{}
-	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ResponseBodyClientCustomContentTypeResponse{}, err
-	}
-	return result, nil
 }
 
 // - options - ResponseBodyClientDefaultOptions contains the optional parameters for the ResponseBodyClient.Default method.
@@ -211,8 +202,7 @@ func (client *ResponseBodyClient) OctetStream(ctx context.Context, options *Resp
 		err = runtime.NewResponseError(httpResp)
 		return ResponseBodyClientOctetStreamResponse{}, err
 	}
-	resp, err := client.octetStreamHandleResponse(httpResp)
-	return resp, err
+	return ResponseBodyClientOctetStreamResponse{Body: httpResp.Body}, nil
 }
 
 // octetStreamCreateRequest creates the OctetStream request.
@@ -222,15 +212,7 @@ func (client *ResponseBodyClient) octetStreamCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
+	runtime.SkipBodyDownload(req)
 	req.Raw().Header["Accept"] = []string{"application/octet-stream"}
 	return req, nil
-}
-
-// octetStreamHandleResponse handles the OctetStream response.
-func (client *ResponseBodyClient) octetStreamHandleResponse(resp *http.Response) (ResponseBodyClientOctetStreamResponse, error) {
-	result := ResponseBodyClientOctetStreamResponse{}
-	if err := runtime.UnmarshalAsByteArray(resp, &result.Value, runtime.Base64StdFormat); err != nil {
-		return ResponseBodyClientOctetStreamResponse{}, err
-	}
-	return result, nil
 }

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_responses.go
@@ -4,6 +4,8 @@
 
 package bytesgroup
 
+import "io"
+
 // HeaderClientBase64Response contains the response from method HeaderClient.Base64.
 type HeaderClientBase64Response struct {
 	// placeholder for future response values
@@ -101,7 +103,8 @@ type ResponseBodyClientBase64URLResponse struct {
 
 // ResponseBodyClientCustomContentTypeResponse contains the response from method ResponseBodyClient.CustomContentType.
 type ResponseBodyClientCustomContentTypeResponse struct {
-	Value []byte
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }
 
 // ResponseBodyClientDefaultResponse contains the response from method ResponseBodyClient.Default.
@@ -111,5 +114,6 @@ type ResponseBodyClientDefaultResponse struct {
 
 // ResponseBodyClientOctetStreamResponse contains the response from method ResponseBodyClient.OctetStream.
 type ResponseBodyClientOctetStreamResponse struct {
-	Value []byte
+	// Body contains the streaming response.
+	Body io.ReadCloser
 }

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/custom_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/custom_client.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package mediatypegroup
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewMediaTypeClient(options *azcore.ClientOptions) (*MediaTypeClient, error) {
+	internal, err := azcore.NewClient("mediatypegroup", "v0.1.0", runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &MediaTypeClient{
+		internal: internal,
+	}, nil
+}

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/fake/zz_stringbody_server.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/fake/zz_stringbody_server.go
@@ -109,7 +109,7 @@ func (s *StringBodyServerTransport) dispatchGetAsText(req *http.Request) (*http.
 	if !contains([]int{http.StatusOK}, respContent.HTTPStatus) {
 		return nil, &nonRetriableError{fmt.Errorf("unexpected status code %d. acceptable values are http.StatusOK", respContent.HTTPStatus)}
 	}
-	resp, err := server.MarshalResponseAsJSON(respContent, server.GetResponse(respr).Value, req)
+	resp, err := server.MarshalResponseAsText(respContent, server.GetResponse(respr).Value, req)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (s *StringBodyServerTransport) dispatchSendAsText(req *http.Request) (*http
 	if s.srv.SendAsText == nil {
 		return nil, &nonRetriableError{errors.New("fake for method SendAsText not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[string](req)
+	body, err := server.UnmarshalRequestAsText(req)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/go.mod
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/go.mod
@@ -2,10 +2,16 @@ module mediatypegroup
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/go.sum
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/go.sum
@@ -3,10 +3,16 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.10.0/go.mod h1:HDcZnuGbiyppErN6l
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=
 golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/stringbody_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/stringbody_client_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package mediatypegroup_test
+
+import (
+	"context"
+	"mediatypegroup"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringBodyClient_GetAsJSON(t *testing.T) {
+	client, err := mediatypegroup.NewMediaTypeClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewStringBodyClient().GetAsJSON(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Value)
+	require.Equal(t, "foo", *resp.Value)
+}
+
+func TestStringBodyClient_GetAsText(t *testing.T) {
+	client, err := mediatypegroup.NewMediaTypeClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewStringBodyClient().GetAsText(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Value)
+	require.Equal(t, "{cat}", *resp.Value)
+}
+
+func TestStringBodyClient_SendAsJSON(t *testing.T) {
+	client, err := mediatypegroup.NewMediaTypeClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewStringBodyClient().SendAsJSON(context.Background(), "foo", nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestStringBodyClient_SendAsText(t *testing.T) {
+	client, err := mediatypegroup.NewMediaTypeClient(nil)
+	require.NoError(t, err)
+	resp, err := client.NewStringBodyClient().SendAsText(context.Background(), "{cat}", nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/fake/zz_formdata_server.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/fake/zz_formdata_server.go
@@ -11,6 +11,7 @@ import (
 	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"io"
 	"multipartgroup"
 	"net/http"
 )
@@ -19,31 +20,31 @@ import (
 type FormDataServer struct {
 	// Basic is the fake for method FormDataClient.Basic
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Basic func(ctx context.Context, body multipartgroup.MultiPartRequest, options *multipartgroup.FormDataClientBasicOptions) (resp azfake.Responder[multipartgroup.FormDataClientBasicResponse], errResp azfake.ErrorResponder)
+	Basic func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientBasicOptions) (resp azfake.Responder[multipartgroup.FormDataClientBasicResponse], errResp azfake.ErrorResponder)
 
 	// BinaryArrayParts is the fake for method FormDataClient.BinaryArrayParts
 	// HTTP status codes to indicate success: http.StatusNoContent
-	BinaryArrayParts func(ctx context.Context, body multipartgroup.BinaryArrayPartsRequest, options *multipartgroup.FormDataClientBinaryArrayPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientBinaryArrayPartsResponse], errResp azfake.ErrorResponder)
+	BinaryArrayParts func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientBinaryArrayPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientBinaryArrayPartsResponse], errResp azfake.ErrorResponder)
 
 	// CheckFileNameAndContentType is the fake for method FormDataClient.CheckFileNameAndContentType
 	// HTTP status codes to indicate success: http.StatusNoContent
-	CheckFileNameAndContentType func(ctx context.Context, body multipartgroup.MultiPartRequest, options *multipartgroup.FormDataClientCheckFileNameAndContentTypeOptions) (resp azfake.Responder[multipartgroup.FormDataClientCheckFileNameAndContentTypeResponse], errResp azfake.ErrorResponder)
+	CheckFileNameAndContentType func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientCheckFileNameAndContentTypeOptions) (resp azfake.Responder[multipartgroup.FormDataClientCheckFileNameAndContentTypeResponse], errResp azfake.ErrorResponder)
 
 	// Complex is the fake for method FormDataClient.Complex
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Complex func(ctx context.Context, body multipartgroup.ComplexPartsRequest, options *multipartgroup.FormDataClientComplexOptions) (resp azfake.Responder[multipartgroup.FormDataClientComplexResponse], errResp azfake.ErrorResponder)
+	Complex func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientComplexOptions) (resp azfake.Responder[multipartgroup.FormDataClientComplexResponse], errResp azfake.ErrorResponder)
 
 	// JSONArrayParts is the fake for method FormDataClient.JSONArrayParts
 	// HTTP status codes to indicate success: http.StatusNoContent
-	JSONArrayParts func(ctx context.Context, body multipartgroup.JSONArrayPartsRequest, options *multipartgroup.FormDataClientJSONArrayPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientJSONArrayPartsResponse], errResp azfake.ErrorResponder)
+	JSONArrayParts func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientJSONArrayPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientJSONArrayPartsResponse], errResp azfake.ErrorResponder)
 
 	// JSONPart is the fake for method FormDataClient.JSONPart
 	// HTTP status codes to indicate success: http.StatusNoContent
-	JSONPart func(ctx context.Context, body multipartgroup.JSONPartRequest, options *multipartgroup.FormDataClientJSONPartOptions) (resp azfake.Responder[multipartgroup.FormDataClientJSONPartResponse], errResp azfake.ErrorResponder)
+	JSONPart func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientJSONPartOptions) (resp azfake.Responder[multipartgroup.FormDataClientJSONPartResponse], errResp azfake.ErrorResponder)
 
 	// MultiBinaryParts is the fake for method FormDataClient.MultiBinaryParts
 	// HTTP status codes to indicate success: http.StatusNoContent
-	MultiBinaryParts func(ctx context.Context, body multipartgroup.MultiBinaryPartsRequest, options *multipartgroup.FormDataClientMultiBinaryPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientMultiBinaryPartsResponse], errResp azfake.ErrorResponder)
+	MultiBinaryParts func(ctx context.Context, body io.ReadSeekCloser, options *multipartgroup.FormDataClientMultiBinaryPartsOptions) (resp azfake.Responder[multipartgroup.FormDataClientMultiBinaryPartsResponse], errResp azfake.ErrorResponder)
 }
 
 // NewFormDataServerTransport creates a new instance of FormDataServerTransport with the provided implementation.
@@ -100,11 +101,7 @@ func (f *FormDataServerTransport) dispatchBasic(req *http.Request) (*http.Respon
 	if f.srv.Basic == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Basic not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.MultiPartRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.Basic(req.Context(), body, nil)
+	respr, errRespr := f.srv.Basic(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -123,11 +120,7 @@ func (f *FormDataServerTransport) dispatchBinaryArrayParts(req *http.Request) (*
 	if f.srv.BinaryArrayParts == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BinaryArrayParts not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.BinaryArrayPartsRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.BinaryArrayParts(req.Context(), body, nil)
+	respr, errRespr := f.srv.BinaryArrayParts(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -146,11 +139,7 @@ func (f *FormDataServerTransport) dispatchCheckFileNameAndContentType(req *http.
 	if f.srv.CheckFileNameAndContentType == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CheckFileNameAndContentType not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.MultiPartRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.CheckFileNameAndContentType(req.Context(), body, nil)
+	respr, errRespr := f.srv.CheckFileNameAndContentType(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -169,11 +158,7 @@ func (f *FormDataServerTransport) dispatchComplex(req *http.Request) (*http.Resp
 	if f.srv.Complex == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Complex not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.ComplexPartsRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.Complex(req.Context(), body, nil)
+	respr, errRespr := f.srv.Complex(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -192,11 +177,7 @@ func (f *FormDataServerTransport) dispatchJSONArrayParts(req *http.Request) (*ht
 	if f.srv.JSONArrayParts == nil {
 		return nil, &nonRetriableError{errors.New("fake for method JSONArrayParts not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.JSONArrayPartsRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.JSONArrayParts(req.Context(), body, nil)
+	respr, errRespr := f.srv.JSONArrayParts(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -215,11 +196,7 @@ func (f *FormDataServerTransport) dispatchJSONPart(req *http.Request) (*http.Res
 	if f.srv.JSONPart == nil {
 		return nil, &nonRetriableError{errors.New("fake for method JSONPart not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.JSONPartRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.JSONPart(req.Context(), body, nil)
+	respr, errRespr := f.srv.JSONPart(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -238,11 +215,7 @@ func (f *FormDataServerTransport) dispatchMultiBinaryParts(req *http.Request) (*
 	if f.srv.MultiBinaryParts == nil {
 		return nil, &nonRetriableError{errors.New("fake for method MultiBinaryParts not implemented")}
 	}
-	body, err := server.UnmarshalRequestAsJSON[multipartgroup.MultiBinaryPartsRequest](req)
-	if err != nil {
-		return nil, err
-	}
-	respr, errRespr := f.srv.MultiBinaryParts(req.Context(), body, nil)
+	respr, errRespr := f.srv.MultiBinaryParts(req.Context(), req.Body.(io.ReadSeekCloser), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_formdata_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_formdata_client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"io"
 	"net/http"
 )
 
@@ -20,7 +21,7 @@ type FormDataClient struct {
 
 // Basic - Test content-type: multipart/form-data
 //   - options - FormDataClientBasicOptions contains the optional parameters for the FormDataClient.Basic method.
-func (client *FormDataClient) Basic(ctx context.Context, body MultiPartRequest, options *FormDataClientBasicOptions) (FormDataClientBasicResponse, error) {
+func (client *FormDataClient) Basic(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientBasicOptions) (FormDataClientBasicResponse, error) {
 	var err error
 	const operationName = "FormDataClient.Basic"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -42,14 +43,14 @@ func (client *FormDataClient) Basic(ctx context.Context, body MultiPartRequest, 
 }
 
 // basicCreateRequest creates the Basic request.
-func (client *FormDataClient) basicCreateRequest(ctx context.Context, body MultiPartRequest, options *FormDataClientBasicOptions) (*policy.Request, error) {
+func (client *FormDataClient) basicCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientBasicOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/mixed-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -58,7 +59,7 @@ func (client *FormDataClient) basicCreateRequest(ctx context.Context, body Multi
 // BinaryArrayParts - Test content-type: multipart/form-data for scenario contains multi binary parts
 //   - options - FormDataClientBinaryArrayPartsOptions contains the optional parameters for the FormDataClient.BinaryArrayParts
 //     method.
-func (client *FormDataClient) BinaryArrayParts(ctx context.Context, body BinaryArrayPartsRequest, options *FormDataClientBinaryArrayPartsOptions) (FormDataClientBinaryArrayPartsResponse, error) {
+func (client *FormDataClient) BinaryArrayParts(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientBinaryArrayPartsOptions) (FormDataClientBinaryArrayPartsResponse, error) {
 	var err error
 	const operationName = "FormDataClient.BinaryArrayParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -80,14 +81,14 @@ func (client *FormDataClient) BinaryArrayParts(ctx context.Context, body BinaryA
 }
 
 // binaryArrayPartsCreateRequest creates the BinaryArrayParts request.
-func (client *FormDataClient) binaryArrayPartsCreateRequest(ctx context.Context, body BinaryArrayPartsRequest, options *FormDataClientBinaryArrayPartsOptions) (*policy.Request, error) {
+func (client *FormDataClient) binaryArrayPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientBinaryArrayPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/binary-array-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -96,7 +97,7 @@ func (client *FormDataClient) binaryArrayPartsCreateRequest(ctx context.Context,
 // CheckFileNameAndContentType - Test content-type: multipart/form-data
 //   - options - FormDataClientCheckFileNameAndContentTypeOptions contains the optional parameters for the FormDataClient.CheckFileNameAndContentType
 //     method.
-func (client *FormDataClient) CheckFileNameAndContentType(ctx context.Context, body MultiPartRequest, options *FormDataClientCheckFileNameAndContentTypeOptions) (FormDataClientCheckFileNameAndContentTypeResponse, error) {
+func (client *FormDataClient) CheckFileNameAndContentType(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientCheckFileNameAndContentTypeOptions) (FormDataClientCheckFileNameAndContentTypeResponse, error) {
 	var err error
 	const operationName = "FormDataClient.CheckFileNameAndContentType"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -118,14 +119,14 @@ func (client *FormDataClient) CheckFileNameAndContentType(ctx context.Context, b
 }
 
 // checkFileNameAndContentTypeCreateRequest creates the CheckFileNameAndContentType request.
-func (client *FormDataClient) checkFileNameAndContentTypeCreateRequest(ctx context.Context, body MultiPartRequest, options *FormDataClientCheckFileNameAndContentTypeOptions) (*policy.Request, error) {
+func (client *FormDataClient) checkFileNameAndContentTypeCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientCheckFileNameAndContentTypeOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/check-filename-and-content-type"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -133,7 +134,7 @@ func (client *FormDataClient) checkFileNameAndContentTypeCreateRequest(ctx conte
 
 // Complex - Test content-type: multipart/form-data for mixed scenarios
 //   - options - FormDataClientComplexOptions contains the optional parameters for the FormDataClient.Complex method.
-func (client *FormDataClient) Complex(ctx context.Context, body ComplexPartsRequest, options *FormDataClientComplexOptions) (FormDataClientComplexResponse, error) {
+func (client *FormDataClient) Complex(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientComplexOptions) (FormDataClientComplexResponse, error) {
 	var err error
 	const operationName = "FormDataClient.Complex"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -155,14 +156,14 @@ func (client *FormDataClient) Complex(ctx context.Context, body ComplexPartsRequ
 }
 
 // complexCreateRequest creates the Complex request.
-func (client *FormDataClient) complexCreateRequest(ctx context.Context, body ComplexPartsRequest, options *FormDataClientComplexOptions) (*policy.Request, error) {
+func (client *FormDataClient) complexCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientComplexOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/complex-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -170,7 +171,7 @@ func (client *FormDataClient) complexCreateRequest(ctx context.Context, body Com
 
 // JSONArrayParts - Test content-type: multipart/form-data for scenario contains multi json parts
 //   - options - FormDataClientJSONArrayPartsOptions contains the optional parameters for the FormDataClient.JSONArrayParts method.
-func (client *FormDataClient) JSONArrayParts(ctx context.Context, body JSONArrayPartsRequest, options *FormDataClientJSONArrayPartsOptions) (FormDataClientJSONArrayPartsResponse, error) {
+func (client *FormDataClient) JSONArrayParts(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientJSONArrayPartsOptions) (FormDataClientJSONArrayPartsResponse, error) {
 	var err error
 	const operationName = "FormDataClient.JSONArrayParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -192,14 +193,14 @@ func (client *FormDataClient) JSONArrayParts(ctx context.Context, body JSONArray
 }
 
 // jsonArrayPartsCreateRequest creates the JSONArrayParts request.
-func (client *FormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, body JSONArrayPartsRequest, options *FormDataClientJSONArrayPartsOptions) (*policy.Request, error) {
+func (client *FormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientJSONArrayPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/json-array-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -207,7 +208,7 @@ func (client *FormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, b
 
 // JSONPart - Test content-type: multipart/form-data for scenario contains json part and binary part
 //   - options - FormDataClientJSONPartOptions contains the optional parameters for the FormDataClient.JSONPart method.
-func (client *FormDataClient) JSONPart(ctx context.Context, body JSONPartRequest, options *FormDataClientJSONPartOptions) (FormDataClientJSONPartResponse, error) {
+func (client *FormDataClient) JSONPart(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientJSONPartOptions) (FormDataClientJSONPartResponse, error) {
 	var err error
 	const operationName = "FormDataClient.JSONPart"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -229,14 +230,14 @@ func (client *FormDataClient) JSONPart(ctx context.Context, body JSONPartRequest
 }
 
 // jsonPartCreateRequest creates the JSONPart request.
-func (client *FormDataClient) jsonPartCreateRequest(ctx context.Context, body JSONPartRequest, options *FormDataClientJSONPartOptions) (*policy.Request, error) {
+func (client *FormDataClient) jsonPartCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientJSONPartOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/json-part"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -245,7 +246,7 @@ func (client *FormDataClient) jsonPartCreateRequest(ctx context.Context, body JS
 // MultiBinaryParts - Test content-type: multipart/form-data for scenario contains multi binary parts
 //   - options - FormDataClientMultiBinaryPartsOptions contains the optional parameters for the FormDataClient.MultiBinaryParts
 //     method.
-func (client *FormDataClient) MultiBinaryParts(ctx context.Context, body MultiBinaryPartsRequest, options *FormDataClientMultiBinaryPartsOptions) (FormDataClientMultiBinaryPartsResponse, error) {
+func (client *FormDataClient) MultiBinaryParts(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientMultiBinaryPartsOptions) (FormDataClientMultiBinaryPartsResponse, error) {
 	var err error
 	const operationName = "FormDataClient.MultiBinaryParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -267,14 +268,14 @@ func (client *FormDataClient) MultiBinaryParts(ctx context.Context, body MultiBi
 }
 
 // multiBinaryPartsCreateRequest creates the MultiBinaryParts request.
-func (client *FormDataClient) multiBinaryPartsCreateRequest(ctx context.Context, body MultiBinaryPartsRequest, options *FormDataClientMultiBinaryPartsOptions) (*policy.Request, error) {
+func (client *FormDataClient) multiBinaryPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *FormDataClientMultiBinaryPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/multi-binary-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := runtime.MarshalAsJSON(req, body); err != nil {
+	if err := req.SetBody(body, "multipart/form-data"); err != nil {
 		return nil, err
 	}
 	return req, nil


### PR DESCRIPTION
This removes some hard-coded JSON content types for parameters and responses and includes support for streaming bodies/responses. The changes to multipart/form will be cleaned up separately.