### PR TITLE
Include all dist files when packing autorest.go

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -107,6 +107,13 @@
       "associatedCommands": ["regenerate", "tspcompile"]
     },
     {
+      "parameterKind": "string",
+      "argumentName": "USEPACKAGE",
+      "longName": "--use-package",
+      "description": "Uses the specified npm tarball instead of local sources",
+      "associatedCommands": ["regenerate"]
+    },
+    {
       "parameterKind": "flag",
       "longName": "--debugger",
       "description": "Starts the build and waits for the debugger to attach",

--- a/eng/steps/build-test-go.yaml
+++ b/eng/steps/build-test-go.yaml
@@ -14,7 +14,7 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
   - script: |
-      $currentVersion = node -p -e "require('package.json').version";
+      export currentVersion=$(node -p -e "require('./package.json').version")
       npm pack
       rush regenerate --use-package=$(System.DefaultWorkingDirectory)/packages/autorest.go/autorest-go-$currentVersion.tgz
       cd test

--- a/eng/steps/build-test-go.yaml
+++ b/eng/steps/build-test-go.yaml
@@ -14,7 +14,7 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
   - script: npm pack
-    displanName: "Create npm tarball"
+    displayName: "Create npm tarball"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
   - script: |

--- a/eng/steps/build-test-go.yaml
+++ b/eng/steps/build-test-go.yaml
@@ -13,9 +13,12 @@ steps:
     displayName: "Run Lint"
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
+  - script: npm pack
+    displanName: "Create npm tarball"
+    workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
+
   - script: |
       export currentVersion=$(node -p -e "require('./package.json').version")
-      npm pack
       rush regenerate --use-package=$(System.DefaultWorkingDirectory)/packages/autorest.go/autorest-go-$currentVersion.tgz
       cd test
       rush modtidy 2>&1

--- a/eng/steps/build-test-go.yaml
+++ b/eng/steps/build-test-go.yaml
@@ -14,12 +14,15 @@ steps:
     workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
 
   - script: |
-      rush regenerate
+      $currentVersion = node -p -e "require('package.json').version";
+      npm pack
+      rush regenerate --use-package=$(System.DefaultWorkingDirectory)/packages/autorest.go/autorest-go-$currentVersion.tgz
+      cd test
       rush modtidy 2>&1
       git add -A .
       git diff --staged -w 1>&2
     displayName: "Regenerate Autorest Tests"
-    workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go/test
+    workingDirectory: $(System.DefaultWorkingDirectory)/packages/autorest.go
     failOnStderr: true
 
   - script: |

--- a/packages/autorest.go/.npmignore
+++ b/packages/autorest.go/.npmignore
@@ -1,6 +1,7 @@
 .rush/
 .scripts/
 .vscode/
+coverage/
 src/
 test/
 .eslint*

--- a/packages/autorest.go/.scripts/regeneration.js
+++ b/packages/autorest.go/.scripts/regeneration.js
@@ -58,12 +58,15 @@ const goMappings = {
 // any new args must also be added to autorest.go\common\config\rush\command-line.json
 const args = process.argv.slice(2);
 var filter = undefined;
+
+// default to using the locally built generator sources
+var generator = './packages/autorest.go';
 const switches = [];
 for (var i = 0 ; i < args.length; i += 1) {
   switch (args[i]) {
     case '--filter':
-      filter = args[i + 1]
-      i += 1
+      filter = args[i + 1];
+      i += 1;
       break;
     case '--verbose':
       switches.push('--debug');
@@ -73,6 +76,10 @@ for (var i = 0 ; i < args.length; i += 1) {
       break;
     case '--dump-code-model':
       switches.push('--output-artifact:code-model-v4');
+      break;
+    case '--use-package':
+      generator = args[i + 1];
+      i += 1;
       break;
     default:
       break;
@@ -155,7 +162,7 @@ function generate(name, inputFile, outputDir, additionalArgs) {
     console.log('generating ' + inputFile);
     outputDir = fullPath(outputDir);
     cleanGeneratedFiles(outputDir);
-    exec('autorest --use=./packages/autorest.go --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --generate-fakes --inject-spans --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
+    exec('autorest --use=' + generator + ' --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --generate-fakes --inject-spans --input-file=' + inputFile + ' --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, inputFile));
   });
 }
 
@@ -170,7 +177,7 @@ function generateFromReadme(name, readme, tag, outputDir, additionalArgs) {
     console.log('generating ' + readme);
     outputDir = fullPath(outputDir);
     cleanGeneratedFiles(outputDir);
-    exec('autorest --use=./packages/autorest.go ' + readme + ' --go --tag=' + tag + ' --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, readme));
+    exec('autorest --use=' + generator + ' ' + readme + ' --go --tag=' + tag + ' --file-prefix="zz_" --modelerfour.lenient-model-deduplication --license-header=MICROSOFT_MIT_NO_VERSION --output-folder=' + outputDir + ' ' + additionalArgs + ' ' + switches.join(' '), autorestCallback(outputDir, readme));
   });
 }
 

--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Fixed missing dependencies.
 
-## 4.0.0-preview.64 (2024-04-23)
+## 4.0.0-preview.64 (2024-04-23) - DEPRECATED
 
 ### Bugs Fixed
 

--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 4.0.0-preview.65 (2024-04-24)
+
+### Bugs Fixed
+
+* Fixed missing dependencies.
+
 ## 4.0.0-preview.64 (2024-04-23)
 
 ### Bugs Fixed

--- a/packages/autorest.go/package.json
+++ b/packages/autorest.go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/go",
-  "version": "4.0.0-preview.64",
+  "version": "4.0.0-preview.65",
   "description": "AutoRest Go Generator",
   "main": "dist/autorest.go/src/main.js",
   "type": "module",
@@ -11,6 +11,10 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "files": [
+    "dist/**",
+    "!dist/test/**"
+  ],
   "scripts": {
     "start": "node --max_old_space_size=4096 ./dist/autorest.go/src/main.js",
     "debug": "node --max_old_space_size=4096 --inspect-brk ./dist/autorest.go/src/main.js",


### PR DESCRIPTION
A recent change in npm pack is no longer picking up all content under the dist directory, resulting in a broken tarball. Exclude the code coverage dir from the tarball.