### PR TITLE
Refactor complextHostParams

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -157,7 +157,7 @@ function adaptClient(group: m4.OperationGroup): go.Client {
 
   client.host = group.language.go!.host;
   if (group.language.go!.complexHostParams) {
-    client.complexHostParams = true;
+    client.templatedHost = true;
   }
   if (group.language.go!.hostParams) {
     for (const hostParam of values(<Array<m4.Parameter>>group.language.go!.hostParams)) {

--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -564,6 +564,12 @@ async function processOperationRequests(session: Session<m4.CodeModel>) {
             if (!values(hostParams).where(p => p.language.go!.name === param.language.go!.name).any()) {
               hostParams.push(param);
             }
+            // we special-case fully templated host param, e.g. {endpoint}
+            // as there's no need to do a find/replace in this case, we'd
+            // just directly use the endpoint param value.
+            if (!(<string>group.language.go!.host).match(/^\{\w+\}$/)) {
+              group.language.go!.complexHostParams = true;
+            }
             continue;
           }
           // add global param info to the operation group

--- a/packages/autorest.go/test/maps/azalias/custom_client.go
+++ b/packages/autorest.go/test/maps/azalias/custom_client.go
@@ -8,13 +8,25 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewClient(endpoint string, options *azcore.ClientOptions) (*Client, error) {
-	client, err := azcore.NewClient("azalias.Client", "v0.0.1", runtime.PipelineOptions{}, options)
+type ClientOptions struct {
+	azcore.ClientOptions
+	Geography *Geography
+}
+
+func NewClient(options *ClientOptions) (*Client, error) {
+	if options == nil {
+		options = &ClientOptions{}
+	}
+	client, err := azcore.NewClient("Client", "v0.0.1", runtime.PipelineOptions{}, &options.ClientOptions)
 	if err != nil {
 		return nil, err
 	}
+	geography := GeographyUs
+	if options.Geography != nil {
+		geography = *options.Geography
+	}
 	return &Client{
-		internal: client,
-		endpoint: endpoint,
+		internal:  client,
+		geography: geography,
 	}, nil
 }

--- a/packages/autorest.go/test/maps/azalias/fakes_test.go
+++ b/packages/autorest.go/test/maps/azalias/fakes_test.go
@@ -40,8 +40,10 @@ func TestFakeCreate(t *testing.T) {
 			return
 		},
 	}
-	client, err := azalias.NewClient("https://contoso.com", &azcore.ClientOptions{
-		Transport: fake.NewServerTransport(&server),
+	client, err := azalias.NewClient(&azalias.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: fake.NewServerTransport(&server),
+		},
 	})
 	require.NoError(t, err)
 	_, err = client.Create(context.Background(), headerBoolsContent, stringQueryContent, boolHeaderEnumContent, unixTimeQueryContent, headerEnumContent, queryEnumContent, &azalias.CreateOptions{
@@ -72,8 +74,10 @@ func TestFakeGetScript(t *testing.T) {
 			return
 		},
 	}
-	client, err := azalias.NewClient("https://contoso.com", &azcore.ClientOptions{
-		Transport: fake.NewServerTransport(&server),
+	client, err := azalias.NewClient(&azalias.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: fake.NewServerTransport(&server),
+		},
 	})
 	require.NoError(t, err)
 	_, err = client.GetScript(context.Background(), headerContent, queryContent, explodedStrings, headerValue, timeContent, azalias.GeoJSONObjectNamedCollection{}, azalias.SomeGroup{

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -21,7 +21,7 @@ import (
 // Don't use this type directly, use a constructor function instead.
 type Client struct {
 	internal            *azcore.Client
-	endpoint            string
+	geography           Geography
 	clientGroup         ClientGroup
 	clientOptionalGroup *ClientOptionalGroup
 	optionalString      *string
@@ -72,8 +72,10 @@ func (client *Client) Create(ctx context.Context, headerBools []bool, stringQuer
 
 // createCreateRequest creates the Create request.
 func (client *Client) createCreateRequest(ctx context.Context, headerBools []bool, stringQuery string, boolHeaderEnum BooleanEnum, unixTimeQuery time.Time, headerEnum SomeEnum, queryEnum SomeEnum, options *CreateOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/aliases"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +157,10 @@ func (client *Client) GetScript(ctx context.Context, headerCounts []int32, query
 
 // getScriptCreateRequest creates the GetScript request.
 func (client *Client) getScriptCreateRequest(ctx context.Context, headerCounts []int32, queryCounts []int64, explodedStringStuff []string, numericHeader int32, headerTime time.Time, props GeoJSONObjectNamedCollection, someGroup SomeGroup, explodedGroup ExplodedGroup, options *GetScriptOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/scripts"
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -243,8 +247,10 @@ func (client *Client) NewListPager(headerEnums []IntEnum, queryEnum IntEnum, opt
 
 // listCreateRequest creates the List request.
 func (client *Client) listCreateRequest(ctx context.Context, headerEnums []IntEnum, queryEnum IntEnum, options *ListOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/aliases"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -348,8 +354,10 @@ func (client *Client) listLRO(ctx context.Context, options *BeginListLROOptions)
 
 // listLROCreateRequest creates the ListLRO request.
 func (client *Client) listLROCreateRequest(ctx context.Context, options *BeginListLROOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/paged"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -396,8 +404,10 @@ func (client *Client) NewListWithSharedNextOnePager(options *ListWithSharedNextO
 
 // listWithSharedNextOneCreateRequest creates the ListWithSharedNextOne request.
 func (client *Client) listWithSharedNextOneCreateRequest(ctx context.Context, options *ListWithSharedNextOneOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/listWithSharedNextOne"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -444,8 +454,10 @@ func (client *Client) NewListWithSharedNextTwoPager(options *ListWithSharedNextT
 
 // listWithSharedNextTwoCreateRequest creates the ListWithSharedNextTwo request.
 func (client *Client) listWithSharedNextTwoCreateRequest(ctx context.Context, options *ListWithSharedNextTwoOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/listWithSharedNextTwo"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -491,8 +503,10 @@ func (client *Client) PolicyAssignment(ctx context.Context, things []Things, pol
 
 // policyAssignmentCreateRequest creates the PolicyAssignment request.
 func (client *Client) policyAssignmentCreateRequest(ctx context.Context, things []Things, polymorphicParam GeoJSONObjectClassification, options *PolicyAssignmentOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/policy"
-	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -558,8 +572,10 @@ func (client *Client) UploadForm(ctx context.Context, requiredString string, req
 
 // uploadFormCreateRequest creates the UploadForm request.
 func (client *Client) uploadFormCreateRequest(ctx context.Context, requiredString string, requiredEnum DataSetting, requiredInt int32, options *UploadFormOptions) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/formdata"
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -584,9 +600,11 @@ func (client *Client) uploadFormCreateRequest(ctx context.Context, requiredStrin
 
 // listLRONextCreateRequest creates the listLRONextCreateRequest request.
 func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/paged"
 	urlPath = strings.ReplaceAll(urlPath, "{nextLink}", nextLink)
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}
@@ -596,8 +614,10 @@ func (client *Client) listLRONextCreateRequest(ctx context.Context, nextLink str
 
 // listWithSharedNextCreateRequest creates the listWithSharedNextCreateRequest request.
 func (client *Client) listWithSharedNextCreateRequest(ctx context.Context, nextLink string) (*policy.Request, error) {
+	host := "https://{geography}.atlas.microsoft.com"
+	host = strings.ReplaceAll(host, "{geography}", string(client.geography))
 	urlPath := "/listWithSharedNext"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.endpoint, urlPath))
+	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -75,15 +75,15 @@ export async function generateOperations(codeModel: go.CodeModel): Promise<Array
     clientText += `\tinternal *${clientPkg}.Client\n`;
     if (azureARM) {
       hostParamName = 'internal.Endpoint()';
-    } else if (client.complexHostParams) {
-      // for the complex case, all the host params must be stashed on
-      // the client as the full URL is constructed in the operations.
-      // MUST check before non-complex host params case.
+    } else if (client.templatedHost) {
+      // for the templated case, all the host params must be stashed on
+      // the client as the full host URL is constructed in the operations.
+      // MUST check before non-template host params case.
       for (const param of values(client.hostParams)) {
         clientText += `\t${param.name} ${go.getTypeDeclaration(param.type)}\n`;
       }
     } else if (client.hostParams.length > 0) {
-      // non-complex case.  the final endpoint URL will be constructed
+      // non-template case.  the final endpoint URL will be constructed
       // from the host param(s) in the client constructor and placed here.
       hostParamName = 'endpoint';
       clientText += `\t${hostParamName} string\n`;
@@ -514,9 +514,9 @@ function createProtocolRequest(client: go.Client, method: go.Method | go.NextPag
   let text = `${comment(name, '// ')} creates the ${method.name} request.\n`;
   text += `func (client *${client.name}) ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(', ')}) {\n`;
   let hostParam: string;
-  if (client.complexHostParams) {
+  if (client.templatedHost) {
     imports.add('strings');
-    // we have a complex parameterized host
+    // we have a templated host
     text += `\thost := "${client.host!}"\n`;
     // get all the host params on the client
     for (const hostParam of values(client.hostParams)) {

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -245,15 +245,16 @@ export interface Client {
   // contains any client accessor methods. can be empty
   clientAccessors: Array<ClientAccessor>;
 
-  // client has a statically defined host
+  // client has a statically defined or templated host
   host?: string;
 
   // can be empty if there are no host params
   hostParams: Array<URIParameter>;
 
-  // complexHostParams indicates that the parameters to construct the full host name
-  // span the client and the method. see custombaseurlgroup for an example of this.
-  complexHostParams: boolean;
+  // templatedHost indicates that there's one or more URIParameters
+  // required to construct the complete host. the parameters can
+  // be solely on the client or span client and method params.
+  templatedHost: boolean;
 
   // the parent client in a hierarchical client
   parent?: Client;
@@ -1059,7 +1060,7 @@ export class CodeModel implements CodeModel {
 export class Client implements Client {
   constructor(name: string, description: string, ctorName: string) {
     this.name = name;
-    this.complexHostParams = false;
+    this.templatedHost = false;
     this.ctorName = ctorName;
     this.description = description;
     this.hostParams = new Array<URIParameter>();

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -92,7 +92,7 @@ export class clientAdapter {
               throw new Error(`client ${goClient.name} has a conflicting host ${goClient.host}`);
             }
           } else {
-            goClient.complexHostParams = true;
+            goClient.templatedHost = true;
             for (const templateArg of param.type.templateArguments) {
               goClient.hostParams.push(this.adaptURIParam(templateArg));
             }
@@ -113,7 +113,7 @@ export class clientAdapter {
       // this is a sub-client. it will share the client/host params of the parent.
       // NOTE: we must propagate parant params before a potential recursive call
       // to create a child client that will need to inherit our client params.
-      goClient.complexHostParams = parent.complexHostParams;
+      goClient.templatedHost = parent.templatedHost;
       goClient.host = parent.host;
       goClient.hostParams = parent.hostParams;
       goClient.parameters = parent.parameters;


### PR DESCRIPTION
Renamed the field to templatedHost which accurately describes how the value is interpreted. The M4 code model was left as-is to avoid breaking anything in gotest.
Fixed an issue for templated hosts with a single param value.