### PR TITLE
Move time SerDe helper logic to code generator

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/adapter.ts
+++ b/packages/autorest.go/src/m4togocodemodel/adapter.ts
@@ -39,24 +39,6 @@ export async function m4ToGoCodeModel(host: AutorestExtensionHost) {
     if (session.model.language.go!.host) {
       codeModel.host = session.model.language.go!.host;
     }
-    if (session.model.language.go!.generateDateTimeRFC1123Helper) {
-      codeModel.marshallingRequirements.generateDateTimeRFC1123Helper = true;
-    }
-    if (session.model.language.go!.generateTimeRFC3339Helper) {
-      codeModel.marshallingRequirements.generateTimeRFC3339Helper = true;
-    }
-    if (session.model.language.go!.generateDateTimeRFC3339Helper) {
-      codeModel.marshallingRequirements.generateDateTimeRFC3339Helper = true;
-    }
-    if (session.model.language.go!.generateUnixTimeHelper) {
-      codeModel.marshallingRequirements.generateUnixTimeHelper = true;
-    }
-    if (session.model.language.go!.generateDateHelper) {
-      codeModel.marshallingRequirements.generateDateHelper = true;
-    }
-    if (session.model.language.go!.needsXMLDictionaryUnmarshalling) {
-      codeModel.marshallingRequirements.generateXMLDictionaryUnmarshallingHelper = true;
-    }
     if (session.model.language.go!.module && session.model.language.go!.moduleVersion) {
       codeModel.options.module = new go.Module(session.model.language.go!.module, session.model.language.go!.moduleVersion);
     } else if (session.model.language.go!.module || session.model.language.go!.moduleVersion) {

--- a/packages/codegen.go/src/xmlAdditionalProps.ts
+++ b/packages/codegen.go/src/xmlAdditionalProps.ts
@@ -10,9 +10,27 @@ import { ImportManager } from './imports.js';
 // Creates the content for required additional properties XML marshalling helpers.
 // Will be empty if no helpers are required.
 export async function generateXMLAdditionalPropsHelpers(codeModel: go.CodeModel): Promise<string> {
-  if (!codeModel.marshallingRequirements.generateXMLDictionaryUnmarshallingHelper) {
+  // check if any models need this helper
+  let required = false;
+  for (const model of codeModel.models) {
+    if (model.format !== 'xml') {
+      continue;
+    }
+    for (const field of model.fields) {
+      if (go.isMapType(field.type)) {
+        required = true;
+        break;
+      }
+    }
+    if (required) {
+      break;
+    }
+  }
+
+  if (!required) {
     return '';
   }
+
   let text = contentPreamble(codeModel);
   // add standard imports
   const imports = new ImportManager();

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -34,8 +34,6 @@ export interface CodeModel {
 
   // all of the interfaces for discriminated types (interfaces.go file)
   interfaceTypes: Array<InterfaceType>;
-
-  marshallingRequirements: MarshallingRequirements;
 }
 
 export type CodeModelType = 'azure-arm' | 'data-plane';
@@ -78,21 +76,6 @@ export interface Module {
   
   // the semantic version x.y.z[-beta.N]
   version: string;
-}
-
-// MarshallingRequirements contains flags for required marshalling helpers
-export interface MarshallingRequirements {
-  generateDateHelper: boolean;
-
-  generateDateTimeRFC1123Helper: boolean;
-
-  generateDateTimeRFC3339Helper: boolean;
-
-  generateTimeRFC3339Helper: boolean;
-
-  generateUnixTimeHelper: boolean;
-
-  generateXMLDictionaryUnmarshallingHelper: boolean;
 }
 
 // Struct describes a vanilla struct definition (pretty much exclusively used for parameter groups/options bag types)
@@ -1029,24 +1012,12 @@ export class Module implements Module {
   }
 }
 
-export class MarshallingRequirements implements MarshallingRequirements {
-  constructor() {
-    this.generateDateHelper = false;
-    this.generateDateTimeRFC1123Helper = false;
-    this.generateDateTimeRFC3339Helper = false;
-    this.generateTimeRFC3339Helper = false;
-    this.generateUnixTimeHelper = false;
-    this.generateXMLDictionaryUnmarshallingHelper = false;
-  }
-}
-
 export class CodeModel implements CodeModel {
   constructor(info: Info, type: CodeModelType, packageName: string, options: Options) {
     this.clients = new Array<Client>();
     this.constants = new Array<ConstantType>();
     this.info = info;
     this.interfaceTypes = new Array<InterfaceType>();
-    this.marshallingRequirements = new MarshallingRequirements();
     this.models = new Array<ModelType | PolymorphicType>();
     this.options = options;
     this.packageName = packageName;

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -250,19 +250,6 @@ export class typeAdapter {
     }
     datetime = new go.TimeType(encoding, utc);
     this.types.set(encoding, datetime);
-    switch (encoding) {
-      case 'dateTimeRFC1123':
-        this.codeModel.marshallingRequirements.generateDateTimeRFC1123Helper = true;
-        break;
-      case 'dateTimeRFC3339':
-        this.codeModel.marshallingRequirements.generateDateTimeRFC3339Helper = true;
-        break;
-      case 'timeUnix':
-        this.codeModel.marshallingRequirements.generateUnixTimeHelper = true;
-        break;
-      default:
-        throw new Error(`unhandled datetime encoding ${encoding}`);
-    }
     return <go.TimeType>datetime;
   }
 
@@ -346,7 +333,6 @@ export class typeAdapter {
         }
         date = new go.TimeType('dateType', false);
         this.types.set(dateKey, date);
-        this.codeModel.marshallingRequirements.generateDateHelper = true;
         return date;
       }
       case 'decimal':
@@ -435,7 +421,6 @@ export class typeAdapter {
         }
         time = new go.TimeType(encoding, false);
         this.types.set(encoding, time);
-        this.codeModel.marshallingRequirements.generateTimeRFC3339Helper = true;
         return time;
       
       }


### PR DESCRIPTION
The need for SerDe helpers is a codegen implementation detail that doesn't belong in the code model and is subject to change. Removed MarshallingRequirements from the code model, replacing it with detection that happens during code generation. This also means we don't have to duplicate the logic across emitters.