### PR TITLE
Fix tsp model doc comments

### DIFF
--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -544,7 +544,12 @@ export class typeAdapter {
       // polymorphic types don't have XMLInfo
       // TODO: XMLInfo
     }
-    modelType.description = model.description;
+    if (model.description) {
+      modelType.description = model.description;
+      if (!modelType.description.startsWith(modelName)) {
+        modelType.description = `${modelName} - ${modelType.description}`;
+      }
+    }
     this.types.set(modelName, modelType);
     return modelType;
   }

--- a/packages/typespec-go/test/armapicenter/zz_models.go
+++ b/packages/typespec-go/test/armapicenter/zz_models.go
@@ -24,7 +24,7 @@ type API struct {
 	Name *string
 }
 
-// API definition entity.
+// APIDefinition - API definition entity.
 type APIDefinition struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -42,7 +42,7 @@ type APIDefinition struct {
 	Name *string
 }
 
-// The response of a ApiDefinition list operation.
+// APIDefinitionListResult - The response of a ApiDefinition list operation.
 type APIDefinitionListResult struct {
 	// REQUIRED; The ApiDefinition items on this page
 	Value []*APIDefinition
@@ -51,7 +51,7 @@ type APIDefinitionListResult struct {
 	NextLink *string
 }
 
-// API definition properties entity.
+// APIDefinitionProperties - API definition properties entity.
 type APIDefinitionProperties struct {
 	// REQUIRED; API definition title.
 	Title *string
@@ -63,7 +63,7 @@ type APIDefinitionProperties struct {
 	Specification *APIDefinitionPropertiesSpecification
 }
 
-// API specification details.
+// APIDefinitionPropertiesSpecification - API specification details.
 type APIDefinitionPropertiesSpecification struct {
 	// Specification name.
 	Name *string
@@ -72,11 +72,11 @@ type APIDefinitionPropertiesSpecification struct {
 	Version *string
 }
 
-// The API specification was successfully imported.
+// APIImportSuccess - The API specification was successfully imported.
 type APIImportSuccess struct {
 }
 
-// The response of a Api list operation.
+// APIListResult - The response of a Api list operation.
 type APIListResult struct {
 	// REQUIRED; The Api items on this page
 	Value []*API
@@ -85,7 +85,7 @@ type APIListResult struct {
 	NextLink *string
 }
 
-// API properties.
+// APIProperties - API properties.
 type APIProperties struct {
 	// REQUIRED; Kind of API. For example, REST or GraphQL.
 	Kind *APIKind
@@ -118,7 +118,7 @@ type APIProperties struct {
 	TermsOfService *TermsOfService
 }
 
-// The API specification export result.
+// APISpecExportResult - The API specification export result.
 type APISpecExportResult struct {
 	// The format of exported result
 	Format *APISpecExportResultFormat
@@ -127,7 +127,7 @@ type APISpecExportResult struct {
 	Value *string
 }
 
-// The API specification source entity properties.
+// APISpecImportRequest - The API specification source entity properties.
 type APISpecImportRequest struct {
 	// Format of the API specification source.
 	Format *APISpecImportSourceFormat
@@ -139,7 +139,7 @@ type APISpecImportRequest struct {
 	Value *string
 }
 
-// API specification details.
+// APISpecImportRequestSpecification - API specification details.
 type APISpecImportRequestSpecification struct {
 	// Specification name.
 	Name *string
@@ -148,7 +148,7 @@ type APISpecImportRequestSpecification struct {
 	Version *string
 }
 
-// API version entity.
+// APIVersion - API version entity.
 type APIVersion struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -166,7 +166,7 @@ type APIVersion struct {
 	Name *string
 }
 
-// The response of a ApiVersion list operation.
+// APIVersionListResult - The response of a ApiVersion list operation.
 type APIVersionListResult struct {
 	// REQUIRED; The ApiVersion items on this page
 	Value []*APIVersion
@@ -175,7 +175,7 @@ type APIVersionListResult struct {
 	NextLink *string
 }
 
-// API version properties entity.
+// APIVersionProperties - API version properties entity.
 type APIVersionProperties struct {
 	// REQUIRED; Current lifecycle stage of the API.
 	LifecycleStage *LifecycleStage
@@ -184,7 +184,7 @@ type APIVersionProperties struct {
 	Title *string
 }
 
-// Common properties for all Azure Resource Manager resources.
+// ArmResource - Common properties for all Azure Resource Manager resources.
 type ArmResource struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -196,7 +196,7 @@ type ArmResource struct {
 	SystemData *SystemData
 }
 
-// Base class used for type definitions
+// ArmResourceBase - Base class used for type definitions
 type ArmResourceBase struct {
 }
 
@@ -212,11 +212,11 @@ type Contact struct {
 	URL *string
 }
 
-// Custom Properties
+// CustomProperties - Custom Properties
 type CustomProperties struct {
 }
 
-// API deployment entity.
+// Deployment - API deployment entity.
 type Deployment struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -234,7 +234,7 @@ type Deployment struct {
 	Name *string
 }
 
-// The response of a Deployment list operation.
+// DeploymentListResult - The response of a Deployment list operation.
 type DeploymentListResult struct {
 	// REQUIRED; The Deployment items on this page
 	Value []*Deployment
@@ -243,7 +243,7 @@ type DeploymentListResult struct {
 	NextLink *string
 }
 
-// API deployment entity properties.
+// DeploymentProperties - API deployment entity properties.
 type DeploymentProperties struct {
 	// The custom metadata defined for API catalog entities.
 	CustomProperties *CustomProperties
@@ -267,7 +267,7 @@ type DeploymentProperties struct {
 	Title *string
 }
 
-// Server
+// DeploymentServer - Server
 type DeploymentServer struct {
 	// Base runtime URLs for this deployment.
 	RuntimeURI []*string
@@ -291,7 +291,7 @@ type Environment struct {
 	Name *string
 }
 
-// The response of a Environment list operation.
+// EnvironmentListResult - The response of a Environment list operation.
 type EnvironmentListResult struct {
 	// REQUIRED; The Environment items on this page
 	Value []*Environment
@@ -300,7 +300,7 @@ type EnvironmentListResult struct {
 	NextLink *string
 }
 
-// Environment properties entity.
+// EnvironmentProperties - Environment properties entity.
 type EnvironmentProperties struct {
 	// REQUIRED; Environment kind.
 	Kind *EnvironmentKind
@@ -321,7 +321,7 @@ type EnvironmentProperties struct {
 	Server *EnvironmentServer
 }
 
-// Server information of the environment.
+// EnvironmentServer - Server information of the environment.
 type EnvironmentServer struct {
 	// The location of the management portal
 	ManagementPortalURI []*string
@@ -333,7 +333,7 @@ type EnvironmentServer struct {
 type ErrorAdditionalInfoInfo struct {
 }
 
-// Additional, external documentation for the API.
+// ExternalDocumentation - Additional, external documentation for the API.
 type ExternalDocumentation struct {
 	// REQUIRED; URL pointing to the documentation.
 	URL *string
@@ -345,7 +345,7 @@ type ExternalDocumentation struct {
 	Title *string
 }
 
-// The license information for the API.
+// License - The license information for the API.
 type License struct {
 	// SPDX license information for the API. The identifier field is mutually
 	// exclusive of the URL field.
@@ -359,7 +359,7 @@ type License struct {
 	URL *string
 }
 
-// The properties of the managed service identities assigned to this resource.
+// ManagedIdentityProperties - The properties of the managed service identities assigned to this resource.
 type ManagedIdentityProperties struct {
 	// REQUIRED; The type of managed identity assigned to this resource.
 	Type *ManagedIdentityType
@@ -374,7 +374,7 @@ type ManagedIdentityProperties struct {
 	UserAssignedIdentities map[string]*UserAssignedIdentity
 }
 
-// Assignment metadata
+// MetadataAssignment - Assignment metadata
 type MetadataAssignment struct {
 	// Deprecated assignment
 	Deprecated *bool
@@ -386,7 +386,7 @@ type MetadataAssignment struct {
 	Required *bool
 }
 
-// Metadata schema entity. Used to define metadata for the entities in API catalog.
+// MetadataSchema - Metadata schema entity. Used to define metadata for the entities in API catalog.
 type MetadataSchema struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -404,13 +404,13 @@ type MetadataSchema struct {
 	Name *string
 }
 
-// The metadata schema export request.
+// MetadataSchemaExportRequest - The metadata schema export request.
 type MetadataSchemaExportRequest struct {
 	// An entity the metadata schema is requested for.
 	AssignedTo *MetadataAssignmentEntity
 }
 
-// The metadata schema export result.
+// MetadataSchemaExportResult - The metadata schema export result.
 type MetadataSchemaExportResult struct {
 	// The export format for the schema
 	Format *MetadataSchemaExportFormat
@@ -419,7 +419,7 @@ type MetadataSchemaExportResult struct {
 	Value *string
 }
 
-// The response of a MetadataSchema list operation.
+// MetadataSchemaListResult - The response of a MetadataSchema list operation.
 type MetadataSchemaListResult struct {
 	// REQUIRED; The MetadataSchema items on this page
 	Value []*MetadataSchema
@@ -428,7 +428,7 @@ type MetadataSchemaListResult struct {
 	NextLink *string
 }
 
-// Metadata schema properties.
+// MetadataSchemaProperties - Metadata schema properties.
 type MetadataSchemaProperties struct {
 	// REQUIRED; The schema defining the type.
 	Schema *string
@@ -446,7 +446,7 @@ type Onboarding struct {
 	Instructions *string
 }
 
-// Details of a REST API operation, returned from the Resource Provider Operations API
+// Operation - Details of a REST API operation, returned from the Resource Provider Operations API
 type Operation struct {
 	// Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
 	ActionType *ActionType
@@ -467,7 +467,7 @@ type Operation struct {
 	Origin *Origin
 }
 
-// Localized display information for and operation.
+// OperationDisplay - Localized display information for and operation.
 type OperationDisplay struct {
 	// The short, localized friendly description of the operation; suitable for tool tips and detailed views.
 	Description *string
@@ -483,7 +483,8 @@ type OperationDisplay struct {
 	Resource *string
 }
 
-// A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.
+// PagedOperation - A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get
+// the next set of results.
 type PagedOperation struct {
 	// REQUIRED; The Operation items on this page
 	Value []*Operation
@@ -492,7 +493,7 @@ type PagedOperation struct {
 	NextLink *string
 }
 
-// The base proxy resource.
+// ProxyResourceBase - The base proxy resource.
 type ProxyResourceBase struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -504,7 +505,7 @@ type ProxyResourceBase struct {
 	SystemData *SystemData
 }
 
-// The service entity.
+// Service - The service entity.
 type Service struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -531,7 +532,7 @@ type Service struct {
 	SystemData *SystemData
 }
 
-// The response of a Service list operation.
+// ServiceListResult - The response of a Service list operation.
 type ServiceListResult struct {
 	// REQUIRED; The Service items on this page
 	Value []*Service
@@ -540,13 +541,13 @@ type ServiceListResult struct {
 	NextLink *string
 }
 
-// The properties of the service.
+// ServiceProperties - The properties of the service.
 type ServiceProperties struct {
 	// Provisioning state of the service.
 	ProvisioningState *ProvisioningState
 }
 
-// The type used for update operations of the Service.
+// ServiceUpdate - The type used for update operations of the Service.
 type ServiceUpdate struct {
 	// The managed service identities assigned to this resource.
 	Identity *ManagedIdentityProperties
@@ -555,7 +556,7 @@ type ServiceUpdate struct {
 	Tags map[string]*string
 }
 
-// Metadata pertaining to creation and last modification of the resource.
+// SystemData - Metadata pertaining to creation and last modification of the resource.
 type SystemData struct {
 	// The type of identity that created the resource.
 	CreatedAt *time.Time
@@ -576,13 +577,13 @@ type SystemData struct {
 	LastModifiedByType *CreatedByType
 }
 
-// Terms of service for the API.
+// TermsOfService - Terms of service for the API.
 type TermsOfService struct {
 	// REQUIRED; URL pointing to the terms of service.
 	URL *string
 }
 
-// The resource model definition for an Azure Resource Manager tracked top level resource
+// TrackedResourceBase - The resource model definition for an Azure Resource Manager tracked top level resource
 type TrackedResourceBase struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -600,7 +601,7 @@ type TrackedResourceBase struct {
 	Tags map[string]*string
 }
 
-// A managed identity assigned by the user.
+// UserAssignedIdentity - A managed identity assigned by the user.
 type UserAssignedIdentity struct {
 	// The active directory client identifier for this principal.
 	ClientID *string
@@ -627,7 +628,7 @@ type Workspace struct {
 	Name *string
 }
 
-// The response of a Workspace list operation.
+// WorkspaceListResult - The response of a Workspace list operation.
 type WorkspaceListResult struct {
 	// REQUIRED; The Workspace items on this page
 	Value []*Workspace
@@ -636,7 +637,7 @@ type WorkspaceListResult struct {
 	NextLink *string
 }
 
-// Workspace properties.
+// WorkspaceProperties - Workspace properties.
 type WorkspaceProperties struct {
 	// REQUIRED; Workspace title.
 	Title *string

--- a/packages/typespec-go/test/armcodesigning/zz_models.go
+++ b/packages/typespec-go/test/armcodesigning/zz_models.go
@@ -6,7 +6,7 @@ package armcodesigning
 
 import "time"
 
-// Trusted signing account resource.
+// Account - Trusted signing account resource.
 type Account struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -30,7 +30,7 @@ type Account struct {
 	Name *string
 }
 
-// The response of a CodeSigningAccount list operation.
+// AccountListResult - The response of a CodeSigningAccount list operation.
 type AccountListResult struct {
 	// REQUIRED; The CodeSigningAccount items on this page
 	Value []*Account
@@ -39,7 +39,7 @@ type AccountListResult struct {
 	NextLink *string
 }
 
-// Parameters for creating or updating a trusted signing account.
+// AccountPatch - Parameters for creating or updating a trusted signing account.
 type AccountPatch struct {
 	// Properties of the trusted signing account.
 	Properties *AccountPatchProperties
@@ -48,13 +48,13 @@ type AccountPatch struct {
 	Tags map[string]*string
 }
 
-// Properties of the trusted signing account.
+// AccountPatchProperties - Properties of the trusted signing account.
 type AccountPatchProperties struct {
 	// SKU of the trusted signing account.
 	SKU *AccountSKU
 }
 
-// Properties of the trusted signing account.
+// AccountProperties - Properties of the trusted signing account.
 type AccountProperties struct {
 	// The URI of the trusted signing account which is used during signing files.
 	AccountURI *string
@@ -66,13 +66,13 @@ type AccountProperties struct {
 	SKU *AccountSKU
 }
 
-// SKU of the trusted signing account.
+// AccountSKU - SKU of the trusted signing account.
 type AccountSKU struct {
 	// REQUIRED; Name of the SKU.
 	Name *SKUName
 }
 
-// Common properties for all Azure Resource Manager resources.
+// ArmResource - Common properties for all Azure Resource Manager resources.
 type ArmResource struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -84,11 +84,11 @@ type ArmResource struct {
 	SystemData *SystemData
 }
 
-// Base class used for type definitions
+// ArmResourceBase - Base class used for type definitions
 type ArmResourceBase struct {
 }
 
-// Properties of the certificate.
+// Certificate - Properties of the certificate.
 type Certificate struct {
 	// Certificate created date.
 	CreatedDate *string
@@ -112,7 +112,7 @@ type Certificate struct {
 	Thumbprint *string
 }
 
-// Certificate profile resource.
+// CertificateProfile - Certificate profile resource.
 type CertificateProfile struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -130,7 +130,7 @@ type CertificateProfile struct {
 	Name *string
 }
 
-// The response of a CertificateProfile list operation.
+// CertificateProfileListResult - The response of a CertificateProfile list operation.
 type CertificateProfileListResult struct {
 	// REQUIRED; The CertificateProfile items on this page
 	Value []*CertificateProfile
@@ -139,7 +139,7 @@ type CertificateProfileListResult struct {
 	NextLink *string
 }
 
-// Properties of the certificate profile.
+// CertificateProfileProperties - Properties of the certificate profile.
 type CertificateProfileProperties struct {
 	// REQUIRED; Profile type of the certificate.
 	ProfileType *ProfileType
@@ -199,13 +199,13 @@ type CertificateProfileProperties struct {
 	StreetAddress *string
 }
 
-// The parameters used to check the availability of the trusted signing account name.
+// CheckNameAvailability - The parameters used to check the availability of the trusted signing account name.
 type CheckNameAvailability struct {
 	// REQUIRED; Trusted signing account name.
 	Name *string
 }
 
-// The CheckNameAvailability operation response.
+// CheckNameAvailabilityResult - The CheckNameAvailability operation response.
 type CheckNameAvailabilityResult struct {
 	// An error message explaining the Reason value in more detail.
 	Message *string
@@ -222,7 +222,7 @@ type CheckNameAvailabilityResult struct {
 type ErrorAdditionalInfoInfo struct {
 }
 
-// Details of a REST API operation, returned from the Resource Provider Operations API
+// Operation - Details of a REST API operation, returned from the Resource Provider Operations API
 type Operation struct {
 	// Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
 	ActionType *ActionType
@@ -243,7 +243,7 @@ type Operation struct {
 	Origin *Origin
 }
 
-// Localized display information for and operation.
+// OperationDisplay - Localized display information for and operation.
 type OperationDisplay struct {
 	// The short, localized friendly description of the operation; suitable for tool tips and detailed views.
 	Description *string
@@ -259,7 +259,8 @@ type OperationDisplay struct {
 	Resource *string
 }
 
-// A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.
+// PagedOperation - A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get
+// the next set of results.
 type PagedOperation struct {
 	// REQUIRED; The Operation items on this page
 	Value []*Operation
@@ -268,7 +269,7 @@ type PagedOperation struct {
 	NextLink *string
 }
 
-// The base proxy resource.
+// ProxyResourceBase - The base proxy resource.
 type ProxyResourceBase struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -301,7 +302,7 @@ type Revocation struct {
 	Status *RevocationStatus
 }
 
-// Defines the certificate revocation properties.
+// RevokeCertificate - Defines the certificate revocation properties.
 type RevokeCertificate struct {
 	// REQUIRED; The timestamp when the revocation is effective.
 	EffectiveAt *time.Time
@@ -319,7 +320,7 @@ type RevokeCertificate struct {
 	Remarks *string
 }
 
-// Metadata pertaining to creation and last modification of the resource.
+// SystemData - Metadata pertaining to creation and last modification of the resource.
 type SystemData struct {
 	// The type of identity that created the resource.
 	CreatedAt *time.Time
@@ -340,7 +341,7 @@ type SystemData struct {
 	LastModifiedByType *CreatedByType
 }
 
-// The resource model definition for an Azure Resource Manager tracked top level resource
+// TrackedResourceBase - The resource model definition for an Azure Resource Manager tracked top level resource
 type TrackedResourceBase struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string

--- a/packages/typespec-go/test/armlargeinstance/zz_models.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_models.go
@@ -6,7 +6,7 @@ package armlargeinstance
 
 import "time"
 
-// Common properties for all Azure Resource Manager resources.
+// ArmResource - Common properties for all Azure Resource Manager resources.
 type ArmResource struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string
@@ -18,11 +18,11 @@ type ArmResource struct {
 	SystemData *SystemData
 }
 
-// Base class used for type definitions
+// ArmResourceBase - Base class used for type definitions
 type ArmResourceBase struct {
 }
 
-// Azure Large Instance info on Azure (ARM properties and AzureLargeInstance
+// AzureLargeInstance - Azure Large Instance info on Azure (ARM properties and AzureLargeInstance
 // properties)
 type AzureLargeInstance struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
@@ -72,7 +72,7 @@ type AzureLargeStorageInstance struct {
 	Name *string
 }
 
-// The response of a AzureLargeStorageInstance list operation.
+// AzureLargeStorageInstanceListResult - The response of a AzureLargeStorageInstance list operation.
 type AzureLargeStorageInstanceListResult struct {
 	// REQUIRED; The AzureLargeStorageInstance items on this page
 	Value []*AzureLargeStorageInstance
@@ -81,7 +81,7 @@ type AzureLargeStorageInstanceListResult struct {
 	NextLink *string
 }
 
-// Describes the properties of an AzureLargeStorageInstance.
+// AzureLargeStorageInstanceProperties - Describes the properties of an AzureLargeStorageInstance.
 type AzureLargeStorageInstanceProperties struct {
 	// Specifies the AzureLargeStorageInstance unique ID.
 	AzureLargeStorageInstanceUniqueIdentifier *string
@@ -90,13 +90,13 @@ type AzureLargeStorageInstanceProperties struct {
 	StorageProperties *StorageProperties
 }
 
-// The type used for updating tags in AzureLargeStorageInstance resources.
+// AzureLargeStorageInstanceTagsUpdate - The type used for updating tags in AzureLargeStorageInstance resources.
 type AzureLargeStorageInstanceTagsUpdate struct {
 	// Resource tags.
 	Tags map[string]*string
 }
 
-// Specifies the disk information fo the Azure Large Instance
+// Disk - Specifies the disk information fo the Azure Large Instance
 type Disk struct {
 	// Specifies the size of an empty data disk in gigabytes.
 	DiskSizeGB *int32
@@ -113,14 +113,14 @@ type Disk struct {
 type ErrorAdditionalInfoInfo struct {
 }
 
-// The active state empowers the server with the ability to forcefully terminate
+// ForceState - The active state empowers the server with the ability to forcefully terminate
 // and halt any existing processes that may be running on the server
 type ForceState struct {
 	// Whether to force restart by shutting all processes.
 	ForceState *ForcePowerState
 }
 
-// Specifies the hardware settings for the Azure Large Instance.
+// HardwareProfile - Specifies the hardware settings for the Azure Large Instance.
 type HardwareProfile struct {
 	// Specifies the Azure Large Instance SKU.
 	AzureLargeInstanceSize *SizeNamesEnum
@@ -129,13 +129,13 @@ type HardwareProfile struct {
 	HardwareType *HardwareTypeNamesEnum
 }
 
-// Specifies the IP address of the network interface.
+// IPAddress - Specifies the IP address of the network interface.
 type IPAddress struct {
 	// Specifies the IP address of the network interface.
 	IPAddress *string
 }
 
-// The response of a AzureLargeInstance list operation.
+// ListResult - The response of a AzureLargeInstance list operation.
 type ListResult struct {
 	// REQUIRED; The AzureLargeInstance items on this page
 	Value []*AzureLargeInstance
@@ -144,7 +144,7 @@ type ListResult struct {
 	NextLink *string
 }
 
-// Specifies the network settings for the Azure Large Instance disks.
+// NetworkProfile - Specifies the network settings for the Azure Large Instance disks.
 type NetworkProfile struct {
 	// Specifies the circuit id for connecting to express route.
 	CircuitID *string
@@ -153,7 +153,7 @@ type NetworkProfile struct {
 	NetworkInterfaces []*IPAddress
 }
 
-// Details of a REST API operation, returned from the Resource Provider Operations API
+// Operation - Details of a REST API operation, returned from the Resource Provider Operations API
 type Operation struct {
 	// Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
 	ActionType *ActionType
@@ -174,7 +174,7 @@ type Operation struct {
 	Origin *Origin
 }
 
-// Localized display information for and operation.
+// OperationDisplay - Localized display information for and operation.
 type OperationDisplay struct {
 	// The short, localized friendly description of the operation; suitable for tool tips and detailed views.
 	Description *string
@@ -190,7 +190,7 @@ type OperationDisplay struct {
 	Resource *string
 }
 
-// Specifies the operating system settings for the Azure Large Instance.
+// OsProfile - Specifies the operating system settings for the Azure Large Instance.
 type OsProfile struct {
 	// Specifies the host OS name of the Azure Large Instance.
 	ComputerName *string
@@ -205,7 +205,8 @@ type OsProfile struct {
 	Version *string
 }
 
-// A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get the next set of results.
+// PagedOperation - A list of REST API operations supported by an Azure Resource Provider. It contains an URL link to get
+// the next set of results.
 type PagedOperation struct {
 	// REQUIRED; The Operation items on this page
 	Value []*Operation
@@ -214,7 +215,7 @@ type PagedOperation struct {
 	NextLink *string
 }
 
-// Describes the properties of an Azure Large Instance.
+// Properties - Describes the properties of an Azure Large Instance.
 type Properties struct {
 	// Specifies the Azure Large Instance unique ID.
 	AzureLargeInstanceID *string
@@ -248,7 +249,7 @@ type Properties struct {
 	StorageProfile *StorageProfile
 }
 
-// Describes the billing related details of the AzureLargeStorageInstance.
+// StorageBillingProperties - Describes the billing related details of the AzureLargeStorageInstance.
 type StorageBillingProperties struct {
 	// the billing mode for the storage instance
 	BillingMode *string
@@ -257,7 +258,7 @@ type StorageBillingProperties struct {
 	SKU *string
 }
 
-// Specifies the storage settings for the Azure Large Instance disks.
+// StorageProfile - Specifies the storage settings for the Azure Large Instance disks.
 type StorageProfile struct {
 	// IP Address to connect to storage.
 	NfsIPAddress *string
@@ -267,7 +268,7 @@ type StorageProfile struct {
 	OSDisks []*Disk
 }
 
-// described the storage properties of the azure large storage instance
+// StorageProperties - described the storage properties of the azure large storage instance
 type StorageProperties struct {
 	// the kind of storage instance
 	Generation *string
@@ -291,7 +292,7 @@ type StorageProperties struct {
 	WorkloadType *string
 }
 
-// Metadata pertaining to creation and last modification of the resource.
+// SystemData - Metadata pertaining to creation and last modification of the resource.
 type SystemData struct {
 	// The type of identity that created the resource.
 	CreatedAt *time.Time
@@ -312,13 +313,13 @@ type SystemData struct {
 	LastModifiedByType *CreatedByType
 }
 
-// The type used for updating tags in AzureLargeInstance resources.
+// TagsUpdate - The type used for updating tags in AzureLargeInstance resources.
 type TagsUpdate struct {
 	// Resource tags.
 	Tags map[string]*string
 }
 
-// The resource model definition for an Azure Resource Manager tracked top level resource
+// TrackedResourceBase - The resource model definition for an Azure Resource Manager tracked top level resource
 type TrackedResourceBase struct {
 	// REQUIRED; Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
 	ID *string

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_models.go
@@ -4,31 +4,31 @@
 
 package accessgroup
 
-// Used in a public operation, should be generated and exported.
+// NoDecoratorModelInPublic - Used in a public operation, should be generated and exported.
 type NoDecoratorModelInPublic struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in an internal operation but with public decorator, should be generated and exported.
+// PublicDecoratorModelInInternal - Used in an internal operation but with public decorator, should be generated and exported.
 type PublicDecoratorModelInInternal struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in a public operation, should be generated and exported.
+// PublicDecoratorModelInPublic - Used in a public operation, should be generated and exported.
 type PublicDecoratorModelInPublic struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used by both public and internal operation. It should be generated and exported.
+// SharedModel - Used by both public and internal operation. It should be generated and exported.
 type SharedModel struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in internal operations, should be generated but not exported.
+// abstractModel - Used in internal operations, should be generated but not exported.
 type abstractModel struct {
 	// REQUIRED
 	Kind *string
@@ -40,31 +40,31 @@ type abstractModel struct {
 // GetabstractModel implements the abstractModelClassification interface for type abstractModel.
 func (a *abstractModel) GetabstractModel() *abstractModel { return a }
 
-// Used in internal operations, should be generated but not exported.
+// baseModel - Used in internal operations, should be generated but not exported.
 type baseModel struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in internal operations, should be generated but not exported.
+// innerModel - Used in internal operations, should be generated but not exported.
 type innerModel struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in an internal operation, should be generated but not exported.
+// internalDecoratorModelInInternal - Used in an internal operation, should be generated but not exported.
 type internalDecoratorModelInInternal struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in an internal operation, should be generated but not exported.
+// noDecoratorModelInInternal - Used in an internal operation, should be generated but not exported.
 type noDecoratorModelInInternal struct {
 	// REQUIRED
 	Name *string
 }
 
-// Used in internal operations, should be generated but not exported.
+// outerModel - Used in internal operations, should be generated but not exported.
 type outerModel struct {
 	// REQUIRED
 	Inner *innerModel
@@ -73,7 +73,7 @@ type outerModel struct {
 	Name *string
 }
 
-// Used in internal operations, should be generated but not exported.
+// realModel - Used in internal operations, should be generated but not exported.
 type realModel struct {
 	// REQUIRED
 	Kind *string

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_models.go
@@ -4,19 +4,19 @@
 
 package coreusagegroup
 
-// Usage override to roundtrip.
+// InputModel - Usage override to roundtrip.
 type InputModel struct {
 	// REQUIRED
 	Name *string
 }
 
-// Not used anywhere, but access is override to public so still need to be generated and exported with serialization.
+// OrphanModel - Not used anywhere, but access is override to public so still need to be generated and exported with serialization.
 type OrphanModel struct {
 	// REQUIRED
 	Name *string
 }
 
-// Usage override to roundtrip.
+// OutputModel - Usage override to roundtrip.
 type OutputModel struct {
 	// REQUIRED
 	Name *string

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/flattengroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/flattengroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package flattengroup
 
-// This is the child model to be flattened. And it has flattened property as well.
+// ChildFlattenModel - This is the child model to be flattened. And it has flattened property as well.
 type ChildFlattenModel struct {
 	// REQUIRED
 	Properties *ChildModel
@@ -13,7 +13,7 @@ type ChildFlattenModel struct {
 	Summary *string
 }
 
-// This is the child model to be flattened.
+// ChildModel - This is the child model to be flattened.
 type ChildModel struct {
 	// REQUIRED
 	Age *int32
@@ -22,7 +22,7 @@ type ChildModel struct {
 	Description *string
 }
 
-// This is the model with one level of flattening.
+// FlattenModel - This is the model with one level of flattening.
 type FlattenModel struct {
 	// REQUIRED
 	Name *string
@@ -31,7 +31,7 @@ type FlattenModel struct {
 	Properties *ChildModel
 }
 
-// This is the model with two levels of flattening.
+// NestedFlattenModel - This is the model with two levels of flattening.
 type NestedFlattenModel struct {
 	// REQUIRED
 	Name *string

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_models.go
@@ -6,19 +6,19 @@ package basicgroup
 
 import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
-// First item.
+// FirstItem - First item.
 type FirstItem struct {
 	// REQUIRED; The id of the item.
 	ID *int32
 }
 
-// The body of the input.
+// ListItemInputBody - The body of the input.
 type ListItemInputBody struct {
 	// REQUIRED; The name of the input.
 	InputName *string
 }
 
-// Paged collection of FirstItem items
+// PagedFirstItem - Paged collection of FirstItem items
 type PagedFirstItem struct {
 	// REQUIRED; The FirstItem items on this page
 	Value []*FirstItem
@@ -27,7 +27,7 @@ type PagedFirstItem struct {
 	NextLink *string
 }
 
-// Paged collection of SecondItem items
+// PagedSecondItem - Paged collection of SecondItem items
 type PagedSecondItem struct {
 	// REQUIRED; The SecondItem items on this page
 	Value []*SecondItem
@@ -36,7 +36,7 @@ type PagedSecondItem struct {
 	NextLink *string
 }
 
-// Paged collection of User items
+// PagedUser - Paged collection of User items
 type PagedUser struct {
 	// REQUIRED; The User items on this page
 	Value []*User
@@ -45,13 +45,13 @@ type PagedUser struct {
 	NextLink *string
 }
 
-// Second item.
+// SecondItem - Second item.
 type SecondItem struct {
 	// REQUIRED; The name of the item.
 	Name *string
 }
 
-// Details about a user.
+// User - Details about a user.
 type User struct {
 	// REQUIRED; The entity tag for this resource.
 	Etag *azcore.ETag

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_models.go
@@ -6,7 +6,7 @@ package lrolegacygroup
 
 import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
-// The error object.
+// Error - The error object.
 type Error struct {
 	// REQUIRED; One of a server-defined set of error codes.
 	Code *string
@@ -24,7 +24,7 @@ type Error struct {
 	Target *string
 }
 
-// An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.
+// InnerError - An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.
 type InnerError struct {
 	// One of a server-defined set of error codes.
 	Code *string
@@ -33,13 +33,13 @@ type InnerError struct {
 	Innererror *InnerError
 }
 
-// Data of the job
+// JobData - Data of the job
 type JobData struct {
 	// REQUIRED; Comment.
 	Comment *string
 }
 
-// Result of the job
+// JobResult - Result of the job
 type JobResult struct {
 	// REQUIRED; Comment.
 	Comment *string

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package lrorpcgroup
 
-// The error object.
+// Error - The error object.
 type Error struct {
 	// REQUIRED; One of a server-defined set of error codes.
 	Code *string
@@ -22,13 +22,13 @@ type Error struct {
 	Target *string
 }
 
-// Options for the generation.
+// GenerationOptions - Options for the generation.
 type GenerationOptions struct {
 	// REQUIRED; Prompt.
 	Prompt *string
 }
 
-// Provides status details for long running operations.
+// GenerationResponse - Provides status details for long running operations.
 type GenerationResponse struct {
 	// REQUIRED; The unique ID of the operation.
 	ID *string
@@ -43,13 +43,13 @@ type GenerationResponse struct {
 	Result *GenerationResult
 }
 
-// Result of the generation.
+// GenerationResult - Result of the generation.
 type GenerationResult struct {
 	// REQUIRED; The data.
 	Data *string
 }
 
-// An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.
+// InnerError - An object containing more specific information about the error. As per Microsoft One API guidelines - https://github.com/Microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses.
 type InnerError struct {
 	// One of a server-defined set of error codes.
 	Code *string

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package lrostdgroup
 
-// The exported user data.
+// ExportedUser - The exported user data.
 type ExportedUser struct {
 	// REQUIRED; The name of user.
 	Name *string
@@ -13,7 +13,7 @@ type ExportedUser struct {
 	ResourceURI *string
 }
 
-// Details about a user.
+// User - Details about a user.
 type User struct {
 	// REQUIRED; The name of user.
 	Name *string

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_models.go
@@ -4,13 +4,13 @@
 
 package jmergepatchgroup
 
-// It is the model used by Resource model
+// InnerModel - It is the model used by Resource model
 type InnerModel struct {
 	Description *string
 	Name        *string
 }
 
-// Details about a resource.
+// Resource - Details about a resource.
 type Resource struct {
 	// REQUIRED
 	Name        *string
@@ -23,7 +23,7 @@ type Resource struct {
 	Map         map[string]*InnerModel
 }
 
-// Details about a resource for patch operation.
+// ResourcePatch - Details about a resource for patch operation.
 type ResourcePatch struct {
 	Array       []*InnerModel
 	Description *string

--- a/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/payload/pageablegroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package pageablegroup
 
-// Paged collection of User items
+// PagedUser - Paged collection of User items
 type PagedUser struct {
 	// REQUIRED; The User items on this page
 	Value []*User

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package arraygroup
 
-// Array inner model
+// InnerModel - Array inner model
 type InnerModel struct {
 	// REQUIRED; Required string property
 	Property *string

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package dictionarygroup
 
-// Dictionary inner model
+// InnerModel - Dictionary inner model
 type InnerModel struct {
 	// REQUIRED; Required string property
 	Property *string

--- a/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_models.go
@@ -4,14 +4,14 @@
 
 package emptygroup
 
-// Empty model used in operation parameters
+// EmptyInput - Empty model used in operation parameters
 type EmptyInput struct {
 }
 
-// Empty model used in both parameter and return type
+// EmptyInputOutput - Empty model used in both parameter and return type
 type EmptyInputOutput struct {
 }
 
-// Empty model used in operation return type
+// EmptyOutput - Empty model used in operation return type
 type EmptyOutput struct {
 }

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_models.go
@@ -22,7 +22,7 @@ func (c *Cobra) GetSnake() *Snake {
 	}
 }
 
-// Test extensible enum type for discriminator
+// Dog - Test extensible enum type for discriminator
 type Dog struct {
 	// REQUIRED; discriminator property
 	Kind *DogKind
@@ -52,7 +52,7 @@ func (g *Golden) GetDog() *Dog {
 	}
 }
 
-// Test fixed enum type for discriminator
+// Snake - Test fixed enum type for discriminator
 type Snake struct {
 	// REQUIRED; discriminator property
 	Kind *SnakeKind

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package nodiscgroup
 
-// The second level model in the normal multiple levels inheritance.
+// Cat - The second level model in the normal multiple levels inheritance.
 type Cat struct {
 	// REQUIRED
 	Age *int32
@@ -13,13 +13,13 @@ type Cat struct {
 	Name *string
 }
 
-// This is base model for not-discriminated normal multiple levels inheritance.
+// Pet - This is base model for not-discriminated normal multiple levels inheritance.
 type Pet struct {
 	// REQUIRED
 	Name *string
 }
 
-// The third level model in the normal multiple levels inheritance.
+// Siamese - The third level model in the normal multiple levels inheritance.
 type Siamese struct {
 	// REQUIRED
 	Age *int32

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_models.go
@@ -4,12 +4,12 @@
 
 package recursivegroup
 
-// element
+// Element - element
 type Element struct {
 	Extension []Extension
 }
 
-// extension
+// Extension - extension
 type Extension struct {
 	// REQUIRED
 	Level     *int8

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package singlediscgroup
 
-// This is base model for polymorphic single level inheritance with a discriminator.
+// Bird - This is base model for polymorphic single level inheritance with a discriminator.
 type Bird struct {
 	// REQUIRED
 	Kind *string
@@ -16,7 +16,7 @@ type Bird struct {
 // GetBird implements the BirdClassification interface for type Bird.
 func (b *Bird) GetBird() *Bird { return b }
 
-// Define a base class in the legacy way. Discriminator property is not explicitly defined in the model.
+// Dinosaur - Define a base class in the legacy way. Discriminator property is not explicitly defined in the model.
 type Dinosaur struct {
 	// REQUIRED
 	Kind *string
@@ -28,7 +28,8 @@ type Dinosaur struct {
 // GetDinosaur implements the DinosaurClassification interface for type Dinosaur.
 func (d *Dinosaur) GetDinosaur() *Dinosaur { return d }
 
-// The second level model in polymorphic single levels inheritance which contains references to other polymorphic instances.
+// Eagle - The second level model in polymorphic single levels inheritance which contains references to other polymorphic
+// instances.
 type Eagle struct {
 	// CONSTANT; undefinedField has constant value "eagle", any specified value is ignored.
 	Kind *string
@@ -48,7 +49,7 @@ func (e *Eagle) GetBird() *Bird {
 	}
 }
 
-// The second level model in polymorphic single level inheritance.
+// Goose - The second level model in polymorphic single level inheritance.
 type Goose struct {
 	// CONSTANT; undefinedField has constant value "goose", any specified value is ignored.
 	Kind *string
@@ -65,7 +66,7 @@ func (g *Goose) GetBird() *Bird {
 	}
 }
 
-// The second level model in polymorphic single level inheritance.
+// SeaGull - The second level model in polymorphic single level inheritance.
 type SeaGull struct {
 	// CONSTANT; undefinedField has constant value "seagull", any specified value is ignored.
 	Kind *string
@@ -82,7 +83,7 @@ func (s *SeaGull) GetBird() *Bird {
 	}
 }
 
-// The second level model in polymorphic single level inheritance.
+// Sparrow - The second level model in polymorphic single level inheritance.
 type Sparrow struct {
 	// CONSTANT; undefinedField has constant value "sparrow", any specified value is ignored.
 	Kind *string
@@ -99,7 +100,7 @@ func (s *Sparrow) GetBird() *Bird {
 	}
 }
 
-// The second level legacy model in polymorphic single level inheritance.
+// TRex - The second level legacy model in polymorphic single level inheritance.
 type TRex struct {
 	// REQUIRED
 	Kind *string

--- a/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_models.go
@@ -4,19 +4,19 @@
 
 package usagegroup
 
-// Record used both as operation parameter and return type
+// InputOutputRecord - Record used both as operation parameter and return type
 type InputOutputRecord struct {
 	// REQUIRED
 	RequiredProp *string
 }
 
-// Record used in operation parameters
+// InputRecord - Record used in operation parameters
 type InputRecord struct {
 	// REQUIRED
 	RequiredProp *string
 }
 
-// Record used in operation return type
+// OutputRecord - Record used in operation return type
 type OutputRecord struct {
 	// REQUIRED
 	RequiredProp *string

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_models.go
@@ -4,7 +4,7 @@
 
 package visibilitygroup
 
-// Output model with visibility properties.
+// VisibilityModel - Output model with visibility properties.
 type VisibilityModel struct {
 	// REQUIRED; Required string[], illustrating a create property.
 	CreateProp []*string

--- a/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/property/addlpropsgroup/zz_models.go
@@ -4,38 +4,38 @@
 
 package addlpropsgroup
 
-// The model extends from Record<float32> type.
+// ExtendsFloatAdditionalProperties - The model extends from Record<float32> type.
 type ExtendsFloatAdditionalProperties struct {
 	// REQUIRED; The id property
 	ID                   *float32
 	AdditionalProperties map[string]*float32
 }
 
-// The model extends from Record<ModelForRecord> type.
+// ExtendsModelAdditionalProperties - The model extends from Record<ModelForRecord> type.
 type ExtendsModelAdditionalProperties struct {
 	AdditionalProperties map[string]*ModelForRecord
 }
 
-// The model extends from Record<ModelForRecord[]> type.
+// ExtendsModelArrayAdditionalProperties - The model extends from Record<ModelForRecord[]> type.
 type ExtendsModelArrayAdditionalProperties struct {
 	AdditionalProperties map[string][]*ModelForRecord
 }
 
-// The model extends from Record<string> type.
+// ExtendsStringAdditionalProperties - The model extends from Record<string> type.
 type ExtendsStringAdditionalProperties struct {
 	// REQUIRED; The name property
 	Name                 *string
 	AdditionalProperties map[string]*string
 }
 
-// The model extends from Record<unknown> type.
+// ExtendsUnknownAdditionalProperties - The model extends from Record<unknown> type.
 type ExtendsUnknownAdditionalProperties struct {
 	// REQUIRED; The name property
 	Name                 *string
 	AdditionalProperties map[string]any
 }
 
-// The model extends from a type that extends from Record<unknown>.
+// ExtendsUnknownAdditionalPropertiesDerived - The model extends from a type that extends from Record<unknown>.
 type ExtendsUnknownAdditionalPropertiesDerived struct {
 	// REQUIRED; The index property
 	Index *int32
@@ -48,7 +48,7 @@ type ExtendsUnknownAdditionalPropertiesDerived struct {
 	Age *float32
 }
 
-// The model extends from Record<unknown> with a discriminator.
+// ExtendsUnknownAdditionalPropertiesDiscriminated - The model extends from Record<unknown> with a discriminator.
 type ExtendsUnknownAdditionalPropertiesDiscriminated struct {
 	// REQUIRED; The discriminator
 	Kind *string
@@ -64,7 +64,7 @@ func (e *ExtendsUnknownAdditionalPropertiesDiscriminated) GetExtendsUnknownAddit
 	return e
 }
 
-// The derived discriminated type
+// ExtendsUnknownAdditionalPropertiesDiscriminatedDerived - The derived discriminated type
 type ExtendsUnknownAdditionalPropertiesDiscriminatedDerived struct {
 	// REQUIRED; The index property
 	Index *int32
@@ -90,38 +90,38 @@ func (e *ExtendsUnknownAdditionalPropertiesDiscriminatedDerived) GetExtendsUnkno
 	}
 }
 
-// The model is from Record<float32> type.
+// IsFloatAdditionalProperties - The model is from Record<float32> type.
 type IsFloatAdditionalProperties struct {
 	// REQUIRED; The id property
 	ID                   *float32
 	AdditionalProperties map[string]*float32
 }
 
-// The model is from Record<ModelForRecord> type.
+// IsModelAdditionalProperties - The model is from Record<ModelForRecord> type.
 type IsModelAdditionalProperties struct {
 	AdditionalProperties map[string]*ModelForRecord
 }
 
-// The model is from Record<ModelForRecord[]> type.
+// IsModelArrayAdditionalProperties - The model is from Record<ModelForRecord[]> type.
 type IsModelArrayAdditionalProperties struct {
 	AdditionalProperties map[string][]*ModelForRecord
 }
 
-// The model is from Record<string> type.
+// IsStringAdditionalProperties - The model is from Record<string> type.
 type IsStringAdditionalProperties struct {
 	// REQUIRED; The name property
 	Name                 *string
 	AdditionalProperties map[string]*string
 }
 
-// The model is from Record<unknown> type.
+// IsUnknownAdditionalProperties - The model is from Record<unknown> type.
 type IsUnknownAdditionalProperties struct {
 	// REQUIRED; The name property
 	Name                 *string
 	AdditionalProperties map[string]any
 }
 
-// The model extends from a type that is Record<unknown> type
+// IsUnknownAdditionalPropertiesDerived - The model extends from a type that is Record<unknown> type
 type IsUnknownAdditionalPropertiesDerived struct {
 	// REQUIRED; The index property
 	Index *int32
@@ -134,7 +134,7 @@ type IsUnknownAdditionalPropertiesDerived struct {
 	Age *float32
 }
 
-// The model is Record<unknown> with a discriminator.
+// IsUnknownAdditionalPropertiesDiscriminated - The model is Record<unknown> with a discriminator.
 type IsUnknownAdditionalPropertiesDiscriminated struct {
 	// REQUIRED; The discriminator
 	Kind *string
@@ -150,7 +150,7 @@ func (i *IsUnknownAdditionalPropertiesDiscriminated) GetIsUnknownAdditionalPrope
 	return i
 }
 
-// The derived discriminated type
+// IsUnknownAdditionalPropertiesDiscriminatedDerived - The derived discriminated type
 type IsUnknownAdditionalPropertiesDiscriminatedDerived struct {
 	// REQUIRED; The index property
 	Index *int32
@@ -176,7 +176,7 @@ func (i *IsUnknownAdditionalPropertiesDiscriminatedDerived) GetIsUnknownAddition
 	}
 }
 
-// model for record
+// ModelForRecord - model for record
 type ModelForRecord struct {
 	// REQUIRED; The state property
 	State *string

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_models.go
@@ -6,7 +6,8 @@ package nullablegroup
 
 import "time"
 
-// Template type for testing models with nullable property. Pass in the type of the property you are looking for
+// BytesProperty - Template type for testing models with nullable property. Pass in the type of the property you are looking
+// for
 type BytesProperty struct {
 	// REQUIRED; Property
 	NullableProperty []byte
@@ -15,7 +16,7 @@ type BytesProperty struct {
 	RequiredProperty *string
 }
 
-// Model with collection bytes properties
+// CollectionsByteProperty - Model with collection bytes properties
 type CollectionsByteProperty struct {
 	// REQUIRED; Property
 	NullableProperty [][]byte
@@ -24,7 +25,7 @@ type CollectionsByteProperty struct {
 	RequiredProperty *string
 }
 
-// Model with collection models properties
+// CollectionsModelProperty - Model with collection models properties
 type CollectionsModelProperty struct {
 	// REQUIRED; Property
 	NullableProperty []*InnerModel
@@ -33,7 +34,7 @@ type CollectionsModelProperty struct {
 	RequiredProperty *string
 }
 
-// Model with a datetime property
+// DatetimeProperty - Model with a datetime property
 type DatetimeProperty struct {
 	// REQUIRED; Property
 	NullableProperty *time.Time
@@ -42,7 +43,7 @@ type DatetimeProperty struct {
 	RequiredProperty *string
 }
 
-// Model with a duration property
+// DurationProperty - Model with a duration property
 type DurationProperty struct {
 	// REQUIRED; Property
 	NullableProperty *string
@@ -51,13 +52,14 @@ type DurationProperty struct {
 	RequiredProperty *string
 }
 
-// Inner model used in collections model property
+// InnerModel - Inner model used in collections model property
 type InnerModel struct {
 	// REQUIRED; Inner model property
 	Property *string
 }
 
-// Template type for testing models with nullable property. Pass in the type of the property you are looking for
+// StringProperty - Template type for testing models with nullable property. Pass in the type of the property you are looking
+// for
 type StringProperty struct {
 	// REQUIRED; Property
 	NullableProperty *string


### PR DESCRIPTION
Struct doc comments were missing the type name prefix. If the doc comment already starts with the type name, don't prepend it.

Fixes https://github.com/Azure/autorest.go/issues/1220