### PR TITLE
Handle tsp offsetDateTime type

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -388,7 +388,7 @@ export function adaptPossibleType(schema: m4.Schema, elementTypeByValue?: boolea
       if (time) {
         return time;
       }
-      time = new go.TimeType(schema.language.go!.internalTimeType);
+      time = new go.TimeType(schema.language.go!.internalTimeType, false);
       types.set(schema.language.go!.internalTimeType, time);
       return time;
     }
@@ -538,7 +538,7 @@ function adaptLiteralValue(constSchema: m4.ConstantSchema): go.LiteralValue {
       if (literalTime) {
         return <go.LiteralValue>literalTime;
       }
-      literalTime = new go.LiteralValue(new go.TimeType(constSchema.valueType.language.go!.internalTimeType), constSchema.value.value);
+      literalTime = new go.LiteralValue(new go.TimeType(constSchema.valueType.language.go!.internalTimeType, false), constSchema.value.value);
       types.set(keyName, literalTime);
       return literalTime;
     }

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -837,6 +837,8 @@ export interface TimeType extends QualifiedType {
   packageName: 'time';
 
   dateTimeFormat: DateTimeFormat;
+
+  utc: boolean;
 }
 
 export type MapValueType = PossibleType;
@@ -1339,8 +1341,9 @@ export class SliceType implements SliceType {
 }
 
 export class TimeType implements TimeType {
-  constructor(format: DateTimeFormat) {
+  constructor(format: DateTimeFormat, utc: boolean) {
     this.dateTimeFormat = format;
+    this.utc = utc;
   }
 }
 


### PR DESCRIPTION
Distinguish between UTC and local time types in the code model. Fixed a regex that was too lenient.
Removed some commented out placeholder code.

Fixes https://github.com/Azure/autorest.go/issues/1214