### PR TITLE
Add head-as-boolean to tsp emitter

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -162,6 +162,7 @@ function generate(moduleName, input, outputDir, additionalArgs) {
       options.push(`--option="@azure-tools/typespec-go.file-prefix=zz_"`);
       options.push(`--option="@azure-tools/typespec-go.generate-fakes=true"`);
       options.push(`--option="@azure-tools/typespec-go.inject-spans=true"`);
+      options.push(`--option="@azure-tools/typespec-go.head-as-boolean=true"`);
       if (switches.includes('--debugger')) {
         options.push(`--option="@azure-tools/typespec-go.debugger=true"`);
       }

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -10,6 +10,7 @@ export interface GoEmitterOptions {
   'disallow-unknown-fields'?: boolean;
   'file-prefix'?: string;
   'generate-fakes'?: boolean;
+  'head-as-boolean'?: boolean;
   'inject-spans'?: boolean;
   'module'?: string;
   'module-version'?: string;
@@ -27,6 +28,7 @@ const EmitterOptionsSchema: JSONSchemaType<GoEmitterOptions> = {
     'disallow-unknown-fields': { type: 'boolean', nullable: true },
     'file-prefix': { type: 'string', nullable: true },
     'generate-fakes': { type: 'boolean', nullable: true },
+    'head-as-boolean': { type: 'boolean', nullable: true },
     'inject-spans': { type: 'boolean', nullable: true },
     'module': { type: 'string', nullable: true },
     'module-version': { type: 'string', nullable: true },

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -399,6 +399,12 @@ export class clientAdapter {
 
     let sdkResponseType = sdkMethod.response.type;
 
+    // since HEAD requests don't return a type, we must check this before checking sdkResponseType
+    if (method.httpMethod === 'head' && this.opts['head-as-boolean'] === true) {
+      respEnv.result = new go.HeadAsBooleanResult('Success');
+      respEnv.result.description = 'Success indicates if the operation succeeded or failed.';
+    }
+
     if (!sdkResponseType) {
       // method doesn't return a type, so we're done
       return respEnv;

--- a/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
@@ -407,7 +407,7 @@ func (client *ApiDefinitionsClient) Head(ctx context.Context, subscriptionID str
 		err = runtime.NewResponseError(httpResp)
 		return ApiDefinitionsClientHeadResponse{}, err
 	}
-	return ApiDefinitionsClientHeadResponse{}, nil
+	return ApiDefinitionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_apis_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apis_client.go
@@ -278,7 +278,7 @@ func (client *ApisClient) Head(ctx context.Context, subscriptionID string, resou
 		err = runtime.NewResponseError(httpResp)
 		return ApisClientHeadResponse{}, err
 	}
-	return ApisClientHeadResponse{}, nil
+	return ApisClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
@@ -295,7 +295,7 @@ func (client *ApiVersionsClient) Head(ctx context.Context, subscriptionID string
 		err = runtime.NewResponseError(httpResp)
 		return ApiVersionsClientHeadResponse{}, err
 	}
-	return ApiVersionsClientHeadResponse{}, nil
+	return ApiVersionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_deployments_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_deployments_client.go
@@ -295,7 +295,7 @@ func (client *DeploymentsClient) Head(ctx context.Context, subscriptionID string
 		err = runtime.NewResponseError(httpResp)
 		return DeploymentsClientHeadResponse{}, err
 	}
-	return DeploymentsClientHeadResponse{}, nil
+	return DeploymentsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_environments_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_environments_client.go
@@ -279,7 +279,7 @@ func (client *EnvironmentsClient) Head(ctx context.Context, subscriptionID strin
 		err = runtime.NewResponseError(httpResp)
 		return EnvironmentsClientHeadResponse{}, err
 	}
-	return EnvironmentsClientHeadResponse{}, nil
+	return EnvironmentsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_metadataschemas_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_metadataschemas_client.go
@@ -263,7 +263,7 @@ func (client *MetadataSchemasClient) Head(ctx context.Context, subscriptionID st
 		err = runtime.NewResponseError(httpResp)
 		return MetadataSchemasClientHeadResponse{}, err
 	}
-	return MetadataSchemasClientHeadResponse{}, nil
+	return MetadataSchemasClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/armapicenter/zz_responses.go
+++ b/packages/typespec-go/test/armapicenter/zz_responses.go
@@ -35,7 +35,8 @@ type ApiDefinitionsClientGetResponse struct {
 
 // ApiDefinitionsClientHeadResponse contains the response from method ApiDefinitionsClient.Head.
 type ApiDefinitionsClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // ApiDefinitionsClientImportSpecificationResponse contains the response from method ApiDefinitionsClient.ImportSpecification.
@@ -75,7 +76,8 @@ type ApiVersionsClientGetResponse struct {
 
 // ApiVersionsClientHeadResponse contains the response from method ApiVersionsClient.Head.
 type ApiVersionsClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // ApiVersionsClientListResponse contains the response from method ApiVersionsClient.NewListPager.
@@ -109,7 +111,8 @@ type ApisClientGetResponse struct {
 
 // ApisClientHeadResponse contains the response from method ApisClient.Head.
 type ApisClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // ApisClientListResponse contains the response from method ApisClient.NewListPager.
@@ -143,7 +146,8 @@ type DeploymentsClientGetResponse struct {
 
 // DeploymentsClientHeadResponse contains the response from method DeploymentsClient.Head.
 type DeploymentsClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // DeploymentsClientListResponse contains the response from method DeploymentsClient.NewListPager.
@@ -177,7 +181,8 @@ type EnvironmentsClientGetResponse struct {
 
 // EnvironmentsClientHeadResponse contains the response from method EnvironmentsClient.Head.
 type EnvironmentsClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // EnvironmentsClientListResponse contains the response from method EnvironmentsClient.NewListPager.
@@ -211,7 +216,8 @@ type MetadataSchemasClientGetResponse struct {
 
 // MetadataSchemasClientHeadResponse contains the response from method MetadataSchemasClient.Head.
 type MetadataSchemasClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // MetadataSchemasClientListResponse contains the response from method MetadataSchemasClient.NewListPager.
@@ -292,7 +298,8 @@ type WorkspacesClientGetResponse struct {
 
 // WorkspacesClientHeadResponse contains the response from method WorkspacesClient.Head.
 type WorkspacesClientHeadResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // WorkspacesClientListResponse contains the response from method WorkspacesClient.NewListPager.

--- a/packages/typespec-go/test/armapicenter/zz_workspaces_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_workspaces_client.go
@@ -263,7 +263,7 @@ func (client *WorkspacesClient) Head(ctx context.Context, subscriptionID string,
 		err = runtime.NewResponseError(httpResp)
 		return WorkspacesClientHeadResponse{}, err
 	}
-	return WorkspacesClientHeadResponse{}, nil
+	return WorkspacesClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/resiliencyservicedriven_client_test.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/resiliencyservicedriven_client_test.go
@@ -27,7 +27,7 @@ func TestResiliencyServiceDrivenClientv1_FromNone(t *testing.T) {
 		NewParameter: to.Ptr("new"),
 	})
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestResiliencyServiceDrivenClientv1_FromOneOptional(t *testing.T) {
@@ -58,7 +58,7 @@ func TestResiliencyServiceDrivenClientv2_FromNone(t *testing.T) {
 		NewParameter: to.Ptr("new"),
 	})
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestResiliencyServiceDrivenClientv2_FromOneOptional(t *testing.T) {

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
@@ -92,7 +92,7 @@ func (client *ResiliencyServiceDrivenClient) FromNone(ctx context.Context, optio
 		err = runtime.NewResponseError(httpResp)
 		return ResiliencyServiceDrivenClientFromNoneResponse{}, err
 	}
-	return ResiliencyServiceDrivenClientFromNoneResponse{}, nil
+	return ResiliencyServiceDrivenClientFromNoneResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // fromNoneCreateRequest creates the FromNone request.

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_responses.go
@@ -11,7 +11,8 @@ type ResiliencyServiceDrivenClientAddOperationResponse struct {
 
 // ResiliencyServiceDrivenClientFromNoneResponse contains the response from method ResiliencyServiceDrivenClient.FromNone.
 type ResiliencyServiceDrivenClientFromNoneResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // ResiliencyServiceDrivenClientFromOneOptionalResponse contains the response from method ResiliencyServiceDrivenClient.FromOneOptional.

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/resiliencyservicedriven_client_test.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/resiliencyservicedriven_client_test.go
@@ -17,7 +17,7 @@ func TestResiliencyServiceDrivenClientv1_FromNone(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.FromNone(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestResiliencyServiceDrivenClientv1_FromOneOptional(t *testing.T) {
@@ -43,7 +43,7 @@ func TestResiliencyServiceDrivenClientv2_FromNone(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.FromNone(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestResiliencyServiceDrivenClientv2_FromOneOptional(t *testing.T) {

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
@@ -45,7 +45,7 @@ func (client *ResiliencyServiceDrivenClient) FromNone(ctx context.Context, optio
 		err = runtime.NewResponseError(httpResp)
 		return ResiliencyServiceDrivenClientFromNoneResponse{}, err
 	}
-	return ResiliencyServiceDrivenClientFromNoneResponse{}, nil
+	return ResiliencyServiceDrivenClientFromNoneResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // fromNoneCreateRequest creates the FromNone request.

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_responses.go
@@ -6,7 +6,8 @@ package srvdrivenoldgroup
 
 // ResiliencyServiceDrivenClientFromNoneResponse contains the response from method ResiliencyServiceDrivenClient.FromNone.
 type ResiliencyServiceDrivenClientFromNoneResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // ResiliencyServiceDrivenClientFromOneOptionalResponse contains the response from method ResiliencyServiceDrivenClient.FromOneOptional.

--- a/packages/typespec-go/test/cadlranch/server/path/singlegroup/single_client_test.go
+++ b/packages/typespec-go/test/cadlranch/server/path/singlegroup/single_client_test.go
@@ -16,5 +16,5 @@ func TestSingleClient_MyOp(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.MyOp(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }

--- a/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_responses.go
@@ -6,5 +6,6 @@ package singlegroup
 
 // SingleClientMyOpResponse contains the response from method SingleClient.MyOp.
 type SingleClientMyOpResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }

--- a/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_single_client.go
+++ b/packages/typespec-go/test/cadlranch/server/path/singlegroup/zz_single_client.go
@@ -39,7 +39,7 @@ func (client *SingleClient) MyOp(ctx context.Context, options *SingleClientMyOpO
 		err = runtime.NewResponseError(httpResp)
 		return SingleClientMyOpResponse{}, err
 	}
-	return SingleClientMyOpResponse{}, nil
+	return SingleClientMyOpResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // myOpCreateRequest creates the MyOp request.

--- a/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/notversioned_client_test.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/notversioned_client_test.go
@@ -16,7 +16,7 @@ func TestNotVersionedClient_WithPathAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithPathAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestNotVersionedClient_WithQueryAPIVersion(t *testing.T) {
@@ -24,7 +24,7 @@ func TestNotVersionedClient_WithQueryAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithQueryAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestNotVersionedClient_WithoutAPIVersion(t *testing.T) {
@@ -32,5 +32,5 @@ func TestNotVersionedClient_WithoutAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithoutAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }

--- a/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/zz_notversioned_client.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/zz_notversioned_client.go
@@ -43,7 +43,7 @@ func (client *NotVersionedClient) WithPathAPIVersion(ctx context.Context, option
 		err = runtime.NewResponseError(httpResp)
 		return NotVersionedClientWithPathAPIVersionResponse{}, err
 	}
-	return NotVersionedClientWithPathAPIVersionResponse{}, nil
+	return NotVersionedClientWithPathAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withPathAPIVersionCreateRequest creates the WithPathAPIVersion request.
@@ -82,7 +82,7 @@ func (client *NotVersionedClient) WithQueryAPIVersion(ctx context.Context, optio
 		err = runtime.NewResponseError(httpResp)
 		return NotVersionedClientWithQueryAPIVersionResponse{}, err
 	}
-	return NotVersionedClientWithQueryAPIVersionResponse{}, nil
+	return NotVersionedClientWithQueryAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withQueryAPIVersionCreateRequest creates the WithQueryAPIVersion request.
@@ -120,7 +120,7 @@ func (client *NotVersionedClient) WithoutAPIVersion(ctx context.Context, options
 		err = runtime.NewResponseError(httpResp)
 		return NotVersionedClientWithoutAPIVersionResponse{}, err
 	}
-	return NotVersionedClientWithoutAPIVersionResponse{}, nil
+	return NotVersionedClientWithoutAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withoutAPIVersionCreateRequest creates the WithoutAPIVersion request.

--- a/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/unversionedgroup/zz_responses.go
@@ -6,15 +6,18 @@ package unversionedgroup
 
 // NotVersionedClientWithPathAPIVersionResponse contains the response from method NotVersionedClient.WithPathAPIVersion.
 type NotVersionedClientWithPathAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // NotVersionedClientWithQueryAPIVersionResponse contains the response from method NotVersionedClient.WithQueryAPIVersion.
 type NotVersionedClientWithQueryAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // NotVersionedClientWithoutAPIVersionResponse contains the response from method NotVersionedClient.WithoutAPIVersion.
 type NotVersionedClientWithoutAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }

--- a/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/versioned_client_test.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/versioned_client_test.go
@@ -16,7 +16,7 @@ func TestVersionedClient_WithPathAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithPathAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestVersionedClient_WithQueryAPIVersion(t *testing.T) {
@@ -24,7 +24,7 @@ func TestVersionedClient_WithQueryAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithQueryAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestVersionedClient_WithoutAPIVersion(t *testing.T) {
@@ -32,5 +32,5 @@ func TestVersionedClient_WithoutAPIVersion(t *testing.T) {
 	require.NoError(t, err)
 	resp, err := client.WithoutAPIVersion(context.Background(), nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }

--- a/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_responses.go
@@ -6,15 +6,18 @@ package versionedgroup
 
 // VersionedClientWithPathAPIVersionResponse contains the response from method VersionedClient.WithPathAPIVersion.
 type VersionedClientWithPathAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // VersionedClientWithQueryAPIVersionResponse contains the response from method VersionedClient.WithQueryAPIVersion.
 type VersionedClientWithQueryAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // VersionedClientWithoutAPIVersionResponse contains the response from method VersionedClient.WithoutAPIVersion.
 type VersionedClientWithoutAPIVersionResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }

--- a/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_versioned_client.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_versioned_client.go
@@ -41,7 +41,7 @@ func (client *VersionedClient) WithPathAPIVersion(ctx context.Context, options *
 		err = runtime.NewResponseError(httpResp)
 		return VersionedClientWithPathAPIVersionResponse{}, err
 	}
-	return VersionedClientWithPathAPIVersionResponse{}, nil
+	return VersionedClientWithPathAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withPathAPIVersionCreateRequest creates the WithPathAPIVersion request.
@@ -77,7 +77,7 @@ func (client *VersionedClient) WithQueryAPIVersion(ctx context.Context, options 
 		err = runtime.NewResponseError(httpResp)
 		return VersionedClientWithQueryAPIVersionResponse{}, err
 	}
-	return VersionedClientWithQueryAPIVersionResponse{}, nil
+	return VersionedClientWithQueryAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withQueryAPIVersionCreateRequest creates the WithQueryAPIVersion request.
@@ -115,7 +115,7 @@ func (client *VersionedClient) WithoutAPIVersion(ctx context.Context, options *V
 		err = runtime.NewResponseError(httpResp)
 		return VersionedClientWithoutAPIVersionResponse{}, err
 	}
-	return VersionedClientWithoutAPIVersionResponse{}, nil
+	return VersionedClientWithoutAPIVersionResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // withoutAPIVersionCreateRequest creates the WithoutAPIVersion request.

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/visibility_client_test.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/visibility_client_test.go
@@ -44,7 +44,7 @@ func TestVisibilityClientHeadModel(t *testing.T) {
 		QueryProp: to.Ptr[int32](123),
 	}, nil)
 	require.NoError(t, err)
-	require.Zero(t, resp)
+	require.True(t, resp.Success)
 }
 
 func TestVisibilityClientPatchModel(t *testing.T) {

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_responses.go
@@ -17,7 +17,8 @@ type VisibilityClientGetModelResponse struct {
 
 // VisibilityClientHeadModelResponse contains the response from method VisibilityClient.HeadModel.
 type VisibilityClientHeadModelResponse struct {
-	// placeholder for future response values
+	// Success indicates if the operation succeeded or failed.
+	Success bool
 }
 
 // VisibilityClientPatchModelResponse contains the response from method VisibilityClient.PatchModel.

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
@@ -120,7 +120,7 @@ func (client *VisibilityClient) HeadModel(ctx context.Context, input VisibilityM
 		err = runtime.NewResponseError(httpResp)
 		return VisibilityClientHeadModelResponse{}, err
 	}
-	return VisibilityClientHeadModelResponse{}, nil
+	return VisibilityClientHeadModelResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headModelCreateRequest creates the HeadModel request.


### PR DESCRIPTION
Enabled for codegen tests.

Fixes https://github.com/Azure/autorest.go/issues/1217