### PR TITLE
Fix hard-coded header map field name

### DIFF
--- a/packages/autorest.go/test/storage/azblob/zz_client.go
+++ b/packages/autorest.go/test/storage/azblob/zz_client.go
@@ -1288,10 +1288,10 @@ func (client *Client) downloadHandleResponse(resp *http.Response) (ClientDownloa
 	}
 	for hh := range resp.Header {
 		if len(hh) > len("x-ms-or-") && strings.EqualFold(hh[:len("x-ms-or-")], "x-ms-or-") {
-			if result.Metadata == nil {
-				result.Metadata = map[string]*string{}
+			if result.ObjectReplicationRules == nil {
+				result.ObjectReplicationRules = map[string]*string{}
 			}
-			result.Metadata[hh[len("x-ms-or-"):]] = to.Ptr(resp.Header.Get(hh))
+			result.ObjectReplicationRules[hh[len("x-ms-or-"):]] = to.Ptr(resp.Header.Get(hh))
 		}
 	}
 	if val := resp.Header.Get("x-ms-request-id"); val != "" {
@@ -1698,10 +1698,10 @@ func (client *Client) getPropertiesHandleResponse(resp *http.Response) (ClientGe
 	}
 	for hh := range resp.Header {
 		if len(hh) > len("x-ms-or-") && strings.EqualFold(hh[:len("x-ms-or-")], "x-ms-or-") {
-			if result.Metadata == nil {
-				result.Metadata = map[string]*string{}
+			if result.ObjectReplicationRules == nil {
+				result.ObjectReplicationRules = map[string]*string{}
 			}
-			result.Metadata[hh[len("x-ms-or-"):]] = to.Ptr(resp.Header.Get(hh))
+			result.ObjectReplicationRules[hh[len("x-ms-or-"):]] = to.Ptr(resp.Header.Get(hh))
 		}
 	}
 	if val := resp.Header.Get("x-ms-rehydrate-priority"); val != "" {

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -244,10 +244,10 @@ function formatHeaderResponseValue(headerResp: go.HeaderResponse | go.HeaderMapR
     const headerPrefix = headerResp.collectionPrefix;
     let text = '\tfor hh := range resp.Header {\n';
     text += `\t\tif len(hh) > len("${headerPrefix}") && strings.EqualFold(hh[:len("${headerPrefix}")], "${headerPrefix}") {\n`;
-    text += `\t\t\tif ${respObj}.Metadata == nil {\n`;
-    text += `\t\t\t\t${respObj}.Metadata = map[string]*string{}\n`;
+    text += `\t\t\tif ${respObj}.${headerResp.fieldName} == nil {\n`;
+    text += `\t\t\t\t${respObj}.${headerResp.fieldName} = map[string]*string{}\n`;
     text += '\t\t\t}\n';
-    text += `\t\t\t${respObj}.Metadata[hh[len("${headerPrefix}"):]] = to.Ptr(resp.Header.Get(hh))\n`;
+    text += `\t\t\t${respObj}.${headerResp.fieldName}[hh[len("${headerPrefix}"):]] = to.Ptr(resp.Header.Get(hh))\n`;
     text += '\t\t}\n';
     text += '\t}\n';
     return text;


### PR DESCRIPTION
Use the applicable field name instead of a hard-coded value.