### PR TITLE
Don't generate empty clients

### DIFF
--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.1.0-dev.2",
+  "version": "0.1.0-dev.3",
   "description": "TypeSpec emitter for Go SDKs",
   "type": "module",
   "main": "dist/typespec-go/src/index.js",

--- a/packages/typespec-go/src/emitter.ts
+++ b/packages/typespec-go/src/emitter.ts
@@ -99,36 +99,38 @@ export async function $onEmit(context: EmitContext<GoEmitterOptions>) {
   }
 
   if (context.options['generate-fakes'] === true) {
-    const fakesDir = context.emitterOutputDir + '/fake';
-    await mkdir(fakesDir, {recursive: true});
     const serverContent = await generateServers(codeModel);
-    for (const op of serverContent.servers) {
-      let fileName = op.name.toLowerCase();
-      // op.name is the server name, e.g. FooServer.
-      // insert a _ before Server, i.e. Foo_Server
-      // if the name isn't simply Server.
-      if (fileName !== 'server') {
-        fileName = fileName.substring(0, fileName.length-6) + '_server';
+    if (serverContent.servers.length > 0) {
+      const fakesDir = context.emitterOutputDir + '/fake';
+      await mkdir(fakesDir, {recursive: true});
+      for (const op of serverContent.servers) {
+        let fileName = op.name.toLowerCase();
+        // op.name is the server name, e.g. FooServer.
+        // insert a _ before Server, i.e. Foo_Server
+        // if the name isn't simply Server.
+        if (fileName !== 'server') {
+          fileName = fileName.substring(0, fileName.length-6) + '_server';
+        }
+        writeFile(`${fakesDir}/${filePrefix}${fileName}.go`, op.content);
       }
-      writeFile(`${fakesDir}/${filePrefix}${fileName}.go`, op.content);
-    }
 
-    // TODO: skip server factory for now as we don't generate it (yet)
-    /*const serverFactory = generateServerFactory(codeModel);
-    if (serverFactory !== '') {
-      writeFile(`${fakesDir}/${filePrefix}server_factory.go`, serverFactory);
-    }*/
+      // TODO: skip server factory for now as we don't generate it (yet)
+      /*const serverFactory = generateServerFactory(codeModel);
+      if (serverFactory !== '') {
+        writeFile(`${fakesDir}/${filePrefix}server_factory.go`, serverFactory);
+      }*/
 
-    writeFile(`${fakesDir}/${filePrefix}internal.go`, serverContent.internals);
+      writeFile(`${fakesDir}/${filePrefix}internal.go`, serverContent.internals);
 
-    const timeHelpers = await generateTimeHelpers(codeModel, 'fake');
-    for (const helper of timeHelpers) {
-      writeFile(`${fakesDir}/${filePrefix}${helper.name.toLowerCase()}.go`, helper.content);
-    }
+      const timeHelpers = await generateTimeHelpers(codeModel, 'fake');
+      for (const helper of timeHelpers) {
+        writeFile(`${fakesDir}/${filePrefix}${helper.name.toLowerCase()}.go`, helper.content);
+      }
 
-    const polymorphics = await generatePolymorphicHelpers(codeModel, 'fake');
-    if (polymorphics.length > 0) {
-      writeFile(`${fakesDir}/${filePrefix}polymorphic_helpers.go`, polymorphics);
+      const polymorphics = await generatePolymorphicHelpers(codeModel, 'fake');
+      if (polymorphics.length > 0) {
+        writeFile(`${fakesDir}/${filePrefix}polymorphic_helpers.go`, polymorphics);
+      }
     }
   }
 }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -33,6 +33,12 @@ export class clientAdapter {
       throw new Error('single-client cannot be enabled when there are multiple clients');
     }
     for (const sdkClient of sdkPackage.clients) {
+      // workaround for https://github.com/Azure/typespec-azure/issues/782
+      if (sdkClient.methods.length === 0) {
+        continue;
+      }
+      // end workaround
+
       // start with instantiable clients and recursively work down
       if (sdkClient.initialization.access === 'public') {
         this.recursiveAdaptClient(sdkClient);


### PR DESCRIPTION
If a client has no methods, skip it. This is a workaround until the underlying issue in TCGC is fixed.
Don't create the fake directory if there are no fakes to generate. Bump emitter version for pending release.