### PR TITLE
Remove working directory when publishing cadl-ranch results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -384,3 +384,5 @@ package-deps.json
 
 tempoutput
 junit.xml
+
+cadl-ranch-coverage.json

--- a/eng/pipelines/cadl-ranch-typespec.yml
+++ b/eng/pipelines/cadl-ranch-typespec.yml
@@ -23,4 +23,3 @@ steps:
       scriptType: "bash"
       scriptLocation: "inlineScript"
       inlineScript: $(cadl-ranch) upload-coverage --generatorName go --storageAccountName azuresdkcadlranch --generatorVersion $(node -p -e "require('$(System.DefaultWorkingDirectory)/packages/typespec-go/package.json').version") --generatorMode azure
-      workingDirectory: $(System.DefaultWorkingDirectory)/packages/typespec-go/node_modules/@azure-tools/cadl-ranch-specs


### PR DESCRIPTION
The rush script defaults to the repo root, so the results file will be written there.