### PR TITLE
Model client constructors

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -153,7 +153,7 @@ function adaptURIPrameterType(schema: m4.Schema): go.URIParameterType {
 
 function adaptClient(group: m4.OperationGroup): go.Client {
   const description = `${group.language.go!.clientName} contains the methods for the ${group.language.go!.name} group.`;
-  const client = new go.Client(group.language.go!.clientName, description, group.language.go!.clientCtorName);
+  const client = new go.Client(group.language.go!.clientName, description);
 
   client.host = group.language.go!.host;
   if (group.language.go!.complexHostParams) {
@@ -163,7 +163,7 @@ function adaptClient(group: m4.OperationGroup): go.Client {
     for (const hostParam of values(<Array<m4.Parameter>>group.language.go!.hostParams)) {
       const uriParam = new go.URIParameter(hostParam.language.go!.name, hostParam.language.go!.serializedName, adaptURIPrameterType(hostParam.schema),
         adaptParameterType(hostParam), hostParam.language.go!.byValue, adaptMethodLocation(hostParam.implementation));
-      client.hostParams.push(uriParam);
+      client.parameters.push(uriParam);
     }
   }
 

--- a/packages/codegen.go/src/clientFactory.ts
+++ b/packages/codegen.go/src/clientFactory.ts
@@ -9,79 +9,82 @@ import { contentPreamble, formatCommentAsBulletItem, formatParameterTypeName, so
 import { ImportManager } from './imports.js';
 
 
-// Creates the content for all <operation>.go files
+// Creates the content for client_factory.go (ARM only)
 export async function generateClientFactory(codeModel: go.CodeModel): Promise<string> {
-  let result = '';
   // generate client factory only for ARM
-  if (codeModel.type === 'azure-arm' && codeModel.clients) {
-    // the list of packages to import
-    const imports = new ImportManager();
-    
-    // there should be at most one client level param: subscriptionID for ARM, any exception is always a wrong swagger definition that we should fix
-    const allClientParams = new Array<go.Parameter>();
-    for (const clients of codeModel.clients) {
-      for (const clientParam of values(clients.parameters)) {
-        if (values(allClientParams).where(param => param.name === clientParam.name).any()) {
-          continue;
-        }
-        allClientParams.push(clientParam);
-      }
-    }
-    allClientParams.sort(sortParametersByRequired);
-
-    // add factory type
-    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
-    result += '// ClientFactory is a client factory used to create any client in this module.\n';
-    result += '// Don\'t use this type directly, use NewClientFactory instead.\n';
-    result += 'type ClientFactory struct {\n';
-    for (const clientParam of values(allClientParams)) {
-      result += `\t${clientParam.name} ${formatParameterTypeName(clientParam)}\n`;
-    }
-    result += '\tinternal *arm.Client\n';
-    result += '}\n\n';
-
-    // add factory CTOR
-    imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/arm');
-    result += '// NewClientFactory creates a new instance of ClientFactory with the specified values.\n';
-    result += '// The parameter values will be propagated to any client created from this factory.\n';
-    for (const clientParam of values(allClientParams)) {
-      result += `${formatCommentAsBulletItem(`${clientParam.name} - ${clientParam.description}`)}\n`;
-    }
-    result += `${formatCommentAsBulletItem('credential - used to authorize requests. Usually a credential from azidentity.')}\n`;
-    result += `${formatCommentAsBulletItem('options - pass nil to accept the default values.')}\n`;
-
-    result += `func NewClientFactory(${allClientParams.map(param => { return `${param.name} ${formatParameterTypeName(param)}`; }).join(', ')}${allClientParams.length>0 ? ',' : ''} credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
-    result += '\tinternal, err := arm.NewClient(moduleName, moduleVersion, credential, options)\n';
-    result += '\tif err != nil {\n';
-    result += '\t\treturn nil, err\n';
-    result += '\t}\n';
-    result += '\treturn &ClientFactory{\n';
-    for (const clientParam of values(allClientParams)) {
-      result += `\t\t${clientParam.name}: ${clientParam.name},\n`;
-    }
-    result += '\t\tinternal: internal,\n';
-    result += '\t}, nil\n';
-    result += '}\n\n';
-
-    // add new sub client method for all operation groups
-    for (const client of codeModel.clients) {
-      result += `// ${client.ctorName} creates a new instance of ${client.name}.\n`;
-      result += `func (c *ClientFactory) ${client.ctorName}() *${client.name} {\n`;
-      result += `\treturn &${client.name}{\n`;
-
-      // some clients (e.g. operations client) don't utilize the client params
-      if (client.parameters.length > 0) {
-        for (const clientParam of values(allClientParams)) {
-          result += `\t\t${clientParam.name}: c.${clientParam.name},\n`;
-        }
-      }
-
-      result += '\t\tinternal: c.internal,\n';
-      result += '\t}\n';
-      result += '}\n\n';
-    }
-
-    result = contentPreamble(codeModel) + imports.text() + result;
+  if (codeModel.type !== 'azure-arm' || codeModel.clients.length === 0) {
+    return '';
   }
+
+  let result = '';
+  // the list of packages to import
+  const imports = new ImportManager();
+  
+  // there should be at most one client level param: subscriptionID for ARM, any exception is always a wrong swagger definition that we should fix
+  const allClientParams = new Array<go.Parameter>();
+  for (const clients of codeModel.clients) {
+    for (const clientParam of values(clients.parameters)) {
+      if (values(allClientParams).where(param => param.name === clientParam.name).any()) {
+        continue;
+      }
+      allClientParams.push(clientParam);
+    }
+  }
+  allClientParams.sort(sortParametersByRequired);
+
+  // add factory type
+  imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore');
+  result += '// ClientFactory is a client factory used to create any client in this module.\n';
+  result += '// Don\'t use this type directly, use NewClientFactory instead.\n';
+  result += 'type ClientFactory struct {\n';
+  for (const clientParam of values(allClientParams)) {
+    result += `\t${clientParam.name} ${formatParameterTypeName(clientParam)}\n`;
+  }
+  result += '\tinternal *arm.Client\n';
+  result += '}\n\n';
+
+  // add factory CTOR
+  imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/arm');
+  result += '// NewClientFactory creates a new instance of ClientFactory with the specified values.\n';
+  result += '// The parameter values will be propagated to any client created from this factory.\n';
+  for (const clientParam of values(allClientParams)) {
+    result += `${formatCommentAsBulletItem(`${clientParam.name} - ${clientParam.description}`)}\n`;
+  }
+  result += `${formatCommentAsBulletItem('credential - used to authorize requests. Usually a credential from azidentity.')}\n`;
+  result += `${formatCommentAsBulletItem('options - pass nil to accept the default values.')}\n`;
+
+  result += `func NewClientFactory(${allClientParams.map(param => { return `${param.name} ${formatParameterTypeName(param)}`; }).join(', ')}${allClientParams.length>0 ? ',' : ''} credential azcore.TokenCredential, options *arm.ClientOptions) (*ClientFactory, error) {\n`;
+  result += '\tinternal, err := arm.NewClient(moduleName, moduleVersion, credential, options)\n';
+  result += '\tif err != nil {\n';
+  result += '\t\treturn nil, err\n';
+  result += '\t}\n';
+  result += '\treturn &ClientFactory{\n';
+  for (const clientParam of values(allClientParams)) {
+    result += `\t\t${clientParam.name}: ${clientParam.name},\n`;
+  }
+  result += '\t\tinternal: internal,\n';
+  result += '\t}, nil\n';
+  result += '}\n\n';
+
+  // add new sub client method for all operation groups
+  for (const client of codeModel.clients) {
+    const ctorName = `New${client.name}`;
+    result += `// ${ctorName} creates a new instance of ${client.name}.\n`;
+    result += `func (c *ClientFactory) ${ctorName}() *${client.name} {\n`;
+    result += `\treturn &${client.name}{\n`;
+
+    // some clients (e.g. operations client) don't utilize the client params
+    if (client.parameters.length > 0) {
+      for (const clientParam of values(allClientParams)) {
+        result += `\t\t${clientParam.name}: c.${clientParam.name},\n`;
+      }
+    }
+
+    result += '\t\tinternal: c.internal,\n';
+    result += '\t}\n';
+    result += '}\n\n';
+  }
+
+  result = contentPreamble(codeModel) + imports.text() + result;
   return result;
 }

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -234,12 +234,13 @@ export interface Client {
 
   description: string;
 
-  // the name of the client's constructor func
-  ctorName: string;
-
-  // contains only modeled client parameters and it's legal for an operation to not have any modeled client parameters
+  // constructor params that are persisted as fields on the client, can be empty
   parameters: Array<Parameter>;
 
+  // all the constructors for this client, can be empty
+  constructors: Array<Constructor>;
+
+  // contains client methods. can be empty
   methods: Array<Method | LROMethod | PageableMethod | LROPageableMethod>;
 
   // contains any client accessor methods. can be empty
@@ -248,9 +249,6 @@ export interface Client {
   // client has a statically defined or templated host
   host?: string;
 
-  // can be empty if there are no host params
-  hostParams: Array<URIParameter>;
-
   // templatedHost indicates that there's one or more URIParameters
   // required to construct the complete host. the parameters can
   // be solely on the client or span client and method params.
@@ -258,6 +256,17 @@ export interface Client {
 
   // the parent client in a hierarchical client
   parent?: Client;
+}
+
+// represents a client constructor function
+export interface Constructor {
+  name: string;
+
+  // the modeled parameters. can be empty
+  parameters: Array<Parameter>;
+
+  // the client options type. for ARM, this will be a QualifiedType (arm.ClientOptions)
+  clientOptions: ParameterGroup | Parameter;
 }
 
 // ClientAccessor is a client method that returns a sub-client instance.
@@ -1058,14 +1067,21 @@ export class CodeModel implements CodeModel {
 }
 
 export class Client implements Client {
-  constructor(name: string, description: string, ctorName: string) {
+  constructor(name: string, description: string) {
     this.name = name;
     this.templatedHost = false;
-    this.ctorName = ctorName;
+    this.constructors = new Array<Constructor>();
     this.description = description;
-    this.hostParams = new Array<URIParameter>();
     this.methods = new Array<Method>();
     this.clientAccessors = new Array<ClientAccessor>();
+    this.parameters = new Array<Parameter>();
+  }
+}
+
+export class Constructor implements Constructor {
+  constructor(name: string, options: ParameterGroup | Parameter) {
+    this.name = name;
+    this.clientOptions = options;
     this.parameters = new Array<Parameter>();
   }
 }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -72,7 +72,7 @@ export class clientAdapter {
       description = `${clientName} contains the methods for the ${sdkClient.nameSpace} namespace.`;
     }
 
-    const goClient = new go.Client(clientName, description, `New${clientName}`);
+    const goClient = new go.Client(clientName, description);
     goClient.parent = parent;
 
     // anything other than public means non-instantiable client
@@ -94,7 +94,7 @@ export class clientAdapter {
           } else {
             goClient.templatedHost = true;
             for (const templateArg of param.type.templateArguments) {
-              goClient.hostParams.push(this.adaptURIParam(templateArg));
+              goClient.parameters.push(this.adaptURIParam(templateArg));
             }
           }
           continue;
@@ -107,7 +107,7 @@ export class clientAdapter {
           continue;
         }
 
-        goClient.hostParams.push(this.adaptURIParam(param));
+        goClient.parameters.push(this.adaptURIParam(param));
       }
     } else if (parent) {
       // this is a sub-client. it will share the client/host params of the parent.
@@ -115,7 +115,6 @@ export class clientAdapter {
       // to create a child client that will need to inherit our client params.
       goClient.templatedHost = parent.templatedHost;
       goClient.host = parent.host;
-      goClient.hostParams = parent.hostParams;
       goClient.parameters = parent.parameters;
     } else {
       throw new Error(`uninstantiable client ${sdkClient.name} has no parent`);


### PR DESCRIPTION
Added type Constructor to the Go code model for modeling constructors. Client types now have an array of Constructors, and the ctorName field has been removed.
Consolidated Client.hostParams into Client.parameters. ARM client constructors are now created via the code model. Handling of the host param has been simplified.