### PR TITLE
Add support for multipart/form data in tsp

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -129,6 +129,12 @@
       "longName": "--stop",
       "description": "Stops the cadl-ranch test server",
       "associatedCommands": ["cadl-ranch"]
+    },
+    {
+      "parameterKind": "flag",
+      "longName": "--serve",
+      "description": "Starts the cadl-ranch test server with output",
+      "associatedCommands": ["cadl-ranch"]
     }
   ]
 }

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -81,7 +81,7 @@ export function adaptModel(obj: m4.ObjectSchema): go.ModelType | go.PolymorphicT
     return <go.ModelType | go.PolymorphicType>modelType;
   }
 
-  const annotations = new go.ModelAnnotations(obj.language.go!.omitSerDeMethods);
+  const annotations = new go.ModelAnnotations(obj.language.go!.omitSerDeMethods, false);
   if (obj.discriminator || obj.discriminatorValue) {
     let ifaceName: string | undefined;
     if (obj.language.go!.discriminatorInterface) {

--- a/packages/autorest.go/test/autorest/formdatagroup/fake/zz_formdata_server.go
+++ b/packages/autorest.go/test/autorest/formdatagroup/fake/zz_formdata_server.go
@@ -92,7 +92,7 @@ func (f *FormdataServerTransport) dispatchUploadFile(req *http.Request) (*http.R
 	for {
 		var part *multipart.Part
 		part, err = reader.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, err
@@ -168,7 +168,7 @@ func (f *FormdataServerTransport) dispatchUploadFiles(req *http.Request) (*http.
 	for {
 		var part *multipart.Part
 		part, err = reader.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, err

--- a/packages/autorest.go/test/maps/azalias/fake/zz_server.go
+++ b/packages/autorest.go/test/maps/azalias/fake/zz_server.go
@@ -628,7 +628,7 @@ func (s *ServerTransport) dispatchUploadForm(req *http.Request) (*http.Response,
 	for {
 		var part *multipart.Part
 		part, err = reader.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return nil, err

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -467,7 +467,7 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
       let assignedValue: string | undefined;
       if (go.isModelType(helpers.recursiveUnwrapMapSlice(type))) {
         imports.add('encoding/json');
-        caseContent += `\t\t\tif err := json.Unmarshal(content, &${paramVar}); err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n`;
+        caseContent += `\t\t\tif err = json.Unmarshal(content, &${paramVar}); err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n`;
       } else if (go.isQualifiedType(type) && type.typeName === 'ReadSeekCloser') {
         imports.add('bytes');
         imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');

--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -406,16 +406,17 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
     for (const param of values(method.parameters)) {
       if (go.isMultipartFormBodyParameter(param)) {
         let pkgPrefix = '';
-        if (go.isConstantType(param.type)) {
+        if (go.isConstantType(param.type) || go.isModelType(param.type)) {
           pkgPrefix = clientPkg + '.';
         }
         content += `\tvar ${param.name} ${pkgPrefix}${go.getTypeDeclaration(param.type)}\n`;
       }
     }
+
     content += '\tfor {\n';
     content += '\t\tvar part *multipart.Part\n';
     content += '\t\tpart, err = reader.NextPart()\n';
-    content += '\t\tif err == io.EOF {\n\t\t\tbreak\n';
+    content += '\t\tif errors.Is(err, io.EOF) {\n\t\t\tbreak\n';
     content += '\t\t} else if err != nil {\n\t\t\treturn nil, err\n\t\t}\n';
     content += '\t\tvar content []byte\n';
     content += '\t\tswitch fn := part.FormName(); fn {\n';
@@ -454,12 +455,20 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
       return parsingCode;
     };
 
+    const isMultipartContentType = function(type: go.PossibleType): type is go.QualifiedType {
+      type = helpers.recursiveUnwrapMapSlice(type);
+      return (go.isQualifiedType(type) && type.typeName === 'MultipartContent');
+    };
+
     const emitCase = function(caseValue: string, paramVar: string, type: go.PossibleType): string {
       let caseContent = `\t\tcase "${caseValue}":\n`;
       caseContent += '\t\t\tcontent, err = io.ReadAll(part)\n';
       caseContent += '\t\t\tif err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n';
       let assignedValue: string | undefined;
-      if (go.isQualifiedType(type) && type.typeName === 'ReadSeekCloser') {
+      if (go.isModelType(helpers.recursiveUnwrapMapSlice(type))) {
+        imports.add('encoding/json');
+        caseContent += `\t\t\tif err := json.Unmarshal(content, &${paramVar}); err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n`;
+      } else if (go.isQualifiedType(type) && type.typeName === 'ReadSeekCloser') {
         imports.add('bytes');
         imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
         assignedValue = 'streaming.NopCloser(bytes.NewReader(content))';
@@ -501,6 +510,23 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
           default:
             throw new Error(`unhandled multipart parameter primitive type ${type.typeName}`);
         }
+      } else if (isMultipartContentType(type)) {
+        imports.add('bytes');
+        imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming');
+        const bodyContent = 'streaming.NopCloser(bytes.NewReader(content))';
+        const contentType = 'part.Header.Get("Content-Type")';
+        const filename = 'part.FileName()';
+        if (go.isSliceType(type)) {
+          caseContent += `\t\t\t${paramVar} = append(${paramVar}, streaming.MultipartContent{\n`;
+          caseContent += `\t\t\t\tBody: ${bodyContent},\n`;
+          caseContent += `\t\t\t\tContentType: ${contentType},\n`;
+          caseContent += `\t\t\t\tFilename: ${filename},\n`;
+          caseContent += '\t\t\t})\n';
+        } else {
+          caseContent += `\t\t\t${paramVar}.Body = ${bodyContent}\n`;
+          caseContent += `\t\t\t${paramVar}.ContentType = ${contentType}\n`;
+          caseContent += `\t\t\t${paramVar}.Filename = ${filename}\n`;
+        }
       } else if (go.isSliceType(type)) {
         if (go.isQualifiedType(type.elementType) && type.elementType.typeName === 'ReadSeekCloser') {
           imports.add('bytes');
@@ -520,7 +546,13 @@ function dispatchForOperationBody(clientPkg: string, receiverName: string, metho
 
     for (const param of values(method.parameters)) {
       if (go.isMultipartFormBodyParameter(param)) {
-        content += emitCase(param.name, param.name, param.type);
+        if (go.isModelType(param.type)) {
+          for (const field of param.type.fields) {
+            content += emitCase(field.serializedName, `${param.name}.${field.name}`, field.type);
+          }
+        } else {
+          content += emitCase(param.name, param.name, param.type);
+        }
       }
     }
 

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -575,3 +575,14 @@ export function getBitSizeForNumber(intSize: 'float32' | 'float64' | 'int8' | 'i
       return '64';
   }
 }
+
+// returns the underlying map/slice element/value type
+// if item isn't a map or slice, item is returned
+export function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType {
+  if (go.isMapType(item)) {
+    return recursiveUnwrapMapSlice(item.valueType);
+  } else if (go.isSliceType(item)) {
+    return recursiveUnwrapMapSlice(item.elementType);
+  }
+  return item;
+}

--- a/packages/codegen.go/src/polymorphics.ts
+++ b/packages/codegen.go/src/polymorphics.ts
@@ -5,7 +5,7 @@
 
 import * as go from '../../codemodel.go/src/gocodemodel.js';
 import { values } from '@azure-tools/linq';
-import { contentPreamble, formatLiteralValue, getParentImport } from './helpers.js';
+import { contentPreamble, formatLiteralValue, getParentImport, recursiveUnwrapMapSlice } from './helpers.js';
 import { ImportManager } from './imports.js';
 
 // Creates the content in polymorphic_helpers.go
@@ -176,13 +176,4 @@ export async function generatePolymorphicHelpers(codeModel: go.CodeModel, fakeSe
     }
   }
   return text;
-}
-
-function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType {
-  if (go.isMapType(item)) {
-    return recursiveUnwrapMapSlice(item.valueType);
-  } else if (go.isSliceType(item)) {
-    return recursiveUnwrapMapSlice(item.elementType);
-  }
-  return item;
 }

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -127,6 +127,9 @@ export interface ModelType extends StructType {
 
 export interface ModelAnnotations {
   omitSerDeMethods: boolean;
+
+  // indicates the model should be converted into multipart/form data
+  multipartFormData: boolean;
 }
 
 // UsageFlags are bit flags indicating how a model/polymorphic type is used
@@ -1208,8 +1211,9 @@ export class ModelType implements ModelType {
 }
 
 export class ModelAnnotations implements ModelAnnotations {
-  constructor(omitSerDe: boolean) {
+  constructor(omitSerDe: boolean, multipartForm: boolean) {
     this.omitSerDeMethods = omitSerDe;
+    this.multipartFormData = multipartForm;
   }
 }
 

--- a/packages/typespec-go/.scripts/cadl-ranch.js
+++ b/packages/typespec-go/.scripts/cadl-ranch.js
@@ -5,7 +5,14 @@ import { execSync } from 'child_process';
 const toolsModRoot = execSync('git rev-parse --show-toplevel').toString().trim() + '/packages/typespec-go/node_modules/@azure-tools/';
 
 const switches = [];
+let execSyncOptions;
+
 switch (process.argv[2]) {
+  case '--serve':
+    switches.push('serve');
+    switches.push(toolsModRoot + 'cadl-ranch-specs/http');
+    execSyncOptions = {stdio: 'inherit'};
+    break;
   case '--start':
     switches.push('server');
     switches.push('start');
@@ -23,4 +30,4 @@ if (switches.length === 0) {
 
 const cmdLine = toolsModRoot + 'cadl-ranch/node_modules/.bin/cadl-ranch ' + switches.join(' ');
 console.log(cmdLine);
-execSync(cmdLine);
+execSync(cmdLine, execSyncOptions);

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -44,7 +44,7 @@ const cadlRanch = {
   'contentneggroup': ['payload/content-negotiation'],
   'jmergepatchgroup': ['payload/json-merge-patch'],
   'mediatypegroup': ['payload/media-type'],
-  'multipartgroup': ['payload/multipart'],  // missing tests
+  'multipartgroup': ['payload/multipart'],
   'pageablegroup': ['payload/pageable'],
   'projectednamegroup': ['projection/projected-name'],
   'srvdrivengroup': ['resiliency/srv-driven'], // missing tests

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/fake/zz_multipartformdata_server.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/fake/zz_multipartformdata_server.go
@@ -288,7 +288,7 @@ func (m *MultiPartFormDataServerTransport) dispatchComplex(req *http.Request) (*
 			if err != nil {
 				return nil, err
 			}
-			if err := json.Unmarshal(content, &body.Address); err != nil {
+			if err = json.Unmarshal(content, &body.Address); err != nil {
 				return nil, err
 			}
 		case "id":
@@ -312,7 +312,7 @@ func (m *MultiPartFormDataServerTransport) dispatchComplex(req *http.Request) (*
 			if err != nil {
 				return nil, err
 			}
-			if err := json.Unmarshal(content, &body.PreviousAddresses); err != nil {
+			if err = json.Unmarshal(content, &body.PreviousAddresses); err != nil {
 				return nil, err
 			}
 		case "profileImage":
@@ -367,7 +367,7 @@ func (m *MultiPartFormDataServerTransport) dispatchJSONArrayParts(req *http.Requ
 			if err != nil {
 				return nil, err
 			}
-			if err := json.Unmarshal(content, &body.PreviousAddresses); err != nil {
+			if err = json.Unmarshal(content, &body.PreviousAddresses); err != nil {
 				return nil, err
 			}
 		case "profileImage":
@@ -422,7 +422,7 @@ func (m *MultiPartFormDataServerTransport) dispatchJSONPart(req *http.Request) (
 			if err != nil {
 				return nil, err
 			}
-			if err := json.Unmarshal(content, &body.Address); err != nil {
+			if err = json.Unmarshal(content, &body.Address); err != nil {
 				return nil, err
 			}
 		case "profileImage":

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/fakes_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/fakes_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package multipartgroup_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"multipartgroup"
+	"multipartgroup/fake"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azfake "github.com/Azure/azure-sdk-for-go/sdk/azcore/fake"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeFormDataClientBasic(t *testing.T) {
+	id := "12345"
+	bodyContent := []byte{1, 2, 3, 4, 5}
+	contentType := "binary"
+	filename := "data.bin"
+	server := fake.MultiPartFormDataServer{
+		Basic: func(ctx context.Context, body multipartgroup.MultiPartRequest, options *multipartgroup.MultiPartFormDataClientBasicOptions) (resp azfake.Responder[multipartgroup.MultiPartFormDataClientBasicResponse], errResp azfake.ErrorResponder) {
+			require.Equal(t, id, body.ID)
+			b, err := io.ReadAll(body.ProfileImage.Body)
+			require.NoError(t, err)
+			require.Equal(t, bodyContent, b)
+			require.Equal(t, contentType, body.ProfileImage.ContentType)
+			require.Equal(t, filename, body.ProfileImage.Filename)
+			resp.SetResponse(http.StatusNoContent, multipartgroup.MultiPartFormDataClientBasicResponse{}, nil)
+			return
+		},
+	}
+	client, err := multipartgroup.NewMultiPartClient(&azcore.ClientOptions{
+		Transport: fake.NewMultiPartFormDataServerTransport(&server),
+	})
+	require.NoError(t, err)
+	_, err = client.NewMultiPartFormDataClient().Basic(context.Background(), multipartgroup.MultiPartRequest{
+		ID: id,
+		ProfileImage: streaming.MultipartContent{
+			Body:        streaming.NopCloser(bytes.NewReader(bodyContent)),
+			ContentType: contentType,
+			Filename:    filename,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestFakeFormDataClientBinaryArrayParts(t *testing.T) {
+	id := "abc123"
+	bodyWithDefaultsContent := []byte{1, 2, 3, 4, 5}
+	dataDotBinContent := []byte{201, 202, 203}
+	stuffContent := []byte{79, 81, 83, 85}
+	server := fake.MultiPartFormDataServer{
+		BinaryArrayParts: func(ctx context.Context, body multipartgroup.BinaryArrayPartsRequest, options *multipartgroup.MultiPartFormDataClientBinaryArrayPartsOptions) (resp azfake.Responder[multipartgroup.MultiPartFormDataClientBinaryArrayPartsResponse], errResp azfake.ErrorResponder) {
+			require.Equal(t, id, body.ID)
+			require.Len(t, body.Pictures, 3)
+			// entries should be in the same order
+			entries := []struct {
+				Body        []byte
+				ContentType string
+				Filename    string
+			}{
+				{
+					Body:        bodyWithDefaultsContent,
+					ContentType: "application/octet-stream",
+					Filename:    "pictures",
+				},
+				{
+					Body:        dataDotBinContent,
+					ContentType: "binary",
+					Filename:    "data.bin",
+				},
+				{
+					Body:        stuffContent,
+					ContentType: "bits",
+					Filename:    "stuff",
+				},
+			}
+			for i, entry := range entries {
+				b, err := io.ReadAll(body.Pictures[i].Body)
+				require.NoError(t, err)
+				require.Equal(t, entry.Body, b)
+				require.EqualValues(t, entry.ContentType, body.Pictures[i].ContentType)
+				require.EqualValues(t, entry.Filename, body.Pictures[i].Filename)
+			}
+			resp.SetResponse(http.StatusNoContent, multipartgroup.MultiPartFormDataClientBinaryArrayPartsResponse{}, nil)
+			return
+		},
+	}
+	client, err := multipartgroup.NewMultiPartClient(&azcore.ClientOptions{
+		Transport: fake.NewMultiPartFormDataServerTransport(&server),
+	})
+	require.NoError(t, err)
+	_, err = client.NewMultiPartFormDataClient().BinaryArrayParts(context.Background(), multipartgroup.BinaryArrayPartsRequest{
+		ID: id,
+		Pictures: []streaming.MultipartContent{
+			{
+				Body: streaming.NopCloser(bytes.NewReader(bodyWithDefaultsContent)),
+			},
+			{
+				Body:        streaming.NopCloser(bytes.NewReader(dataDotBinContent)),
+				ContentType: "binary",
+				Filename:    "data.bin",
+			},
+			{
+				Body:        streaming.NopCloser(bytes.NewReader(stuffContent)),
+				ContentType: "bits",
+				Filename:    "stuff",
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestFakeFormDataClientJSONPart(t *testing.T) {
+	city := "Someplace"
+	bodyContent := []byte{1, 2, 3, 4, 5}
+	contentType := "binary"
+	filename := "data.bin"
+	server := fake.MultiPartFormDataServer{
+		JSONPart: func(ctx context.Context, body multipartgroup.JSONPartRequest, options *multipartgroup.MultiPartFormDataClientJSONPartOptions) (resp azfake.Responder[multipartgroup.MultiPartFormDataClientJSONPartResponse], errResp azfake.ErrorResponder) {
+			require.NotNil(t, body.Address.City)
+			require.Equal(t, city, *body.Address.City)
+			b, err := io.ReadAll(body.ProfileImage.Body)
+			require.NoError(t, err)
+			require.Equal(t, bodyContent, b)
+			require.Equal(t, contentType, body.ProfileImage.ContentType)
+			require.Equal(t, filename, body.ProfileImage.Filename)
+			resp.SetResponse(http.StatusNoContent, multipartgroup.MultiPartFormDataClientJSONPartResponse{}, nil)
+			return
+		},
+	}
+	client, err := multipartgroup.NewMultiPartClient(&azcore.ClientOptions{
+		Transport: fake.NewMultiPartFormDataServerTransport(&server),
+	})
+	require.NoError(t, err)
+	_, err = client.NewMultiPartFormDataClient().JSONPart(context.Background(), multipartgroup.JSONPartRequest{
+		Address: multipartgroup.Address{
+			City: &city,
+		},
+		ProfileImage: streaming.MultipartContent{
+			Body:        streaming.NopCloser(bytes.NewReader(bodyContent)),
+			ContentType: contentType,
+			Filename:    filename,
+		},
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestFakeFormDataClientJSONArrayParts(t *testing.T) {
+	previous := []multipartgroup.Address{
+		{
+			City: to.Ptr("City1"),
+		},
+		{
+			City: to.Ptr("CitwTwo"),
+		},
+	}
+	bodyContent := []byte{1, 2, 3, 4, 5}
+	contentType := "binary"
+	filename := "data.bin"
+	server := fake.MultiPartFormDataServer{
+		JSONArrayParts: func(ctx context.Context, body multipartgroup.JSONArrayPartsRequest, options *multipartgroup.MultiPartFormDataClientJSONArrayPartsOptions) (resp azfake.Responder[multipartgroup.MultiPartFormDataClientJSONArrayPartsResponse], errResp azfake.ErrorResponder) {
+			require.EqualValues(t, previous, body.PreviousAddresses)
+			b, err := io.ReadAll(body.ProfileImage.Body)
+			require.NoError(t, err)
+			require.Equal(t, bodyContent, b)
+			require.Equal(t, contentType, body.ProfileImage.ContentType)
+			require.Equal(t, filename, body.ProfileImage.Filename)
+			resp.SetResponse(http.StatusNoContent, multipartgroup.MultiPartFormDataClientJSONArrayPartsResponse{}, nil)
+			return
+		},
+	}
+	client, err := multipartgroup.NewMultiPartClient(&azcore.ClientOptions{
+		Transport: fake.NewMultiPartFormDataServerTransport(&server),
+	})
+	require.NoError(t, err)
+	_, err = client.NewMultiPartFormDataClient().JSONArrayParts(context.Background(), multipartgroup.JSONArrayPartsRequest{
+		PreviousAddresses: previous,
+		ProfileImage: streaming.MultipartContent{
+			Body:        streaming.NopCloser(bytes.NewReader(bodyContent)),
+			ContentType: contentType,
+			Filename:    filename,
+		},
+	}, nil)
+	require.NoError(t, err)
+}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package multipartgroup_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"multipartgroup"
+	"os"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormDataClient_Basic(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	resp, err := client.NewMultiPartFormDataClient().Basic(context.Background(), multipartgroup.MultiPartRequest{
+		ID: "123",
+		ProfileImage: streaming.MultipartContent{
+			Body: jpgFile,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_BinaryArrayParts(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	data, err := io.ReadAll(pngFile)
+	require.NoError(t, err)
+	require.NoError(t, pngFile.Close())
+	resp, err := client.NewMultiPartFormDataClient().BinaryArrayParts(context.Background(), multipartgroup.BinaryArrayPartsRequest{
+		ID: "123",
+		Pictures: []streaming.MultipartContent{
+			{
+				Body: streaming.NopCloser(bytes.NewReader(data)),
+			},
+			{
+				Body: streaming.NopCloser(bytes.NewReader(data)),
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_CheckFileNameAndContentType(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	resp, err := client.NewMultiPartFormDataClient().CheckFileNameAndContentType(context.Background(), multipartgroup.MultiPartRequest{
+		ID: "123",
+		ProfileImage: streaming.MultipartContent{
+			Body:        jpgFile,
+			ContentType: "image/jpg",
+			Filename:    "hello.jpg",
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_Complex(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	data, err := io.ReadAll(pngFile)
+	require.NoError(t, err)
+	require.NoError(t, pngFile.Close())
+	resp, err := client.NewMultiPartFormDataClient().Complex(context.Background(), multipartgroup.ComplexPartsRequest{
+		Address: multipartgroup.Address{
+			City: to.Ptr("X"),
+		},
+		ID: "123",
+		Pictures: []streaming.MultipartContent{
+			{
+				Body: streaming.NopCloser(bytes.NewReader(data)),
+			},
+			{
+				Body: streaming.NopCloser(bytes.NewReader(data)),
+			},
+		},
+		PreviousAddresses: []multipartgroup.Address{
+			{
+				City: to.Ptr("Y"),
+			},
+			{
+				City: to.Ptr("Z"),
+			},
+		},
+		ProfileImage: streaming.MultipartContent{Body: jpgFile},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_JSONArrayParts(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	resp, err := client.NewMultiPartFormDataClient().JSONArrayParts(context.Background(), multipartgroup.JSONArrayPartsRequest{
+		PreviousAddresses: []multipartgroup.Address{
+			{
+				City: to.Ptr("Y"),
+			},
+			{
+				City: to.Ptr("Z"),
+			},
+		},
+		ProfileImage: streaming.MultipartContent{
+			Body: jpgFile,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_JSONPart(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	resp, err := client.NewMultiPartFormDataClient().JSONPart(context.Background(), multipartgroup.JSONPartRequest{
+		Address: multipartgroup.Address{
+			City: to.Ptr("X"),
+		},
+		ProfileImage: streaming.MultipartContent{
+			Body: jpgFile,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}
+
+func TestFormDataClient_MultiBinaryParts(t *testing.T) {
+	client, err := multipartgroup.NewMultiPartClient(nil)
+	require.NoError(t, err)
+	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer jpgFile.Close()
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer pngFile.Close()
+	resp, err := client.NewMultiPartFormDataClient().MultiBinaryParts(context.Background(), multipartgroup.MultiBinaryPartsRequest{
+		ProfileImage: streaming.MultipartContent{
+			Body: jpgFile,
+		},
+		Picture: streaming.MultipartContent{
+			Body: pngFile,
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
@@ -6,7 +6,6 @@ package multipartgroup_test
 import (
 	"bytes"
 	"context"
-	"io"
 	"multipartgroup"
 	"os"
 	"testing"
@@ -35,19 +34,16 @@ func TestFormDataClient_Basic(t *testing.T) {
 func TestFormDataClient_BinaryArrayParts(t *testing.T) {
 	client, err := multipartgroup.NewMultiPartClient(nil)
 	require.NoError(t, err)
-	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	pngFile, err := os.ReadFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png")
 	require.NoError(t, err)
-	data, err := io.ReadAll(pngFile)
-	require.NoError(t, err)
-	require.NoError(t, pngFile.Close())
 	resp, err := client.NewMultiPartFormDataClient().BinaryArrayParts(context.Background(), multipartgroup.BinaryArrayPartsRequest{
 		ID: "123",
 		Pictures: []streaming.MultipartContent{
 			{
-				Body: streaming.NopCloser(bytes.NewReader(data)),
+				Body: streaming.NopCloser(bytes.NewReader(pngFile)),
 			},
 			{
-				Body: streaming.NopCloser(bytes.NewReader(data)),
+				Body: streaming.NopCloser(bytes.NewReader(pngFile)),
 			},
 		},
 	}, nil)
@@ -79,11 +75,8 @@ func TestFormDataClient_Complex(t *testing.T) {
 	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer jpgFile.Close()
-	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	pngFile, err := os.ReadFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png")
 	require.NoError(t, err)
-	data, err := io.ReadAll(pngFile)
-	require.NoError(t, err)
-	require.NoError(t, pngFile.Close())
 	resp, err := client.NewMultiPartFormDataClient().Complex(context.Background(), multipartgroup.ComplexPartsRequest{
 		Address: multipartgroup.Address{
 			City: to.Ptr("X"),
@@ -91,10 +84,10 @@ func TestFormDataClient_Complex(t *testing.T) {
 		ID: "123",
 		Pictures: []streaming.MultipartContent{
 			{
-				Body: streaming.NopCloser(bytes.NewReader(data)),
+				Body: streaming.NopCloser(bytes.NewReader(pngFile)),
 			},
 			{
-				Body: streaming.NopCloser(bytes.NewReader(data)),
+				Body: streaming.NopCloser(bytes.NewReader(pngFile)),
 			},
 		},
 		PreviousAddresses: []multipartgroup.Address{

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/go.mod
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/go.mod
@@ -2,10 +2,16 @@ module multipartgroup
 
 go 1.18
 
-require github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.0
+require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.22.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/go.sum
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/go.sum
@@ -3,10 +3,16 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.0/go.mod h1:a6xsAQUZg+VsS3TJ0
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
 golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/multipart_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/multipart_client.go
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package multipartgroup
+
+import (
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+)
+
+func NewMultiPartClient(options *azcore.ClientOptions) (*MultiPartClient, error) {
+	internal, err := azcore.NewClient("multipartgroup", "v0.1.0", runtime.PipelineOptions{}, options)
+	if err != nil {
+		return nil, err
+	}
+	return &MultiPartClient{
+		internal: internal,
+	}, nil
+}

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models.go
@@ -4,6 +4,8 @@
 
 package multipartgroup
 
+import "github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+
 type Address struct {
 	// REQUIRED
 	City *string
@@ -11,55 +13,55 @@ type Address struct {
 
 type BinaryArrayPartsRequest struct {
 	// REQUIRED
-	ID *string
+	ID string
 
 	// REQUIRED
-	Pictures [][]byte
+	Pictures []streaming.MultipartContent
 }
 
 type ComplexPartsRequest struct {
 	// REQUIRED
-	Address *Address
+	Address Address
 
 	// REQUIRED
-	ID *string
+	ID string
 
 	// REQUIRED
-	Pictures [][]byte
+	Pictures []streaming.MultipartContent
 
 	// REQUIRED
-	PreviousAddresses []*Address
+	PreviousAddresses []Address
 
 	// REQUIRED
-	ProfileImage []byte
+	ProfileImage streaming.MultipartContent
 }
 
 type JSONArrayPartsRequest struct {
 	// REQUIRED
-	PreviousAddresses []*Address
+	PreviousAddresses []Address
 
 	// REQUIRED
-	ProfileImage []byte
+	ProfileImage streaming.MultipartContent
 }
 
 type JSONPartRequest struct {
 	// REQUIRED
-	Address *Address
+	Address Address
 
 	// REQUIRED
-	ProfileImage []byte
+	ProfileImage streaming.MultipartContent
 }
 
 type MultiBinaryPartsRequest struct {
 	// REQUIRED
-	ProfileImage []byte
-	Picture      []byte
+	ProfileImage streaming.MultipartContent
+	Picture      streaming.MultipartContent
 }
 
 type MultiPartRequest struct {
 	// REQUIRED
-	ID *string
+	ID string
 
 	// REQUIRED
-	ProfileImage []byte
+	ProfileImage streaming.MultipartContent
 }

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models_serde.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models_serde.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"reflect"
 )
 
@@ -39,252 +38,63 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// MarshalJSON implements the json.Marshaller interface for type BinaryArrayPartsRequest.
-func (b BinaryArrayPartsRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts BinaryArrayPartsRequest to multipart/form data.
+func (b BinaryArrayPartsRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", b.ID)
-	populateByteArray(objectMap, "pictures", b.Pictures, func() any {
-		encodedValue := make([]string, len(b.Pictures))
-		for i := 0; i < len(b.Pictures); i++ {
-			encodedValue[i] = runtime.EncodeByteArray(b.Pictures[i], runtime.Base64StdFormat)
-		}
-		return encodedValue
-	})
-	return json.Marshal(objectMap)
+	objectMap["id"] = b.ID
+	objectMap["pictures"] = b.Pictures
+	return objectMap, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type BinaryArrayPartsRequest.
-func (b *BinaryArrayPartsRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", b, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &b.ID)
-			delete(rawMsg, key)
-		case "pictures":
-			var encodedValue []string
-			err = unpopulate(val, "Pictures", &encodedValue)
-			if err == nil && len(encodedValue) > 0 {
-				b.Pictures = make([][]byte, len(encodedValue))
-				for i := 0; i < len(encodedValue) && err == nil; i++ {
-					err = runtime.DecodeByteArray(encodedValue[i], &b.Pictures[i], runtime.Base64StdFormat)
-				}
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", b, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type ComplexPartsRequest.
-func (c ComplexPartsRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts ComplexPartsRequest to multipart/form data.
+func (c ComplexPartsRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "address", c.Address)
-	populate(objectMap, "id", c.ID)
-	populateByteArray(objectMap, "pictures", c.Pictures, func() any {
-		encodedValue := make([]string, len(c.Pictures))
-		for i := 0; i < len(c.Pictures); i++ {
-			encodedValue[i] = runtime.EncodeByteArray(c.Pictures[i], runtime.Base64StdFormat)
-		}
-		return encodedValue
-	})
-	populate(objectMap, "previousAddresses", c.PreviousAddresses)
-	populateByteArray(objectMap, "profileImage", c.ProfileImage, func() any {
-		return runtime.EncodeByteArray(c.ProfileImage, runtime.Base64StdFormat)
-	})
-	return json.Marshal(objectMap)
+	if err := populateMultipartJSON(objectMap, "address", c.Address); err != nil {
+		return nil, err
+	}
+	objectMap["id"] = c.ID
+	objectMap["pictures"] = c.Pictures
+	if err := populateMultipartJSON(objectMap, "previousAddresses", c.PreviousAddresses); err != nil {
+		return nil, err
+	}
+	objectMap["profileImage"] = c.ProfileImage
+	return objectMap, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type ComplexPartsRequest.
-func (c *ComplexPartsRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", c, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "address":
-			err = unpopulate(val, "Address", &c.Address)
-			delete(rawMsg, key)
-		case "id":
-			err = unpopulate(val, "ID", &c.ID)
-			delete(rawMsg, key)
-		case "pictures":
-			var encodedValue []string
-			err = unpopulate(val, "Pictures", &encodedValue)
-			if err == nil && len(encodedValue) > 0 {
-				c.Pictures = make([][]byte, len(encodedValue))
-				for i := 0; i < len(encodedValue) && err == nil; i++ {
-					err = runtime.DecodeByteArray(encodedValue[i], &c.Pictures[i], runtime.Base64StdFormat)
-				}
-			}
-			delete(rawMsg, key)
-		case "previousAddresses":
-			err = unpopulate(val, "PreviousAddresses", &c.PreviousAddresses)
-			delete(rawMsg, key)
-		case "profileImage":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &c.ProfileImage, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", c, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type JSONArrayPartsRequest.
-func (j JSONArrayPartsRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts JSONArrayPartsRequest to multipart/form data.
+func (j JSONArrayPartsRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "previousAddresses", j.PreviousAddresses)
-	populateByteArray(objectMap, "profileImage", j.ProfileImage, func() any {
-		return runtime.EncodeByteArray(j.ProfileImage, runtime.Base64StdFormat)
-	})
-	return json.Marshal(objectMap)
+	if err := populateMultipartJSON(objectMap, "previousAddresses", j.PreviousAddresses); err != nil {
+		return nil, err
+	}
+	objectMap["profileImage"] = j.ProfileImage
+	return objectMap, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type JSONArrayPartsRequest.
-func (j *JSONArrayPartsRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", j, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "previousAddresses":
-			err = unpopulate(val, "PreviousAddresses", &j.PreviousAddresses)
-			delete(rawMsg, key)
-		case "profileImage":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &j.ProfileImage, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", j, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type JSONPartRequest.
-func (j JSONPartRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts JSONPartRequest to multipart/form data.
+func (j JSONPartRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "address", j.Address)
-	populateByteArray(objectMap, "profileImage", j.ProfileImage, func() any {
-		return runtime.EncodeByteArray(j.ProfileImage, runtime.Base64StdFormat)
-	})
-	return json.Marshal(objectMap)
+	if err := populateMultipartJSON(objectMap, "address", j.Address); err != nil {
+		return nil, err
+	}
+	objectMap["profileImage"] = j.ProfileImage
+	return objectMap, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type JSONPartRequest.
-func (j *JSONPartRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", j, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "address":
-			err = unpopulate(val, "Address", &j.Address)
-			delete(rawMsg, key)
-		case "profileImage":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &j.ProfileImage, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", j, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type MultiBinaryPartsRequest.
-func (m MultiBinaryPartsRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts MultiBinaryPartsRequest to multipart/form data.
+func (m MultiBinaryPartsRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populateByteArray(objectMap, "picture", m.Picture, func() any {
-		return runtime.EncodeByteArray(m.Picture, runtime.Base64StdFormat)
-	})
-	populateByteArray(objectMap, "profileImage", m.ProfileImage, func() any {
-		return runtime.EncodeByteArray(m.ProfileImage, runtime.Base64StdFormat)
-	})
-	return json.Marshal(objectMap)
+	objectMap["picture"] = m.Picture
+	objectMap["profileImage"] = m.ProfileImage
+	return objectMap, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaller interface for type MultiBinaryPartsRequest.
-func (m *MultiBinaryPartsRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", m, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "picture":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &m.Picture, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		case "profileImage":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &m.ProfileImage, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", m, err)
-		}
-	}
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaller interface for type MultiPartRequest.
-func (m MultiPartRequest) MarshalJSON() ([]byte, error) {
+// toMultipartFormData converts MultiPartRequest to multipart/form data.
+func (m MultiPartRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	populate(objectMap, "id", m.ID)
-	populateByteArray(objectMap, "profileImage", m.ProfileImage, func() any {
-		return runtime.EncodeByteArray(m.ProfileImage, runtime.Base64StdFormat)
-	})
-	return json.Marshal(objectMap)
-}
-
-// UnmarshalJSON implements the json.Unmarshaller interface for type MultiPartRequest.
-func (m *MultiPartRequest) UnmarshalJSON(data []byte) error {
-	var rawMsg map[string]json.RawMessage
-	if err := json.Unmarshal(data, &rawMsg); err != nil {
-		return fmt.Errorf("unmarshalling type %T: %v", m, err)
-	}
-	for key, val := range rawMsg {
-		var err error
-		switch key {
-		case "id":
-			err = unpopulate(val, "ID", &m.ID)
-			delete(rawMsg, key)
-		case "profileImage":
-			if val != nil && string(val) != "null" {
-				err = runtime.DecodeByteArray(string(val), &m.ProfileImage, runtime.Base64StdFormat)
-			}
-			delete(rawMsg, key)
-		}
-		if err != nil {
-			return fmt.Errorf("unmarshalling type %T: %v", m, err)
-		}
-	}
-	return nil
+	objectMap["id"] = m.ID
+	objectMap["profileImage"] = m.ProfileImage
+	return objectMap, nil
 }
 
 func populate(m map[string]any, k string, v any) {
@@ -297,16 +107,6 @@ func populate(m map[string]any, k string, v any) {
 	}
 }
 
-func populateByteArray[T any](m map[string]any, k string, b []T, convert func() any) {
-	if azcore.IsNullValue(b) {
-		m[k] = nil
-	} else if len(b) == 0 {
-		return
-	} else {
-		m[k] = convert()
-	}
-}
-
 func unpopulate(data json.RawMessage, fn string, v any) error {
 	if data == nil || string(data) == "null" {
 		return nil
@@ -314,5 +114,14 @@ func unpopulate(data json.RawMessage, fn string, v any) error {
 	if err := json.Unmarshal(data, v); err != nil {
 		return fmt.Errorf("struct field %s: %v", fn, err)
 	}
+	return nil
+}
+
+func populateMultipartJSON(m map[string]any, k string, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	m[k] = data
 	return nil
 }

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_multipartformdata_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_multipartformdata_client.go
@@ -9,7 +9,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"io"
 	"net/http"
 )
 
@@ -21,7 +20,7 @@ type MultiPartFormDataClient struct {
 
 // Basic - Test content-type: multipart/form-data
 //   - options - MultiPartFormDataClientBasicOptions contains the optional parameters for the MultiPartFormDataClient.Basic method.
-func (client *MultiPartFormDataClient) Basic(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientBasicOptions) (MultiPartFormDataClientBasicResponse, error) {
+func (client *MultiPartFormDataClient) Basic(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientBasicOptions) (MultiPartFormDataClientBasicResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.Basic"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -43,14 +42,18 @@ func (client *MultiPartFormDataClient) Basic(ctx context.Context, body io.ReadSe
 }
 
 // basicCreateRequest creates the Basic request.
-func (client *MultiPartFormDataClient) basicCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientBasicOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) basicCreateRequest(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientBasicOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/mixed-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -59,7 +62,7 @@ func (client *MultiPartFormDataClient) basicCreateRequest(ctx context.Context, b
 // BinaryArrayParts - Test content-type: multipart/form-data for scenario contains multi binary parts
 //   - options - MultiPartFormDataClientBinaryArrayPartsOptions contains the optional parameters for the MultiPartFormDataClient.BinaryArrayParts
 //     method.
-func (client *MultiPartFormDataClient) BinaryArrayParts(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientBinaryArrayPartsOptions) (MultiPartFormDataClientBinaryArrayPartsResponse, error) {
+func (client *MultiPartFormDataClient) BinaryArrayParts(ctx context.Context, body BinaryArrayPartsRequest, options *MultiPartFormDataClientBinaryArrayPartsOptions) (MultiPartFormDataClientBinaryArrayPartsResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.BinaryArrayParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -81,14 +84,18 @@ func (client *MultiPartFormDataClient) BinaryArrayParts(ctx context.Context, bod
 }
 
 // binaryArrayPartsCreateRequest creates the BinaryArrayParts request.
-func (client *MultiPartFormDataClient) binaryArrayPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientBinaryArrayPartsOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) binaryArrayPartsCreateRequest(ctx context.Context, body BinaryArrayPartsRequest, options *MultiPartFormDataClientBinaryArrayPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/binary-array-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -97,7 +104,7 @@ func (client *MultiPartFormDataClient) binaryArrayPartsCreateRequest(ctx context
 // CheckFileNameAndContentType - Test content-type: multipart/form-data
 //   - options - MultiPartFormDataClientCheckFileNameAndContentTypeOptions contains the optional parameters for the MultiPartFormDataClient.CheckFileNameAndContentType
 //     method.
-func (client *MultiPartFormDataClient) CheckFileNameAndContentType(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientCheckFileNameAndContentTypeOptions) (MultiPartFormDataClientCheckFileNameAndContentTypeResponse, error) {
+func (client *MultiPartFormDataClient) CheckFileNameAndContentType(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientCheckFileNameAndContentTypeOptions) (MultiPartFormDataClientCheckFileNameAndContentTypeResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.CheckFileNameAndContentType"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -119,14 +126,18 @@ func (client *MultiPartFormDataClient) CheckFileNameAndContentType(ctx context.C
 }
 
 // checkFileNameAndContentTypeCreateRequest creates the CheckFileNameAndContentType request.
-func (client *MultiPartFormDataClient) checkFileNameAndContentTypeCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientCheckFileNameAndContentTypeOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) checkFileNameAndContentTypeCreateRequest(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientCheckFileNameAndContentTypeOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/check-filename-and-content-type"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -135,7 +146,7 @@ func (client *MultiPartFormDataClient) checkFileNameAndContentTypeCreateRequest(
 // Complex - Test content-type: multipart/form-data for mixed scenarios
 //   - options - MultiPartFormDataClientComplexOptions contains the optional parameters for the MultiPartFormDataClient.Complex
 //     method.
-func (client *MultiPartFormDataClient) Complex(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientComplexOptions) (MultiPartFormDataClientComplexResponse, error) {
+func (client *MultiPartFormDataClient) Complex(ctx context.Context, body ComplexPartsRequest, options *MultiPartFormDataClientComplexOptions) (MultiPartFormDataClientComplexResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.Complex"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -157,14 +168,18 @@ func (client *MultiPartFormDataClient) Complex(ctx context.Context, body io.Read
 }
 
 // complexCreateRequest creates the Complex request.
-func (client *MultiPartFormDataClient) complexCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientComplexOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) complexCreateRequest(ctx context.Context, body ComplexPartsRequest, options *MultiPartFormDataClientComplexOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/complex-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -173,7 +188,7 @@ func (client *MultiPartFormDataClient) complexCreateRequest(ctx context.Context,
 // JSONArrayParts - Test content-type: multipart/form-data for scenario contains multi json parts
 //   - options - MultiPartFormDataClientJSONArrayPartsOptions contains the optional parameters for the MultiPartFormDataClient.JSONArrayParts
 //     method.
-func (client *MultiPartFormDataClient) JSONArrayParts(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientJSONArrayPartsOptions) (MultiPartFormDataClientJSONArrayPartsResponse, error) {
+func (client *MultiPartFormDataClient) JSONArrayParts(ctx context.Context, body JSONArrayPartsRequest, options *MultiPartFormDataClientJSONArrayPartsOptions) (MultiPartFormDataClientJSONArrayPartsResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.JSONArrayParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -195,14 +210,18 @@ func (client *MultiPartFormDataClient) JSONArrayParts(ctx context.Context, body 
 }
 
 // jsonArrayPartsCreateRequest creates the JSONArrayParts request.
-func (client *MultiPartFormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientJSONArrayPartsOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) jsonArrayPartsCreateRequest(ctx context.Context, body JSONArrayPartsRequest, options *MultiPartFormDataClientJSONArrayPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/json-array-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -211,7 +230,7 @@ func (client *MultiPartFormDataClient) jsonArrayPartsCreateRequest(ctx context.C
 // JSONPart - Test content-type: multipart/form-data for scenario contains json part and binary part
 //   - options - MultiPartFormDataClientJSONPartOptions contains the optional parameters for the MultiPartFormDataClient.JSONPart
 //     method.
-func (client *MultiPartFormDataClient) JSONPart(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientJSONPartOptions) (MultiPartFormDataClientJSONPartResponse, error) {
+func (client *MultiPartFormDataClient) JSONPart(ctx context.Context, body JSONPartRequest, options *MultiPartFormDataClientJSONPartOptions) (MultiPartFormDataClientJSONPartResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.JSONPart"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -233,14 +252,18 @@ func (client *MultiPartFormDataClient) JSONPart(ctx context.Context, body io.Rea
 }
 
 // jsonPartCreateRequest creates the JSONPart request.
-func (client *MultiPartFormDataClient) jsonPartCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientJSONPartOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) jsonPartCreateRequest(ctx context.Context, body JSONPartRequest, options *MultiPartFormDataClientJSONPartOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/json-part"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil
@@ -249,7 +272,7 @@ func (client *MultiPartFormDataClient) jsonPartCreateRequest(ctx context.Context
 // MultiBinaryParts - Test content-type: multipart/form-data for scenario contains multi binary parts
 //   - options - MultiPartFormDataClientMultiBinaryPartsOptions contains the optional parameters for the MultiPartFormDataClient.MultiBinaryParts
 //     method.
-func (client *MultiPartFormDataClient) MultiBinaryParts(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientMultiBinaryPartsOptions) (MultiPartFormDataClientMultiBinaryPartsResponse, error) {
+func (client *MultiPartFormDataClient) MultiBinaryParts(ctx context.Context, body MultiBinaryPartsRequest, options *MultiPartFormDataClientMultiBinaryPartsOptions) (MultiPartFormDataClientMultiBinaryPartsResponse, error) {
 	var err error
 	const operationName = "MultiPartFormDataClient.MultiBinaryParts"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -271,14 +294,18 @@ func (client *MultiPartFormDataClient) MultiBinaryParts(ctx context.Context, bod
 }
 
 // multiBinaryPartsCreateRequest creates the MultiBinaryParts request.
-func (client *MultiPartFormDataClient) multiBinaryPartsCreateRequest(ctx context.Context, body io.ReadSeekCloser, options *MultiPartFormDataClientMultiBinaryPartsOptions) (*policy.Request, error) {
+func (client *MultiPartFormDataClient) multiBinaryPartsCreateRequest(ctx context.Context, body MultiBinaryPartsRequest, options *MultiPartFormDataClientMultiBinaryPartsOptions) (*policy.Request, error) {
 	urlPath := "/multipart/form-data/multi-binary-parts"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
 	req.Raw().Header["Content-Type"] = []string{"multipart/form-data"}
-	if err := req.SetBody(body, "multipart/form-data"); err != nil {
+	formData, err := body.toMultipartFormData()
+	if err != nil {
+		return nil, err
+	}
+	if err := runtime.SetMultipartFormData(req, formData); err != nil {
 		return nil, err
 	}
 	return req, nil


### PR DESCRIPTION
In tsp, multipart/form params can be model types (M4 promotes the fields to discrete parameters). Added a model annotation multipartFormData indicating the model is used to generate multipart/form content. Models with this annotation omit standard SerDe methods in favor of a helper to convert the contents to multipart/form data.
Replaced an error comparison for io.EOF with errors.Is. Added --serve switch to cadl-ranch rush command to start in interactive model which is useful for debugging failures.