### PR TITLE
Move client options definition to Client

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -20,7 +20,7 @@ const paramGroups = new Map<string, go.ParameterGroup>();
 
 export function adaptClients(m4CodeModel: m4.CodeModel, codeModel: go.CodeModel) {
   for (const group of values(m4CodeModel.operationGroups)) {
-    const client = adaptClient(group);
+    const client = adaptClient(codeModel.type, group);
 
     for (const op of values(group.operations)) {
       const httpPath = <string>op.requests![0].protocol.http!.path;
@@ -151,9 +151,9 @@ function adaptURIPrameterType(schema: m4.Schema): go.URIParameterType {
   return type;
 }
 
-function adaptClient(group: m4.OperationGroup): go.Client {
+function adaptClient(type: go.CodeModelType, group: m4.OperationGroup): go.Client {
   const description = `${group.language.go!.clientName} contains the methods for the ${group.language.go!.name} group.`;
-  const client = new go.Client(group.language.go!.clientName, description);
+  const client = new go.Client(group.language.go!.clientName, description, go.newClientOptions(type, group.language.go!.clientName));
 
   client.host = group.language.go!.host;
   if (group.language.go!.complexHostParams) {

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -187,8 +187,8 @@ function generateConstructors(azureARM: boolean, client: go.Client, imports: Imp
     }
 
     // add client options last
-    ctorParams.push(`${constructor.clientOptions.name} ${helpers.formatParameterTypeName(constructor.clientOptions)}`);
-    paramDocs.push(helpers.formatCommentAsBulletItem(`${constructor.clientOptions.name} - ${constructor.clientOptions.description}`));
+    ctorParams.push(`${client.options.name} ${helpers.formatParameterTypeName(client.options)}`);
+    paramDocs.push(helpers.formatCommentAsBulletItem(`${client.options.name} - ${client.options.description}`));
 
     ctorText += `// ${constructor.name} creates a new instance of ${client.name} with the specified values.\n`;
     for (const doc of paramDocs) {
@@ -224,9 +224,7 @@ function generateConstructors(azureARM: boolean, client: go.Client, imports: Imp
 // creates a modeled constructor for an ARM client
 function createARMClientConstructor(client: go.Client, imports: ImportManager): go.Constructor {
   imports.add('github.com/Azure/azure-sdk-for-go/sdk/azcore/arm');
-  const options = new go.Parameter('options', new go.QualifiedType('ClientOptions', 'github.com/Azure/azure-sdk-for-go/sdk/azcore/arm'), 'optional', false, 'client');
-  options.description = 'pass nil to accept the default values.';
-  const ctor = new go.Constructor(`New${client.name}`, options);
+  const ctor = new go.Constructor(`New${client.name}`);
   // add any modeled parameter first, which should only be the subscriptionID, then add TokenCredential
   for (const param of client.parameters) {
     ctor.parameters.push(param);

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -72,7 +72,7 @@ export class clientAdapter {
       description = `${clientName} contains the methods for the ${sdkClient.nameSpace} namespace.`;
     }
 
-    const goClient = new go.Client(clientName, description);
+    const goClient = new go.Client(clientName, description, go.newClientOptions(this.ta.codeModel.type, clientName));
     goClient.parent = parent;
 
     // anything other than public means non-instantiable client


### PR DESCRIPTION
Since there's one client options type per client, it makes more sense to define it on the Client and not per constructor.
Consolidate creation of client options.