### PR TITLE
Fix up some tsp naming

### DIFF
--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -41,7 +41,7 @@ export class clientAdapter {
   }
 
   private recursiveAdaptClient(sdkClient: tcgc.SdkClientType<tcgc.SdkHttpOperation>, parent?: go.Client): go.Client {
-    let clientName = sdkClient.name;
+    let clientName = ensureNameCase(sdkClient.name);
     if (parent) {
       // for hierarchical clients, the child client names are built
       // from the parent client name. this is because tsp allows subclients
@@ -194,6 +194,9 @@ export class clientAdapter {
       let prefix = method.client.name;
       if (this.opts['single-client']) {
         prefix = '';
+      }
+      if (go.isLROMethod(method)) {
+        prefix += 'Begin';
       }
       let optionalParamsGroupName = `${prefix}${method.name}Options`;
       if (sdkMethod.access === 'internal') {

--- a/packages/typespec-go/test/armapicenter/fake/zz_apidefinitions_server.go
+++ b/packages/typespec-go/test/armapicenter/fake/zz_apidefinitions_server.go
@@ -18,60 +18,60 @@ import (
 	"regexp"
 )
 
-// ApiDefinitionsServer is a fake server for instances of the armapicenter.ApiDefinitionsClient type.
-type ApiDefinitionsServer struct {
-	// CreateOrUpdate is the fake for method ApiDefinitionsClient.CreateOrUpdate
+// APIDefinitionsServer is a fake server for instances of the armapicenter.APIDefinitionsClient type.
+type APIDefinitionsServer struct {
+	// CreateOrUpdate is the fake for method APIDefinitionsClient.CreateOrUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	CreateOrUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload armapicenter.APIDefinition, options *armapicenter.ApiDefinitionsClientCreateOrUpdateOptions) (resp azfake.Responder[armapicenter.ApiDefinitionsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
+	CreateOrUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload armapicenter.APIDefinition, options *armapicenter.APIDefinitionsClientCreateOrUpdateOptions) (resp azfake.Responder[armapicenter.APIDefinitionsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
 
-	// Delete is the fake for method ApiDefinitionsClient.Delete
+	// Delete is the fake for method APIDefinitionsClient.Delete
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusNoContent
-	Delete func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.ApiDefinitionsClientDeleteOptions) (resp azfake.Responder[armapicenter.ApiDefinitionsClientDeleteResponse], errResp azfake.ErrorResponder)
+	Delete func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.APIDefinitionsClientDeleteOptions) (resp azfake.Responder[armapicenter.APIDefinitionsClientDeleteResponse], errResp azfake.ErrorResponder)
 
-	// BeginExportSpecification is the fake for method ApiDefinitionsClient.BeginExportSpecification
+	// BeginExportSpecification is the fake for method APIDefinitionsClient.BeginExportSpecification
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginExportSpecification func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *armapicenter.ApiDefinitionsClientExportSpecificationOptions) (resp azfake.PollerResponder[armapicenter.ApiDefinitionsClientExportSpecificationResponse], errResp azfake.ErrorResponder)
+	BeginExportSpecification func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *armapicenter.APIDefinitionsClientBeginExportSpecificationOptions) (resp azfake.PollerResponder[armapicenter.APIDefinitionsClientExportSpecificationResponse], errResp azfake.ErrorResponder)
 
-	// Get is the fake for method ApiDefinitionsClient.Get
+	// Get is the fake for method APIDefinitionsClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
-	Get func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.ApiDefinitionsClientGetOptions) (resp azfake.Responder[armapicenter.ApiDefinitionsClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.APIDefinitionsClientGetOptions) (resp azfake.Responder[armapicenter.APIDefinitionsClientGetResponse], errResp azfake.ErrorResponder)
 
-	// Head is the fake for method ApiDefinitionsClient.Head
+	// Head is the fake for method APIDefinitionsClient.Head
 	// HTTP status codes to indicate success: http.StatusOK
-	Head func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.ApiDefinitionsClientHeadOptions) (resp azfake.Responder[armapicenter.ApiDefinitionsClientHeadResponse], errResp azfake.ErrorResponder)
+	Head func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *armapicenter.APIDefinitionsClientHeadOptions) (resp azfake.Responder[armapicenter.APIDefinitionsClientHeadResponse], errResp azfake.ErrorResponder)
 
-	// BeginImportSpecification is the fake for method ApiDefinitionsClient.BeginImportSpecification
+	// BeginImportSpecification is the fake for method APIDefinitionsClient.BeginImportSpecification
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginImportSpecification func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload armapicenter.APISpecImportRequest, options *armapicenter.ApiDefinitionsClientImportSpecificationOptions) (resp azfake.PollerResponder[armapicenter.ApiDefinitionsClientImportSpecificationResponse], errResp azfake.ErrorResponder)
+	BeginImportSpecification func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload armapicenter.APISpecImportRequest, options *armapicenter.APIDefinitionsClientBeginImportSpecificationOptions) (resp azfake.PollerResponder[armapicenter.APIDefinitionsClientImportSpecificationResponse], errResp azfake.ErrorResponder)
 
-	// NewListPager is the fake for method ApiDefinitionsClient.NewListPager
+	// NewListPager is the fake for method APIDefinitionsClient.NewListPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListPager func(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.ApiDefinitionsClientListOptions) (resp azfake.PagerResponder[armapicenter.ApiDefinitionsClientListResponse])
+	NewListPager func(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.APIDefinitionsClientListOptions) (resp azfake.PagerResponder[armapicenter.APIDefinitionsClientListResponse])
 }
 
-// NewApiDefinitionsServerTransport creates a new instance of ApiDefinitionsServerTransport with the provided implementation.
-// The returned ApiDefinitionsServerTransport instance is connected to an instance of armapicenter.ApiDefinitionsClient via the
+// NewAPIDefinitionsServerTransport creates a new instance of APIDefinitionsServerTransport with the provided implementation.
+// The returned APIDefinitionsServerTransport instance is connected to an instance of armapicenter.APIDefinitionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewApiDefinitionsServerTransport(srv *ApiDefinitionsServer) *ApiDefinitionsServerTransport {
-	return &ApiDefinitionsServerTransport{
+func NewAPIDefinitionsServerTransport(srv *APIDefinitionsServer) *APIDefinitionsServerTransport {
+	return &APIDefinitionsServerTransport{
 		srv:                      srv,
-		beginExportSpecification: newTracker[azfake.PollerResponder[armapicenter.ApiDefinitionsClientExportSpecificationResponse]](),
-		beginImportSpecification: newTracker[azfake.PollerResponder[armapicenter.ApiDefinitionsClientImportSpecificationResponse]](),
-		newListPager:             newTracker[azfake.PagerResponder[armapicenter.ApiDefinitionsClientListResponse]](),
+		beginExportSpecification: newTracker[azfake.PollerResponder[armapicenter.APIDefinitionsClientExportSpecificationResponse]](),
+		beginImportSpecification: newTracker[azfake.PollerResponder[armapicenter.APIDefinitionsClientImportSpecificationResponse]](),
+		newListPager:             newTracker[azfake.PagerResponder[armapicenter.APIDefinitionsClientListResponse]](),
 	}
 }
 
-// ApiDefinitionsServerTransport connects instances of armapicenter.ApiDefinitionsClient to instances of ApiDefinitionsServer.
-// Don't use this type directly, use NewApiDefinitionsServerTransport instead.
-type ApiDefinitionsServerTransport struct {
-	srv                      *ApiDefinitionsServer
-	beginExportSpecification *tracker[azfake.PollerResponder[armapicenter.ApiDefinitionsClientExportSpecificationResponse]]
-	beginImportSpecification *tracker[azfake.PollerResponder[armapicenter.ApiDefinitionsClientImportSpecificationResponse]]
-	newListPager             *tracker[azfake.PagerResponder[armapicenter.ApiDefinitionsClientListResponse]]
+// APIDefinitionsServerTransport connects instances of armapicenter.APIDefinitionsClient to instances of APIDefinitionsServer.
+// Don't use this type directly, use NewAPIDefinitionsServerTransport instead.
+type APIDefinitionsServerTransport struct {
+	srv                      *APIDefinitionsServer
+	beginExportSpecification *tracker[azfake.PollerResponder[armapicenter.APIDefinitionsClientExportSpecificationResponse]]
+	beginImportSpecification *tracker[azfake.PollerResponder[armapicenter.APIDefinitionsClientImportSpecificationResponse]]
+	newListPager             *tracker[azfake.PagerResponder[armapicenter.APIDefinitionsClientListResponse]]
 }
 
-// Do implements the policy.Transporter interface for ApiDefinitionsServerTransport.
-func (a *ApiDefinitionsServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for APIDefinitionsServerTransport.
+func (a *APIDefinitionsServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -81,24 +81,24 @@ func (a *ApiDefinitionsServerTransport) Do(req *http.Request) (*http.Response, e
 	return a.dispatchToMethodFake(req, method)
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "ApiDefinitionsClient.CreateOrUpdate":
+	case "APIDefinitionsClient.CreateOrUpdate":
 		resp, err = a.dispatchCreateOrUpdate(req)
-	case "ApiDefinitionsClient.Delete":
+	case "APIDefinitionsClient.Delete":
 		resp, err = a.dispatchDelete(req)
-	case "ApiDefinitionsClient.BeginExportSpecification":
+	case "APIDefinitionsClient.BeginExportSpecification":
 		resp, err = a.dispatchBeginExportSpecification(req)
-	case "ApiDefinitionsClient.Get":
+	case "APIDefinitionsClient.Get":
 		resp, err = a.dispatchGet(req)
-	case "ApiDefinitionsClient.Head":
+	case "APIDefinitionsClient.Head":
 		resp, err = a.dispatchHead(req)
-	case "ApiDefinitionsClient.BeginImportSpecification":
+	case "APIDefinitionsClient.BeginImportSpecification":
 		resp, err = a.dispatchBeginImportSpecification(req)
-	case "ApiDefinitionsClient.NewListPager":
+	case "APIDefinitionsClient.NewListPager":
 		resp, err = a.dispatchNewListPager(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -107,7 +107,7 @@ func (a *ApiDefinitionsServerTransport) dispatchToMethodFake(req *http.Request, 
 	return resp, err
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchCreateOrUpdate(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchCreateOrUpdate(req *http.Request) (*http.Response, error) {
 	if a.srv.CreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateOrUpdate not implemented")}
 	}
@@ -167,7 +167,7 @@ func (a *ApiDefinitionsServerTransport) dispatchCreateOrUpdate(req *http.Request
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchDelete(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchDelete(req *http.Request) (*http.Response, error) {
 	if a.srv.Delete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete not implemented")}
 	}
@@ -220,7 +220,7 @@ func (a *ApiDefinitionsServerTransport) dispatchDelete(req *http.Request) (*http
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchBeginExportSpecification(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchBeginExportSpecification(req *http.Request) (*http.Response, error) {
 	if a.srv.BeginExportSpecification == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginExportSpecification not implemented")}
 	}
@@ -288,7 +288,7 @@ func (a *ApiDefinitionsServerTransport) dispatchBeginExportSpecification(req *ht
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
 	if a.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
@@ -344,7 +344,7 @@ func (a *ApiDefinitionsServerTransport) dispatchGet(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchHead(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchHead(req *http.Request) (*http.Response, error) {
 	if a.srv.Head == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Head not implemented")}
 	}
@@ -397,7 +397,7 @@ func (a *ApiDefinitionsServerTransport) dispatchHead(req *http.Request) (*http.R
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchBeginImportSpecification(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchBeginImportSpecification(req *http.Request) (*http.Response, error) {
 	if a.srv.BeginImportSpecification == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginImportSpecification not implemented")}
 	}
@@ -465,7 +465,7 @@ func (a *ApiDefinitionsServerTransport) dispatchBeginImportSpecification(req *ht
 	return resp, nil
 }
 
-func (a *ApiDefinitionsServerTransport) dispatchNewListPager(req *http.Request) (*http.Response, error) {
+func (a *APIDefinitionsServerTransport) dispatchNewListPager(req *http.Request) (*http.Response, error) {
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
@@ -507,16 +507,16 @@ func (a *ApiDefinitionsServerTransport) dispatchNewListPager(req *http.Request) 
 			return nil, err
 		}
 		filterParam := getOptional(filterUnescaped)
-		var options *armapicenter.ApiDefinitionsClientListOptions
+		var options *armapicenter.APIDefinitionsClientListOptions
 		if filterParam != nil {
-			options = &armapicenter.ApiDefinitionsClientListOptions{
+			options = &armapicenter.APIDefinitionsClientListOptions{
 				Filter: filterParam,
 			}
 		}
 		resp := a.srv.NewListPager(subscriptionIDParam, resourceGroupNameParam, serviceNameParam, workspaceNameParam, apiNameParam, versionNameParam, options)
 		newListPager = &resp
 		a.newListPager.add(req, newListPager)
-		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armapicenter.ApiDefinitionsClientListResponse, createLink func() string) {
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armapicenter.APIDefinitionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}

--- a/packages/typespec-go/test/armapicenter/fake/zz_apiversions_server.go
+++ b/packages/typespec-go/test/armapicenter/fake/zz_apiversions_server.go
@@ -18,48 +18,48 @@ import (
 	"regexp"
 )
 
-// ApiVersionsServer is a fake server for instances of the armapicenter.ApiVersionsClient type.
-type ApiVersionsServer struct {
-	// CreateOrUpdate is the fake for method ApiVersionsClient.CreateOrUpdate
+// APIVersionsServer is a fake server for instances of the armapicenter.APIVersionsClient type.
+type APIVersionsServer struct {
+	// CreateOrUpdate is the fake for method APIVersionsClient.CreateOrUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	CreateOrUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload armapicenter.APIVersion, options *armapicenter.ApiVersionsClientCreateOrUpdateOptions) (resp azfake.Responder[armapicenter.ApiVersionsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
+	CreateOrUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload armapicenter.APIVersion, options *armapicenter.APIVersionsClientCreateOrUpdateOptions) (resp azfake.Responder[armapicenter.APIVersionsClientCreateOrUpdateResponse], errResp azfake.ErrorResponder)
 
-	// Delete is the fake for method ApiVersionsClient.Delete
+	// Delete is the fake for method APIVersionsClient.Delete
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusNoContent
-	Delete func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.ApiVersionsClientDeleteOptions) (resp azfake.Responder[armapicenter.ApiVersionsClientDeleteResponse], errResp azfake.ErrorResponder)
+	Delete func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.APIVersionsClientDeleteOptions) (resp azfake.Responder[armapicenter.APIVersionsClientDeleteResponse], errResp azfake.ErrorResponder)
 
-	// Get is the fake for method ApiVersionsClient.Get
+	// Get is the fake for method APIVersionsClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
-	Get func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.ApiVersionsClientGetOptions) (resp azfake.Responder[armapicenter.ApiVersionsClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.APIVersionsClientGetOptions) (resp azfake.Responder[armapicenter.APIVersionsClientGetResponse], errResp azfake.ErrorResponder)
 
-	// Head is the fake for method ApiVersionsClient.Head
+	// Head is the fake for method APIVersionsClient.Head
 	// HTTP status codes to indicate success: http.StatusOK
-	Head func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.ApiVersionsClientHeadOptions) (resp azfake.Responder[armapicenter.ApiVersionsClientHeadResponse], errResp azfake.ErrorResponder)
+	Head func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *armapicenter.APIVersionsClientHeadOptions) (resp azfake.Responder[armapicenter.APIVersionsClientHeadResponse], errResp azfake.ErrorResponder)
 
-	// NewListPager is the fake for method ApiVersionsClient.NewListPager
+	// NewListPager is the fake for method APIVersionsClient.NewListPager
 	// HTTP status codes to indicate success: http.StatusOK
-	NewListPager func(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *armapicenter.ApiVersionsClientListOptions) (resp azfake.PagerResponder[armapicenter.ApiVersionsClientListResponse])
+	NewListPager func(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *armapicenter.APIVersionsClientListOptions) (resp azfake.PagerResponder[armapicenter.APIVersionsClientListResponse])
 }
 
-// NewApiVersionsServerTransport creates a new instance of ApiVersionsServerTransport with the provided implementation.
-// The returned ApiVersionsServerTransport instance is connected to an instance of armapicenter.ApiVersionsClient via the
+// NewAPIVersionsServerTransport creates a new instance of APIVersionsServerTransport with the provided implementation.
+// The returned APIVersionsServerTransport instance is connected to an instance of armapicenter.APIVersionsClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewApiVersionsServerTransport(srv *ApiVersionsServer) *ApiVersionsServerTransport {
-	return &ApiVersionsServerTransport{
+func NewAPIVersionsServerTransport(srv *APIVersionsServer) *APIVersionsServerTransport {
+	return &APIVersionsServerTransport{
 		srv:          srv,
-		newListPager: newTracker[azfake.PagerResponder[armapicenter.ApiVersionsClientListResponse]](),
+		newListPager: newTracker[azfake.PagerResponder[armapicenter.APIVersionsClientListResponse]](),
 	}
 }
 
-// ApiVersionsServerTransport connects instances of armapicenter.ApiVersionsClient to instances of ApiVersionsServer.
-// Don't use this type directly, use NewApiVersionsServerTransport instead.
-type ApiVersionsServerTransport struct {
-	srv          *ApiVersionsServer
-	newListPager *tracker[azfake.PagerResponder[armapicenter.ApiVersionsClientListResponse]]
+// APIVersionsServerTransport connects instances of armapicenter.APIVersionsClient to instances of APIVersionsServer.
+// Don't use this type directly, use NewAPIVersionsServerTransport instead.
+type APIVersionsServerTransport struct {
+	srv          *APIVersionsServer
+	newListPager *tracker[azfake.PagerResponder[armapicenter.APIVersionsClientListResponse]]
 }
 
-// Do implements the policy.Transporter interface for ApiVersionsServerTransport.
-func (a *ApiVersionsServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for APIVersionsServerTransport.
+func (a *APIVersionsServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -69,20 +69,20 @@ func (a *ApiVersionsServerTransport) Do(req *http.Request) (*http.Response, erro
 	return a.dispatchToMethodFake(req, method)
 }
 
-func (a *ApiVersionsServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "ApiVersionsClient.CreateOrUpdate":
+	case "APIVersionsClient.CreateOrUpdate":
 		resp, err = a.dispatchCreateOrUpdate(req)
-	case "ApiVersionsClient.Delete":
+	case "APIVersionsClient.Delete":
 		resp, err = a.dispatchDelete(req)
-	case "ApiVersionsClient.Get":
+	case "APIVersionsClient.Get":
 		resp, err = a.dispatchGet(req)
-	case "ApiVersionsClient.Head":
+	case "APIVersionsClient.Head":
 		resp, err = a.dispatchHead(req)
-	case "ApiVersionsClient.NewListPager":
+	case "APIVersionsClient.NewListPager":
 		resp, err = a.dispatchNewListPager(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -91,7 +91,7 @@ func (a *ApiVersionsServerTransport) dispatchToMethodFake(req *http.Request, met
 	return resp, err
 }
 
-func (a *ApiVersionsServerTransport) dispatchCreateOrUpdate(req *http.Request) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchCreateOrUpdate(req *http.Request) (*http.Response, error) {
 	if a.srv.CreateOrUpdate == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateOrUpdate not implemented")}
 	}
@@ -147,7 +147,7 @@ func (a *ApiVersionsServerTransport) dispatchCreateOrUpdate(req *http.Request) (
 	return resp, nil
 }
 
-func (a *ApiVersionsServerTransport) dispatchDelete(req *http.Request) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchDelete(req *http.Request) (*http.Response, error) {
 	if a.srv.Delete == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Delete not implemented")}
 	}
@@ -196,7 +196,7 @@ func (a *ApiVersionsServerTransport) dispatchDelete(req *http.Request) (*http.Re
 	return resp, nil
 }
 
-func (a *ApiVersionsServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
 	if a.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
@@ -248,7 +248,7 @@ func (a *ApiVersionsServerTransport) dispatchGet(req *http.Request) (*http.Respo
 	return resp, nil
 }
 
-func (a *ApiVersionsServerTransport) dispatchHead(req *http.Request) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchHead(req *http.Request) (*http.Response, error) {
 	if a.srv.Head == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Head not implemented")}
 	}
@@ -297,7 +297,7 @@ func (a *ApiVersionsServerTransport) dispatchHead(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-func (a *ApiVersionsServerTransport) dispatchNewListPager(req *http.Request) (*http.Response, error) {
+func (a *APIVersionsServerTransport) dispatchNewListPager(req *http.Request) (*http.Response, error) {
 	if a.srv.NewListPager == nil {
 		return nil, &nonRetriableError{errors.New("fake for method NewListPager not implemented")}
 	}
@@ -335,16 +335,16 @@ func (a *ApiVersionsServerTransport) dispatchNewListPager(req *http.Request) (*h
 			return nil, err
 		}
 		filterParam := getOptional(filterUnescaped)
-		var options *armapicenter.ApiVersionsClientListOptions
+		var options *armapicenter.APIVersionsClientListOptions
 		if filterParam != nil {
-			options = &armapicenter.ApiVersionsClientListOptions{
+			options = &armapicenter.APIVersionsClientListOptions{
 				Filter: filterParam,
 			}
 		}
 		resp := a.srv.NewListPager(subscriptionIDParam, resourceGroupNameParam, serviceNameParam, workspaceNameParam, apiNameParam, options)
 		newListPager = &resp
 		a.newListPager.add(req, newListPager)
-		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armapicenter.ApiVersionsClientListResponse, createLink func() string) {
+		server.PagerResponderInjectNextLinks(newListPager, req, func(page *armapicenter.APIVersionsClientListResponse, createLink func() string) {
 			page.NextLink = to.Ptr(createLink())
 		})
 	}

--- a/packages/typespec-go/test/armapicenter/fake/zz_server.go
+++ b/packages/typespec-go/test/armapicenter/fake/zz_server.go
@@ -15,11 +15,11 @@ import (
 
 // Server is a fake server for instances of the armapicenter.Client type.
 type Server struct {
-	// ApiDefinitionsServer contains the fakes for client ApiDefinitionsClient
-	ApiDefinitionsServer ApiDefinitionsServer
+	// APIDefinitionsServer contains the fakes for client APIDefinitionsClient
+	APIDefinitionsServer APIDefinitionsServer
 
-	// ApiVersionsServer contains the fakes for client ApiVersionsClient
-	ApiVersionsServer ApiVersionsServer
+	// APIVersionsServer contains the fakes for client APIVersionsClient
+	APIVersionsServer APIVersionsServer
 
 	// ApisServer contains the fakes for client ApisClient
 	ApisServer ApisServer
@@ -55,8 +55,8 @@ func NewServerTransport(srv *Server) *ServerTransport {
 type ServerTransport struct {
 	srv                     *Server
 	trMu                    sync.Mutex
-	trApiDefinitionsServer  *ApiDefinitionsServerTransport
-	trApiVersionsServer     *ApiVersionsServerTransport
+	trAPIDefinitionsServer  *APIDefinitionsServerTransport
+	trAPIVersionsServer     *APIVersionsServerTransport
 	trApisServer            *ApisServerTransport
 	trDeploymentsServer     *DeploymentsServerTransport
 	trEnvironmentsServer    *EnvironmentsServerTransport
@@ -82,16 +82,16 @@ func (s *ServerTransport) dispatchToClientFake(req *http.Request, client string)
 	var err error
 
 	switch client {
-	case "ApiDefinitionsClient":
-		initServer(&s.trMu, &s.trApiDefinitionsServer, func() *ApiDefinitionsServerTransport {
-			return NewApiDefinitionsServerTransport(&s.srv.ApiDefinitionsServer)
+	case "APIDefinitionsClient":
+		initServer(&s.trMu, &s.trAPIDefinitionsServer, func() *APIDefinitionsServerTransport {
+			return NewAPIDefinitionsServerTransport(&s.srv.APIDefinitionsServer)
 		})
-		resp, err = s.trApiDefinitionsServer.Do(req)
-	case "ApiVersionsClient":
-		initServer(&s.trMu, &s.trApiVersionsServer, func() *ApiVersionsServerTransport {
-			return NewApiVersionsServerTransport(&s.srv.ApiVersionsServer)
+		resp, err = s.trAPIDefinitionsServer.Do(req)
+	case "APIVersionsClient":
+		initServer(&s.trMu, &s.trAPIVersionsServer, func() *APIVersionsServerTransport {
+			return NewAPIVersionsServerTransport(&s.srv.APIVersionsServer)
 		})
-		resp, err = s.trApiVersionsServer.Do(req)
+		resp, err = s.trAPIVersionsServer.Do(req)
 	case "ApisClient":
 		initServer(&s.trMu, &s.trApisServer, func() *ApisServerTransport {
 			return NewApisServerTransport(&s.srv.ApisServer)

--- a/packages/typespec-go/test/armapicenter/fake/zz_services_server.go
+++ b/packages/typespec-go/test/armapicenter/fake/zz_services_server.go
@@ -30,7 +30,7 @@ type ServicesServer struct {
 
 	// BeginExportMetadataSchema is the fake for method ServicesClient.BeginExportMetadataSchema
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginExportMetadataSchema func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload armapicenter.MetadataSchemaExportRequest, options *armapicenter.ServicesClientExportMetadataSchemaOptions) (resp azfake.PollerResponder[armapicenter.ServicesClientExportMetadataSchemaResponse], errResp azfake.ErrorResponder)
+	BeginExportMetadataSchema func(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload armapicenter.MetadataSchemaExportRequest, options *armapicenter.ServicesClientBeginExportMetadataSchemaOptions) (resp azfake.PollerResponder[armapicenter.ServicesClientExportMetadataSchemaResponse], errResp azfake.ErrorResponder)
 
 	// Get is the fake for method ServicesClient.Get
 	// HTTP status codes to indicate success: http.StatusOK

--- a/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
@@ -16,21 +16,21 @@ import (
 	"strings"
 )
 
-// ApiDefinitionsClient contains the methods for the Microsoft.ApiCenter namespace.
-// Don't use this type directly, use NewApiDefinitionsClient() instead.
-type ApiDefinitionsClient struct {
+// APIDefinitionsClient contains the methods for the Microsoft.ApiCenter namespace.
+// Don't use this type directly, use NewAPIDefinitionsClient() instead.
+type APIDefinitionsClient struct {
 	internal *arm.Client
 }
 
-// NewApiDefinitionsClient creates a new instance of ApiDefinitionsClient with the specified values.
+// NewAPIDefinitionsClient creates a new instance of APIDefinitionsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewApiDefinitionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ApiDefinitionsClient, error) {
+func NewAPIDefinitionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*APIDefinitionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
-	client := &ApiDefinitionsClient{
+	client := &APIDefinitionsClient{
 		internal: cl,
 	}
 	return client, nil
@@ -45,32 +45,32 @@ func NewApiDefinitionsClient(credential azcore.TokenCredential, options *arm.Cli
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
 //   - payload - Resource create parameters.
-//   - options - ApiDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the ApiDefinitionsClient.CreateOrUpdate
+//   - options - APIDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the APIDefinitionsClient.CreateOrUpdate
 //     method.
-func (client *ApiDefinitionsClient) CreateOrUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APIDefinition, options *ApiDefinitionsClientCreateOrUpdateOptions) (ApiDefinitionsClientCreateOrUpdateResponse, error) {
+func (client *APIDefinitionsClient) CreateOrUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APIDefinition, options *APIDefinitionsClientCreateOrUpdateOptions) (APIDefinitionsClientCreateOrUpdateResponse, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.CreateOrUpdate"
+	const operationName = "APIDefinitionsClient.CreateOrUpdate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.createOrUpdateCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, payload, options)
 	if err != nil {
-		return ApiDefinitionsClientCreateOrUpdateResponse{}, err
+		return APIDefinitionsClientCreateOrUpdateResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiDefinitionsClientCreateOrUpdateResponse{}, err
+		return APIDefinitionsClientCreateOrUpdateResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiDefinitionsClientCreateOrUpdateResponse{}, err
+		return APIDefinitionsClientCreateOrUpdateResponse{}, err
 	}
 	resp, err := client.createOrUpdateHandleResponse(httpResp)
 	return resp, err
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ApiDefinitionsClient) createOrUpdateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APIDefinition, options *ApiDefinitionsClientCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) createOrUpdateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APIDefinition, options *APIDefinitionsClientCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -116,13 +116,13 @@ func (client *ApiDefinitionsClient) createOrUpdateCreateRequest(ctx context.Cont
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApiDefinitionsClient) createOrUpdateHandleResponse(resp *http.Response) (ApiDefinitionsClientCreateOrUpdateResponse, error) {
-	result := ApiDefinitionsClientCreateOrUpdateResponse{}
+func (client *APIDefinitionsClient) createOrUpdateHandleResponse(resp *http.Response) (APIDefinitionsClientCreateOrUpdateResponse, error) {
+	result := APIDefinitionsClientCreateOrUpdateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIDefinition); err != nil {
-		return ApiDefinitionsClientCreateOrUpdateResponse{}, err
+		return APIDefinitionsClientCreateOrUpdateResponse{}, err
 	}
 	return result, nil
 }
@@ -135,30 +135,30 @@ func (client *ApiDefinitionsClient) createOrUpdateHandleResponse(resp *http.Resp
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
-//   - options - ApiDefinitionsClientDeleteOptions contains the optional parameters for the ApiDefinitionsClient.Delete method.
-func (client *ApiDefinitionsClient) Delete(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientDeleteOptions) (ApiDefinitionsClientDeleteResponse, error) {
+//   - options - APIDefinitionsClientDeleteOptions contains the optional parameters for the APIDefinitionsClient.Delete method.
+func (client *APIDefinitionsClient) Delete(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientDeleteOptions) (APIDefinitionsClientDeleteResponse, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.Delete"
+	const operationName = "APIDefinitionsClient.Delete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.deleteCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, options)
 	if err != nil {
-		return ApiDefinitionsClientDeleteResponse{}, err
+		return APIDefinitionsClientDeleteResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiDefinitionsClientDeleteResponse{}, err
+		return APIDefinitionsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiDefinitionsClientDeleteResponse{}, err
+		return APIDefinitionsClientDeleteResponse{}, err
 	}
-	return ApiDefinitionsClientDeleteResponse{}, nil
+	return APIDefinitionsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *ApiDefinitionsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientDeleteOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -208,29 +208,29 @@ func (client *ApiDefinitionsClient) deleteCreateRequest(ctx context.Context, sub
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
 //   - payload - The content of the action request
-//   - options - ApiDefinitionsClientExportSpecificationOptions contains the optional parameters for the ApiDefinitionsClient.ExportSpecification
+//   - options - APIDefinitionsClientBeginExportSpecificationOptions contains the optional parameters for the APIDefinitionsClient.ExportSpecification
 //     method.
-func (client *ApiDefinitionsClient) BeginExportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *ApiDefinitionsClientExportSpecificationOptions) (*runtime.Poller[ApiDefinitionsClientExportSpecificationResponse], error) {
+func (client *APIDefinitionsClient) BeginExportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *APIDefinitionsClientBeginExportSpecificationOptions) (*runtime.Poller[APIDefinitionsClientExportSpecificationResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.exportSpecification(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, payload, options)
 		if err != nil {
 			return nil, err
 		}
-		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApiDefinitionsClientExportSpecificationResponse]{
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[APIDefinitionsClientExportSpecificationResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 		return poller, err
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[ApiDefinitionsClientExportSpecificationResponse]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[APIDefinitionsClientExportSpecificationResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 	}
 }
 
 // ExportSpecification - Exports the API specification.
-func (client *ApiDefinitionsClient) exportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *ApiDefinitionsClientExportSpecificationOptions) (*http.Response, error) {
+func (client *APIDefinitionsClient) exportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *APIDefinitionsClientBeginExportSpecificationOptions) (*http.Response, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.BeginExportSpecification"
+	const operationName = "APIDefinitionsClient.BeginExportSpecification"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
@@ -250,7 +250,7 @@ func (client *ApiDefinitionsClient) exportSpecification(ctx context.Context, sub
 }
 
 // exportSpecificationCreateRequest creates the ExportSpecification request.
-func (client *ApiDefinitionsClient) exportSpecificationCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *ApiDefinitionsClientExportSpecificationOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) exportSpecificationCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *APIDefinitionsClientBeginExportSpecificationOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}/exportSpecification"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -303,31 +303,31 @@ func (client *ApiDefinitionsClient) exportSpecificationCreateRequest(ctx context
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
-//   - options - ApiDefinitionsClientGetOptions contains the optional parameters for the ApiDefinitionsClient.Get method.
-func (client *ApiDefinitionsClient) Get(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientGetOptions) (ApiDefinitionsClientGetResponse, error) {
+//   - options - APIDefinitionsClientGetOptions contains the optional parameters for the APIDefinitionsClient.Get method.
+func (client *APIDefinitionsClient) Get(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientGetOptions) (APIDefinitionsClientGetResponse, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.Get"
+	const operationName = "APIDefinitionsClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, options)
 	if err != nil {
-		return ApiDefinitionsClientGetResponse{}, err
+		return APIDefinitionsClientGetResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiDefinitionsClientGetResponse{}, err
+		return APIDefinitionsClientGetResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiDefinitionsClientGetResponse{}, err
+		return APIDefinitionsClientGetResponse{}, err
 	}
 	resp, err := client.getHandleResponse(httpResp)
 	return resp, err
 }
 
 // getCreateRequest creates the Get request.
-func (client *ApiDefinitionsClient) getCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientGetOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) getCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -369,13 +369,13 @@ func (client *ApiDefinitionsClient) getCreateRequest(ctx context.Context, subscr
 }
 
 // getHandleResponse handles the Get response.
-func (client *ApiDefinitionsClient) getHandleResponse(resp *http.Response) (ApiDefinitionsClientGetResponse, error) {
-	result := ApiDefinitionsClientGetResponse{}
+func (client *APIDefinitionsClient) getHandleResponse(resp *http.Response) (APIDefinitionsClientGetResponse, error) {
+	result := APIDefinitionsClientGetResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIDefinition); err != nil {
-		return ApiDefinitionsClientGetResponse{}, err
+		return APIDefinitionsClientGetResponse{}, err
 	}
 	return result, nil
 }
@@ -388,30 +388,30 @@ func (client *ApiDefinitionsClient) getHandleResponse(resp *http.Response) (ApiD
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
-//   - options - ApiDefinitionsClientHeadOptions contains the optional parameters for the ApiDefinitionsClient.Head method.
-func (client *ApiDefinitionsClient) Head(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientHeadOptions) (ApiDefinitionsClientHeadResponse, error) {
+//   - options - APIDefinitionsClientHeadOptions contains the optional parameters for the APIDefinitionsClient.Head method.
+func (client *APIDefinitionsClient) Head(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientHeadOptions) (APIDefinitionsClientHeadResponse, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.Head"
+	const operationName = "APIDefinitionsClient.Head"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.headCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, options)
 	if err != nil {
-		return ApiDefinitionsClientHeadResponse{}, err
+		return APIDefinitionsClientHeadResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiDefinitionsClientHeadResponse{}, err
+		return APIDefinitionsClientHeadResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiDefinitionsClientHeadResponse{}, err
+		return APIDefinitionsClientHeadResponse{}, err
 	}
-	return ApiDefinitionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
+	return APIDefinitionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.
-func (client *ApiDefinitionsClient) headCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *ApiDefinitionsClientHeadOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) headCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, options *APIDefinitionsClientHeadOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -461,29 +461,29 @@ func (client *ApiDefinitionsClient) headCreateRequest(ctx context.Context, subsc
 //   - versionName - The name of the API version.
 //   - definitionName - The name of the API definition.
 //   - payload - The content of the action request
-//   - options - ApiDefinitionsClientImportSpecificationOptions contains the optional parameters for the ApiDefinitionsClient.ImportSpecification
+//   - options - APIDefinitionsClientBeginImportSpecificationOptions contains the optional parameters for the APIDefinitionsClient.ImportSpecification
 //     method.
-func (client *ApiDefinitionsClient) BeginImportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *ApiDefinitionsClientImportSpecificationOptions) (*runtime.Poller[ApiDefinitionsClientImportSpecificationResponse], error) {
+func (client *APIDefinitionsClient) BeginImportSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *APIDefinitionsClientBeginImportSpecificationOptions) (*runtime.Poller[APIDefinitionsClientImportSpecificationResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.importSpecification(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, definitionName, payload, options)
 		if err != nil {
 			return nil, err
 		}
-		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[ApiDefinitionsClientImportSpecificationResponse]{
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[APIDefinitionsClientImportSpecificationResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 		return poller, err
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[ApiDefinitionsClientImportSpecificationResponse]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[APIDefinitionsClientImportSpecificationResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 	}
 }
 
 // ImportSpecification - Imports the API specification.
-func (client *ApiDefinitionsClient) importSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *ApiDefinitionsClientImportSpecificationOptions) (*http.Response, error) {
+func (client *APIDefinitionsClient) importSpecification(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *APIDefinitionsClientBeginImportSpecificationOptions) (*http.Response, error) {
 	var err error
-	const operationName = "ApiDefinitionsClient.BeginImportSpecification"
+	const operationName = "APIDefinitionsClient.BeginImportSpecification"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
@@ -503,7 +503,7 @@ func (client *ApiDefinitionsClient) importSpecification(ctx context.Context, sub
 }
 
 // importSpecificationCreateRequest creates the ImportSpecification request.
-func (client *ApiDefinitionsClient) importSpecificationCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *ApiDefinitionsClientImportSpecificationOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) importSpecificationCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *APIDefinitionsClientBeginImportSpecificationOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions/{definitionName}/importSpecification"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -555,14 +555,14 @@ func (client *ApiDefinitionsClient) importSpecificationCreateRequest(ctx context
 //   - workspaceName - The name of the workspace.
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
-//   - options - ApiDefinitionsClientListOptions contains the optional parameters for the ApiDefinitionsClient.NewListPager method.
-func (client *ApiDefinitionsClient) NewListPager(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiDefinitionsClientListOptions) *runtime.Pager[ApiDefinitionsClientListResponse] {
-	return runtime.NewPager(runtime.PagingHandler[ApiDefinitionsClientListResponse]{
-		More: func(page ApiDefinitionsClientListResponse) bool {
+//   - options - APIDefinitionsClientListOptions contains the optional parameters for the APIDefinitionsClient.NewListPager method.
+func (client *APIDefinitionsClient) NewListPager(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIDefinitionsClientListOptions) *runtime.Pager[APIDefinitionsClientListResponse] {
+	return runtime.NewPager(runtime.PagingHandler[APIDefinitionsClientListResponse]{
+		More: func(page APIDefinitionsClientListResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ApiDefinitionsClientListResponse) (ApiDefinitionsClientListResponse, error) {
-			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApiDefinitionsClient.NewListPager")
+		Fetcher: func(ctx context.Context, page *APIDefinitionsClientListResponse) (APIDefinitionsClientListResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "APIDefinitionsClient.NewListPager")
 			nextLink := ""
 			if page != nil {
 				nextLink = *page.NextLink
@@ -571,7 +571,7 @@ func (client *ApiDefinitionsClient) NewListPager(subscriptionID string, resource
 				return client.listCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, options)
 			}, nil)
 			if err != nil {
-				return ApiDefinitionsClientListResponse{}, err
+				return APIDefinitionsClientListResponse{}, err
 			}
 			return client.listHandleResponse(resp)
 		},
@@ -580,7 +580,7 @@ func (client *ApiDefinitionsClient) NewListPager(subscriptionID string, resource
 }
 
 // listCreateRequest creates the List request.
-func (client *ApiDefinitionsClient) listCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiDefinitionsClientListOptions) (*policy.Request, error) {
+func (client *APIDefinitionsClient) listCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIDefinitionsClientListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}/definitions"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -621,10 +621,10 @@ func (client *ApiDefinitionsClient) listCreateRequest(ctx context.Context, subsc
 }
 
 // listHandleResponse handles the List response.
-func (client *ApiDefinitionsClient) listHandleResponse(resp *http.Response) (ApiDefinitionsClientListResponse, error) {
-	result := ApiDefinitionsClientListResponse{}
+func (client *APIDefinitionsClient) listHandleResponse(resp *http.Response) (APIDefinitionsClientListResponse, error) {
+	result := APIDefinitionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIDefinitionListResult); err != nil {
-		return ApiDefinitionsClientListResponse{}, err
+		return APIDefinitionsClientListResponse{}, err
 	}
 	return result, nil
 }

--- a/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
@@ -16,21 +16,21 @@ import (
 	"strings"
 )
 
-// ApiVersionsClient contains the methods for the Microsoft.ApiCenter namespace.
-// Don't use this type directly, use NewApiVersionsClient() instead.
-type ApiVersionsClient struct {
+// APIVersionsClient contains the methods for the Microsoft.ApiCenter namespace.
+// Don't use this type directly, use NewAPIVersionsClient() instead.
+type APIVersionsClient struct {
 	internal *arm.Client
 }
 
-// NewApiVersionsClient creates a new instance of ApiVersionsClient with the specified values.
+// NewAPIVersionsClient creates a new instance of APIVersionsClient with the specified values.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewApiVersionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*ApiVersionsClient, error) {
+func NewAPIVersionsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*APIVersionsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
-	client := &ApiVersionsClient{
+	client := &APIVersionsClient{
 		internal: cl,
 	}
 	return client, nil
@@ -44,32 +44,32 @@ func NewApiVersionsClient(credential azcore.TokenCredential, options *arm.Client
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
 //   - payload - Resource create parameters.
-//   - options - ApiVersionsClientCreateOrUpdateOptions contains the optional parameters for the ApiVersionsClient.CreateOrUpdate
+//   - options - APIVersionsClientCreateOrUpdateOptions contains the optional parameters for the APIVersionsClient.CreateOrUpdate
 //     method.
-func (client *ApiVersionsClient) CreateOrUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload APIVersion, options *ApiVersionsClientCreateOrUpdateOptions) (ApiVersionsClientCreateOrUpdateResponse, error) {
+func (client *APIVersionsClient) CreateOrUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload APIVersion, options *APIVersionsClientCreateOrUpdateOptions) (APIVersionsClientCreateOrUpdateResponse, error) {
 	var err error
-	const operationName = "ApiVersionsClient.CreateOrUpdate"
+	const operationName = "APIVersionsClient.CreateOrUpdate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.createOrUpdateCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, payload, options)
 	if err != nil {
-		return ApiVersionsClientCreateOrUpdateResponse{}, err
+		return APIVersionsClientCreateOrUpdateResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiVersionsClientCreateOrUpdateResponse{}, err
+		return APIVersionsClientCreateOrUpdateResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusCreated) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiVersionsClientCreateOrUpdateResponse{}, err
+		return APIVersionsClientCreateOrUpdateResponse{}, err
 	}
 	resp, err := client.createOrUpdateHandleResponse(httpResp)
 	return resp, err
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ApiVersionsClient) createOrUpdateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload APIVersion, options *ApiVersionsClientCreateOrUpdateOptions) (*policy.Request, error) {
+func (client *APIVersionsClient) createOrUpdateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, payload APIVersion, options *APIVersionsClientCreateOrUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -111,13 +111,13 @@ func (client *ApiVersionsClient) createOrUpdateCreateRequest(ctx context.Context
 }
 
 // createOrUpdateHandleResponse handles the CreateOrUpdate response.
-func (client *ApiVersionsClient) createOrUpdateHandleResponse(resp *http.Response) (ApiVersionsClientCreateOrUpdateResponse, error) {
-	result := ApiVersionsClientCreateOrUpdateResponse{}
+func (client *APIVersionsClient) createOrUpdateHandleResponse(resp *http.Response) (APIVersionsClientCreateOrUpdateResponse, error) {
+	result := APIVersionsClientCreateOrUpdateResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIVersion); err != nil {
-		return ApiVersionsClientCreateOrUpdateResponse{}, err
+		return APIVersionsClientCreateOrUpdateResponse{}, err
 	}
 	return result, nil
 }
@@ -129,30 +129,30 @@ func (client *ApiVersionsClient) createOrUpdateHandleResponse(resp *http.Respons
 //   - workspaceName - The name of the workspace.
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
-//   - options - ApiVersionsClientDeleteOptions contains the optional parameters for the ApiVersionsClient.Delete method.
-func (client *ApiVersionsClient) Delete(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientDeleteOptions) (ApiVersionsClientDeleteResponse, error) {
+//   - options - APIVersionsClientDeleteOptions contains the optional parameters for the APIVersionsClient.Delete method.
+func (client *APIVersionsClient) Delete(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientDeleteOptions) (APIVersionsClientDeleteResponse, error) {
 	var err error
-	const operationName = "ApiVersionsClient.Delete"
+	const operationName = "APIVersionsClient.Delete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.deleteCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, options)
 	if err != nil {
-		return ApiVersionsClientDeleteResponse{}, err
+		return APIVersionsClientDeleteResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiVersionsClientDeleteResponse{}, err
+		return APIVersionsClientDeleteResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiVersionsClientDeleteResponse{}, err
+		return APIVersionsClientDeleteResponse{}, err
 	}
-	return ApiVersionsClientDeleteResponse{}, nil
+	return APIVersionsClientDeleteResponse{}, nil
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *ApiVersionsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientDeleteOptions) (*policy.Request, error) {
+func (client *APIVersionsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -196,31 +196,31 @@ func (client *ApiVersionsClient) deleteCreateRequest(ctx context.Context, subscr
 //   - workspaceName - The name of the workspace.
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
-//   - options - ApiVersionsClientGetOptions contains the optional parameters for the ApiVersionsClient.Get method.
-func (client *ApiVersionsClient) Get(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientGetOptions) (ApiVersionsClientGetResponse, error) {
+//   - options - APIVersionsClientGetOptions contains the optional parameters for the APIVersionsClient.Get method.
+func (client *APIVersionsClient) Get(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientGetOptions) (APIVersionsClientGetResponse, error) {
 	var err error
-	const operationName = "ApiVersionsClient.Get"
+	const operationName = "APIVersionsClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, options)
 	if err != nil {
-		return ApiVersionsClientGetResponse{}, err
+		return APIVersionsClientGetResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiVersionsClientGetResponse{}, err
+		return APIVersionsClientGetResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiVersionsClientGetResponse{}, err
+		return APIVersionsClientGetResponse{}, err
 	}
 	resp, err := client.getHandleResponse(httpResp)
 	return resp, err
 }
 
 // getCreateRequest creates the Get request.
-func (client *ApiVersionsClient) getCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientGetOptions) (*policy.Request, error) {
+func (client *APIVersionsClient) getCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -258,13 +258,13 @@ func (client *ApiVersionsClient) getCreateRequest(ctx context.Context, subscript
 }
 
 // getHandleResponse handles the Get response.
-func (client *ApiVersionsClient) getHandleResponse(resp *http.Response) (ApiVersionsClientGetResponse, error) {
-	result := ApiVersionsClientGetResponse{}
+func (client *APIVersionsClient) getHandleResponse(resp *http.Response) (APIVersionsClientGetResponse, error) {
+	result := APIVersionsClientGetResponse{}
 	if val := resp.Header.Get("ETag"); val != "" {
 		result.ETag = &val
 	}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIVersion); err != nil {
-		return ApiVersionsClientGetResponse{}, err
+		return APIVersionsClientGetResponse{}, err
 	}
 	return result, nil
 }
@@ -276,30 +276,30 @@ func (client *ApiVersionsClient) getHandleResponse(resp *http.Response) (ApiVers
 //   - workspaceName - The name of the workspace.
 //   - apiName - The name of the API.
 //   - versionName - The name of the API version.
-//   - options - ApiVersionsClientHeadOptions contains the optional parameters for the ApiVersionsClient.Head method.
-func (client *ApiVersionsClient) Head(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientHeadOptions) (ApiVersionsClientHeadResponse, error) {
+//   - options - APIVersionsClientHeadOptions contains the optional parameters for the APIVersionsClient.Head method.
+func (client *APIVersionsClient) Head(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientHeadOptions) (APIVersionsClientHeadResponse, error) {
 	var err error
-	const operationName = "ApiVersionsClient.Head"
+	const operationName = "APIVersionsClient.Head"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.headCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, versionName, options)
 	if err != nil {
-		return ApiVersionsClientHeadResponse{}, err
+		return APIVersionsClientHeadResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiVersionsClientHeadResponse{}, err
+		return APIVersionsClientHeadResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiVersionsClientHeadResponse{}, err
+		return APIVersionsClientHeadResponse{}, err
 	}
-	return ApiVersionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
+	return APIVersionsClientHeadResponse{Success: httpResp.StatusCode >= 200 && httpResp.StatusCode < 300}, nil
 }
 
 // headCreateRequest creates the Head request.
-func (client *ApiVersionsClient) headCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *ApiVersionsClientHeadOptions) (*policy.Request, error) {
+func (client *APIVersionsClient) headCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, options *APIVersionsClientHeadOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions/{versionName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -342,14 +342,14 @@ func (client *ApiVersionsClient) headCreateRequest(ctx context.Context, subscrip
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
 //   - apiName - The name of the API.
-//   - options - ApiVersionsClientListOptions contains the optional parameters for the ApiVersionsClient.NewListPager method.
-func (client *ApiVersionsClient) NewListPager(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *ApiVersionsClientListOptions) *runtime.Pager[ApiVersionsClientListResponse] {
-	return runtime.NewPager(runtime.PagingHandler[ApiVersionsClientListResponse]{
-		More: func(page ApiVersionsClientListResponse) bool {
+//   - options - APIVersionsClientListOptions contains the optional parameters for the APIVersionsClient.NewListPager method.
+func (client *APIVersionsClient) NewListPager(subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *APIVersionsClientListOptions) *runtime.Pager[APIVersionsClientListResponse] {
+	return runtime.NewPager(runtime.PagingHandler[APIVersionsClientListResponse]{
+		More: func(page APIVersionsClientListResponse) bool {
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
-		Fetcher: func(ctx context.Context, page *ApiVersionsClientListResponse) (ApiVersionsClientListResponse, error) {
-			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "ApiVersionsClient.NewListPager")
+		Fetcher: func(ctx context.Context, page *APIVersionsClientListResponse) (APIVersionsClientListResponse, error) {
+			ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "APIVersionsClient.NewListPager")
 			nextLink := ""
 			if page != nil {
 				nextLink = *page.NextLink
@@ -358,7 +358,7 @@ func (client *ApiVersionsClient) NewListPager(subscriptionID string, resourceGro
 				return client.listCreateRequest(ctx, subscriptionID, resourceGroupName, serviceName, workspaceName, apiName, options)
 			}, nil)
 			if err != nil {
-				return ApiVersionsClientListResponse{}, err
+				return APIVersionsClientListResponse{}, err
 			}
 			return client.listHandleResponse(resp)
 		},
@@ -367,7 +367,7 @@ func (client *ApiVersionsClient) NewListPager(subscriptionID string, resourceGro
 }
 
 // listCreateRequest creates the List request.
-func (client *ApiVersionsClient) listCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *ApiVersionsClientListOptions) (*policy.Request, error) {
+func (client *APIVersionsClient) listCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, workspaceName string, apiName string, options *APIVersionsClientListOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/workspaces/{workspaceName}/apis/{apiName}/versions"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -404,10 +404,10 @@ func (client *ApiVersionsClient) listCreateRequest(ctx context.Context, subscrip
 }
 
 // listHandleResponse handles the List response.
-func (client *ApiVersionsClient) listHandleResponse(resp *http.Response) (ApiVersionsClientListResponse, error) {
-	result := ApiVersionsClientListResponse{}
+func (client *APIVersionsClient) listHandleResponse(resp *http.Response) (APIVersionsClientListResponse, error) {
+	result := APIVersionsClientListResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.APIVersionListResult); err != nil {
-		return ApiVersionsClientListResponse{}, err
+		return APIVersionsClientListResponse{}, err
 	}
 	return result, nil
 }

--- a/packages/typespec-go/test/armapicenter/zz_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_client.go
@@ -29,16 +29,16 @@ func NewClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*
 	return client, nil
 }
 
-// NewApiDefinitionsClient creates a new instance of [ApiDefinitionsClient].
-func (client *Client) NewApiDefinitionsClient() *ApiDefinitionsClient {
-	return &ApiDefinitionsClient{
+// NewAPIDefinitionsClient creates a new instance of [APIDefinitionsClient].
+func (client *Client) NewAPIDefinitionsClient() *APIDefinitionsClient {
+	return &APIDefinitionsClient{
 		internal: client.internal,
 	}
 }
 
-// NewApiVersionsClient creates a new instance of [ApiVersionsClient].
-func (client *Client) NewApiVersionsClient() *ApiVersionsClient {
-	return &ApiVersionsClient{
+// NewAPIVersionsClient creates a new instance of [APIVersionsClient].
+func (client *Client) NewAPIVersionsClient() *APIVersionsClient {
+	return &APIVersionsClient{
 		internal: client.internal,
 	}
 }

--- a/packages/typespec-go/test/armapicenter/zz_options.go
+++ b/packages/typespec-go/test/armapicenter/zz_options.go
@@ -4,67 +4,67 @@
 
 package armapicenter
 
-// ApiDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the ApiDefinitionsClient.CreateOrUpdate
+// APIDefinitionsClientBeginExportSpecificationOptions contains the optional parameters for the APIDefinitionsClient.ExportSpecification
 // method.
-type ApiDefinitionsClientCreateOrUpdateOptions struct {
-	// placeholder for future optional parameters
-}
-
-// ApiDefinitionsClientDeleteOptions contains the optional parameters for the ApiDefinitionsClient.Delete method.
-type ApiDefinitionsClientDeleteOptions struct {
-	// placeholder for future optional parameters
-}
-
-// ApiDefinitionsClientExportSpecificationOptions contains the optional parameters for the ApiDefinitionsClient.ExportSpecification
-// method.
-type ApiDefinitionsClientExportSpecificationOptions struct {
+type APIDefinitionsClientBeginExportSpecificationOptions struct {
 	ResumeToken string
 }
 
-// ApiDefinitionsClientGetOptions contains the optional parameters for the ApiDefinitionsClient.Get method.
-type ApiDefinitionsClientGetOptions struct {
-	// placeholder for future optional parameters
-}
-
-// ApiDefinitionsClientHeadOptions contains the optional parameters for the ApiDefinitionsClient.Head method.
-type ApiDefinitionsClientHeadOptions struct {
-	// placeholder for future optional parameters
-}
-
-// ApiDefinitionsClientImportSpecificationOptions contains the optional parameters for the ApiDefinitionsClient.ImportSpecification
+// APIDefinitionsClientBeginImportSpecificationOptions contains the optional parameters for the APIDefinitionsClient.ImportSpecification
 // method.
-type ApiDefinitionsClientImportSpecificationOptions struct {
+type APIDefinitionsClientBeginImportSpecificationOptions struct {
 	ResumeToken string
 }
 
-// ApiDefinitionsClientListOptions contains the optional parameters for the ApiDefinitionsClient.NewListPager method.
-type ApiDefinitionsClientListOptions struct {
+// APIDefinitionsClientCreateOrUpdateOptions contains the optional parameters for the APIDefinitionsClient.CreateOrUpdate
+// method.
+type APIDefinitionsClientCreateOrUpdateOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIDefinitionsClientDeleteOptions contains the optional parameters for the APIDefinitionsClient.Delete method.
+type APIDefinitionsClientDeleteOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIDefinitionsClientGetOptions contains the optional parameters for the APIDefinitionsClient.Get method.
+type APIDefinitionsClientGetOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIDefinitionsClientHeadOptions contains the optional parameters for the APIDefinitionsClient.Head method.
+type APIDefinitionsClientHeadOptions struct {
+	// placeholder for future optional parameters
+}
+
+// APIDefinitionsClientListOptions contains the optional parameters for the APIDefinitionsClient.NewListPager method.
+type APIDefinitionsClientListOptions struct {
 	// OData filter parameter.
 	Filter *string
 }
 
-// ApiVersionsClientCreateOrUpdateOptions contains the optional parameters for the ApiVersionsClient.CreateOrUpdate method.
-type ApiVersionsClientCreateOrUpdateOptions struct {
+// APIVersionsClientCreateOrUpdateOptions contains the optional parameters for the APIVersionsClient.CreateOrUpdate method.
+type APIVersionsClientCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ApiVersionsClientDeleteOptions contains the optional parameters for the ApiVersionsClient.Delete method.
-type ApiVersionsClientDeleteOptions struct {
+// APIVersionsClientDeleteOptions contains the optional parameters for the APIVersionsClient.Delete method.
+type APIVersionsClientDeleteOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ApiVersionsClientGetOptions contains the optional parameters for the ApiVersionsClient.Get method.
-type ApiVersionsClientGetOptions struct {
+// APIVersionsClientGetOptions contains the optional parameters for the APIVersionsClient.Get method.
+type APIVersionsClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ApiVersionsClientHeadOptions contains the optional parameters for the ApiVersionsClient.Head method.
-type ApiVersionsClientHeadOptions struct {
+// APIVersionsClientHeadOptions contains the optional parameters for the APIVersionsClient.Head method.
+type APIVersionsClientHeadOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ApiVersionsClientListOptions contains the optional parameters for the ApiVersionsClient.NewListPager method.
-type ApiVersionsClientListOptions struct {
+// APIVersionsClientListOptions contains the optional parameters for the APIVersionsClient.NewListPager method.
+type APIVersionsClientListOptions struct {
 	// OData filter parameter.
 	Filter *string
 }
@@ -179,6 +179,12 @@ type OperationsClientListOptions struct {
 	// placeholder for future optional parameters
 }
 
+// ServicesClientBeginExportMetadataSchemaOptions contains the optional parameters for the ServicesClient.ExportMetadataSchema
+// method.
+type ServicesClientBeginExportMetadataSchemaOptions struct {
+	ResumeToken string
+}
+
 // ServicesClientCreateOrUpdateOptions contains the optional parameters for the ServicesClient.CreateOrUpdate method.
 type ServicesClientCreateOrUpdateOptions struct {
 	// placeholder for future optional parameters
@@ -187,12 +193,6 @@ type ServicesClientCreateOrUpdateOptions struct {
 // ServicesClientDeleteOptions contains the optional parameters for the ServicesClient.Delete method.
 type ServicesClientDeleteOptions struct {
 	// placeholder for future optional parameters
-}
-
-// ServicesClientExportMetadataSchemaOptions contains the optional parameters for the ServicesClient.ExportMetadataSchema
-// method.
-type ServicesClientExportMetadataSchemaOptions struct {
-	ResumeToken string
 }
 
 // ServicesClientGetOptions contains the optional parameters for the ServicesClient.Get method.

--- a/packages/typespec-go/test/armapicenter/zz_responses.go
+++ b/packages/typespec-go/test/armapicenter/zz_responses.go
@@ -4,8 +4,8 @@
 
 package armapicenter
 
-// ApiDefinitionsClientCreateOrUpdateResponse contains the response from method ApiDefinitionsClient.CreateOrUpdate.
-type ApiDefinitionsClientCreateOrUpdateResponse struct {
+// APIDefinitionsClientCreateOrUpdateResponse contains the response from method APIDefinitionsClient.CreateOrUpdate.
+type APIDefinitionsClientCreateOrUpdateResponse struct {
 	// API definition entity.
 	APIDefinition
 
@@ -13,19 +13,19 @@ type ApiDefinitionsClientCreateOrUpdateResponse struct {
 	ETag *string
 }
 
-// ApiDefinitionsClientDeleteResponse contains the response from method ApiDefinitionsClient.Delete.
-type ApiDefinitionsClientDeleteResponse struct {
+// APIDefinitionsClientDeleteResponse contains the response from method APIDefinitionsClient.Delete.
+type APIDefinitionsClientDeleteResponse struct {
 	// placeholder for future response values
 }
 
-// ApiDefinitionsClientExportSpecificationResponse contains the response from method ApiDefinitionsClient.ExportSpecification.
-type ApiDefinitionsClientExportSpecificationResponse struct {
+// APIDefinitionsClientExportSpecificationResponse contains the response from method APIDefinitionsClient.ExportSpecification.
+type APIDefinitionsClientExportSpecificationResponse struct {
 	// The API specification export result.
 	APISpecExportResult
 }
 
-// ApiDefinitionsClientGetResponse contains the response from method ApiDefinitionsClient.Get.
-type ApiDefinitionsClientGetResponse struct {
+// APIDefinitionsClientGetResponse contains the response from method APIDefinitionsClient.Get.
+type APIDefinitionsClientGetResponse struct {
 	// API definition entity.
 	APIDefinition
 
@@ -33,26 +33,26 @@ type ApiDefinitionsClientGetResponse struct {
 	ETag *string
 }
 
-// ApiDefinitionsClientHeadResponse contains the response from method ApiDefinitionsClient.Head.
-type ApiDefinitionsClientHeadResponse struct {
+// APIDefinitionsClientHeadResponse contains the response from method APIDefinitionsClient.Head.
+type APIDefinitionsClientHeadResponse struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
-// ApiDefinitionsClientImportSpecificationResponse contains the response from method ApiDefinitionsClient.ImportSpecification.
-type ApiDefinitionsClientImportSpecificationResponse struct {
+// APIDefinitionsClientImportSpecificationResponse contains the response from method APIDefinitionsClient.ImportSpecification.
+type APIDefinitionsClientImportSpecificationResponse struct {
 	// The API specification was successfully imported.
 	APIImportSuccess
 }
 
-// ApiDefinitionsClientListResponse contains the response from method ApiDefinitionsClient.NewListPager.
-type ApiDefinitionsClientListResponse struct {
+// APIDefinitionsClientListResponse contains the response from method APIDefinitionsClient.NewListPager.
+type APIDefinitionsClientListResponse struct {
 	// The response of a ApiDefinition list operation.
 	APIDefinitionListResult
 }
 
-// ApiVersionsClientCreateOrUpdateResponse contains the response from method ApiVersionsClient.CreateOrUpdate.
-type ApiVersionsClientCreateOrUpdateResponse struct {
+// APIVersionsClientCreateOrUpdateResponse contains the response from method APIVersionsClient.CreateOrUpdate.
+type APIVersionsClientCreateOrUpdateResponse struct {
 	// API version entity.
 	APIVersion
 
@@ -60,13 +60,13 @@ type ApiVersionsClientCreateOrUpdateResponse struct {
 	ETag *string
 }
 
-// ApiVersionsClientDeleteResponse contains the response from method ApiVersionsClient.Delete.
-type ApiVersionsClientDeleteResponse struct {
+// APIVersionsClientDeleteResponse contains the response from method APIVersionsClient.Delete.
+type APIVersionsClientDeleteResponse struct {
 	// placeholder for future response values
 }
 
-// ApiVersionsClientGetResponse contains the response from method ApiVersionsClient.Get.
-type ApiVersionsClientGetResponse struct {
+// APIVersionsClientGetResponse contains the response from method APIVersionsClient.Get.
+type APIVersionsClientGetResponse struct {
 	// API version entity.
 	APIVersion
 
@@ -74,14 +74,14 @@ type ApiVersionsClientGetResponse struct {
 	ETag *string
 }
 
-// ApiVersionsClientHeadResponse contains the response from method ApiVersionsClient.Head.
-type ApiVersionsClientHeadResponse struct {
+// APIVersionsClientHeadResponse contains the response from method APIVersionsClient.Head.
+type APIVersionsClientHeadResponse struct {
 	// Success indicates if the operation succeeded or failed.
 	Success bool
 }
 
-// ApiVersionsClientListResponse contains the response from method ApiVersionsClient.NewListPager.
-type ApiVersionsClientListResponse struct {
+// APIVersionsClientListResponse contains the response from method APIVersionsClient.NewListPager.
+type APIVersionsClientListResponse struct {
 	// The response of a ApiVersion list operation.
 	APIVersionListResult
 }

--- a/packages/typespec-go/test/armapicenter/zz_services_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_services_client.go
@@ -160,9 +160,9 @@ func (client *ServicesClient) deleteCreateRequest(ctx context.Context, subscript
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - payload - The content of the action request
-//   - options - ServicesClientExportMetadataSchemaOptions contains the optional parameters for the ServicesClient.ExportMetadataSchema
+//   - options - ServicesClientBeginExportMetadataSchemaOptions contains the optional parameters for the ServicesClient.ExportMetadataSchema
 //     method.
-func (client *ServicesClient) BeginExportMetadataSchema(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientExportMetadataSchemaOptions) (*runtime.Poller[ServicesClientExportMetadataSchemaResponse], error) {
+func (client *ServicesClient) BeginExportMetadataSchema(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientBeginExportMetadataSchemaOptions) (*runtime.Poller[ServicesClientExportMetadataSchemaResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.exportMetadataSchema(ctx, subscriptionID, resourceGroupName, serviceName, payload, options)
 		if err != nil {
@@ -180,7 +180,7 @@ func (client *ServicesClient) BeginExportMetadataSchema(ctx context.Context, sub
 }
 
 // ExportMetadataSchema - Exports the effective metadata schema.
-func (client *ServicesClient) exportMetadataSchema(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientExportMetadataSchemaOptions) (*http.Response, error) {
+func (client *ServicesClient) exportMetadataSchema(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientBeginExportMetadataSchemaOptions) (*http.Response, error) {
 	var err error
 	const operationName = "ServicesClient.BeginExportMetadataSchema"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -202,7 +202,7 @@ func (client *ServicesClient) exportMetadataSchema(ctx context.Context, subscrip
 }
 
 // exportMetadataSchemaCreateRequest creates the ExportMetadataSchema request.
-func (client *ServicesClient) exportMetadataSchemaCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientExportMetadataSchemaOptions) (*policy.Request, error) {
+func (client *ServicesClient) exportMetadataSchemaCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientBeginExportMetadataSchemaOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiCenter/services/{serviceName}/exportMetadataSchema"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")

--- a/packages/typespec-go/test/armcodesigning/fake/zz_accounts_server.go
+++ b/packages/typespec-go/test/armcodesigning/fake/zz_accounts_server.go
@@ -26,11 +26,11 @@ type AccountsServer struct {
 
 	// BeginCreate is the fake for method AccountsClient.BeginCreate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	BeginCreate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource armcodesigning.Account, options *armcodesigning.AccountsClientCreateOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientCreateResponse], errResp azfake.ErrorResponder)
+	BeginCreate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource armcodesigning.Account, options *armcodesigning.AccountsClientBeginCreateOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientCreateResponse], errResp azfake.ErrorResponder)
 
 	// BeginDelete is the fake for method AccountsClient.BeginDelete
 	// HTTP status codes to indicate success: http.StatusAccepted, http.StatusNoContent
-	BeginDelete func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *armcodesigning.AccountsClientDeleteOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientDeleteResponse], errResp azfake.ErrorResponder)
+	BeginDelete func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *armcodesigning.AccountsClientBeginDeleteOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientDeleteResponse], errResp azfake.ErrorResponder)
 
 	// Get is the fake for method AccountsClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
@@ -46,7 +46,7 @@ type AccountsServer struct {
 
 	// BeginUpdate is the fake for method AccountsClient.BeginUpdate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties armcodesigning.AccountPatch, options *armcodesigning.AccountsClientUpdateOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientUpdateResponse], errResp azfake.ErrorResponder)
+	BeginUpdate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties armcodesigning.AccountPatch, options *armcodesigning.AccountsClientBeginUpdateOptions) (resp azfake.PollerResponder[armcodesigning.AccountsClientUpdateResponse], errResp azfake.ErrorResponder)
 }
 
 // NewAccountsServerTransport creates a new instance of AccountsServerTransport with the provided implementation.

--- a/packages/typespec-go/test/armcodesigning/fake/zz_certificateprofiles_server.go
+++ b/packages/typespec-go/test/armcodesigning/fake/zz_certificateprofiles_server.go
@@ -22,11 +22,11 @@ import (
 type CertificateProfilesServer struct {
 	// BeginCreate is the fake for method CertificateProfilesClient.BeginCreate
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	BeginCreate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource armcodesigning.CertificateProfile, options *armcodesigning.CertificateProfilesClientCreateOptions) (resp azfake.PollerResponder[armcodesigning.CertificateProfilesClientCreateResponse], errResp azfake.ErrorResponder)
+	BeginCreate func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource armcodesigning.CertificateProfile, options *armcodesigning.CertificateProfilesClientBeginCreateOptions) (resp azfake.PollerResponder[armcodesigning.CertificateProfilesClientCreateResponse], errResp azfake.ErrorResponder)
 
 	// BeginDelete is the fake for method CertificateProfilesClient.BeginDelete
 	// HTTP status codes to indicate success: http.StatusAccepted, http.StatusNoContent
-	BeginDelete func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *armcodesigning.CertificateProfilesClientDeleteOptions) (resp azfake.PollerResponder[armcodesigning.CertificateProfilesClientDeleteResponse], errResp azfake.ErrorResponder)
+	BeginDelete func(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *armcodesigning.CertificateProfilesClientBeginDeleteOptions) (resp azfake.PollerResponder[armcodesigning.CertificateProfilesClientDeleteResponse], errResp azfake.ErrorResponder)
 
 	// Get is the fake for method CertificateProfilesClient.Get
 	// HTTP status codes to indicate success: http.StatusOK

--- a/packages/typespec-go/test/armcodesigning/zz_accounts_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_accounts_client.go
@@ -99,8 +99,8 @@ func (client *AccountsClient) checkNameAvailabilityHandleResponse(resp *http.Res
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - resource - Parameters to create the trusted signing account
-//   - options - AccountsClientCreateOptions contains the optional parameters for the AccountsClient.Create method.
-func (client *AccountsClient) BeginCreate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientCreateOptions) (*runtime.Poller[AccountsClientCreateResponse], error) {
+//   - options - AccountsClientBeginCreateOptions contains the optional parameters for the AccountsClient.Create method.
+func (client *AccountsClient) BeginCreate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientBeginCreateOptions) (*runtime.Poller[AccountsClientCreateResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.create(ctx, subscriptionID, resourceGroupName, accountName, resource, options)
 		if err != nil {
@@ -118,7 +118,7 @@ func (client *AccountsClient) BeginCreate(ctx context.Context, subscriptionID st
 }
 
 // Create - Create a trusted Signing Account.
-func (client *AccountsClient) create(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientCreateOptions) (*http.Response, error) {
+func (client *AccountsClient) create(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientBeginCreateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginCreate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -140,7 +140,7 @@ func (client *AccountsClient) create(ctx context.Context, subscriptionID string,
 }
 
 // createCreateRequest creates the Create request.
-func (client *AccountsClient) createCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientCreateOptions) (*policy.Request, error) {
+func (client *AccountsClient) createCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, resource Account, options *AccountsClientBeginCreateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -173,8 +173,8 @@ func (client *AccountsClient) createCreateRequest(ctx context.Context, subscript
 //   - subscriptionID - The ID of the target subscription.
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
-//   - options - AccountsClientDeleteOptions contains the optional parameters for the AccountsClient.Delete method.
-func (client *AccountsClient) BeginDelete(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientDeleteOptions) (*runtime.Poller[AccountsClientDeleteResponse], error) {
+//   - options - AccountsClientBeginDeleteOptions contains the optional parameters for the AccountsClient.Delete method.
+func (client *AccountsClient) BeginDelete(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientBeginDeleteOptions) (*runtime.Poller[AccountsClientDeleteResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteOperation(ctx, subscriptionID, resourceGroupName, accountName, options)
 		if err != nil {
@@ -192,7 +192,7 @@ func (client *AccountsClient) BeginDelete(ctx context.Context, subscriptionID st
 }
 
 // Delete - Delete a trusted signing account.
-func (client *AccountsClient) deleteOperation(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientDeleteOptions) (*http.Response, error) {
+func (client *AccountsClient) deleteOperation(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginDelete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -214,7 +214,7 @@ func (client *AccountsClient) deleteOperation(ctx context.Context, subscriptionI
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *AccountsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientDeleteOptions) (*policy.Request, error) {
+func (client *AccountsClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, options *AccountsClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -419,8 +419,8 @@ func (client *AccountsClient) listBySubscriptionHandleResponse(resp *http.Respon
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - properties - Parameters supplied to update the trusted signing account
-//   - options - AccountsClientUpdateOptions contains the optional parameters for the AccountsClient.Update method.
-func (client *AccountsClient) BeginUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientUpdateOptions) (*runtime.Poller[AccountsClientUpdateResponse], error) {
+//   - options - AccountsClientBeginUpdateOptions contains the optional parameters for the AccountsClient.Update method.
+func (client *AccountsClient) BeginUpdate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientBeginUpdateOptions) (*runtime.Poller[AccountsClientUpdateResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.update(ctx, subscriptionID, resourceGroupName, accountName, properties, options)
 		if err != nil {
@@ -438,7 +438,7 @@ func (client *AccountsClient) BeginUpdate(ctx context.Context, subscriptionID st
 }
 
 // Update - Update a trusted signing account.
-func (client *AccountsClient) update(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientUpdateOptions) (*http.Response, error) {
+func (client *AccountsClient) update(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientBeginUpdateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginUpdate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -460,7 +460,7 @@ func (client *AccountsClient) update(ctx context.Context, subscriptionID string,
 }
 
 // updateCreateRequest creates the Update request.
-func (client *AccountsClient) updateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientUpdateOptions) (*policy.Request, error) {
+func (client *AccountsClient) updateCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientBeginUpdateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")

--- a/packages/typespec-go/test/armcodesigning/zz_certificateprofiles_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_certificateprofiles_client.go
@@ -42,9 +42,9 @@ func NewCertificateProfilesClient(credential azcore.TokenCredential, options *ar
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.
 //   - resource - Parameters to create the certificate profile
-//   - options - CertificateProfilesClientCreateOptions contains the optional parameters for the CertificateProfilesClient.Create
+//   - options - CertificateProfilesClientBeginCreateOptions contains the optional parameters for the CertificateProfilesClient.Create
 //     method.
-func (client *CertificateProfilesClient) BeginCreate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientCreateOptions) (*runtime.Poller[CertificateProfilesClientCreateResponse], error) {
+func (client *CertificateProfilesClient) BeginCreate(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientBeginCreateOptions) (*runtime.Poller[CertificateProfilesClientCreateResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.create(ctx, subscriptionID, resourceGroupName, accountName, profileName, resource, options)
 		if err != nil {
@@ -62,7 +62,7 @@ func (client *CertificateProfilesClient) BeginCreate(ctx context.Context, subscr
 }
 
 // Create - Create a certificate profile.
-func (client *CertificateProfilesClient) create(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientCreateOptions) (*http.Response, error) {
+func (client *CertificateProfilesClient) create(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientBeginCreateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "CertificateProfilesClient.BeginCreate"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -84,7 +84,7 @@ func (client *CertificateProfilesClient) create(ctx context.Context, subscriptio
 }
 
 // createCreateRequest creates the Create request.
-func (client *CertificateProfilesClient) createCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientCreateOptions) (*policy.Request, error) {
+func (client *CertificateProfilesClient) createCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientBeginCreateOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}/certificateProfiles/{profileName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -122,9 +122,9 @@ func (client *CertificateProfilesClient) createCreateRequest(ctx context.Context
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.
-//   - options - CertificateProfilesClientDeleteOptions contains the optional parameters for the CertificateProfilesClient.Delete
+//   - options - CertificateProfilesClientBeginDeleteOptions contains the optional parameters for the CertificateProfilesClient.Delete
 //     method.
-func (client *CertificateProfilesClient) BeginDelete(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientDeleteOptions) (*runtime.Poller[CertificateProfilesClientDeleteResponse], error) {
+func (client *CertificateProfilesClient) BeginDelete(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientBeginDeleteOptions) (*runtime.Poller[CertificateProfilesClientDeleteResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteOperation(ctx, subscriptionID, resourceGroupName, accountName, profileName, options)
 		if err != nil {
@@ -142,7 +142,7 @@ func (client *CertificateProfilesClient) BeginDelete(ctx context.Context, subscr
 }
 
 // Delete - Delete a certificate profile.
-func (client *CertificateProfilesClient) deleteOperation(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientDeleteOptions) (*http.Response, error) {
+func (client *CertificateProfilesClient) deleteOperation(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "CertificateProfilesClient.BeginDelete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -164,7 +164,7 @@ func (client *CertificateProfilesClient) deleteOperation(ctx context.Context, su
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *CertificateProfilesClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientDeleteOptions) (*policy.Request, error) {
+func (client *CertificateProfilesClient) deleteCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CodeSigning/codeSigningAccounts/{accountName}/certificateProfiles/{profileName}"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")

--- a/packages/typespec-go/test/armcodesigning/zz_options.go
+++ b/packages/typespec-go/test/armcodesigning/zz_options.go
@@ -4,20 +4,25 @@
 
 package armcodesigning
 
+// AccountsClientBeginCreateOptions contains the optional parameters for the AccountsClient.Create method.
+type AccountsClientBeginCreateOptions struct {
+	ResumeToken string
+}
+
+// AccountsClientBeginDeleteOptions contains the optional parameters for the AccountsClient.Delete method.
+type AccountsClientBeginDeleteOptions struct {
+	ResumeToken string
+}
+
+// AccountsClientBeginUpdateOptions contains the optional parameters for the AccountsClient.Update method.
+type AccountsClientBeginUpdateOptions struct {
+	ResumeToken string
+}
+
 // AccountsClientCheckNameAvailabilityOptions contains the optional parameters for the AccountsClient.CheckNameAvailability
 // method.
 type AccountsClientCheckNameAvailabilityOptions struct {
 	// placeholder for future optional parameters
-}
-
-// AccountsClientCreateOptions contains the optional parameters for the AccountsClient.Create method.
-type AccountsClientCreateOptions struct {
-	ResumeToken string
-}
-
-// AccountsClientDeleteOptions contains the optional parameters for the AccountsClient.Delete method.
-type AccountsClientDeleteOptions struct {
-	ResumeToken string
 }
 
 // AccountsClientGetOptions contains the optional parameters for the AccountsClient.Get method.
@@ -37,18 +42,13 @@ type AccountsClientListBySubscriptionOptions struct {
 	// placeholder for future optional parameters
 }
 
-// AccountsClientUpdateOptions contains the optional parameters for the AccountsClient.Update method.
-type AccountsClientUpdateOptions struct {
+// CertificateProfilesClientBeginCreateOptions contains the optional parameters for the CertificateProfilesClient.Create method.
+type CertificateProfilesClientBeginCreateOptions struct {
 	ResumeToken string
 }
 
-// CertificateProfilesClientCreateOptions contains the optional parameters for the CertificateProfilesClient.Create method.
-type CertificateProfilesClientCreateOptions struct {
-	ResumeToken string
-}
-
-// CertificateProfilesClientDeleteOptions contains the optional parameters for the CertificateProfilesClient.Delete method.
-type CertificateProfilesClientDeleteOptions struct {
+// CertificateProfilesClientBeginDeleteOptions contains the optional parameters for the CertificateProfilesClient.Delete method.
+type CertificateProfilesClientBeginDeleteOptions struct {
 	ResumeToken string
 }
 

--- a/packages/typespec-go/test/armlargeinstance/fake/zz_azurelargeinstances_server.go
+++ b/packages/typespec-go/test/armlargeinstance/fake/zz_azurelargeinstances_server.go
@@ -35,15 +35,15 @@ type AzureLargeInstancesServer struct {
 
 	// BeginRestart is the fake for method AzureLargeInstancesClient.BeginRestart
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginRestart func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientRestartOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientRestartResponse], errResp azfake.ErrorResponder)
+	BeginRestart func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientBeginRestartOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientRestartResponse], errResp azfake.ErrorResponder)
 
 	// BeginShutdown is the fake for method AzureLargeInstancesClient.BeginShutdown
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginShutdown func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientShutdownOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientShutdownResponse], errResp azfake.ErrorResponder)
+	BeginShutdown func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientBeginShutdownOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientShutdownResponse], errResp azfake.ErrorResponder)
 
 	// BeginStart is the fake for method AzureLargeInstancesClient.BeginStart
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusAccepted
-	BeginStart func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientStartOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientStartResponse], errResp azfake.ErrorResponder)
+	BeginStart func(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *armlargeinstance.AzureLargeInstancesClientBeginStartOptions) (resp azfake.PollerResponder[armlargeinstance.AzureLargeInstancesClientStartResponse], errResp azfake.ErrorResponder)
 
 	// Update is the fake for method AzureLargeInstancesClient.Update
 	// HTTP status codes to indicate success: http.StatusOK
@@ -255,9 +255,9 @@ func (a *AzureLargeInstancesServerTransport) dispatchBeginRestart(req *http.Requ
 		if err != nil {
 			return nil, err
 		}
-		var options *armlargeinstance.AzureLargeInstancesClientRestartOptions
+		var options *armlargeinstance.AzureLargeInstancesClientBeginRestartOptions
 		if !reflect.ValueOf(body).IsZero() {
-			options = &armlargeinstance.AzureLargeInstancesClientRestartOptions{
+			options = &armlargeinstance.AzureLargeInstancesClientBeginRestartOptions{
 				ForceParameter: &body,
 			}
 		}

--- a/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstances_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstances_client.go
@@ -218,9 +218,9 @@ func (client *AzureLargeInstancesClient) listBySubscriptionHandleResponse(resp *
 //   - subscriptionID - The ID of the target subscription.
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
-//   - options - AzureLargeInstancesClientRestartOptions contains the optional parameters for the AzureLargeInstancesClient.Restart
+//   - options - AzureLargeInstancesClientBeginRestartOptions contains the optional parameters for the AzureLargeInstancesClient.Restart
 //     method.
-func (client *AzureLargeInstancesClient) BeginRestart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientRestartOptions) (*runtime.Poller[AzureLargeInstancesClientRestartResponse], error) {
+func (client *AzureLargeInstancesClient) BeginRestart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginRestartOptions) (*runtime.Poller[AzureLargeInstancesClientRestartResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.restart(ctx, subscriptionID, resourceGroupName, azureLargeInstanceName, options)
 		if err != nil {
@@ -238,7 +238,7 @@ func (client *AzureLargeInstancesClient) BeginRestart(ctx context.Context, subsc
 }
 
 // Restart - The operation to restart an Azure Large Instance (only for compute instances)
-func (client *AzureLargeInstancesClient) restart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientRestartOptions) (*http.Response, error) {
+func (client *AzureLargeInstancesClient) restart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginRestartOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginRestart"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -260,7 +260,7 @@ func (client *AzureLargeInstancesClient) restart(ctx context.Context, subscripti
 }
 
 // restartCreateRequest creates the Restart request.
-func (client *AzureLargeInstancesClient) restartCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientRestartOptions) (*policy.Request, error) {
+func (client *AzureLargeInstancesClient) restartCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginRestartOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/restart"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -296,9 +296,9 @@ func (client *AzureLargeInstancesClient) restartCreateRequest(ctx context.Contex
 //   - subscriptionID - The ID of the target subscription.
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
-//   - options - AzureLargeInstancesClientShutdownOptions contains the optional parameters for the AzureLargeInstancesClient.Shutdown
+//   - options - AzureLargeInstancesClientBeginShutdownOptions contains the optional parameters for the AzureLargeInstancesClient.Shutdown
 //     method.
-func (client *AzureLargeInstancesClient) BeginShutdown(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientShutdownOptions) (*runtime.Poller[AzureLargeInstancesClientShutdownResponse], error) {
+func (client *AzureLargeInstancesClient) BeginShutdown(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginShutdownOptions) (*runtime.Poller[AzureLargeInstancesClientShutdownResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.shutdown(ctx, subscriptionID, resourceGroupName, azureLargeInstanceName, options)
 		if err != nil {
@@ -316,7 +316,7 @@ func (client *AzureLargeInstancesClient) BeginShutdown(ctx context.Context, subs
 }
 
 // Shutdown - The operation to shutdown an Azure Large Instance (only for compute instances)
-func (client *AzureLargeInstancesClient) shutdown(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientShutdownOptions) (*http.Response, error) {
+func (client *AzureLargeInstancesClient) shutdown(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginShutdownOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginShutdown"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -338,7 +338,7 @@ func (client *AzureLargeInstancesClient) shutdown(ctx context.Context, subscript
 }
 
 // shutdownCreateRequest creates the Shutdown request.
-func (client *AzureLargeInstancesClient) shutdownCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientShutdownOptions) (*policy.Request, error) {
+func (client *AzureLargeInstancesClient) shutdownCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginShutdownOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/shutdown"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")
@@ -367,9 +367,9 @@ func (client *AzureLargeInstancesClient) shutdownCreateRequest(ctx context.Conte
 //   - subscriptionID - The ID of the target subscription.
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
-//   - options - AzureLargeInstancesClientStartOptions contains the optional parameters for the AzureLargeInstancesClient.Start
+//   - options - AzureLargeInstancesClientBeginStartOptions contains the optional parameters for the AzureLargeInstancesClient.Start
 //     method.
-func (client *AzureLargeInstancesClient) BeginStart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientStartOptions) (*runtime.Poller[AzureLargeInstancesClientStartResponse], error) {
+func (client *AzureLargeInstancesClient) BeginStart(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginStartOptions) (*runtime.Poller[AzureLargeInstancesClientStartResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.start(ctx, subscriptionID, resourceGroupName, azureLargeInstanceName, options)
 		if err != nil {
@@ -387,7 +387,7 @@ func (client *AzureLargeInstancesClient) BeginStart(ctx context.Context, subscri
 }
 
 // Start - The operation to start an Azure Large Instance (only for compute instances)
-func (client *AzureLargeInstancesClient) start(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientStartOptions) (*http.Response, error) {
+func (client *AzureLargeInstancesClient) start(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginStartOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginStart"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -409,7 +409,7 @@ func (client *AzureLargeInstancesClient) start(ctx context.Context, subscription
 }
 
 // startCreateRequest creates the Start request.
-func (client *AzureLargeInstancesClient) startCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientStartOptions) (*policy.Request, error) {
+func (client *AzureLargeInstancesClient) startCreateRequest(ctx context.Context, subscriptionID string, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginStartOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AzureLargeInstance/azureLargeInstances/{azureLargeInstanceName}/start"
 	if subscriptionID == "" {
 		return nil, errors.New("parameter subscriptionID cannot be empty")

--- a/packages/typespec-go/test/armlargeinstance/zz_options.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_options.go
@@ -4,6 +4,27 @@
 
 package armlargeinstance
 
+// AzureLargeInstancesClientBeginRestartOptions contains the optional parameters for the AzureLargeInstancesClient.Restart
+// method.
+type AzureLargeInstancesClientBeginRestartOptions struct {
+	ResumeToken string
+
+	// When set to 'active', this parameter empowers the server with the ability to forcefully terminate and halt any existing
+	// processes that may be running on the server
+	ForceParameter *ForceState
+}
+
+// AzureLargeInstancesClientBeginShutdownOptions contains the optional parameters for the AzureLargeInstancesClient.Shutdown
+// method.
+type AzureLargeInstancesClientBeginShutdownOptions struct {
+	ResumeToken string
+}
+
+// AzureLargeInstancesClientBeginStartOptions contains the optional parameters for the AzureLargeInstancesClient.Start method.
+type AzureLargeInstancesClientBeginStartOptions struct {
+	ResumeToken string
+}
+
 // AzureLargeInstancesClientGetOptions contains the optional parameters for the AzureLargeInstancesClient.Get method.
 type AzureLargeInstancesClientGetOptions struct {
 	// placeholder for future optional parameters
@@ -19,25 +40,6 @@ type AzureLargeInstancesClientListByResourceGroupOptions struct {
 // method.
 type AzureLargeInstancesClientListBySubscriptionOptions struct {
 	// placeholder for future optional parameters
-}
-
-// AzureLargeInstancesClientRestartOptions contains the optional parameters for the AzureLargeInstancesClient.Restart method.
-type AzureLargeInstancesClientRestartOptions struct {
-	ResumeToken string
-
-	// When set to 'active', this parameter empowers the server with the ability to forcefully terminate and halt any existing
-	// processes that may be running on the server
-	ForceParameter *ForceState
-}
-
-// AzureLargeInstancesClientShutdownOptions contains the optional parameters for the AzureLargeInstancesClient.Shutdown method.
-type AzureLargeInstancesClientShutdownOptions struct {
-	ResumeToken string
-}
-
-// AzureLargeInstancesClientStartOptions contains the optional parameters for the AzureLargeInstancesClient.Start method.
-type AzureLargeInstancesClientStartOptions struct {
-	ResumeToken string
 }
 
 // AzureLargeInstancesClientUpdateOptions contains the optional parameters for the AzureLargeInstancesClient.Update method.

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/fake/zz_apikey_server.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/fake/zz_apikey_server.go
@@ -15,32 +15,32 @@ import (
 	"net/http"
 )
 
-// ApiKeyServer is a fake server for instances of the apikeygroup.ApiKeyClient type.
-type ApiKeyServer struct {
-	// Invalid is the fake for method ApiKeyClient.Invalid
+// APIKeyServer is a fake server for instances of the apikeygroup.APIKeyClient type.
+type APIKeyServer struct {
+	// Invalid is the fake for method APIKeyClient.Invalid
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Invalid func(ctx context.Context, options *apikeygroup.ApiKeyClientInvalidOptions) (resp azfake.Responder[apikeygroup.ApiKeyClientInvalidResponse], errResp azfake.ErrorResponder)
+	Invalid func(ctx context.Context, options *apikeygroup.APIKeyClientInvalidOptions) (resp azfake.Responder[apikeygroup.APIKeyClientInvalidResponse], errResp azfake.ErrorResponder)
 
-	// Valid is the fake for method ApiKeyClient.Valid
+	// Valid is the fake for method APIKeyClient.Valid
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Valid func(ctx context.Context, options *apikeygroup.ApiKeyClientValidOptions) (resp azfake.Responder[apikeygroup.ApiKeyClientValidResponse], errResp azfake.ErrorResponder)
+	Valid func(ctx context.Context, options *apikeygroup.APIKeyClientValidOptions) (resp azfake.Responder[apikeygroup.APIKeyClientValidResponse], errResp azfake.ErrorResponder)
 }
 
-// NewApiKeyServerTransport creates a new instance of ApiKeyServerTransport with the provided implementation.
-// The returned ApiKeyServerTransport instance is connected to an instance of apikeygroup.ApiKeyClient via the
+// NewAPIKeyServerTransport creates a new instance of APIKeyServerTransport with the provided implementation.
+// The returned APIKeyServerTransport instance is connected to an instance of apikeygroup.APIKeyClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewApiKeyServerTransport(srv *ApiKeyServer) *ApiKeyServerTransport {
-	return &ApiKeyServerTransport{srv: srv}
+func NewAPIKeyServerTransport(srv *APIKeyServer) *APIKeyServerTransport {
+	return &APIKeyServerTransport{srv: srv}
 }
 
-// ApiKeyServerTransport connects instances of apikeygroup.ApiKeyClient to instances of ApiKeyServer.
-// Don't use this type directly, use NewApiKeyServerTransport instead.
-type ApiKeyServerTransport struct {
-	srv *ApiKeyServer
+// APIKeyServerTransport connects instances of apikeygroup.APIKeyClient to instances of APIKeyServer.
+// Don't use this type directly, use NewAPIKeyServerTransport instead.
+type APIKeyServerTransport struct {
+	srv *APIKeyServer
 }
 
-// Do implements the policy.Transporter interface for ApiKeyServerTransport.
-func (a *ApiKeyServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for APIKeyServerTransport.
+func (a *APIKeyServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -50,14 +50,14 @@ func (a *ApiKeyServerTransport) Do(req *http.Request) (*http.Response, error) {
 	return a.dispatchToMethodFake(req, method)
 }
 
-func (a *ApiKeyServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (a *APIKeyServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "ApiKeyClient.Invalid":
+	case "APIKeyClient.Invalid":
 		resp, err = a.dispatchInvalid(req)
-	case "ApiKeyClient.Valid":
+	case "APIKeyClient.Valid":
 		resp, err = a.dispatchValid(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -66,7 +66,7 @@ func (a *ApiKeyServerTransport) dispatchToMethodFake(req *http.Request, method s
 	return resp, err
 }
 
-func (a *ApiKeyServerTransport) dispatchInvalid(req *http.Request) (*http.Response, error) {
+func (a *APIKeyServerTransport) dispatchInvalid(req *http.Request) (*http.Response, error) {
 	if a.srv.Invalid == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Invalid not implemented")}
 	}
@@ -85,7 +85,7 @@ func (a *ApiKeyServerTransport) dispatchInvalid(req *http.Request) (*http.Respon
 	return resp, nil
 }
 
-func (a *ApiKeyServerTransport) dispatchValid(req *http.Request) (*http.Response, error) {
+func (a *APIKeyServerTransport) dispatchValid(req *http.Request) (*http.Response, error) {
 	if a.srv.Valid == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Valid not implemented")}
 	}

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
@@ -12,37 +12,37 @@ import (
 	"net/http"
 )
 
-// ApiKeyClient - Illustrates clients generated with ApiKey authentication.
+// APIKeyClient - Illustrates clients generated with ApiKey authentication.
 // Don't use this type directly, use a constructor function instead.
-type ApiKeyClient struct {
+type APIKeyClient struct {
 	internal *azcore.Client
 }
 
 // Invalid - Check whether client is authenticated.
-//   - options - ApiKeyClientInvalidOptions contains the optional parameters for the ApiKeyClient.Invalid method.
-func (client *ApiKeyClient) Invalid(ctx context.Context, options *ApiKeyClientInvalidOptions) (ApiKeyClientInvalidResponse, error) {
+//   - options - APIKeyClientInvalidOptions contains the optional parameters for the APIKeyClient.Invalid method.
+func (client *APIKeyClient) Invalid(ctx context.Context, options *APIKeyClientInvalidOptions) (APIKeyClientInvalidResponse, error) {
 	var err error
-	const operationName = "ApiKeyClient.Invalid"
+	const operationName = "APIKeyClient.Invalid"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.invalidCreateRequest(ctx, options)
 	if err != nil {
-		return ApiKeyClientInvalidResponse{}, err
+		return APIKeyClientInvalidResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiKeyClientInvalidResponse{}, err
+		return APIKeyClientInvalidResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiKeyClientInvalidResponse{}, err
+		return APIKeyClientInvalidResponse{}, err
 	}
-	return ApiKeyClientInvalidResponse{}, nil
+	return APIKeyClientInvalidResponse{}, nil
 }
 
 // invalidCreateRequest creates the Invalid request.
-func (client *ApiKeyClient) invalidCreateRequest(ctx context.Context, options *ApiKeyClientInvalidOptions) (*policy.Request, error) {
+func (client *APIKeyClient) invalidCreateRequest(ctx context.Context, options *APIKeyClientInvalidOptions) (*policy.Request, error) {
 	urlPath := "/authentication/api-key/invalid"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -53,30 +53,30 @@ func (client *ApiKeyClient) invalidCreateRequest(ctx context.Context, options *A
 }
 
 // Valid - Check whether client is authenticated
-//   - options - ApiKeyClientValidOptions contains the optional parameters for the ApiKeyClient.Valid method.
-func (client *ApiKeyClient) Valid(ctx context.Context, options *ApiKeyClientValidOptions) (ApiKeyClientValidResponse, error) {
+//   - options - APIKeyClientValidOptions contains the optional parameters for the APIKeyClient.Valid method.
+func (client *APIKeyClient) Valid(ctx context.Context, options *APIKeyClientValidOptions) (APIKeyClientValidResponse, error) {
 	var err error
-	const operationName = "ApiKeyClient.Valid"
+	const operationName = "APIKeyClient.Valid"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.validCreateRequest(ctx, options)
 	if err != nil {
-		return ApiKeyClientValidResponse{}, err
+		return APIKeyClientValidResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ApiKeyClientValidResponse{}, err
+		return APIKeyClientValidResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ApiKeyClientValidResponse{}, err
+		return APIKeyClientValidResponse{}, err
 	}
-	return ApiKeyClientValidResponse{}, nil
+	return APIKeyClientValidResponse{}, nil
 }
 
 // validCreateRequest creates the Valid request.
-func (client *ApiKeyClient) validCreateRequest(ctx context.Context, options *ApiKeyClientValidOptions) (*policy.Request, error) {
+func (client *APIKeyClient) validCreateRequest(ctx context.Context, options *APIKeyClientValidOptions) (*policy.Request, error) {
 	urlPath := "/authentication/api-key/valid"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_options.go
@@ -4,12 +4,12 @@
 
 package apikeygroup
 
-// ApiKeyClientInvalidOptions contains the optional parameters for the ApiKeyClient.Invalid method.
-type ApiKeyClientInvalidOptions struct {
+// APIKeyClientInvalidOptions contains the optional parameters for the APIKeyClient.Invalid method.
+type APIKeyClientInvalidOptions struct {
 	// placeholder for future optional parameters
 }
 
-// ApiKeyClientValidOptions contains the optional parameters for the ApiKeyClient.Valid method.
-type ApiKeyClientValidOptions struct {
+// APIKeyClientValidOptions contains the optional parameters for the APIKeyClient.Valid method.
+type APIKeyClientValidOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_responses.go
@@ -4,12 +4,12 @@
 
 package apikeygroup
 
-// ApiKeyClientInvalidResponse contains the response from method ApiKeyClient.Invalid.
-type ApiKeyClientInvalidResponse struct {
+// APIKeyClientInvalidResponse contains the response from method APIKeyClient.Invalid.
+type APIKeyClientInvalidResponse struct {
 	// placeholder for future response values
 }
 
-// ApiKeyClientValidResponse contains the response from method ApiKeyClient.Valid.
-type ApiKeyClientValidResponse struct {
+// APIKeyClientValidResponse contains the response from method APIKeyClient.Valid.
+type APIKeyClientValidResponse struct {
 	// placeholder for future response values
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/fake/zz_legacycreateresourcepollviaoperationlocation_server.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/fake/zz_legacycreateresourcepollviaoperationlocation_server.go
@@ -21,7 +21,7 @@ import (
 type LegacyCreateResourcePollViaOperationLocationServer struct {
 	// BeginCreateJob is the fake for method LegacyCreateResourcePollViaOperationLocationClient.BeginCreateJob
 	// HTTP status codes to indicate success: http.StatusAccepted
-	BeginCreateJob func(ctx context.Context, jobData lrolegacygroup.JobData, options *lrolegacygroup.LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions) (resp azfake.PollerResponder[lrolegacygroup.LegacyCreateResourcePollViaOperationLocationClientCreateJobResponse], errResp azfake.ErrorResponder)
+	BeginCreateJob func(ctx context.Context, jobData lrolegacygroup.JobData, options *lrolegacygroup.LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions) (resp azfake.PollerResponder[lrolegacygroup.LegacyCreateResourcePollViaOperationLocationClientCreateJobResponse], errResp azfake.ErrorResponder)
 
 	// GetJob is the fake for method LegacyCreateResourcePollViaOperationLocationClient.GetJob
 	// HTTP status codes to indicate success: http.StatusOK

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_legacycreateresourcepollviaoperationlocation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_legacycreateresourcepollviaoperationlocation_client.go
@@ -22,9 +22,9 @@ type LegacyCreateResourcePollViaOperationLocationClient struct {
 }
 
 // BeginCreateJob - Creates a Job
-//   - options - LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions contains the optional parameters for the LegacyCreateResourcePollViaOperationLocationClient.CreateJob
-//     method.
-func (client *LegacyCreateResourcePollViaOperationLocationClient) BeginCreateJob(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions) (*runtime.Poller[LegacyCreateResourcePollViaOperationLocationClientCreateJobResponse], error) {
+//   - options - LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions contains the optional parameters for
+//     the LegacyCreateResourcePollViaOperationLocationClient.CreateJob method.
+func (client *LegacyCreateResourcePollViaOperationLocationClient) BeginCreateJob(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions) (*runtime.Poller[LegacyCreateResourcePollViaOperationLocationClientCreateJobResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createJob(ctx, jobData, options)
 		if err != nil {
@@ -42,7 +42,7 @@ func (client *LegacyCreateResourcePollViaOperationLocationClient) BeginCreateJob
 }
 
 // CreateJob - Creates a Job
-func (client *LegacyCreateResourcePollViaOperationLocationClient) createJob(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions) (*http.Response, error) {
+func (client *LegacyCreateResourcePollViaOperationLocationClient) createJob(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions) (*http.Response, error) {
 	var err error
 	const operationName = "LegacyCreateResourcePollViaOperationLocationClient.BeginCreateJob"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -64,7 +64,7 @@ func (client *LegacyCreateResourcePollViaOperationLocationClient) createJob(ctx 
 }
 
 // createJobCreateRequest creates the CreateJob request.
-func (client *LegacyCreateResourcePollViaOperationLocationClient) createJobCreateRequest(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions) (*policy.Request, error) {
+func (client *LegacyCreateResourcePollViaOperationLocationClient) createJobCreateRequest(ctx context.Context, jobData JobData, options *LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions) (*policy.Request, error) {
 	urlPath := "/azure/core/lro/rpc/legacy/create-resource-poll-via-operation-location/jobs"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrolegacygroup/zz_options.go
@@ -4,9 +4,9 @@
 
 package lrolegacygroup
 
-// LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions contains the optional parameters for the LegacyCreateResourcePollViaOperationLocationClient.CreateJob
+// LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions contains the optional parameters for the LegacyCreateResourcePollViaOperationLocationClient.CreateJob
 // method.
-type LegacyCreateResourcePollViaOperationLocationClientCreateJobOptions struct {
+type LegacyCreateResourcePollViaOperationLocationClientBeginCreateJobOptions struct {
 	ResumeToken string
 }
 

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/custom_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/custom_client.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewRpcClient(options *azcore.ClientOptions) (*RpcClient, error) {
+func NewRPCClient(options *azcore.ClientOptions) (*RPCClient, error) {
 	const apiVersion = "2022-12-01-preview"
 	internal, err := azcore.NewClient("lrorpcgroup", "v0.1.0", runtime.PipelineOptions{
 		PerCall: []policy.Policy{&apiVersionPolicy{apiVersion: apiVersion}},
@@ -19,7 +19,7 @@ func NewRpcClient(options *azcore.ClientOptions) (*RpcClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &RpcClient{
+	return &RPCClient{
 		internal: internal,
 	}, nil
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/fake/zz_rpc_server.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/fake/zz_rpc_server.go
@@ -15,32 +15,32 @@ import (
 	"net/http"
 )
 
-// RpcServer is a fake server for instances of the lrorpcgroup.RpcClient type.
-type RpcServer struct {
-	// BeginLongRunningRPC is the fake for method RpcClient.BeginLongRunningRPC
+// RPCServer is a fake server for instances of the lrorpcgroup.RPCClient type.
+type RPCServer struct {
+	// BeginLongRunningRPC is the fake for method RPCClient.BeginLongRunningRPC
 	// HTTP status codes to indicate success: http.StatusAccepted
-	BeginLongRunningRPC func(ctx context.Context, generationOptions lrorpcgroup.GenerationOptions, options *lrorpcgroup.RpcClientLongRunningRPCOptions) (resp azfake.PollerResponder[lrorpcgroup.RpcClientLongRunningRPCResponse], errResp azfake.ErrorResponder)
+	BeginLongRunningRPC func(ctx context.Context, generationOptions lrorpcgroup.GenerationOptions, options *lrorpcgroup.RPCClientBeginLongRunningRPCOptions) (resp azfake.PollerResponder[lrorpcgroup.RPCClientLongRunningRPCResponse], errResp azfake.ErrorResponder)
 }
 
-// NewRpcServerTransport creates a new instance of RpcServerTransport with the provided implementation.
-// The returned RpcServerTransport instance is connected to an instance of lrorpcgroup.RpcClient via the
+// NewRPCServerTransport creates a new instance of RPCServerTransport with the provided implementation.
+// The returned RPCServerTransport instance is connected to an instance of lrorpcgroup.RPCClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewRpcServerTransport(srv *RpcServer) *RpcServerTransport {
-	return &RpcServerTransport{
+func NewRPCServerTransport(srv *RPCServer) *RPCServerTransport {
+	return &RPCServerTransport{
 		srv:                 srv,
-		beginLongRunningRPC: newTracker[azfake.PollerResponder[lrorpcgroup.RpcClientLongRunningRPCResponse]](),
+		beginLongRunningRPC: newTracker[azfake.PollerResponder[lrorpcgroup.RPCClientLongRunningRPCResponse]](),
 	}
 }
 
-// RpcServerTransport connects instances of lrorpcgroup.RpcClient to instances of RpcServer.
-// Don't use this type directly, use NewRpcServerTransport instead.
-type RpcServerTransport struct {
-	srv                 *RpcServer
-	beginLongRunningRPC *tracker[azfake.PollerResponder[lrorpcgroup.RpcClientLongRunningRPCResponse]]
+// RPCServerTransport connects instances of lrorpcgroup.RPCClient to instances of RPCServer.
+// Don't use this type directly, use NewRPCServerTransport instead.
+type RPCServerTransport struct {
+	srv                 *RPCServer
+	beginLongRunningRPC *tracker[azfake.PollerResponder[lrorpcgroup.RPCClientLongRunningRPCResponse]]
 }
 
-// Do implements the policy.Transporter interface for RpcServerTransport.
-func (r *RpcServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for RPCServerTransport.
+func (r *RPCServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -50,12 +50,12 @@ func (r *RpcServerTransport) Do(req *http.Request) (*http.Response, error) {
 	return r.dispatchToMethodFake(req, method)
 }
 
-func (r *RpcServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (r *RPCServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "RpcClient.BeginLongRunningRPC":
+	case "RPCClient.BeginLongRunningRPC":
 		resp, err = r.dispatchBeginLongRunningRPC(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -64,7 +64,7 @@ func (r *RpcServerTransport) dispatchToMethodFake(req *http.Request, method stri
 	return resp, err
 }
 
-func (r *RpcServerTransport) dispatchBeginLongRunningRPC(req *http.Request) (*http.Response, error) {
+func (r *RPCServerTransport) dispatchBeginLongRunningRPC(req *http.Request) (*http.Response, error) {
 	if r.srv.BeginLongRunningRPC == nil {
 		return nil, &nonRetriableError{errors.New("fake for method BeginLongRunningRPC not implemented")}
 	}

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/rcp_client_test.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/rcp_client_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRpcClient_BeginLongRunningRPC(t *testing.T) {
 	t.Skip("https://github.com/Azure/azure-sdk-for-go/issues/22433")
-	client, err := lrorpcgroup.NewRpcClient(nil)
+	client, err := lrorpcgroup.NewRPCClient(nil)
 	require.NoError(t, err)
 	poller, err := client.BeginLongRunningRPC(context.Background(), lrorpcgroup.GenerationOptions{
 		Prompt: to.Ptr("text"),

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_options.go
@@ -4,7 +4,7 @@
 
 package lrorpcgroup
 
-// RpcClientLongRunningRPCOptions contains the optional parameters for the RpcClient.LongRunningRPC method.
-type RpcClientLongRunningRPCOptions struct {
+// RPCClientBeginLongRunningRPCOptions contains the optional parameters for the RPCClient.LongRunningRPC method.
+type RPCClientBeginLongRunningRPCOptions struct {
 	ResumeToken string
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_responses.go
@@ -4,8 +4,8 @@
 
 package lrorpcgroup
 
-// RpcClientLongRunningRPCResponse contains the response from method RpcClient.LongRunningRPC.
-type RpcClientLongRunningRPCResponse struct {
+// RPCClientLongRunningRPCResponse contains the response from method RPCClient.LongRunningRPC.
+type RPCClientLongRunningRPCResponse struct {
 	// Result of the generation.
 	GenerationResult
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_rpc_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_rpc_client.go
@@ -12,35 +12,35 @@ import (
 	"net/http"
 )
 
-// RpcClient - Illustrates bodies templated with Azure Core with long-running RPC operation
+// RPCClient - Illustrates bodies templated with Azure Core with long-running RPC operation
 // Don't use this type directly, use a constructor function instead.
-type RpcClient struct {
+type RPCClient struct {
 	internal *azcore.Client
 }
 
 // BeginLongRunningRPC - Generate data.
-//   - options - RpcClientLongRunningRPCOptions contains the optional parameters for the RpcClient.LongRunningRPC method.
-func (client *RpcClient) BeginLongRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RpcClientLongRunningRPCOptions) (*runtime.Poller[RpcClientLongRunningRPCResponse], error) {
+//   - options - RPCClientBeginLongRunningRPCOptions contains the optional parameters for the RPCClient.LongRunningRPC method.
+func (client *RPCClient) BeginLongRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RPCClientBeginLongRunningRPCOptions) (*runtime.Poller[RPCClientLongRunningRPCResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.longRunningRPC(ctx, generationOptions, options)
 		if err != nil {
 			return nil, err
 		}
-		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RpcClientLongRunningRPCResponse]{
+		poller, err := runtime.NewPoller(resp, client.internal.Pipeline(), &runtime.NewPollerOptions[RPCClientLongRunningRPCResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 		return poller, err
 	} else {
-		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[RpcClientLongRunningRPCResponse]{
+		return runtime.NewPollerFromResumeToken(options.ResumeToken, client.internal.Pipeline(), &runtime.NewPollerFromResumeTokenOptions[RPCClientLongRunningRPCResponse]{
 			Tracer: client.internal.Tracer(),
 		})
 	}
 }
 
 // LongRunningRPC - Generate data.
-func (client *RpcClient) longRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RpcClientLongRunningRPCOptions) (*http.Response, error) {
+func (client *RPCClient) longRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RPCClientBeginLongRunningRPCOptions) (*http.Response, error) {
 	var err error
-	const operationName = "RpcClient.BeginLongRunningRPC"
+	const operationName = "RPCClient.BeginLongRunningRPC"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
@@ -60,7 +60,7 @@ func (client *RpcClient) longRunningRPC(ctx context.Context, generationOptions G
 }
 
 // longRunningRPCCreateRequest creates the LongRunningRPC request.
-func (client *RpcClient) longRunningRPCCreateRequest(ctx context.Context, generationOptions GenerationOptions, options *RpcClientLongRunningRPCOptions) (*policy.Request, error) {
+func (client *RPCClient) longRunningRPCCreateRequest(ctx context.Context, generationOptions GenerationOptions, options *RPCClientBeginLongRunningRPCOptions) (*policy.Request, error) {
 	urlPath := "/azure/core/lro/rpc/generations:submit"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/fake/zz_standard_server.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/fake/zz_standard_server.go
@@ -21,15 +21,15 @@ import (
 type StandardServer struct {
 	// BeginCreateOrReplace is the fake for method StandardClient.BeginCreateOrReplace
 	// HTTP status codes to indicate success: http.StatusOK, http.StatusCreated
-	BeginCreateOrReplace func(ctx context.Context, name string, resource lrostdgroup.User, options *lrostdgroup.StandardClientCreateOrReplaceOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientCreateOrReplaceResponse], errResp azfake.ErrorResponder)
+	BeginCreateOrReplace func(ctx context.Context, name string, resource lrostdgroup.User, options *lrostdgroup.StandardClientBeginCreateOrReplaceOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientCreateOrReplaceResponse], errResp azfake.ErrorResponder)
 
 	// BeginDelete is the fake for method StandardClient.BeginDelete
 	// HTTP status codes to indicate success: http.StatusAccepted
-	BeginDelete func(ctx context.Context, name string, options *lrostdgroup.StandardClientDeleteOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientDeleteResponse], errResp azfake.ErrorResponder)
+	BeginDelete func(ctx context.Context, name string, options *lrostdgroup.StandardClientBeginDeleteOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientDeleteResponse], errResp azfake.ErrorResponder)
 
 	// BeginExport is the fake for method StandardClient.BeginExport
 	// HTTP status codes to indicate success: http.StatusAccepted
-	BeginExport func(ctx context.Context, name string, formatParam string, options *lrostdgroup.StandardClientExportOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientExportResponse], errResp azfake.ErrorResponder)
+	BeginExport func(ctx context.Context, name string, formatParam string, options *lrostdgroup.StandardClientBeginExportOptions) (resp azfake.PollerResponder[lrostdgroup.StandardClientExportResponse], errResp azfake.ErrorResponder)
 }
 
 // NewStandardServerTransport creates a new instance of StandardServerTransport with the provided implementation.

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_options.go
@@ -4,17 +4,17 @@
 
 package lrostdgroup
 
-// StandardClientCreateOrReplaceOptions contains the optional parameters for the StandardClient.CreateOrReplace method.
-type StandardClientCreateOrReplaceOptions struct {
+// StandardClientBeginCreateOrReplaceOptions contains the optional parameters for the StandardClient.CreateOrReplace method.
+type StandardClientBeginCreateOrReplaceOptions struct {
 	ResumeToken string
 }
 
-// StandardClientDeleteOptions contains the optional parameters for the StandardClient.Delete method.
-type StandardClientDeleteOptions struct {
+// StandardClientBeginDeleteOptions contains the optional parameters for the StandardClient.Delete method.
+type StandardClientBeginDeleteOptions struct {
 	ResumeToken string
 }
 
-// StandardClientExportOptions contains the optional parameters for the StandardClient.Export method.
-type StandardClientExportOptions struct {
+// StandardClientBeginExportOptions contains the optional parameters for the StandardClient.Export method.
+type StandardClientBeginExportOptions struct {
 	ResumeToken string
 }

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_standard_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_standard_client.go
@@ -24,9 +24,9 @@ type StandardClient struct {
 // BeginCreateOrReplace - Adds a user or replaces a user's fields.
 //   - name - The name of user.
 //   - resource - The resource instance.
-//   - options - StandardClientCreateOrReplaceOptions contains the optional parameters for the StandardClient.CreateOrReplace
+//   - options - StandardClientBeginCreateOrReplaceOptions contains the optional parameters for the StandardClient.CreateOrReplace
 //     method.
-func (client *StandardClient) BeginCreateOrReplace(ctx context.Context, name string, resource User, options *StandardClientCreateOrReplaceOptions) (*runtime.Poller[StandardClientCreateOrReplaceResponse], error) {
+func (client *StandardClient) BeginCreateOrReplace(ctx context.Context, name string, resource User, options *StandardClientBeginCreateOrReplaceOptions) (*runtime.Poller[StandardClientCreateOrReplaceResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.createOrReplace(ctx, name, resource, options)
 		if err != nil {
@@ -44,7 +44,7 @@ func (client *StandardClient) BeginCreateOrReplace(ctx context.Context, name str
 }
 
 // CreateOrReplace - Adds a user or replaces a user's fields.
-func (client *StandardClient) createOrReplace(ctx context.Context, name string, resource User, options *StandardClientCreateOrReplaceOptions) (*http.Response, error) {
+func (client *StandardClient) createOrReplace(ctx context.Context, name string, resource User, options *StandardClientBeginCreateOrReplaceOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginCreateOrReplace"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -66,7 +66,7 @@ func (client *StandardClient) createOrReplace(ctx context.Context, name string, 
 }
 
 // createOrReplaceCreateRequest creates the CreateOrReplace request.
-func (client *StandardClient) createOrReplaceCreateRequest(ctx context.Context, name string, resource User, options *StandardClientCreateOrReplaceOptions) (*policy.Request, error) {
+func (client *StandardClient) createOrReplaceCreateRequest(ctx context.Context, name string, resource User, options *StandardClientBeginCreateOrReplaceOptions) (*policy.Request, error) {
 	urlPath := "/azure/core/lro/standard/users/{name}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -89,8 +89,8 @@ func (client *StandardClient) createOrReplaceCreateRequest(ctx context.Context, 
 
 // BeginDelete - Deletes a user.
 //   - name - The name of user.
-//   - options - StandardClientDeleteOptions contains the optional parameters for the StandardClient.Delete method.
-func (client *StandardClient) BeginDelete(ctx context.Context, name string, options *StandardClientDeleteOptions) (*runtime.Poller[StandardClientDeleteResponse], error) {
+//   - options - StandardClientBeginDeleteOptions contains the optional parameters for the StandardClient.Delete method.
+func (client *StandardClient) BeginDelete(ctx context.Context, name string, options *StandardClientBeginDeleteOptions) (*runtime.Poller[StandardClientDeleteResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.deleteOperation(ctx, name, options)
 		if err != nil {
@@ -108,7 +108,7 @@ func (client *StandardClient) BeginDelete(ctx context.Context, name string, opti
 }
 
 // Delete - Deletes a user.
-func (client *StandardClient) deleteOperation(ctx context.Context, name string, options *StandardClientDeleteOptions) (*http.Response, error) {
+func (client *StandardClient) deleteOperation(ctx context.Context, name string, options *StandardClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginDelete"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -130,7 +130,7 @@ func (client *StandardClient) deleteOperation(ctx context.Context, name string, 
 }
 
 // deleteCreateRequest creates the Delete request.
-func (client *StandardClient) deleteCreateRequest(ctx context.Context, name string, options *StandardClientDeleteOptions) (*policy.Request, error) {
+func (client *StandardClient) deleteCreateRequest(ctx context.Context, name string, options *StandardClientBeginDeleteOptions) (*policy.Request, error) {
 	urlPath := "/azure/core/lro/standard/users/{name}"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")
@@ -150,8 +150,8 @@ func (client *StandardClient) deleteCreateRequest(ctx context.Context, name stri
 // BeginExport - Exports a user.
 //   - name - The name of user.
 //   - formatParam - The format of the data.
-//   - options - StandardClientExportOptions contains the optional parameters for the StandardClient.Export method.
-func (client *StandardClient) BeginExport(ctx context.Context, name string, formatParam string, options *StandardClientExportOptions) (*runtime.Poller[StandardClientExportResponse], error) {
+//   - options - StandardClientBeginExportOptions contains the optional parameters for the StandardClient.Export method.
+func (client *StandardClient) BeginExport(ctx context.Context, name string, formatParam string, options *StandardClientBeginExportOptions) (*runtime.Poller[StandardClientExportResponse], error) {
 	if options == nil || options.ResumeToken == "" {
 		resp, err := client.export(ctx, name, formatParam, options)
 		if err != nil {
@@ -169,7 +169,7 @@ func (client *StandardClient) BeginExport(ctx context.Context, name string, form
 }
 
 // Export - Exports a user.
-func (client *StandardClient) export(ctx context.Context, name string, formatParam string, options *StandardClientExportOptions) (*http.Response, error) {
+func (client *StandardClient) export(ctx context.Context, name string, formatParam string, options *StandardClientBeginExportOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginExport"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
@@ -191,7 +191,7 @@ func (client *StandardClient) export(ctx context.Context, name string, formatPar
 }
 
 // exportCreateRequest creates the Export request.
-func (client *StandardClient) exportCreateRequest(ctx context.Context, name string, formatParam string, options *StandardClientExportOptions) (*policy.Request, error) {
+func (client *StandardClient) exportCreateRequest(ctx context.Context, name string, formatParam string, options *StandardClientBeginExportOptions) (*policy.Request, error) {
 	urlPath := "/azure/core/lro/standard/users/{name}:export"
 	if name == "" {
 		return nil, errors.New("parameter name cannot be empty")

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/custom_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/custom_client.go
@@ -8,12 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewJsonMergePatchClient(options *azcore.ClientOptions) (*JsonMergePatchClient, error) {
+func NewJSONMergePatchClient(options *azcore.ClientOptions) (*JSONMergePatchClient, error) {
 	internal, err := azcore.NewClient("jmergepatchgroup", "v0.1.0", runtime.PipelineOptions{}, options)
 	if err != nil {
 		return nil, err
 	}
-	return &JsonMergePatchClient{
+	return &JSONMergePatchClient{
 		internal: internal,
 	}, nil
 }

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/fake/zz_jsonmergepatch_server.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/fake/zz_jsonmergepatch_server.go
@@ -16,36 +16,36 @@ import (
 	"reflect"
 )
 
-// JsonMergePatchServer is a fake server for instances of the jmergepatchgroup.JsonMergePatchClient type.
-type JsonMergePatchServer struct {
-	// CreateResource is the fake for method JsonMergePatchClient.CreateResource
+// JSONMergePatchServer is a fake server for instances of the jmergepatchgroup.JSONMergePatchClient type.
+type JSONMergePatchServer struct {
+	// CreateResource is the fake for method JSONMergePatchClient.CreateResource
 	// HTTP status codes to indicate success: http.StatusOK
-	CreateResource func(ctx context.Context, body jmergepatchgroup.Resource, options *jmergepatchgroup.JsonMergePatchClientCreateResourceOptions) (resp azfake.Responder[jmergepatchgroup.JsonMergePatchClientCreateResourceResponse], errResp azfake.ErrorResponder)
+	CreateResource func(ctx context.Context, body jmergepatchgroup.Resource, options *jmergepatchgroup.JSONMergePatchClientCreateResourceOptions) (resp azfake.Responder[jmergepatchgroup.JSONMergePatchClientCreateResourceResponse], errResp azfake.ErrorResponder)
 
-	// UpdateOptionalResource is the fake for method JsonMergePatchClient.UpdateOptionalResource
+	// UpdateOptionalResource is the fake for method JSONMergePatchClient.UpdateOptionalResource
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateOptionalResource func(ctx context.Context, options *jmergepatchgroup.JsonMergePatchClientUpdateOptionalResourceOptions) (resp azfake.Responder[jmergepatchgroup.JsonMergePatchClientUpdateOptionalResourceResponse], errResp azfake.ErrorResponder)
+	UpdateOptionalResource func(ctx context.Context, options *jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions) (resp azfake.Responder[jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceResponse], errResp azfake.ErrorResponder)
 
-	// UpdateResource is the fake for method JsonMergePatchClient.UpdateResource
+	// UpdateResource is the fake for method JSONMergePatchClient.UpdateResource
 	// HTTP status codes to indicate success: http.StatusOK
-	UpdateResource func(ctx context.Context, body jmergepatchgroup.ResourcePatch, options *jmergepatchgroup.JsonMergePatchClientUpdateResourceOptions) (resp azfake.Responder[jmergepatchgroup.JsonMergePatchClientUpdateResourceResponse], errResp azfake.ErrorResponder)
+	UpdateResource func(ctx context.Context, body jmergepatchgroup.ResourcePatch, options *jmergepatchgroup.JSONMergePatchClientUpdateResourceOptions) (resp azfake.Responder[jmergepatchgroup.JSONMergePatchClientUpdateResourceResponse], errResp azfake.ErrorResponder)
 }
 
-// NewJsonMergePatchServerTransport creates a new instance of JsonMergePatchServerTransport with the provided implementation.
-// The returned JsonMergePatchServerTransport instance is connected to an instance of jmergepatchgroup.JsonMergePatchClient via the
+// NewJSONMergePatchServerTransport creates a new instance of JSONMergePatchServerTransport with the provided implementation.
+// The returned JSONMergePatchServerTransport instance is connected to an instance of jmergepatchgroup.JSONMergePatchClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewJsonMergePatchServerTransport(srv *JsonMergePatchServer) *JsonMergePatchServerTransport {
-	return &JsonMergePatchServerTransport{srv: srv}
+func NewJSONMergePatchServerTransport(srv *JSONMergePatchServer) *JSONMergePatchServerTransport {
+	return &JSONMergePatchServerTransport{srv: srv}
 }
 
-// JsonMergePatchServerTransport connects instances of jmergepatchgroup.JsonMergePatchClient to instances of JsonMergePatchServer.
-// Don't use this type directly, use NewJsonMergePatchServerTransport instead.
-type JsonMergePatchServerTransport struct {
-	srv *JsonMergePatchServer
+// JSONMergePatchServerTransport connects instances of jmergepatchgroup.JSONMergePatchClient to instances of JSONMergePatchServer.
+// Don't use this type directly, use NewJSONMergePatchServerTransport instead.
+type JSONMergePatchServerTransport struct {
+	srv *JSONMergePatchServer
 }
 
-// Do implements the policy.Transporter interface for JsonMergePatchServerTransport.
-func (j *JsonMergePatchServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for JSONMergePatchServerTransport.
+func (j *JSONMergePatchServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -55,16 +55,16 @@ func (j *JsonMergePatchServerTransport) Do(req *http.Request) (*http.Response, e
 	return j.dispatchToMethodFake(req, method)
 }
 
-func (j *JsonMergePatchServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (j *JSONMergePatchServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "JsonMergePatchClient.CreateResource":
+	case "JSONMergePatchClient.CreateResource":
 		resp, err = j.dispatchCreateResource(req)
-	case "JsonMergePatchClient.UpdateOptionalResource":
+	case "JSONMergePatchClient.UpdateOptionalResource":
 		resp, err = j.dispatchUpdateOptionalResource(req)
-	case "JsonMergePatchClient.UpdateResource":
+	case "JSONMergePatchClient.UpdateResource":
 		resp, err = j.dispatchUpdateResource(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -73,7 +73,7 @@ func (j *JsonMergePatchServerTransport) dispatchToMethodFake(req *http.Request, 
 	return resp, err
 }
 
-func (j *JsonMergePatchServerTransport) dispatchCreateResource(req *http.Request) (*http.Response, error) {
+func (j *JSONMergePatchServerTransport) dispatchCreateResource(req *http.Request) (*http.Response, error) {
 	if j.srv.CreateResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method CreateResource not implemented")}
 	}
@@ -96,7 +96,7 @@ func (j *JsonMergePatchServerTransport) dispatchCreateResource(req *http.Request
 	return resp, nil
 }
 
-func (j *JsonMergePatchServerTransport) dispatchUpdateOptionalResource(req *http.Request) (*http.Response, error) {
+func (j *JSONMergePatchServerTransport) dispatchUpdateOptionalResource(req *http.Request) (*http.Response, error) {
 	if j.srv.UpdateOptionalResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method UpdateOptionalResource not implemented")}
 	}
@@ -104,9 +104,9 @@ func (j *JsonMergePatchServerTransport) dispatchUpdateOptionalResource(req *http
 	if err != nil {
 		return nil, err
 	}
-	var options *jmergepatchgroup.JsonMergePatchClientUpdateOptionalResourceOptions
+	var options *jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions
 	if !reflect.ValueOf(body).IsZero() {
-		options = &jmergepatchgroup.JsonMergePatchClientUpdateOptionalResourceOptions{
+		options = &jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions{
 			Body: &body,
 		}
 	}
@@ -125,7 +125,7 @@ func (j *JsonMergePatchServerTransport) dispatchUpdateOptionalResource(req *http
 	return resp, nil
 }
 
-func (j *JsonMergePatchServerTransport) dispatchUpdateResource(req *http.Request) (*http.Response, error) {
+func (j *JSONMergePatchServerTransport) dispatchUpdateResource(req *http.Request) (*http.Response, error) {
 	if j.srv.UpdateResource == nil {
 		return nil, &nonRetriableError{errors.New("fake for method UpdateResource not implemented")}
 	}

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/jsonmergepatch_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/jsonmergepatch_client_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestJsonMergePatchClient_CreateResource(t *testing.T) {
-	client, err := jmergepatchgroup.NewJsonMergePatchClient(nil)
+	client, err := jmergepatchgroup.NewJSONMergePatchClient(nil)
 	require.NoError(t, err)
 	resp, err := client.CreateResource(context.Background(), jmergepatchgroup.Resource{
 		Name:        to.Ptr("Madge"),
@@ -74,9 +74,9 @@ func TestJsonMergePatchClient_CreateResource(t *testing.T) {
 }
 
 func TestJsonMergePatchClient_UpdateOptionalResource(t *testing.T) {
-	client, err := jmergepatchgroup.NewJsonMergePatchClient(nil)
+	client, err := jmergepatchgroup.NewJSONMergePatchClient(nil)
 	require.NoError(t, err)
-	resp, err := client.UpdateOptionalResource(context.Background(), &jmergepatchgroup.JsonMergePatchClientUpdateOptionalResourceOptions{
+	resp, err := client.UpdateOptionalResource(context.Background(), &jmergepatchgroup.JSONMergePatchClientUpdateOptionalResourceOptions{
 		Body: &jmergepatchgroup.ResourcePatch{
 			Description: azcore.NullValue[*string](),
 			Map: map[string]*jmergepatchgroup.InnerModel{
@@ -104,7 +104,7 @@ func TestJsonMergePatchClient_UpdateOptionalResource(t *testing.T) {
 }
 
 func TestJsonMergePatchClient_UpdateResource(t *testing.T) {
-	client, err := jmergepatchgroup.NewJsonMergePatchClient(nil)
+	client, err := jmergepatchgroup.NewJSONMergePatchClient(nil)
 	require.NoError(t, err)
 	resp, err := client.UpdateResource(context.Background(), jmergepatchgroup.ResourcePatch{
 		Description: azcore.NullValue[*string](),

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -12,39 +12,39 @@ import (
 	"net/http"
 )
 
-// JsonMergePatchClient - Test for merge-patch+json content-type
+// JSONMergePatchClient - Test for merge-patch+json content-type
 // Don't use this type directly, use a constructor function instead.
-type JsonMergePatchClient struct {
+type JSONMergePatchClient struct {
 	internal *azcore.Client
 }
 
 // CreateResource - Test content-type: application/merge-patch+json with required body
-//   - options - JsonMergePatchClientCreateResourceOptions contains the optional parameters for the JsonMergePatchClient.CreateResource
+//   - options - JSONMergePatchClientCreateResourceOptions contains the optional parameters for the JSONMergePatchClient.CreateResource
 //     method.
-func (client *JsonMergePatchClient) CreateResource(ctx context.Context, body Resource, options *JsonMergePatchClientCreateResourceOptions) (JsonMergePatchClientCreateResourceResponse, error) {
+func (client *JSONMergePatchClient) CreateResource(ctx context.Context, body Resource, options *JSONMergePatchClientCreateResourceOptions) (JSONMergePatchClientCreateResourceResponse, error) {
 	var err error
-	const operationName = "JsonMergePatchClient.CreateResource"
+	const operationName = "JSONMergePatchClient.CreateResource"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.createResourceCreateRequest(ctx, body, options)
 	if err != nil {
-		return JsonMergePatchClientCreateResourceResponse{}, err
+		return JSONMergePatchClientCreateResourceResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return JsonMergePatchClientCreateResourceResponse{}, err
+		return JSONMergePatchClientCreateResourceResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return JsonMergePatchClientCreateResourceResponse{}, err
+		return JSONMergePatchClientCreateResourceResponse{}, err
 	}
 	resp, err := client.createResourceHandleResponse(httpResp)
 	return resp, err
 }
 
 // createResourceCreateRequest creates the CreateResource request.
-func (client *JsonMergePatchClient) createResourceCreateRequest(ctx context.Context, body Resource, options *JsonMergePatchClientCreateResourceOptions) (*policy.Request, error) {
+func (client *JSONMergePatchClient) createResourceCreateRequest(ctx context.Context, body Resource, options *JSONMergePatchClientCreateResourceOptions) (*policy.Request, error) {
 	urlPath := "/json-merge-patch/create/resource"
 	req, err := runtime.NewRequest(ctx, http.MethodPut, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -59,41 +59,41 @@ func (client *JsonMergePatchClient) createResourceCreateRequest(ctx context.Cont
 }
 
 // createResourceHandleResponse handles the CreateResource response.
-func (client *JsonMergePatchClient) createResourceHandleResponse(resp *http.Response) (JsonMergePatchClientCreateResourceResponse, error) {
-	result := JsonMergePatchClientCreateResourceResponse{}
+func (client *JSONMergePatchClient) createResourceHandleResponse(resp *http.Response) (JSONMergePatchClientCreateResourceResponse, error) {
+	result := JSONMergePatchClientCreateResourceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Resource); err != nil {
-		return JsonMergePatchClientCreateResourceResponse{}, err
+		return JSONMergePatchClientCreateResourceResponse{}, err
 	}
 	return result, nil
 }
 
 // UpdateOptionalResource - Test content-type: application/merge-patch+json with optional body
-//   - options - JsonMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JsonMergePatchClient.UpdateOptionalResource
+//   - options - JSONMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateOptionalResource
 //     method.
-func (client *JsonMergePatchClient) UpdateOptionalResource(ctx context.Context, options *JsonMergePatchClientUpdateOptionalResourceOptions) (JsonMergePatchClientUpdateOptionalResourceResponse, error) {
+func (client *JSONMergePatchClient) UpdateOptionalResource(ctx context.Context, options *JSONMergePatchClientUpdateOptionalResourceOptions) (JSONMergePatchClientUpdateOptionalResourceResponse, error) {
 	var err error
-	const operationName = "JsonMergePatchClient.UpdateOptionalResource"
+	const operationName = "JSONMergePatchClient.UpdateOptionalResource"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.updateOptionalResourceCreateRequest(ctx, options)
 	if err != nil {
-		return JsonMergePatchClientUpdateOptionalResourceResponse{}, err
+		return JSONMergePatchClientUpdateOptionalResourceResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return JsonMergePatchClientUpdateOptionalResourceResponse{}, err
+		return JSONMergePatchClientUpdateOptionalResourceResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return JsonMergePatchClientUpdateOptionalResourceResponse{}, err
+		return JSONMergePatchClientUpdateOptionalResourceResponse{}, err
 	}
 	resp, err := client.updateOptionalResourceHandleResponse(httpResp)
 	return resp, err
 }
 
 // updateOptionalResourceCreateRequest creates the UpdateOptionalResource request.
-func (client *JsonMergePatchClient) updateOptionalResourceCreateRequest(ctx context.Context, options *JsonMergePatchClientUpdateOptionalResourceOptions) (*policy.Request, error) {
+func (client *JSONMergePatchClient) updateOptionalResourceCreateRequest(ctx context.Context, options *JSONMergePatchClientUpdateOptionalResourceOptions) (*policy.Request, error) {
 	urlPath := "/json-merge-patch/update/resource/optional"
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -111,41 +111,41 @@ func (client *JsonMergePatchClient) updateOptionalResourceCreateRequest(ctx cont
 }
 
 // updateOptionalResourceHandleResponse handles the UpdateOptionalResource response.
-func (client *JsonMergePatchClient) updateOptionalResourceHandleResponse(resp *http.Response) (JsonMergePatchClientUpdateOptionalResourceResponse, error) {
-	result := JsonMergePatchClientUpdateOptionalResourceResponse{}
+func (client *JSONMergePatchClient) updateOptionalResourceHandleResponse(resp *http.Response) (JSONMergePatchClientUpdateOptionalResourceResponse, error) {
+	result := JSONMergePatchClientUpdateOptionalResourceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Resource); err != nil {
-		return JsonMergePatchClientUpdateOptionalResourceResponse{}, err
+		return JSONMergePatchClientUpdateOptionalResourceResponse{}, err
 	}
 	return result, nil
 }
 
 // UpdateResource - Test content-type: application/merge-patch+json with required body
-//   - options - JsonMergePatchClientUpdateResourceOptions contains the optional parameters for the JsonMergePatchClient.UpdateResource
+//   - options - JSONMergePatchClientUpdateResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateResource
 //     method.
-func (client *JsonMergePatchClient) UpdateResource(ctx context.Context, body ResourcePatch, options *JsonMergePatchClientUpdateResourceOptions) (JsonMergePatchClientUpdateResourceResponse, error) {
+func (client *JSONMergePatchClient) UpdateResource(ctx context.Context, body ResourcePatch, options *JSONMergePatchClientUpdateResourceOptions) (JSONMergePatchClientUpdateResourceResponse, error) {
 	var err error
-	const operationName = "JsonMergePatchClient.UpdateResource"
+	const operationName = "JSONMergePatchClient.UpdateResource"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.updateResourceCreateRequest(ctx, body, options)
 	if err != nil {
-		return JsonMergePatchClientUpdateResourceResponse{}, err
+		return JSONMergePatchClientUpdateResourceResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return JsonMergePatchClientUpdateResourceResponse{}, err
+		return JSONMergePatchClientUpdateResourceResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return JsonMergePatchClientUpdateResourceResponse{}, err
+		return JSONMergePatchClientUpdateResourceResponse{}, err
 	}
 	resp, err := client.updateResourceHandleResponse(httpResp)
 	return resp, err
 }
 
 // updateResourceCreateRequest creates the UpdateResource request.
-func (client *JsonMergePatchClient) updateResourceCreateRequest(ctx context.Context, body ResourcePatch, options *JsonMergePatchClientUpdateResourceOptions) (*policy.Request, error) {
+func (client *JSONMergePatchClient) updateResourceCreateRequest(ctx context.Context, body ResourcePatch, options *JSONMergePatchClientUpdateResourceOptions) (*policy.Request, error) {
 	urlPath := "/json-merge-patch/update/resource"
 	req, err := runtime.NewRequest(ctx, http.MethodPatch, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -160,10 +160,10 @@ func (client *JsonMergePatchClient) updateResourceCreateRequest(ctx context.Cont
 }
 
 // updateResourceHandleResponse handles the UpdateResource response.
-func (client *JsonMergePatchClient) updateResourceHandleResponse(resp *http.Response) (JsonMergePatchClientUpdateResourceResponse, error) {
-	result := JsonMergePatchClientUpdateResourceResponse{}
+func (client *JSONMergePatchClient) updateResourceHandleResponse(resp *http.Response) (JSONMergePatchClientUpdateResourceResponse, error) {
+	result := JSONMergePatchClientUpdateResourceResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.Resource); err != nil {
-		return JsonMergePatchClientUpdateResourceResponse{}, err
+		return JSONMergePatchClientUpdateResourceResponse{}, err
 	}
 	return result, nil
 }

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_options.go
@@ -4,20 +4,20 @@
 
 package jmergepatchgroup
 
-// JsonMergePatchClientCreateResourceOptions contains the optional parameters for the JsonMergePatchClient.CreateResource
+// JSONMergePatchClientCreateResourceOptions contains the optional parameters for the JSONMergePatchClient.CreateResource
 // method.
-type JsonMergePatchClientCreateResourceOptions struct {
+type JSONMergePatchClientCreateResourceOptions struct {
 	// placeholder for future optional parameters
 }
 
-// JsonMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JsonMergePatchClient.UpdateOptionalResource
+// JSONMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateOptionalResource
 // method.
-type JsonMergePatchClientUpdateOptionalResourceOptions struct {
+type JSONMergePatchClientUpdateOptionalResourceOptions struct {
 	Body *ResourcePatch
 }
 
-// JsonMergePatchClientUpdateResourceOptions contains the optional parameters for the JsonMergePatchClient.UpdateResource
+// JSONMergePatchClientUpdateResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateResource
 // method.
-type JsonMergePatchClientUpdateResourceOptions struct {
+type JSONMergePatchClientUpdateResourceOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_responses.go
@@ -4,20 +4,20 @@
 
 package jmergepatchgroup
 
-// JsonMergePatchClientCreateResourceResponse contains the response from method JsonMergePatchClient.CreateResource.
-type JsonMergePatchClientCreateResourceResponse struct {
+// JSONMergePatchClientCreateResourceResponse contains the response from method JSONMergePatchClient.CreateResource.
+type JSONMergePatchClientCreateResourceResponse struct {
 	// Details about a resource.
 	Resource
 }
 
-// JsonMergePatchClientUpdateOptionalResourceResponse contains the response from method JsonMergePatchClient.UpdateOptionalResource.
-type JsonMergePatchClientUpdateOptionalResourceResponse struct {
+// JSONMergePatchClientUpdateOptionalResourceResponse contains the response from method JSONMergePatchClient.UpdateOptionalResource.
+type JSONMergePatchClientUpdateOptionalResourceResponse struct {
 	// Details about a resource.
 	Resource
 }
 
-// JsonMergePatchClientUpdateResourceResponse contains the response from method JsonMergePatchClient.UpdateResource.
-type JsonMergePatchClientUpdateResourceResponse struct {
+// JSONMergePatchClientUpdateResourceResponse contains the response from method JSONMergePatchClient.UpdateResource.
+type JSONMergePatchClientUpdateResourceResponse struct {
 	// Details about a resource.
 	Resource
 }

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/fake/zz_json_server.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/fake/zz_json_server.go
@@ -13,29 +13,29 @@ import (
 	"sync"
 )
 
-// JsonServer is a fake server for instances of the jsongroup.JsonClient type.
-type JsonServer struct {
-	// JsonPropertyServer contains the fakes for client JsonPropertyClient
-	JsonPropertyServer JsonPropertyServer
+// JSONServer is a fake server for instances of the jsongroup.JSONClient type.
+type JSONServer struct {
+	// JSONPropertyServer contains the fakes for client JSONPropertyClient
+	JSONPropertyServer JSONPropertyServer
 }
 
-// NewJsonServerTransport creates a new instance of JsonServerTransport with the provided implementation.
-// The returned JsonServerTransport instance is connected to an instance of jsongroup.JsonClient via the
+// NewJSONServerTransport creates a new instance of JSONServerTransport with the provided implementation.
+// The returned JSONServerTransport instance is connected to an instance of jsongroup.JSONClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewJsonServerTransport(srv *JsonServer) *JsonServerTransport {
-	return &JsonServerTransport{srv: srv}
+func NewJSONServerTransport(srv *JSONServer) *JSONServerTransport {
+	return &JSONServerTransport{srv: srv}
 }
 
-// JsonServerTransport connects instances of jsongroup.JsonClient to instances of JsonServer.
-// Don't use this type directly, use NewJsonServerTransport instead.
-type JsonServerTransport struct {
-	srv                  *JsonServer
+// JSONServerTransport connects instances of jsongroup.JSONClient to instances of JSONServer.
+// Don't use this type directly, use NewJSONServerTransport instead.
+type JSONServerTransport struct {
+	srv                  *JSONServer
 	trMu                 sync.Mutex
-	trJsonPropertyServer *JsonPropertyServerTransport
+	trJSONPropertyServer *JSONPropertyServerTransport
 }
 
-// Do implements the policy.Transporter interface for JsonServerTransport.
-func (j *JsonServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for JSONServerTransport.
+func (j *JSONServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -45,16 +45,16 @@ func (j *JsonServerTransport) Do(req *http.Request) (*http.Response, error) {
 	return j.dispatchToClientFake(req, method[:strings.Index(method, ".")])
 }
 
-func (j *JsonServerTransport) dispatchToClientFake(req *http.Request, client string) (*http.Response, error) {
+func (j *JSONServerTransport) dispatchToClientFake(req *http.Request, client string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch client {
-	case "JsonPropertyClient":
-		initServer(&j.trMu, &j.trJsonPropertyServer, func() *JsonPropertyServerTransport {
-			return NewJsonPropertyServerTransport(&j.srv.JsonPropertyServer)
+	case "JSONPropertyClient":
+		initServer(&j.trMu, &j.trJSONPropertyServer, func() *JSONPropertyServerTransport {
+			return NewJSONPropertyServerTransport(&j.srv.JSONPropertyServer)
 		})
-		resp, err = j.trJsonPropertyServer.Do(req)
+		resp, err = j.trJSONPropertyServer.Do(req)
 	default:
 		err = fmt.Errorf("unhandled client %s", client)
 	}

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/fake/zz_jsonproperty_server.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/fake/zz_jsonproperty_server.go
@@ -15,32 +15,32 @@ import (
 	"net/http"
 )
 
-// JsonPropertyServer is a fake server for instances of the jsongroup.JsonPropertyClient type.
-type JsonPropertyServer struct {
-	// Get is the fake for method JsonPropertyClient.Get
+// JSONPropertyServer is a fake server for instances of the jsongroup.JSONPropertyClient type.
+type JSONPropertyServer struct {
+	// Get is the fake for method JSONPropertyClient.Get
 	// HTTP status codes to indicate success: http.StatusOK
-	Get func(ctx context.Context, options *jsongroup.JsonPropertyClientGetOptions) (resp azfake.Responder[jsongroup.JsonPropertyClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, options *jsongroup.JSONPropertyClientGetOptions) (resp azfake.Responder[jsongroup.JSONPropertyClientGetResponse], errResp azfake.ErrorResponder)
 
-	// Send is the fake for method JsonPropertyClient.Send
+	// Send is the fake for method JSONPropertyClient.Send
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Send func(ctx context.Context, jsonEncodedNameModel jsongroup.JSONEncodedNameModel, options *jsongroup.JsonPropertyClientSendOptions) (resp azfake.Responder[jsongroup.JsonPropertyClientSendResponse], errResp azfake.ErrorResponder)
+	Send func(ctx context.Context, jsonEncodedNameModel jsongroup.JSONEncodedNameModel, options *jsongroup.JSONPropertyClientSendOptions) (resp azfake.Responder[jsongroup.JSONPropertyClientSendResponse], errResp azfake.ErrorResponder)
 }
 
-// NewJsonPropertyServerTransport creates a new instance of JsonPropertyServerTransport with the provided implementation.
-// The returned JsonPropertyServerTransport instance is connected to an instance of jsongroup.JsonPropertyClient via the
+// NewJSONPropertyServerTransport creates a new instance of JSONPropertyServerTransport with the provided implementation.
+// The returned JSONPropertyServerTransport instance is connected to an instance of jsongroup.JSONPropertyClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewJsonPropertyServerTransport(srv *JsonPropertyServer) *JsonPropertyServerTransport {
-	return &JsonPropertyServerTransport{srv: srv}
+func NewJSONPropertyServerTransport(srv *JSONPropertyServer) *JSONPropertyServerTransport {
+	return &JSONPropertyServerTransport{srv: srv}
 }
 
-// JsonPropertyServerTransport connects instances of jsongroup.JsonPropertyClient to instances of JsonPropertyServer.
-// Don't use this type directly, use NewJsonPropertyServerTransport instead.
-type JsonPropertyServerTransport struct {
-	srv *JsonPropertyServer
+// JSONPropertyServerTransport connects instances of jsongroup.JSONPropertyClient to instances of JSONPropertyServer.
+// Don't use this type directly, use NewJSONPropertyServerTransport instead.
+type JSONPropertyServerTransport struct {
+	srv *JSONPropertyServer
 }
 
-// Do implements the policy.Transporter interface for JsonPropertyServerTransport.
-func (j *JsonPropertyServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for JSONPropertyServerTransport.
+func (j *JSONPropertyServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -50,14 +50,14 @@ func (j *JsonPropertyServerTransport) Do(req *http.Request) (*http.Response, err
 	return j.dispatchToMethodFake(req, method)
 }
 
-func (j *JsonPropertyServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (j *JSONPropertyServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "JsonPropertyClient.Get":
+	case "JSONPropertyClient.Get":
 		resp, err = j.dispatchGet(req)
-	case "JsonPropertyClient.Send":
+	case "JSONPropertyClient.Send":
 		resp, err = j.dispatchSend(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -66,7 +66,7 @@ func (j *JsonPropertyServerTransport) dispatchToMethodFake(req *http.Request, me
 	return resp, err
 }
 
-func (j *JsonPropertyServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
+func (j *JSONPropertyServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
 	if j.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
@@ -85,7 +85,7 @@ func (j *JsonPropertyServerTransport) dispatchGet(req *http.Request) (*http.Resp
 	return resp, nil
 }
 
-func (j *JsonPropertyServerTransport) dispatchSend(req *http.Request) (*http.Response, error) {
+func (j *JSONPropertyServerTransport) dispatchSend(req *http.Request) (*http.Response, error) {
 	if j.srv.Send == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Send not implemented")}
 	}

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/json_client.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/json_client.go
@@ -8,12 +8,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewJsonClient(options *azcore.ClientOptions) (*JsonClient, error) {
+func NewJSONClient(options *azcore.ClientOptions) (*JSONClient, error) {
 	internal, err := azcore.NewClient("jsongroup", "v0.1.0", runtime.PipelineOptions{}, options)
 	if err != nil {
 		return nil, err
 	}
-	return &JsonClient{
+	return &JSONClient{
 		internal: internal,
 	}, nil
 }

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/property_client_test.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/property_client_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestPropertyClient_Get(t *testing.T) {
-	client, err := jsongroup.NewJsonClient(nil)
+	client, err := jsongroup.NewJSONClient(nil)
 	require.NoError(t, err)
-	resp, err := client.NewJsonPropertyClient().Get(context.Background(), nil)
+	resp, err := client.NewJSONPropertyClient().Get(context.Background(), nil)
 	require.NoError(t, err)
 	require.Equal(t, jsongroup.JSONEncodedNameModel{
 		DefaultName: to.Ptr(true),
@@ -23,9 +23,9 @@ func TestPropertyClient_Get(t *testing.T) {
 }
 
 func TestPropertyClient_Send(t *testing.T) {
-	client, err := jsongroup.NewJsonClient(nil)
+	client, err := jsongroup.NewJSONClient(nil)
 	require.NoError(t, err)
-	resp, err := client.NewJsonPropertyClient().Send(context.Background(), jsongroup.JSONEncodedNameModel{
+	resp, err := client.NewJSONPropertyClient().Send(context.Background(), jsongroup.JSONEncodedNameModel{
 		DefaultName: to.Ptr(true),
 	}, nil)
 	require.NoError(t, err)

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_json_client.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_json_client.go
@@ -6,15 +6,15 @@ package jsongroup
 
 import "github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
-// JsonClient - Projection
+// JSONClient - Projection
 // Don't use this type directly, use a constructor function instead.
-type JsonClient struct {
+type JSONClient struct {
 	internal *azcore.Client
 }
 
-// NewJsonPropertyClient creates a new instance of [JsonPropertyClient].
-func (client *JsonClient) NewJsonPropertyClient() *JsonPropertyClient {
-	return &JsonPropertyClient{
+// NewJSONPropertyClient creates a new instance of [JSONPropertyClient].
+func (client *JSONClient) NewJSONPropertyClient() *JSONPropertyClient {
+	return &JSONPropertyClient{
 		internal: client.internal,
 	}
 }

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_jsonproperty_client.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_jsonproperty_client.go
@@ -12,37 +12,37 @@ import (
 	"net/http"
 )
 
-// JsonPropertyClient contains the methods for the Serialization.EncodedName.Json namespace.
-// Don't use this type directly, use [JsonClient.NewJsonPropertyClient] instead.
-type JsonPropertyClient struct {
+// JSONPropertyClient contains the methods for the Serialization.EncodedName.Json namespace.
+// Don't use this type directly, use [JSONClient.NewJSONPropertyClient] instead.
+type JSONPropertyClient struct {
 	internal *azcore.Client
 }
 
-// - options - JsonPropertyClientGetOptions contains the optional parameters for the JsonPropertyClient.Get method.
-func (client *JsonPropertyClient) Get(ctx context.Context, options *JsonPropertyClientGetOptions) (JsonPropertyClientGetResponse, error) {
+// - options - JSONPropertyClientGetOptions contains the optional parameters for the JSONPropertyClient.Get method.
+func (client *JSONPropertyClient) Get(ctx context.Context, options *JSONPropertyClientGetOptions) (JSONPropertyClientGetResponse, error) {
 	var err error
-	const operationName = "JsonPropertyClient.Get"
+	const operationName = "JSONPropertyClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getCreateRequest(ctx, options)
 	if err != nil {
-		return JsonPropertyClientGetResponse{}, err
+		return JSONPropertyClientGetResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return JsonPropertyClientGetResponse{}, err
+		return JSONPropertyClientGetResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusOK) {
 		err = runtime.NewResponseError(httpResp)
-		return JsonPropertyClientGetResponse{}, err
+		return JSONPropertyClientGetResponse{}, err
 	}
 	resp, err := client.getHandleResponse(httpResp)
 	return resp, err
 }
 
 // getCreateRequest creates the Get request.
-func (client *JsonPropertyClient) getCreateRequest(ctx context.Context, options *JsonPropertyClientGetOptions) (*policy.Request, error) {
+func (client *JSONPropertyClient) getCreateRequest(ctx context.Context, options *JSONPropertyClientGetOptions) (*policy.Request, error) {
 	urlPath := "/serialization/encoded-name/json/property"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {
@@ -53,38 +53,38 @@ func (client *JsonPropertyClient) getCreateRequest(ctx context.Context, options 
 }
 
 // getHandleResponse handles the Get response.
-func (client *JsonPropertyClient) getHandleResponse(resp *http.Response) (JsonPropertyClientGetResponse, error) {
-	result := JsonPropertyClientGetResponse{}
+func (client *JSONPropertyClient) getHandleResponse(resp *http.Response) (JSONPropertyClientGetResponse, error) {
+	result := JSONPropertyClientGetResponse{}
 	if err := runtime.UnmarshalAsJSON(resp, &result.JSONEncodedNameModel); err != nil {
-		return JsonPropertyClientGetResponse{}, err
+		return JSONPropertyClientGetResponse{}, err
 	}
 	return result, nil
 }
 
-// - options - JsonPropertyClientSendOptions contains the optional parameters for the JsonPropertyClient.Send method.
-func (client *JsonPropertyClient) Send(ctx context.Context, jsonEncodedNameModel JSONEncodedNameModel, options *JsonPropertyClientSendOptions) (JsonPropertyClientSendResponse, error) {
+// - options - JSONPropertyClientSendOptions contains the optional parameters for the JSONPropertyClient.Send method.
+func (client *JSONPropertyClient) Send(ctx context.Context, jsonEncodedNameModel JSONEncodedNameModel, options *JSONPropertyClientSendOptions) (JSONPropertyClientSendResponse, error) {
 	var err error
-	const operationName = "JsonPropertyClient.Send"
+	const operationName = "JSONPropertyClient.Send"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.sendCreateRequest(ctx, jsonEncodedNameModel, options)
 	if err != nil {
-		return JsonPropertyClientSendResponse{}, err
+		return JSONPropertyClientSendResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return JsonPropertyClientSendResponse{}, err
+		return JSONPropertyClientSendResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return JsonPropertyClientSendResponse{}, err
+		return JSONPropertyClientSendResponse{}, err
 	}
-	return JsonPropertyClientSendResponse{}, nil
+	return JSONPropertyClientSendResponse{}, nil
 }
 
 // sendCreateRequest creates the Send request.
-func (client *JsonPropertyClient) sendCreateRequest(ctx context.Context, jsonEncodedNameModel JSONEncodedNameModel, options *JsonPropertyClientSendOptions) (*policy.Request, error) {
+func (client *JSONPropertyClient) sendCreateRequest(ctx context.Context, jsonEncodedNameModel JSONEncodedNameModel, options *JSONPropertyClientSendOptions) (*policy.Request, error) {
 	urlPath := "/serialization/encoded-name/json/property"
 	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_options.go
@@ -4,12 +4,12 @@
 
 package jsongroup
 
-// JsonPropertyClientGetOptions contains the optional parameters for the JsonPropertyClient.Get method.
-type JsonPropertyClientGetOptions struct {
+// JSONPropertyClientGetOptions contains the optional parameters for the JSONPropertyClient.Get method.
+type JSONPropertyClientGetOptions struct {
 	// placeholder for future optional parameters
 }
 
-// JsonPropertyClientSendOptions contains the optional parameters for the JsonPropertyClient.Send method.
-type JsonPropertyClientSendOptions struct {
+// JSONPropertyClientSendOptions contains the optional parameters for the JSONPropertyClient.Send method.
+type JSONPropertyClientSendOptions struct {
 	// placeholder for future optional parameters
 }

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_responses.go
@@ -4,12 +4,12 @@
 
 package jsongroup
 
-// JsonPropertyClientGetResponse contains the response from method JsonPropertyClient.Get.
-type JsonPropertyClientGetResponse struct {
+// JSONPropertyClientGetResponse contains the response from method JSONPropertyClient.Get.
+type JSONPropertyClientGetResponse struct {
 	JSONEncodedNameModel
 }
 
-// JsonPropertyClientSendResponse contains the response from method JsonPropertyClient.Send.
-type JsonPropertyClientSendResponse struct {
+// JSONPropertyClientSendResponse contains the response from method JSONPropertyClient.Send.
+type JSONPropertyClientSendResponse struct {
 	// placeholder for future response values
 }

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/clientrequestid_client_test.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/clientrequestid_client_test.go
@@ -18,13 +18,13 @@ import (
 
 func TestClientRequestIdClient_Get(t *testing.T) {
 	// TODO: https://github.com/Azure/typespec-azure/issues/155 causes ClientRequestID optional param
-	_ = clientreqidgroup.ClientRequestIdClientGetOptions{
+	_ = clientreqidgroup.ClientRequestIDClientGetOptions{
 		ClientRequestID: nil, // this should evaporate
 	}
-	client, err := clientreqidgroup.NewClientRequestIdClient(nil)
+	client, err := clientreqidgroup.NewClientRequestIDClient(nil)
 	require.NoError(t, err)
 	var httpResp *http.Response
-	resp, err := client.Get(policy.WithCaptureResponse(context.Background(), &httpResp), &clientreqidgroup.ClientRequestIdClientGetOptions{})
+	resp, err := client.Get(policy.WithCaptureResponse(context.Background(), &httpResp), &clientreqidgroup.ClientRequestIDClientGetOptions{})
 	require.NoError(t, err)
 	require.Zero(t, resp)
 	require.EqualValues(t, httpResp.Header.Get("client-request-id"), "00000000-0000-0000-0000-000000000000")

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/custom_client.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/custom_client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 )
 
-func NewClientRequestIdClient(options *azcore.ClientOptions) (*ClientRequestIdClient, error) {
+func NewClientRequestIDClient(options *azcore.ClientOptions) (*ClientRequestIDClient, error) {
 	internal, err := azcore.NewClient("clientreqidgroup", "v0.1.0", runtime.PipelineOptions{
 		PerCall: []policy.Policy{
 			newRequestIDPolicy(),
@@ -23,7 +23,7 @@ func NewClientRequestIdClient(options *azcore.ClientOptions) (*ClientRequestIdCl
 	if err != nil {
 		return nil, err
 	}
-	return &ClientRequestIdClient{
+	return &ClientRequestIDClient{
 		internal: internal,
 	}, nil
 }

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/fake/zz_clientrequestid_server.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/fake/zz_clientrequestid_server.go
@@ -15,28 +15,28 @@ import (
 	"net/http"
 )
 
-// ClientRequestIdServer is a fake server for instances of the clientreqidgroup.ClientRequestIdClient type.
-type ClientRequestIdServer struct {
-	// Get is the fake for method ClientRequestIdClient.Get
+// ClientRequestIDServer is a fake server for instances of the clientreqidgroup.ClientRequestIDClient type.
+type ClientRequestIDServer struct {
+	// Get is the fake for method ClientRequestIDClient.Get
 	// HTTP status codes to indicate success: http.StatusNoContent
-	Get func(ctx context.Context, options *clientreqidgroup.ClientRequestIdClientGetOptions) (resp azfake.Responder[clientreqidgroup.ClientRequestIdClientGetResponse], errResp azfake.ErrorResponder)
+	Get func(ctx context.Context, options *clientreqidgroup.ClientRequestIDClientGetOptions) (resp azfake.Responder[clientreqidgroup.ClientRequestIDClientGetResponse], errResp azfake.ErrorResponder)
 }
 
-// NewClientRequestIdServerTransport creates a new instance of ClientRequestIdServerTransport with the provided implementation.
-// The returned ClientRequestIdServerTransport instance is connected to an instance of clientreqidgroup.ClientRequestIdClient via the
+// NewClientRequestIDServerTransport creates a new instance of ClientRequestIDServerTransport with the provided implementation.
+// The returned ClientRequestIDServerTransport instance is connected to an instance of clientreqidgroup.ClientRequestIDClient via the
 // azcore.ClientOptions.Transporter field in the client's constructor parameters.
-func NewClientRequestIdServerTransport(srv *ClientRequestIdServer) *ClientRequestIdServerTransport {
-	return &ClientRequestIdServerTransport{srv: srv}
+func NewClientRequestIDServerTransport(srv *ClientRequestIDServer) *ClientRequestIDServerTransport {
+	return &ClientRequestIDServerTransport{srv: srv}
 }
 
-// ClientRequestIdServerTransport connects instances of clientreqidgroup.ClientRequestIdClient to instances of ClientRequestIdServer.
-// Don't use this type directly, use NewClientRequestIdServerTransport instead.
-type ClientRequestIdServerTransport struct {
-	srv *ClientRequestIdServer
+// ClientRequestIDServerTransport connects instances of clientreqidgroup.ClientRequestIDClient to instances of ClientRequestIDServer.
+// Don't use this type directly, use NewClientRequestIDServerTransport instead.
+type ClientRequestIDServerTransport struct {
+	srv *ClientRequestIDServer
 }
 
-// Do implements the policy.Transporter interface for ClientRequestIdServerTransport.
-func (c *ClientRequestIdServerTransport) Do(req *http.Request) (*http.Response, error) {
+// Do implements the policy.Transporter interface for ClientRequestIDServerTransport.
+func (c *ClientRequestIDServerTransport) Do(req *http.Request) (*http.Response, error) {
 	rawMethod := req.Context().Value(runtime.CtxAPINameKey{})
 	method, ok := rawMethod.(string)
 	if !ok {
@@ -46,12 +46,12 @@ func (c *ClientRequestIdServerTransport) Do(req *http.Request) (*http.Response, 
 	return c.dispatchToMethodFake(req, method)
 }
 
-func (c *ClientRequestIdServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
+func (c *ClientRequestIDServerTransport) dispatchToMethodFake(req *http.Request, method string) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 
 	switch method {
-	case "ClientRequestIdClient.Get":
+	case "ClientRequestIDClient.Get":
 		resp, err = c.dispatchGet(req)
 	default:
 		err = fmt.Errorf("unhandled API %s", method)
@@ -60,14 +60,14 @@ func (c *ClientRequestIdServerTransport) dispatchToMethodFake(req *http.Request,
 	return resp, err
 }
 
-func (c *ClientRequestIdServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
+func (c *ClientRequestIDServerTransport) dispatchGet(req *http.Request) (*http.Response, error) {
 	if c.srv.Get == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Get not implemented")}
 	}
 	clientRequestIDParam := getOptional(getHeaderValue(req.Header, "client-request-id"))
-	var options *clientreqidgroup.ClientRequestIdClientGetOptions
+	var options *clientreqidgroup.ClientRequestIDClientGetOptions
 	if clientRequestIDParam != nil {
-		options = &clientreqidgroup.ClientRequestIdClientGetOptions{
+		options = &clientreqidgroup.ClientRequestIDClientGetOptions{
 			ClientRequestID: clientRequestIDParam,
 		}
 	}

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_clientrequestid_client.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_clientrequestid_client.go
@@ -12,37 +12,37 @@ import (
 	"net/http"
 )
 
-// ClientRequestIdClient - Azure client request id header configurations.
+// ClientRequestIDClient - Azure client request id header configurations.
 // Don't use this type directly, use a constructor function instead.
-type ClientRequestIdClient struct {
+type ClientRequestIDClient struct {
 	internal *azcore.Client
 }
 
 // Get - Get operation with azure client request id header.
-//   - options - ClientRequestIdClientGetOptions contains the optional parameters for the ClientRequestIdClient.Get method.
-func (client *ClientRequestIdClient) Get(ctx context.Context, options *ClientRequestIdClientGetOptions) (ClientRequestIdClientGetResponse, error) {
+//   - options - ClientRequestIDClientGetOptions contains the optional parameters for the ClientRequestIDClient.Get method.
+func (client *ClientRequestIDClient) Get(ctx context.Context, options *ClientRequestIDClientGetOptions) (ClientRequestIDClientGetResponse, error) {
 	var err error
-	const operationName = "ClientRequestIdClient.Get"
+	const operationName = "ClientRequestIDClient.Get"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
 	req, err := client.getCreateRequest(ctx, options)
 	if err != nil {
-		return ClientRequestIdClientGetResponse{}, err
+		return ClientRequestIDClientGetResponse{}, err
 	}
 	httpResp, err := client.internal.Pipeline().Do(req)
 	if err != nil {
-		return ClientRequestIdClientGetResponse{}, err
+		return ClientRequestIDClientGetResponse{}, err
 	}
 	if !runtime.HasStatusCode(httpResp, http.StatusNoContent) {
 		err = runtime.NewResponseError(httpResp)
-		return ClientRequestIdClientGetResponse{}, err
+		return ClientRequestIDClientGetResponse{}, err
 	}
-	return ClientRequestIdClientGetResponse{}, nil
+	return ClientRequestIDClientGetResponse{}, nil
 }
 
 // getCreateRequest creates the Get request.
-func (client *ClientRequestIdClient) getCreateRequest(ctx context.Context, options *ClientRequestIdClientGetOptions) (*policy.Request, error) {
+func (client *ClientRequestIDClient) getCreateRequest(ctx context.Context, options *ClientRequestIDClientGetOptions) (*policy.Request, error) {
 	urlPath := "/special-headers/client-request-id"
 	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(host, urlPath))
 	if err != nil {

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_options.go
@@ -4,7 +4,7 @@
 
 package clientreqidgroup
 
-// ClientRequestIdClientGetOptions contains the optional parameters for the ClientRequestIdClient.Get method.
-type ClientRequestIdClientGetOptions struct {
+// ClientRequestIDClientGetOptions contains the optional parameters for the ClientRequestIDClient.Get method.
+type ClientRequestIDClientGetOptions struct {
 	ClientRequestID *string
 }

--- a/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_responses.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/clientreqidgroup/zz_responses.go
@@ -4,7 +4,7 @@
 
 package clientreqidgroup
 
-// ClientRequestIdClientGetResponse contains the response from method ClientRequestIdClient.Get.
-type ClientRequestIdClientGetResponse struct {
+// ClientRequestIDClientGetResponse contains the response from method ClientRequestIDClient.Get.
+type ClientRequestIDClientGetResponse struct {
 	// placeholder for future response values
 }


### PR DESCRIPTION
Cleaned up client names.
Include Begin prefix for LRO method options type.

Fixes https://github.com/Azure/autorest.go/issues/1207