### PR TITLE
Add missing doc comments

### DIFF
--- a/packages/autorest.go/src/transform/transform.ts
+++ b/packages/autorest.go/src/transform/transform.ts
@@ -711,11 +711,6 @@ function processOperationResponses(session: Session<m4.CodeModel>) {
   }
   for (const group of values(session.model.operationGroups)) {
     for (const op of values(group.operations)) {
-      if (!(session.model.language.go!.headAsBoolean && op.requests![0].protocol.http!.method === 'head') && !helpers.isPageableOperation(op)) {
-        // when head-as-boolean is enabled, no error is returned for 4xx status codes.
-        // pager constructors don't return an error
-        op.language.go!.description += '\nIf the operation fails it returns an *azcore.ResponseError type.';
-      }
       // recursively add the marshalling format to the responses if applicable.
       // also remove any HTTP redirects from the list of responses.
       const filtered = new Array<m4.Response>();

--- a/packages/autorest.go/test/maps/azalias/zz_client.go
+++ b/packages/autorest.go/test/maps/azalias/zz_client.go
@@ -374,7 +374,10 @@ func (client *Client) listLROHandleResponse(resp *http.Response) (ListLRORespons
 	return result, nil
 }
 
-// - options - ListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
+// NewListWithSharedNextOnePager -
+//
+// Generated from API version 2.0
+//   - options - ListWithSharedNextOneOptions contains the optional parameters for the Client.NewListWithSharedNextOnePager method.
 func (client *Client) NewListWithSharedNextOnePager(options *ListWithSharedNextOneOptions) *runtime.Pager[ListWithSharedNextOneResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ListWithSharedNextOneResponse]{
 		More: func(page ListWithSharedNextOneResponse) bool {
@@ -424,7 +427,10 @@ func (client *Client) listWithSharedNextOneHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
-// - options - ListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
+// NewListWithSharedNextTwoPager -
+//
+// Generated from API version 2.0
+//   - options - ListWithSharedNextTwoOptions contains the optional parameters for the Client.NewListWithSharedNextTwoPager method.
 func (client *Client) NewListWithSharedNextTwoPager(options *ListWithSharedNextTwoOptions) *runtime.Pager[ListWithSharedNextTwoResponse] {
 	return runtime.NewPager(runtime.PagingHandler[ListWithSharedNextTwoResponse]{
 		More: func(page ListWithSharedNextTwoResponse) bool {

--- a/packages/codegen.go/src/operations.ts
+++ b/packages/codegen.go/src/operations.ts
@@ -435,11 +435,18 @@ function generateOperation(client: go.Client, method: go.Method, imports: Import
     methodName = fixUpMethodName(method);
   }
   let text = '';
+  const respErrDoc = genRespErrorDoc(method);
+  const apiVerDoc = genApiVersionDoc(method.apiVersions);
   if (method.description) {
     text += `${comment(`${methodName} - ${method.description}`, '//', undefined, helpers.commentLength)}\n`;
-    text += genRespErrorDoc(method);
-    text += genApiVersionDoc(method.apiVersions);
+  } else if (respErrDoc.length > 0 || apiVerDoc.length > 0) {
+    // if the method has no doc comment but we're adding other
+    // doc comments, add an empty method name comment. this preserves
+    // existing behavior and makes the docs look better overall.
+    text += `// ${methodName} -\n`;
   }
+  text += respErrDoc;
+  text += apiVerDoc;
   if (go.isLROMethod(method)) {
     methodName = method.naming.internalMethod;
   } else {

--- a/packages/codemodel.go/src/gocodemodel.ts
+++ b/packages/codemodel.go/src/gocodemodel.ts
@@ -287,7 +287,7 @@ export interface Method {
 
   naming: MethodNaming;
 
-  apiVersions: Array<string>; // TODO: not sure why this needs to be an array
+  apiVersions: Array<string>;
 }
 
 export type HTTPMethod = 'delete' | 'get' | 'head' | 'patch' | 'post' | 'put';
@@ -333,7 +333,7 @@ export interface NextPageMethod {
 
   client: Client;
 
-  apiVersions: Array<string>; // TODO: not sure why this needs to be an array
+  apiVersions: Array<string>;
 
   isNextPageMethod: true;
 }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -221,7 +221,17 @@ export class clientAdapter {
     } else {
       throw new Error('NYI');
     }
-  
+
+    // find the api version param to use for the doc comment.
+    // we can't use sdkMethod.apiVersions as that includes all
+    // of the api versions supported by the service.
+    for (const opParam of sdkMethod.operation.parameters) {
+      if (opParam.isApiVersionParam && opParam.clientDefaultValue) {
+        method.apiVersions.push(opParam.clientDefaultValue);
+        break;
+      }
+    }
+
     this.adaptMethodParameters(sdkMethod, method);
 
     // we must do this after adapting method params as it can add optional params

--- a/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apidefinitions_client.go
@@ -40,6 +40,9 @@ func NewAPIDefinitionsClient(subscriptionID string, credential azcore.TokenCrede
 }
 
 // CreateOrUpdate - Creates new or updates existing API definition.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -130,6 +133,9 @@ func (client *APIDefinitionsClient) createOrUpdateHandleResponse(resp *http.Resp
 }
 
 // Delete - Deletes specified API definition.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -201,6 +207,9 @@ func (client *APIDefinitionsClient) deleteCreateRequest(ctx context.Context, res
 }
 
 // BeginExportSpecification - Exports the API specification.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -228,6 +237,9 @@ func (client *APIDefinitionsClient) BeginExportSpecification(ctx context.Context
 }
 
 // ExportSpecification - Exports the API specification.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 func (client *APIDefinitionsClient) exportSpecification(ctx context.Context, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload any, options *APIDefinitionsClientBeginExportSpecificationOptions) (*http.Response, error) {
 	var err error
 	const operationName = "APIDefinitionsClient.BeginExportSpecification"
@@ -296,6 +308,9 @@ func (client *APIDefinitionsClient) exportSpecificationCreateRequest(ctx context
 }
 
 // Get - Returns details of the API definition.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -380,6 +395,8 @@ func (client *APIDefinitionsClient) getHandleResponse(resp *http.Response) (APID
 }
 
 // Head - Checks if specified API definition exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -451,6 +468,9 @@ func (client *APIDefinitionsClient) headCreateRequest(ctx context.Context, resou
 }
 
 // BeginImportSpecification - Imports the API specification.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -478,6 +498,9 @@ func (client *APIDefinitionsClient) BeginImportSpecification(ctx context.Context
 }
 
 // ImportSpecification - Imports the API specification.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 func (client *APIDefinitionsClient) importSpecification(ctx context.Context, resourceGroupName string, serviceName string, workspaceName string, apiName string, versionName string, definitionName string, payload APISpecImportRequest, options *APIDefinitionsClientBeginImportSpecificationOptions) (*http.Response, error) {
 	var err error
 	const operationName = "APIDefinitionsClient.BeginImportSpecification"
@@ -546,6 +569,8 @@ func (client *APIDefinitionsClient) importSpecificationCreateRequest(ctx context
 }
 
 // NewListPager - Returns a collection of API definitions.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.

--- a/packages/typespec-go/test/armapicenter/zz_apis_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apis_client.go
@@ -40,6 +40,9 @@ func NewApisClient(subscriptionID string, credential azcore.TokenCredential, opt
 }
 
 // CreateOrUpdate - Creates new or updates existing API.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -119,6 +122,9 @@ func (client *ApisClient) createOrUpdateHandleResponse(resp *http.Response) (Api
 }
 
 // Delete - Deletes specified API.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -180,6 +186,9 @@ func (client *ApisClient) deleteCreateRequest(ctx context.Context, resourceGroup
 }
 
 // Get - Returns details of the API.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -254,6 +263,8 @@ func (client *ApisClient) getHandleResponse(resp *http.Response) (ApisClientGetR
 }
 
 // Head - Checks if specified API exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -315,6 +326,8 @@ func (client *ApisClient) headCreateRequest(ctx context.Context, resourceGroupNa
 }
 
 // NewListPager - Returns a collection of APIs.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.

--- a/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_apiversions_client.go
@@ -40,6 +40,9 @@ func NewAPIVersionsClient(subscriptionID string, credential azcore.TokenCredenti
 }
 
 // CreateOrUpdate - Creates new or updates existing API version.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -125,6 +128,9 @@ func (client *APIVersionsClient) createOrUpdateHandleResponse(resp *http.Respons
 }
 
 // Delete - Deletes specified API version
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -191,6 +197,9 @@ func (client *APIVersionsClient) deleteCreateRequest(ctx context.Context, resour
 }
 
 // Get - Returns details of the API version.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -270,6 +279,8 @@ func (client *APIVersionsClient) getHandleResponse(resp *http.Response) (APIVers
 }
 
 // Head - Checks if specified API version exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -336,6 +347,8 @@ func (client *APIVersionsClient) headCreateRequest(ctx context.Context, resource
 }
 
 // NewListPager - Returns a collection of API versions.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.

--- a/packages/typespec-go/test/armapicenter/zz_deletedservices_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_deletedservices_client.go
@@ -40,6 +40,9 @@ func NewDeletedServicesClient(subscriptionID string, credential azcore.TokenCred
 }
 
 // Delete - Permanently deletes specified service.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - deletedServiceName - The name of the deleted service.
 //   - options - DeletedServicesClientDeleteOptions contains the optional parameters for the DeletedServicesClient.Delete method.
@@ -91,6 +94,9 @@ func (client *DeletedServicesClient) deleteCreateRequest(ctx context.Context, re
 }
 
 // Get - Returns details of the soft-deleted service.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - deletedServiceName - The name of the deleted service.
 //   - options - DeletedServicesClientGetOptions contains the optional parameters for the DeletedServicesClient.Get method.
@@ -155,6 +161,8 @@ func (client *DeletedServicesClient) getHandleResponse(resp *http.Response) (Del
 }
 
 // NewListPager - Lists soft-deleted services.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - DeletedServicesClientListOptions contains the optional parameters for the DeletedServicesClient.NewListPager
 //     method.
@@ -216,6 +224,8 @@ func (client *DeletedServicesClient) listHandleResponse(resp *http.Response) (De
 }
 
 // NewListBySubscriptionPager - Lists services within an Azure subscription.
+//
+// Generated from API version 2024-03-15-preview
 //   - options - DeletedServicesClientListBySubscriptionOptions contains the optional parameters for the DeletedServicesClient.NewListBySubscriptionPager
 //     method.
 func (client *DeletedServicesClient) NewListBySubscriptionPager(options *DeletedServicesClientListBySubscriptionOptions) *runtime.Pager[DeletedServicesClientListBySubscriptionResponse] {

--- a/packages/typespec-go/test/armapicenter/zz_deployments_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_deployments_client.go
@@ -40,6 +40,9 @@ func NewDeploymentsClient(subscriptionID string, credential azcore.TokenCredenti
 }
 
 // CreateOrUpdate - Creates new or updates existing API deployment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -125,6 +128,9 @@ func (client *DeploymentsClient) createOrUpdateHandleResponse(resp *http.Respons
 }
 
 // Delete - Deletes API deployment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -191,6 +197,9 @@ func (client *DeploymentsClient) deleteCreateRequest(ctx context.Context, resour
 }
 
 // Get - Returns details of the API deployment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -270,6 +279,8 @@ func (client *DeploymentsClient) getHandleResponse(resp *http.Response) (Deploym
 }
 
 // Head - Checks if specified API deployment exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -336,6 +347,8 @@ func (client *DeploymentsClient) headCreateRequest(ctx context.Context, resource
 }
 
 // NewListPager - Returns a collection of API deployments.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.

--- a/packages/typespec-go/test/armapicenter/zz_environments_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_environments_client.go
@@ -40,6 +40,9 @@ func NewEnvironmentsClient(subscriptionID string, credential azcore.TokenCredent
 }
 
 // CreateOrUpdate - Creates new or updates existing environment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -120,6 +123,9 @@ func (client *EnvironmentsClient) createOrUpdateHandleResponse(resp *http.Respon
 }
 
 // Delete - Deletes the environment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -181,6 +187,9 @@ func (client *EnvironmentsClient) deleteCreateRequest(ctx context.Context, resou
 }
 
 // Get - Returns details of the environment.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -255,6 +264,8 @@ func (client *EnvironmentsClient) getHandleResponse(resp *http.Response) (Enviro
 }
 
 // Head - Checks if specified environment exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -316,6 +327,8 @@ func (client *EnvironmentsClient) headCreateRequest(ctx context.Context, resourc
 }
 
 // NewListPager - Returns a collection of environments.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.

--- a/packages/typespec-go/test/armapicenter/zz_metadataschemas_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_metadataschemas_client.go
@@ -40,6 +40,9 @@ func NewMetadataSchemasClient(subscriptionID string, credential azcore.TokenCred
 }
 
 // CreateOrUpdate - Creates new or updates existing metadata schema.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - metadataSchemaName - The name of the metadata schema.
@@ -115,6 +118,9 @@ func (client *MetadataSchemasClient) createOrUpdateHandleResponse(resp *http.Res
 }
 
 // Delete - Deletes specified metadata schema.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - metadataSchemaName - The name of the metadata schema.
@@ -171,6 +177,9 @@ func (client *MetadataSchemasClient) deleteCreateRequest(ctx context.Context, re
 }
 
 // Get - Returns details of the metadata schema.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - metadataSchemaName - The name of the metadata schema.
@@ -240,6 +249,8 @@ func (client *MetadataSchemasClient) getHandleResponse(resp *http.Response) (Met
 }
 
 // Head - Checks if specified metadata schema exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - metadataSchemaName - The name of the metadata schema.
@@ -296,6 +307,8 @@ func (client *MetadataSchemasClient) headCreateRequest(ctx context.Context, reso
 }
 
 // NewListPager - Returns a collection of metadata schemas.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - options - MetadataSchemasClientListOptions contains the optional parameters for the MetadataSchemasClient.NewListPager

--- a/packages/typespec-go/test/armapicenter/zz_operations_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_operations_client.go
@@ -37,6 +37,8 @@ func NewOperationsClient(subscriptionID string, credential azcore.TokenCredentia
 }
 
 // NewListPager - List the operations for the provider
+//
+// Generated from API version 2024-03-15-preview
 //   - options - OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[OperationsClientListResponse]{

--- a/packages/typespec-go/test/armapicenter/zz_services_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_services_client.go
@@ -40,6 +40,9 @@ func NewServicesClient(subscriptionID string, credential azcore.TokenCredential,
 }
 
 // CreateOrUpdate - Creates new or updates existing API.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - resource - Resource create parameters.
@@ -106,6 +109,9 @@ func (client *ServicesClient) createOrUpdateHandleResponse(resp *http.Response) 
 }
 
 // Delete - Deletes specified service.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - options - ServicesClientDeleteOptions contains the optional parameters for the ServicesClient.Delete method.
@@ -157,6 +163,9 @@ func (client *ServicesClient) deleteCreateRequest(ctx context.Context, resourceG
 }
 
 // BeginExportMetadataSchema - Exports the effective metadata schema.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - payload - The content of the action request
@@ -180,6 +189,9 @@ func (client *ServicesClient) BeginExportMetadataSchema(ctx context.Context, res
 }
 
 // ExportMetadataSchema - Exports the effective metadata schema.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 func (client *ServicesClient) exportMetadataSchema(ctx context.Context, resourceGroupName string, serviceName string, payload MetadataSchemaExportRequest, options *ServicesClientBeginExportMetadataSchemaOptions) (*http.Response, error) {
 	var err error
 	const operationName = "ServicesClient.BeginExportMetadataSchema"
@@ -232,6 +244,9 @@ func (client *ServicesClient) exportMetadataSchemaCreateRequest(ctx context.Cont
 }
 
 // Get - Returns details of the service.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - options - ServicesClientGetOptions contains the optional parameters for the ServicesClient.Get method.
@@ -293,6 +308,8 @@ func (client *ServicesClient) getHandleResponse(resp *http.Response) (ServicesCl
 }
 
 // NewListByResourceGroupPager - Returns a collection of services within the resource group.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - ServicesClientListByResourceGroupOptions contains the optional parameters for the ServicesClient.NewListByResourceGroupPager
 //     method.
@@ -351,6 +368,8 @@ func (client *ServicesClient) listByResourceGroupHandleResponse(resp *http.Respo
 }
 
 // NewListBySubscriptionPager - Lists services within an Azure subscription.
+//
+// Generated from API version 2024-03-15-preview
 //   - options - ServicesClientListBySubscriptionOptions contains the optional parameters for the ServicesClient.NewListBySubscriptionPager
 //     method.
 func (client *ServicesClient) NewListBySubscriptionPager(options *ServicesClientListBySubscriptionOptions) *runtime.Pager[ServicesClientListBySubscriptionResponse] {
@@ -404,6 +423,9 @@ func (client *ServicesClient) listBySubscriptionHandleResponse(resp *http.Respon
 }
 
 // Update - Updates existing service.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - payload - The resource properties to be updated.

--- a/packages/typespec-go/test/armapicenter/zz_workspaces_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_workspaces_client.go
@@ -40,6 +40,9 @@ func NewWorkspacesClient(subscriptionID string, credential azcore.TokenCredentia
 }
 
 // CreateOrUpdate - Creates new or updates existing workspace.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -115,6 +118,9 @@ func (client *WorkspacesClient) createOrUpdateHandleResponse(resp *http.Response
 }
 
 // Delete - Deletes specified workspace.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -171,6 +177,9 @@ func (client *WorkspacesClient) deleteCreateRequest(ctx context.Context, resourc
 }
 
 // Get - Returns details of the workspace.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -240,6 +249,8 @@ func (client *WorkspacesClient) getHandleResponse(resp *http.Response) (Workspac
 }
 
 // Head - Checks if specified workspace exists.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - workspaceName - The name of the workspace.
@@ -296,6 +307,8 @@ func (client *WorkspacesClient) headCreateRequest(ctx context.Context, resourceG
 }
 
 // NewListPager - Returns a collection of workspaces.
+//
+// Generated from API version 2024-03-15-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - serviceName - The name of Azure API Center service.
 //   - options - WorkspacesClientListOptions contains the optional parameters for the WorkspacesClient.NewListPager method.

--- a/packages/typespec-go/test/armcodesigning/zz_accounts_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_accounts_client.go
@@ -40,6 +40,9 @@ func NewAccountsClient(subscriptionID string, credential azcore.TokenCredential,
 }
 
 // CheckNameAvailability - Checks that the trusted signing account name is valid and is not already in use.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - body - The CheckAvailability request
 //   - options - AccountsClientCheckNameAvailabilityOptions contains the optional parameters for the AccountsClient.CheckNameAvailability
 //     method.
@@ -97,6 +100,9 @@ func (client *AccountsClient) checkNameAvailabilityHandleResponse(resp *http.Res
 }
 
 // BeginCreate - Create a trusted Signing Account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - resource - Parameters to create the trusted signing account
@@ -119,6 +125,9 @@ func (client *AccountsClient) BeginCreate(ctx context.Context, resourceGroupName
 }
 
 // Create - Create a trusted Signing Account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 func (client *AccountsClient) create(ctx context.Context, resourceGroupName string, accountName string, resource Account, options *AccountsClientBeginCreateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginCreate"
@@ -171,6 +180,9 @@ func (client *AccountsClient) createCreateRequest(ctx context.Context, resourceG
 }
 
 // BeginDelete - Delete a trusted signing account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - options - AccountsClientBeginDeleteOptions contains the optional parameters for the AccountsClient.BeginDelete method.
@@ -192,6 +204,9 @@ func (client *AccountsClient) BeginDelete(ctx context.Context, resourceGroupName
 }
 
 // Delete - Delete a trusted signing account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 func (client *AccountsClient) deleteOperation(ctx context.Context, resourceGroupName string, accountName string, options *AccountsClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginDelete"
@@ -240,6 +255,9 @@ func (client *AccountsClient) deleteCreateRequest(ctx context.Context, resourceG
 }
 
 // Get - Get a trusted Signing Account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - options - AccountsClientGetOptions contains the optional parameters for the AccountsClient.Get method.
@@ -301,6 +319,8 @@ func (client *AccountsClient) getHandleResponse(resp *http.Response) (AccountsCl
 }
 
 // NewListByResourceGroupPager - Lists trusted signing accounts within a resource group.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - AccountsClientListByResourceGroupOptions contains the optional parameters for the AccountsClient.NewListByResourceGroupPager
 //     method.
@@ -359,6 +379,8 @@ func (client *AccountsClient) listByResourceGroupHandleResponse(resp *http.Respo
 }
 
 // NewListBySubscriptionPager - Lists trusted signing accounts within a subscription.
+//
+// Generated from API version 2024-02-05-preview
 //   - options - AccountsClientListBySubscriptionOptions contains the optional parameters for the AccountsClient.NewListBySubscriptionPager
 //     method.
 func (client *AccountsClient) NewListBySubscriptionPager(options *AccountsClientListBySubscriptionOptions) *runtime.Pager[AccountsClientListBySubscriptionResponse] {
@@ -412,6 +434,9 @@ func (client *AccountsClient) listBySubscriptionHandleResponse(resp *http.Respon
 }
 
 // BeginUpdate - Update a trusted signing account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - properties - Parameters supplied to update the trusted signing account
@@ -434,6 +459,9 @@ func (client *AccountsClient) BeginUpdate(ctx context.Context, resourceGroupName
 }
 
 // Update - Update a trusted signing account.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 func (client *AccountsClient) update(ctx context.Context, resourceGroupName string, accountName string, properties AccountPatch, options *AccountsClientBeginUpdateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AccountsClient.BeginUpdate"

--- a/packages/typespec-go/test/armcodesigning/zz_certificateprofiles_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_certificateprofiles_client.go
@@ -40,6 +40,9 @@ func NewCertificateProfilesClient(subscriptionID string, credential azcore.Token
 }
 
 // BeginCreate - Create a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.
@@ -64,6 +67,9 @@ func (client *CertificateProfilesClient) BeginCreate(ctx context.Context, resour
 }
 
 // Create - Create a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 func (client *CertificateProfilesClient) create(ctx context.Context, resourceGroupName string, accountName string, profileName string, resource CertificateProfile, options *CertificateProfilesClientBeginCreateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "CertificateProfilesClient.BeginCreate"
@@ -120,6 +126,9 @@ func (client *CertificateProfilesClient) createCreateRequest(ctx context.Context
 }
 
 // BeginDelete - Delete a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.
@@ -143,6 +152,9 @@ func (client *CertificateProfilesClient) BeginDelete(ctx context.Context, resour
 }
 
 // Delete - Delete a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 func (client *CertificateProfilesClient) deleteOperation(ctx context.Context, resourceGroupName string, accountName string, profileName string, options *CertificateProfilesClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "CertificateProfilesClient.BeginDelete"
@@ -195,6 +207,9 @@ func (client *CertificateProfilesClient) deleteCreateRequest(ctx context.Context
 }
 
 // Get - Get details of a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.
@@ -261,6 +276,8 @@ func (client *CertificateProfilesClient) getHandleResponse(resp *http.Response) 
 }
 
 // NewListByCodeSigningAccountPager - List certificate profiles under a trusted signing account.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - options - CertificateProfilesClientListByCodeSigningAccountOptions contains the optional parameters for the CertificateProfilesClient.NewListByCodeSigningAccountPager
@@ -324,6 +341,9 @@ func (client *CertificateProfilesClient) listByCodeSigningAccountHandleResponse(
 }
 
 // RevokeCertificate - Revoke a certificate under a certificate profile.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2024-02-05-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - accountName - Trusted Signing account name.
 //   - profileName - Certificate profile name.

--- a/packages/typespec-go/test/armcodesigning/zz_operations_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_operations_client.go
@@ -37,6 +37,8 @@ func NewOperationsClient(subscriptionID string, credential azcore.TokenCredentia
 }
 
 // NewListPager - List the operations for the provider
+//
+// Generated from API version 2024-02-05-preview
 //   - options - OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[OperationsClientListResponse]{

--- a/packages/typespec-go/test/armdatabasewatcher/zz_operations_client.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_operations_client.go
@@ -37,6 +37,8 @@ func NewOperationsClient(subscriptionID string, credential azcore.TokenCredentia
 }
 
 // NewListPager - List the operations for the provider
+//
+// Generated from API version 2023-09-01-preview
 //   - options - OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[OperationsClientListResponse]{

--- a/packages/typespec-go/test/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_sharedprivatelinkresources_client.go
@@ -40,6 +40,9 @@ func NewSharedPrivateLinkResourcesClient(subscriptionID string, credential azcor
 }
 
 // BeginCreate - Create a SharedPrivateLinkResource
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - sharedPrivateLinkResourceName - The Shared Private Link resource name.
@@ -64,6 +67,9 @@ func (client *SharedPrivateLinkResourcesClient) BeginCreate(ctx context.Context,
 }
 
 // Create - Create a SharedPrivateLinkResource
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *SharedPrivateLinkResourcesClient) create(ctx context.Context, resourceGroupName string, watcherName string, sharedPrivateLinkResourceName string, resource SharedPrivateLinkResource, options *SharedPrivateLinkResourcesClientBeginCreateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "SharedPrivateLinkResourcesClient.BeginCreate"
@@ -120,6 +126,9 @@ func (client *SharedPrivateLinkResourcesClient) createCreateRequest(ctx context.
 }
 
 // BeginDelete - Delete a SharedPrivateLinkResource
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - sharedPrivateLinkResourceName - The Shared Private Link resource name.
@@ -143,6 +152,9 @@ func (client *SharedPrivateLinkResourcesClient) BeginDelete(ctx context.Context,
 }
 
 // Delete - Delete a SharedPrivateLinkResource
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *SharedPrivateLinkResourcesClient) deleteOperation(ctx context.Context, resourceGroupName string, watcherName string, sharedPrivateLinkResourceName string, options *SharedPrivateLinkResourcesClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "SharedPrivateLinkResourcesClient.BeginDelete"
@@ -195,6 +207,9 @@ func (client *SharedPrivateLinkResourcesClient) deleteCreateRequest(ctx context.
 }
 
 // Get - Get a SharedPrivateLinkResource
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - sharedPrivateLinkResourceName - The Shared Private Link resource name.
@@ -262,6 +277,8 @@ func (client *SharedPrivateLinkResourcesClient) getHandleResponse(resp *http.Res
 }
 
 // NewListByWatcherPager - List SharedPrivateLinkResource resources by Watcher
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - SharedPrivateLinkResourcesClientListByWatcherOptions contains the optional parameters for the SharedPrivateLinkResourcesClient.NewListByWatcherPager

--- a/packages/typespec-go/test/armdatabasewatcher/zz_targets_client.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_targets_client.go
@@ -40,6 +40,9 @@ func NewTargetsClient(subscriptionID string, credential azcore.TokenCredential, 
 }
 
 // CreateOrUpdate - Create a Target
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - targetName - The target resource name.
@@ -111,6 +114,9 @@ func (client *TargetsClient) createOrUpdateHandleResponse(resp *http.Response) (
 }
 
 // Delete - Delete a Target
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - targetName - The target resource name.
@@ -167,6 +173,9 @@ func (client *TargetsClient) deleteCreateRequest(ctx context.Context, resourceGr
 }
 
 // Get - Get a Target
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - targetName - The target resource name.
@@ -233,6 +242,8 @@ func (client *TargetsClient) getHandleResponse(resp *http.Response) (TargetsClie
 }
 
 // NewListByWatcherPager - List Target resources by Watcher
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - TargetsClientListByWatcherOptions contains the optional parameters for the TargetsClient.NewListByWatcherPager

--- a/packages/typespec-go/test/armdatabasewatcher/zz_watchers_client.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_watchers_client.go
@@ -40,6 +40,9 @@ func NewWatchersClient(subscriptionID string, credential azcore.TokenCredential,
 }
 
 // BeginCreateOrUpdate - Create a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - resource - Resource create parameters.
@@ -63,6 +66,9 @@ func (client *WatchersClient) BeginCreateOrUpdate(ctx context.Context, resourceG
 }
 
 // CreateOrUpdate - Create a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *WatchersClient) createOrUpdate(ctx context.Context, resourceGroupName string, watcherName string, resource Watcher, options *WatchersClientBeginCreateOrUpdateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "WatchersClient.BeginCreateOrUpdate"
@@ -115,6 +121,9 @@ func (client *WatchersClient) createOrUpdateCreateRequest(ctx context.Context, r
 }
 
 // BeginDelete - Delete a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - WatchersClientBeginDeleteOptions contains the optional parameters for the WatchersClient.BeginDelete method.
@@ -136,6 +145,9 @@ func (client *WatchersClient) BeginDelete(ctx context.Context, resourceGroupName
 }
 
 // Delete - Delete a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *WatchersClient) deleteOperation(ctx context.Context, resourceGroupName string, watcherName string, options *WatchersClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "WatchersClient.BeginDelete"
@@ -184,6 +196,9 @@ func (client *WatchersClient) deleteCreateRequest(ctx context.Context, resourceG
 }
 
 // Get - Get a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - WatchersClientGetOptions contains the optional parameters for the WatchersClient.Get method.
@@ -245,6 +260,8 @@ func (client *WatchersClient) getHandleResponse(resp *http.Response) (WatchersCl
 }
 
 // NewListByResourceGroupPager - List Watcher resources by resource group
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - WatchersClientListByResourceGroupOptions contains the optional parameters for the WatchersClient.NewListByResourceGroupPager
 //     method.
@@ -303,6 +320,8 @@ func (client *WatchersClient) listByResourceGroupHandleResponse(resp *http.Respo
 }
 
 // NewListBySubscriptionPager - List Watcher resources by subscription ID
+//
+// Generated from API version 2023-09-01-preview
 //   - options - WatchersClientListBySubscriptionOptions contains the optional parameters for the WatchersClient.NewListBySubscriptionPager
 //     method.
 func (client *WatchersClient) NewListBySubscriptionPager(options *WatchersClientListBySubscriptionOptions) *runtime.Pager[WatchersClientListBySubscriptionResponse] {
@@ -356,6 +375,9 @@ func (client *WatchersClient) listBySubscriptionHandleResponse(resp *http.Respon
 }
 
 // BeginStart - The action to start monitoring all targets configured for a database watcher.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - WatchersClientBeginStartOptions contains the optional parameters for the WatchersClient.BeginStart method.
@@ -377,6 +399,9 @@ func (client *WatchersClient) BeginStart(ctx context.Context, resourceGroupName 
 }
 
 // Start - The action to start monitoring all targets configured for a database watcher.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *WatchersClient) start(ctx context.Context, resourceGroupName string, watcherName string, options *WatchersClientBeginStartOptions) (*http.Response, error) {
 	var err error
 	const operationName = "WatchersClient.BeginStart"
@@ -425,6 +450,9 @@ func (client *WatchersClient) startCreateRequest(ctx context.Context, resourceGr
 }
 
 // BeginStop - The action to stop monitoring all targets configured for a database watcher.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - options - WatchersClientBeginStopOptions contains the optional parameters for the WatchersClient.BeginStop method.
@@ -446,6 +474,9 @@ func (client *WatchersClient) BeginStop(ctx context.Context, resourceGroupName s
 }
 
 // Stop - The action to stop monitoring all targets configured for a database watcher.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *WatchersClient) stop(ctx context.Context, resourceGroupName string, watcherName string, options *WatchersClientBeginStopOptions) (*http.Response, error) {
 	var err error
 	const operationName = "WatchersClient.BeginStop"
@@ -494,6 +525,9 @@ func (client *WatchersClient) stopCreateRequest(ctx context.Context, resourceGro
 }
 
 // BeginUpdate - Update a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - watcherName - The database watcher name.
 //   - properties - The resource properties to be updated.
@@ -516,6 +550,9 @@ func (client *WatchersClient) BeginUpdate(ctx context.Context, resourceGroupName
 }
 
 // Update - Update a Watcher
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-09-01-preview
 func (client *WatchersClient) update(ctx context.Context, resourceGroupName string, watcherName string, properties WatcherUpdate, options *WatchersClientBeginUpdateOptions) (*http.Response, error) {
 	var err error
 	const operationName = "WatchersClient.BeginUpdate"

--- a/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstances_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstances_client.go
@@ -41,6 +41,9 @@ func NewAzureLargeInstancesClient(subscriptionID string, credential azcore.Token
 
 // Get - Gets an Azure Large Instance for the specified subscription, resource group,
 // and instance name.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
 //   - options - AzureLargeInstancesClientGetOptions contains the optional parameters for the AzureLargeInstancesClient.Get method.
@@ -103,6 +106,8 @@ func (client *AzureLargeInstancesClient) getHandleResponse(resp *http.Response) 
 
 // NewListByResourceGroupPager - Gets a list of Azure Large Instances in the specified subscription and resource
 // group. The operations returns various properties of each Azure Large Instance.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - AzureLargeInstancesClientListByResourceGroupOptions contains the optional parameters for the AzureLargeInstancesClient.NewListByResourceGroupPager
 //     method.
@@ -162,6 +167,8 @@ func (client *AzureLargeInstancesClient) listByResourceGroupHandleResponse(resp 
 
 // NewListBySubscriptionPager - Gets a list of Azure Large Instances in the specified subscription. The
 // operations returns various properties of each Azure Large Instance.
+//
+// Generated from API version 2023-07-20-preview
 //   - options - AzureLargeInstancesClientListBySubscriptionOptions contains the optional parameters for the AzureLargeInstancesClient.NewListBySubscriptionPager
 //     method.
 func (client *AzureLargeInstancesClient) NewListBySubscriptionPager(options *AzureLargeInstancesClientListBySubscriptionOptions) *runtime.Pager[AzureLargeInstancesClientListBySubscriptionResponse] {
@@ -215,6 +222,9 @@ func (client *AzureLargeInstancesClient) listBySubscriptionHandleResponse(resp *
 }
 
 // BeginRestart - The operation to restart an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
 //   - options - AzureLargeInstancesClientBeginRestartOptions contains the optional parameters for the AzureLargeInstancesClient.BeginRestart
@@ -237,6 +247,9 @@ func (client *AzureLargeInstancesClient) BeginRestart(ctx context.Context, resou
 }
 
 // Restart - The operation to restart an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 func (client *AzureLargeInstancesClient) restart(ctx context.Context, resourceGroupName string, azureLargeInstanceName string, options *AzureLargeInstancesClientBeginRestartOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginRestart"
@@ -292,6 +305,9 @@ func (client *AzureLargeInstancesClient) restartCreateRequest(ctx context.Contex
 }
 
 // BeginShutdown - The operation to shutdown an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
 //   - body - The content of the action request
@@ -315,6 +331,9 @@ func (client *AzureLargeInstancesClient) BeginShutdown(ctx context.Context, reso
 }
 
 // Shutdown - The operation to shutdown an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 func (client *AzureLargeInstancesClient) shutdown(ctx context.Context, resourceGroupName string, azureLargeInstanceName string, body any, options *AzureLargeInstancesClientBeginShutdownOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginShutdown"
@@ -367,6 +386,9 @@ func (client *AzureLargeInstancesClient) shutdownCreateRequest(ctx context.Conte
 }
 
 // BeginStart - The operation to start an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
 //   - body - The content of the action request
@@ -390,6 +412,9 @@ func (client *AzureLargeInstancesClient) BeginStart(ctx context.Context, resourc
 }
 
 // Start - The operation to start an Azure Large Instance (only for compute instances)
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 func (client *AzureLargeInstancesClient) start(ctx context.Context, resourceGroupName string, azureLargeInstanceName string, body any, options *AzureLargeInstancesClientBeginStartOptions) (*http.Response, error) {
 	var err error
 	const operationName = "AzureLargeInstancesClient.BeginStart"
@@ -443,6 +468,9 @@ func (client *AzureLargeInstancesClient) startCreateRequest(ctx context.Context,
 
 // Update - Patches the Tags field of an Azure Large Instance for the specified
 // subscription, resource group, and instance name.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeInstanceName - Name of the AzureLargeInstance.
 //   - properties - The resource properties to be updated.

--- a/packages/typespec-go/test/armlargeinstance/zz_azurelargestorageinstances_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_azurelargestorageinstances_client.go
@@ -41,6 +41,9 @@ func NewAzureLargeStorageInstancesClient(subscriptionID string, credential azcor
 
 // Get - Gets an Azure Large Storage instance for the specified subscription, resource
 // group, and instance name.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeStorageInstanceName - Name of the AzureLargeStorageInstance.
 //   - options - AzureLargeStorageInstancesClientGetOptions contains the optional parameters for the AzureLargeStorageInstancesClient.Get
@@ -105,6 +108,8 @@ func (client *AzureLargeStorageInstancesClient) getHandleResponse(resp *http.Res
 // NewListByResourceGroupPager - Gets a list of AzureLargeStorageInstances in the specified subscription and
 // resource group. The operations returns various properties of each Azure
 // LargeStorage instance.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - options - AzureLargeStorageInstancesClientListByResourceGroupOptions contains the optional parameters for the AzureLargeStorageInstancesClient.NewListByResourceGroupPager
 //     method.
@@ -164,6 +169,8 @@ func (client *AzureLargeStorageInstancesClient) listByResourceGroupHandleRespons
 
 // NewListBySubscriptionPager - Gets a list of AzureLargeStorageInstances in the specified subscription. The
 // operations returns various properties of each Azure LargeStorage instance.
+//
+// Generated from API version 2023-07-20-preview
 //   - options - AzureLargeStorageInstancesClientListBySubscriptionOptions contains the optional parameters for the AzureLargeStorageInstancesClient.NewListBySubscriptionPager
 //     method.
 func (client *AzureLargeStorageInstancesClient) NewListBySubscriptionPager(options *AzureLargeStorageInstancesClientListBySubscriptionOptions) *runtime.Pager[AzureLargeStorageInstancesClientListBySubscriptionResponse] {
@@ -218,6 +225,9 @@ func (client *AzureLargeStorageInstancesClient) listBySubscriptionHandleResponse
 
 // Update - Patches the Tags field of a Azure Large Storage Instance for the specified
 // subscription, resource group, and instance name.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2023-07-20-preview
 //   - resourceGroupName - The name of the resource group. The name is case insensitive.
 //   - azureLargeStorageInstanceName - Name of the AzureLargeStorageInstance.
 //   - properties - The resource properties to be updated.

--- a/packages/typespec-go/test/armlargeinstance/zz_operations_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_operations_client.go
@@ -37,6 +37,8 @@ func NewOperationsClient(subscriptionID string, credential azcore.TokenCredentia
 }
 
 // NewListPager - List the operations for the provider
+//
+// Generated from API version 2023-07-20-preview
 //   - options - OperationsClientListOptions contains the optional parameters for the OperationsClient.NewListPager method.
 func (client *OperationsClient) NewListPager(options *OperationsClientListOptions) *runtime.Pager[OperationsClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[OperationsClientListResponse]{

--- a/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/apikeygroup/zz_apikey_client.go
@@ -19,6 +19,7 @@ type APIKeyClient struct {
 }
 
 // Invalid - Check whether client is authenticated.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - APIKeyClientInvalidOptions contains the optional parameters for the APIKeyClient.Invalid method.
 func (client *APIKeyClient) Invalid(ctx context.Context, options *APIKeyClientInvalidOptions) (APIKeyClientInvalidResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *APIKeyClient) invalidHandleResponse(resp *http.Response) (APIKeyCl
 }
 
 // Valid - Check whether client is authenticated
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - APIKeyClientValidOptions contains the optional parameters for the APIKeyClient.Valid method.
 func (client *APIKeyClient) Valid(ctx context.Context, options *APIKeyClientValidOptions) (APIKeyClientValidResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_custom_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/http/customgroup/zz_custom_client.go
@@ -19,6 +19,7 @@ type CustomClient struct {
 }
 
 // Invalid - Check whether client is authenticated.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - CustomClientInvalidOptions contains the optional parameters for the CustomClient.Invalid method.
 func (client *CustomClient) Invalid(ctx context.Context, options *CustomClientInvalidOptions) (CustomClientInvalidResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *CustomClient) invalidHandleResponse(resp *http.Response) (CustomCl
 }
 
 // Valid - Check whether client is authenticated
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - CustomClientValidOptions contains the optional parameters for the CustomClient.Valid method.
 func (client *CustomClient) Valid(ctx context.Context, options *CustomClientValidOptions) (CustomClientValidResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_oauth2_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/oauth2group/zz_oauth2_client.go
@@ -19,6 +19,7 @@ type OAuth2Client struct {
 }
 
 // Invalid - Check whether client is authenticated. Will return an invalid bearer error.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OAuth2ClientInvalidOptions contains the optional parameters for the OAuth2Client.Invalid method.
 func (client *OAuth2Client) Invalid(ctx context.Context, options *OAuth2ClientInvalidOptions) (OAuth2ClientInvalidResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *OAuth2Client) invalidHandleResponse(resp *http.Response) (OAuth2Cl
 }
 
 // Valid - Check whether client is authenticated
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OAuth2ClientValidOptions contains the optional parameters for the OAuth2Client.Valid method.
 func (client *OAuth2Client) Valid(ctx context.Context, options *OAuth2ClientValidOptions) (OAuth2ClientValidResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_union_client.go
+++ b/packages/typespec-go/test/cadlranch/authentication/unionauthgroup/zz_union_client.go
@@ -19,6 +19,7 @@ type UnionClient struct {
 }
 
 // ValidKey - Check whether client is authenticated
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - UnionClientValidKeyOptions contains the optional parameters for the UnionClient.ValidKey method.
 func (client *UnionClient) ValidKey(ctx context.Context, options *UnionClientValidKeyOptions) (UnionClientValidKeyResponse, error) {
 	var err error
@@ -52,6 +53,7 @@ func (client *UnionClient) validKeyCreateRequest(ctx context.Context, _ *UnionCl
 }
 
 // ValidToken - Check whether client is authenticated
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - UnionClientValidTokenOptions contains the optional parameters for the UnionClient.ValidToken method.
 func (client *UnionClient) ValidToken(ctx context.Context, options *UnionClientValidTokenOptions) (UnionClientValidTokenResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accessinternaloperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accessinternaloperation_client.go
@@ -18,6 +18,8 @@ type AccessInternalOperationClient struct {
 	internal *azcore.Client
 }
 
+// internalDecoratorInInternal -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessInternalOperationClientinternalDecoratorInInternalOptions contains the optional parameters for the AccessInternalOperationClient.internalDecoratorInInternal
 //     method.
 func (client *AccessInternalOperationClient) internalDecoratorInInternal(ctx context.Context, name string, options *accessInternalOperationClientinternalDecoratorInInternalOptions) (accessInternalOperationClientinternalDecoratorInInternalResponse, error) {
@@ -65,6 +67,8 @@ func (client *AccessInternalOperationClient) internalDecoratorInInternalHandleRe
 	return result, nil
 }
 
+// noDecoratorInInternal -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessInternalOperationClientnoDecoratorInInternalOptions contains the optional parameters for the AccessInternalOperationClient.noDecoratorInInternal
 //     method.
 func (client *AccessInternalOperationClient) noDecoratorInInternal(ctx context.Context, name string, options *accessInternalOperationClientnoDecoratorInInternalOptions) (accessInternalOperationClientnoDecoratorInInternalResponse, error) {
@@ -112,6 +116,8 @@ func (client *AccessInternalOperationClient) noDecoratorInInternalHandleResponse
 	return result, nil
 }
 
+// publicDecoratorInInternal -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessInternalOperationClientpublicDecoratorInInternalOptions contains the optional parameters for the AccessInternalOperationClient.publicDecoratorInInternal
 //     method.
 func (client *AccessInternalOperationClient) publicDecoratorInInternal(ctx context.Context, name string, options *accessInternalOperationClientpublicDecoratorInInternalOptions) (accessInternalOperationClientpublicDecoratorInInternalResponse, error) {

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accesspublicoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accesspublicoperation_client.go
@@ -18,6 +18,8 @@ type AccessPublicOperationClient struct {
 	internal *azcore.Client
 }
 
+// NoDecoratorInPublic -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - AccessPublicOperationClientNoDecoratorInPublicOptions contains the optional parameters for the AccessPublicOperationClient.NoDecoratorInPublic
 //     method.
 func (client *AccessPublicOperationClient) NoDecoratorInPublic(ctx context.Context, name string, options *AccessPublicOperationClientNoDecoratorInPublicOptions) (AccessPublicOperationClientNoDecoratorInPublicResponse, error) {
@@ -65,6 +67,8 @@ func (client *AccessPublicOperationClient) noDecoratorInPublicHandleResponse(res
 	return result, nil
 }
 
+// PublicDecoratorInPublic -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - AccessPublicOperationClientPublicDecoratorInPublicOptions contains the optional parameters for the AccessPublicOperationClient.PublicDecoratorInPublic
 //     method.
 func (client *AccessPublicOperationClient) PublicDecoratorInPublic(ctx context.Context, name string, options *AccessPublicOperationClientPublicDecoratorInPublicOptions) (AccessPublicOperationClientPublicDecoratorInPublicResponse, error) {

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accessrelativemodelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accessrelativemodelinoperation_client.go
@@ -26,6 +26,7 @@ type AccessRelativeModelInOperationClient struct {
 // "kind": "real"
 // }
 // ```
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessRelativeModelInOperationClientdiscriminatorOptions contains the optional parameters for the AccessRelativeModelInOperationClient.discriminator
 //     method.
 func (client *AccessRelativeModelInOperationClient) discriminator(ctx context.Context, kind string, options *accessRelativeModelInOperationClientdiscriminatorOptions) (accessRelativeModelInOperationClientdiscriminatorResponse, error) {
@@ -84,6 +85,7 @@ func (client *AccessRelativeModelInOperationClient) discriminatorHandleResponse(
 // }
 // }
 // ```
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessRelativeModelInOperationClientoperationOptions contains the optional parameters for the AccessRelativeModelInOperationClient.operation
 //     method.
 func (client *AccessRelativeModelInOperationClient) operation(ctx context.Context, name string, options *accessRelativeModelInOperationClientoperationOptions) (accessRelativeModelInOperationClientoperationResponse, error) {

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accesssharedmodelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/accessgroup/zz_accesssharedmodelinoperation_client.go
@@ -18,6 +18,8 @@ type AccessSharedModelInOperationClient struct {
 	internal *azcore.Client
 }
 
+// Public -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - AccessSharedModelInOperationClientPublicOptions contains the optional parameters for the AccessSharedModelInOperationClient.Public
 //     method.
 func (client *AccessSharedModelInOperationClient) Public(ctx context.Context, name string, options *AccessSharedModelInOperationClientPublicOptions) (AccessSharedModelInOperationClientPublicResponse, error) {
@@ -65,6 +67,8 @@ func (client *AccessSharedModelInOperationClient) publicHandleResponse(resp *htt
 	return result, nil
 }
 
+// internalMethod -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - accessSharedModelInOperationClientinternalMethodOptions contains the optional parameters for the AccessSharedModelInOperationClient.internalMethod
 //     method.
 func (client *AccessSharedModelInOperationClient) internalMethod(ctx context.Context, name string, options *accessSharedModelInOperationClientinternalMethodOptions) (accessSharedModelInOperationClientinternalMethodResponse, error) {

--- a/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_usagemodelinoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/client-generator-core/coreusagegroup/zz_usagemodelinoperation_client.go
@@ -24,6 +24,7 @@ type UsageModelInOperationClient struct {
 // "name": <any string>
 // }
 // ```
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - UsageModelInOperationClientInputToInputOutputOptions contains the optional parameters for the UsageModelInOperationClient.InputToInputOutput
 //     method.
 func (client *UsageModelInOperationClient) InputToInputOutput(ctx context.Context, body InputModel, options *UsageModelInOperationClientInputToInputOutputOptions) (UsageModelInOperationClientInputToInputOutputResponse, error) {
@@ -67,6 +68,7 @@ func (client *UsageModelInOperationClient) inputToInputOutputCreateRequest(ctx c
 // "name": <any string>
 // }
 // ```
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - UsageModelInOperationClientOutputToInputOutputOptions contains the optional parameters for the UsageModelInOperationClient.OutputToInputOutput
 //     method.
 func (client *UsageModelInOperationClient) OutputToInputOutput(ctx context.Context, options *UsageModelInOperationClientOutputToInputOutputOptions) (UsageModelInOperationClientOutputToInputOutputResponse, error) {

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basic_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basic_client.go
@@ -29,6 +29,9 @@ func (client *BasicClient) NewBasicTwoModelsAsPageItemClient() *BasicTwoModelsAs
 }
 
 // CreateOrReplace - Adds a user or replaces a user's fields.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - id - The user's id.
 //   - resource - The resource instance.
 //   - options - BasicClientCreateOrReplaceOptions contains the optional parameters for the BasicClient.CreateOrReplace method.
@@ -83,6 +86,9 @@ func (client *BasicClient) createOrReplaceHandleResponse(resp *http.Response) (B
 }
 
 // CreateOrUpdate - Adds a user or updates a user's fields.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - id - The user's id.
 //   - resource - The resource instance.
 //   - options - BasicClientCreateOrUpdateOptions contains the optional parameters for the BasicClient.CreateOrUpdate method.
@@ -137,6 +143,9 @@ func (client *BasicClient) createOrUpdateHandleResponse(resp *http.Response) (Ba
 }
 
 // Delete - Deletes a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - id - The user's id.
 //   - options - BasicClientDeleteOptions contains the optional parameters for the BasicClient.Delete method.
 func (client *BasicClient) Delete(ctx context.Context, id int32, options *BasicClientDeleteOptions) (BasicClientDeleteResponse, error) {
@@ -176,6 +185,9 @@ func (client *BasicClient) deleteCreateRequest(ctx context.Context, id int32, _ 
 }
 
 // Export - Exports a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - id - The user's id.
 //   - formatParam - The format of the data.
 //   - options - BasicClientExportOptions contains the optional parameters for the BasicClient.Export method.
@@ -227,6 +239,9 @@ func (client *BasicClient) exportHandleResponse(resp *http.Response) (BasicClien
 }
 
 // Get - Gets a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - id - The user's id.
 //   - options - BasicClientGetOptions contains the optional parameters for the BasicClient.Get method.
 func (client *BasicClient) Get(ctx context.Context, id int32, options *BasicClientGetOptions) (BasicClientGetResponse, error) {
@@ -276,6 +291,8 @@ func (client *BasicClient) getHandleResponse(resp *http.Response) (BasicClientGe
 }
 
 // NewListPager - Lists all users.
+//
+// Generated from API version 2022-12-01-preview
 //   - options - BasicClientListOptions contains the optional parameters for the BasicClient.NewListPager method.
 func (client *BasicClient) NewListPager(options *BasicClientListOptions) *runtime.Pager[BasicClientListResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListResponse]{
@@ -351,6 +368,8 @@ func (client *BasicClient) listHandleResponse(resp *http.Response) (BasicClientL
 }
 
 // NewListWithCustomPageModelPager - List with custom page model.
+//
+// Generated from API version 2022-12-01-preview
 //   - options - BasicClientListWithCustomPageModelOptions contains the optional parameters for the BasicClient.NewListWithCustomPageModelPager
 //     method.
 func (client *BasicClient) NewListWithCustomPageModelPager(options *BasicClientListWithCustomPageModelOptions) *runtime.Pager[BasicClientListWithCustomPageModelResponse] {
@@ -400,6 +419,8 @@ func (client *BasicClient) listWithCustomPageModelHandleResponse(resp *http.Resp
 }
 
 // NewListWithPagePager - List with Azure.Core.Page<>.
+//
+// Generated from API version 2022-12-01-preview
 //   - options - BasicClientListWithPageOptions contains the optional parameters for the BasicClient.NewListWithPagePager method.
 func (client *BasicClient) NewListWithPagePager(options *BasicClientListWithPageOptions) *runtime.Pager[BasicClientListWithPageResponse] {
 	return runtime.NewPager(runtime.PagingHandler[BasicClientListWithPageResponse]{
@@ -448,6 +469,8 @@ func (client *BasicClient) listWithPageHandleResponse(resp *http.Response) (Basi
 }
 
 // NewListWithParametersPager - List with extensible enum parameter Azure.Core.Page<>.
+//
+// Generated from API version 2022-12-01-preview
 //   - bodyInput - The body of the input.
 //   - options - BasicClientListWithParametersOptions contains the optional parameters for the BasicClient.NewListWithParametersPager
 //     method.

--- a/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basictwomodelsaspageitem_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/basicgroup/zz_basictwomodelsaspageitem_client.go
@@ -20,6 +20,8 @@ type BasicTwoModelsAsPageItemClient struct {
 
 // NewListFirstItemPager - Two operations with two different page item types should be successfully generated. Should generate
 // model for FirstItem.
+//
+// Generated from API version 2022-12-01-preview
 //   - options - BasicTwoModelsAsPageItemClientListFirstItemOptions contains the optional parameters for the BasicTwoModelsAsPageItemClient.NewListFirstItemPager
 //     method.
 func (client *BasicTwoModelsAsPageItemClient) NewListFirstItemPager(options *BasicTwoModelsAsPageItemClientListFirstItemOptions) *runtime.Pager[BasicTwoModelsAsPageItemClientListFirstItemResponse] {
@@ -70,6 +72,8 @@ func (client *BasicTwoModelsAsPageItemClient) listFirstItemHandleResponse(resp *
 
 // NewListSecondItemPager - Two operations with two different page item types should be successfully generated. Should generate
 // model for SecondItem.
+//
+// Generated from API version 2022-12-01-preview
 //   - options - BasicTwoModelsAsPageItemClientListSecondItemOptions contains the optional parameters for the BasicTwoModelsAsPageItemClient.NewListSecondItemPager
 //     method.
 func (client *BasicTwoModelsAsPageItemClient) NewListSecondItemPager(options *BasicTwoModelsAsPageItemClientListSecondItemOptions) *runtime.Pager[BasicTwoModelsAsPageItemClientListSecondItemResponse] {

--- a/packages/typespec-go/test/cadlranch/azure/core/corescalargroup/zz_scalarazurelocationscalar_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/corescalargroup/zz_scalarazurelocationscalar_client.go
@@ -19,6 +19,7 @@ type ScalarAzureLocationScalarClient struct {
 }
 
 // Get - get azureLocation value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarAzureLocationScalarClientGetOptions contains the optional parameters for the ScalarAzureLocationScalarClient.Get
 //     method.
 func (client *ScalarAzureLocationScalarClient) Get(ctx context.Context, options *ScalarAzureLocationScalarClientGetOptions) (ScalarAzureLocationScalarClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ScalarAzureLocationScalarClient) getHandleResponse(resp *http.Resp
 }
 
 // Header - azureLocation value header
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - region - _
 //   - options - ScalarAzureLocationScalarClientHeaderOptions contains the optional parameters for the ScalarAzureLocationScalarClient.Header
 //     method.
@@ -100,6 +102,7 @@ func (client *ScalarAzureLocationScalarClient) headerCreateRequest(ctx context.C
 }
 
 // Post - post a model which has azureLocation property
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - ScalarAzureLocationScalarClientPostOptions contains the optional parameters for the ScalarAzureLocationScalarClient.Post
 //     method.
@@ -150,6 +153,7 @@ func (client *ScalarAzureLocationScalarClient) postHandleResponse(resp *http.Res
 }
 
 // Put - put azureLocation value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - ScalarAzureLocationScalarClientPutOptions contains the optional parameters for the ScalarAzureLocationScalarClient.Put
 //     method.
@@ -189,6 +193,7 @@ func (client *ScalarAzureLocationScalarClient) putCreateRequest(ctx context.Cont
 }
 
 // Query - azureLocation value query
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - region - _
 //   - options - ScalarAzureLocationScalarClientQueryOptions contains the optional parameters for the ScalarAzureLocationScalarClient.Query
 //     method.

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_rpc_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrorpcgroup/zz_rpc_client.go
@@ -19,6 +19,9 @@ type RPCClient struct {
 }
 
 // BeginLongRunningRPC - Generate data.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - generationOptions - Options for the generation.
 //   - options - RPCClientBeginLongRunningRPCOptions contains the optional parameters for the RPCClient.BeginLongRunningRPC method.
 func (client *RPCClient) BeginLongRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RPCClientBeginLongRunningRPCOptions) (*runtime.Poller[RPCClientLongRunningRPCResponse], error) {
@@ -39,6 +42,9 @@ func (client *RPCClient) BeginLongRunningRPC(ctx context.Context, generationOpti
 }
 
 // LongRunningRPC - Generate data.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 func (client *RPCClient) longRunningRPC(ctx context.Context, generationOptions GenerationOptions, options *RPCClientBeginLongRunningRPCOptions) (*http.Response, error) {
 	var err error
 	const operationName = "RPCClient.BeginLongRunningRPC"

--- a/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_standard_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/core/lro/lrostdgroup/zz_standard_client.go
@@ -22,6 +22,9 @@ type StandardClient struct {
 }
 
 // BeginCreateOrReplace - Adds a user or replaces a user's fields.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - name - The name of user.
 //   - resource - The resource instance.
 //   - options - StandardClientBeginCreateOrReplaceOptions contains the optional parameters for the StandardClient.BeginCreateOrReplace
@@ -44,6 +47,9 @@ func (client *StandardClient) BeginCreateOrReplace(ctx context.Context, name str
 }
 
 // CreateOrReplace - Adds a user or replaces a user's fields.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 func (client *StandardClient) createOrReplace(ctx context.Context, name string, resource User, options *StandardClientBeginCreateOrReplaceOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginCreateOrReplace"
@@ -88,6 +94,9 @@ func (client *StandardClient) createOrReplaceCreateRequest(ctx context.Context, 
 }
 
 // BeginDelete - Deletes a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - name - The name of user.
 //   - options - StandardClientBeginDeleteOptions contains the optional parameters for the StandardClient.BeginDelete method.
 func (client *StandardClient) BeginDelete(ctx context.Context, name string, options *StandardClientBeginDeleteOptions) (*runtime.Poller[StandardClientDeleteResponse], error) {
@@ -108,6 +117,9 @@ func (client *StandardClient) BeginDelete(ctx context.Context, name string, opti
 }
 
 // Delete - Deletes a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 func (client *StandardClient) deleteOperation(ctx context.Context, name string, options *StandardClientBeginDeleteOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginDelete"
@@ -148,6 +160,9 @@ func (client *StandardClient) deleteCreateRequest(ctx context.Context, name stri
 }
 
 // BeginExport - Exports a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 //   - name - The name of user.
 //   - formatParam - The format of the data.
 //   - options - StandardClientBeginExportOptions contains the optional parameters for the StandardClient.BeginExport method.
@@ -169,6 +184,9 @@ func (client *StandardClient) BeginExport(ctx context.Context, name string, form
 }
 
 // Export - Exports a user.
+// If the operation fails it returns an *azcore.ResponseError type.
+//
+// Generated from API version 2022-12-01-preview
 func (client *StandardClient) export(ctx context.Context, name string, formatParam string, options *StandardClientBeginExportOptions) (*http.Response, error) {
 	var err error
 	const operationName = "StandardClient.BeginExport"

--- a/packages/typespec-go/test/cadlranch/azure/special-headers/xmsclientreqidgroup/zz_xmsclientrequestid_client.go
+++ b/packages/typespec-go/test/cadlranch/azure/special-headers/xmsclientreqidgroup/zz_xmsclientrequestid_client.go
@@ -19,6 +19,7 @@ type XMSClientRequestIDClient struct {
 }
 
 // Get - Get operation with azure `x-ms-client-request-id` header.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - XMSClientRequestIDClientGetOptions contains the optional parameters for the XMSClientRequestIDClient.Get method.
 func (client *XMSClientRequestIDClient) Get(ctx context.Context, options *XMSClientRequestIDClientGetOptions) (XMSClientRequestIDClientGetResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/client/naminggroup/zz_naming_client.go
+++ b/packages/typespec-go/test/cadlranch/client/naminggroup/zz_naming_client.go
@@ -32,7 +32,9 @@ func (client *NamingClient) NewNamingUnionEnumClient() *NamingUnionEnumClient {
 	}
 }
 
-// - options - NamingClientClientOptions contains the optional parameters for the NamingClient.Client method.
+// Client -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientClientOptions contains the optional parameters for the NamingClient.Client method.
 func (client *NamingClient) Client(ctx context.Context, clientNameModel ClientNameModel, options *NamingClientClientOptions) (NamingClientClientResponse, error) {
 	var err error
 	const operationName = "NamingClient.Client"
@@ -68,7 +70,9 @@ func (client *NamingClient) clientCreateRequest(ctx context.Context, clientNameM
 	return req, nil
 }
 
-// - options - NamingClientClientNameOptions contains the optional parameters for the NamingClient.ClientName method.
+// ClientName -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientClientNameOptions contains the optional parameters for the NamingClient.ClientName method.
 func (client *NamingClient) ClientName(ctx context.Context, options *NamingClientClientNameOptions) (NamingClientClientNameResponse, error) {
 	var err error
 	const operationName = "NamingClient.ClientName"
@@ -100,6 +104,8 @@ func (client *NamingClient) clientNameCreateRequest(ctx context.Context, _ *Nami
 	return req, nil
 }
 
+// CompatibleWithEncodedName -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NamingClientCompatibleWithEncodedNameOptions contains the optional parameters for the NamingClient.CompatibleWithEncodedName
 //     method.
 func (client *NamingClient) CompatibleWithEncodedName(ctx context.Context, clientNameAndJSONEncodedNameModel ClientNameAndJSONEncodedNameModel, options *NamingClientCompatibleWithEncodedNameOptions) (NamingClientCompatibleWithEncodedNameResponse, error) {
@@ -137,7 +143,9 @@ func (client *NamingClient) compatibleWithEncodedNameCreateRequest(ctx context.C
 	return req, nil
 }
 
-// - options - NamingClientLanguageOptions contains the optional parameters for the NamingClient.Language method.
+// Language -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientLanguageOptions contains the optional parameters for the NamingClient.Language method.
 func (client *NamingClient) Language(ctx context.Context, languageClientNameModel LanguageClientNameModel, options *NamingClientLanguageOptions) (NamingClientLanguageResponse, error) {
 	var err error
 	const operationName = "NamingClient.Language"
@@ -173,7 +181,9 @@ func (client *NamingClient) languageCreateRequest(ctx context.Context, languageC
 	return req, nil
 }
 
-// - options - NamingClientParameterOptions contains the optional parameters for the NamingClient.Parameter method.
+// Parameter -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientParameterOptions contains the optional parameters for the NamingClient.Parameter method.
 func (client *NamingClient) Parameter(ctx context.Context, clientName string, options *NamingClientParameterOptions) (NamingClientParameterResponse, error) {
 	var err error
 	const operationName = "NamingClient.Parameter"
@@ -208,7 +218,9 @@ func (client *NamingClient) parameterCreateRequest(ctx context.Context, clientNa
 	return req, nil
 }
 
-// - options - NamingClientRequestOptions contains the optional parameters for the NamingClient.Request method.
+// Request -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientRequestOptions contains the optional parameters for the NamingClient.Request method.
 func (client *NamingClient) Request(ctx context.Context, clientName string, options *NamingClientRequestOptions) (NamingClientRequestResponse, error) {
 	var err error
 	const operationName = "NamingClient.Request"
@@ -241,7 +253,9 @@ func (client *NamingClient) requestCreateRequest(ctx context.Context, clientName
 	return req, nil
 }
 
-// - options - NamingClientResponseOptions contains the optional parameters for the NamingClient.Response method.
+// Response -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingClientResponseOptions contains the optional parameters for the NamingClient.Response method.
 func (client *NamingClient) Response(ctx context.Context, options *NamingClientResponseOptions) (NamingClientResponseResponse, error) {
 	var err error
 	const operationName = "NamingClient.Response"

--- a/packages/typespec-go/test/cadlranch/client/naminggroup/zz_namingmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/client/naminggroup/zz_namingmodel_client.go
@@ -18,7 +18,9 @@ type NamingModelClient struct {
 	internal *azcore.Client
 }
 
-// - options - NamingModelClientClientOptions contains the optional parameters for the NamingModelClient.Client method.
+// Client -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingModelClientClientOptions contains the optional parameters for the NamingModelClient.Client method.
 func (client *NamingModelClient) Client(ctx context.Context, clientModel ClientModel, options *NamingModelClientClientOptions) (NamingModelClientClientResponse, error) {
 	var err error
 	const operationName = "NamingModelClient.Client"
@@ -54,7 +56,9 @@ func (client *NamingModelClient) clientCreateRequest(ctx context.Context, client
 	return req, nil
 }
 
-// - options - NamingModelClientLanguageOptions contains the optional parameters for the NamingModelClient.Language method.
+// Language -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - NamingModelClientLanguageOptions contains the optional parameters for the NamingModelClient.Language method.
 func (client *NamingModelClient) Language(ctx context.Context, goModel GoModel, options *NamingModelClientLanguageOptions) (NamingModelClientLanguageResponse, error) {
 	var err error
 	const operationName = "NamingModelClient.Language"

--- a/packages/typespec-go/test/cadlranch/client/naminggroup/zz_namingunionenum_client.go
+++ b/packages/typespec-go/test/cadlranch/client/naminggroup/zz_namingunionenum_client.go
@@ -18,6 +18,8 @@ type NamingUnionEnumClient struct {
 	internal *azcore.Client
 }
 
+// UnionEnumMemberName -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NamingUnionEnumClientUnionEnumMemberNameOptions contains the optional parameters for the NamingUnionEnumClient.UnionEnumMemberName
 //     method.
 func (client *NamingUnionEnumClient) UnionEnumMemberName(ctx context.Context, body ExtensibleEnum, options *NamingUnionEnumClientUnionEnumMemberNameOptions) (NamingUnionEnumClientUnionEnumMemberNameResponse, error) {
@@ -55,6 +57,8 @@ func (client *NamingUnionEnumClient) unionEnumMemberNameCreateRequest(ctx contex
 	return req, nil
 }
 
+// UnionEnumName -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NamingUnionEnumClientUnionEnumNameOptions contains the optional parameters for the NamingUnionEnumClient.UnionEnumName
 //     method.
 func (client *NamingUnionEnumClient) UnionEnumName(ctx context.Context, body ClientExtensibleEnum, options *NamingUnionEnumClientUnionEnumNameOptions) (NamingUnionEnumClientUnionEnumNameResponse, error) {

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_service_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_service_client.go
@@ -64,7 +64,9 @@ func (client *ServiceClient) NewServiceQuxClient() *ServiceQuxClient {
 	}
 }
 
-// - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
+// One -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceClientOneOptions contains the optional parameters for the ServiceClient.One method.
 func (client *ServiceClient) One(ctx context.Context, options *ServiceClientOneOptions) (ServiceClientOneResponse, error) {
 	var err error
 	const operationName = "ServiceClient.One"
@@ -99,7 +101,9 @@ func (client *ServiceClient) oneCreateRequest(ctx context.Context, _ *ServiceCli
 	return req, nil
 }
 
-// - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
+// Two -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceClientTwoOptions contains the optional parameters for the ServiceClient.Two method.
 func (client *ServiceClient) Two(ctx context.Context, options *ServiceClientTwoOptions) (ServiceClientTwoResponse, error) {
 	var err error
 	const operationName = "ServiceClient.Two"

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicebar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicebar_client.go
@@ -21,7 +21,9 @@ type ServiceBarClient struct {
 	client   ClientType
 }
 
-// - options - ServiceBarClientFiveOptions contains the optional parameters for the ServiceBarClient.Five method.
+// Five -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceBarClientFiveOptions contains the optional parameters for the ServiceBarClient.Five method.
 func (client *ServiceBarClient) Five(ctx context.Context, options *ServiceBarClientFiveOptions) (ServiceBarClientFiveResponse, error) {
 	var err error
 	const operationName = "ServiceBarClient.Five"
@@ -56,7 +58,9 @@ func (client *ServiceBarClient) fiveCreateRequest(ctx context.Context, _ *Servic
 	return req, nil
 }
 
-// - options - ServiceBarClientSixOptions contains the optional parameters for the ServiceBarClient.Six method.
+// Six -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceBarClientSixOptions contains the optional parameters for the ServiceBarClient.Six method.
 func (client *ServiceBarClient) Six(ctx context.Context, options *ServiceBarClientSixOptions) (ServiceBarClientSixResponse, error) {
 	var err error
 	const operationName = "ServiceBarClient.Six"

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicebazfoo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicebazfoo_client.go
@@ -21,7 +21,9 @@ type ServiceBazFooClient struct {
 	client   ClientType
 }
 
-// - options - ServiceBazFooClientSevenOptions contains the optional parameters for the ServiceBazFooClient.Seven method.
+// Seven -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceBazFooClientSevenOptions contains the optional parameters for the ServiceBazFooClient.Seven method.
 func (client *ServiceBazFooClient) Seven(ctx context.Context, options *ServiceBazFooClientSevenOptions) (ServiceBazFooClientSevenResponse, error) {
 	var err error
 	const operationName = "ServiceBazFooClient.Seven"

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicefoo_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicefoo_client.go
@@ -21,7 +21,9 @@ type ServiceFooClient struct {
 	client   ClientType
 }
 
-// - options - ServiceFooClientFourOptions contains the optional parameters for the ServiceFooClient.Four method.
+// Four -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceFooClientFourOptions contains the optional parameters for the ServiceFooClient.Four method.
 func (client *ServiceFooClient) Four(ctx context.Context, options *ServiceFooClientFourOptions) (ServiceFooClientFourResponse, error) {
 	var err error
 	const operationName = "ServiceFooClient.Four"
@@ -56,7 +58,9 @@ func (client *ServiceFooClient) fourCreateRequest(ctx context.Context, _ *Servic
 	return req, nil
 }
 
-// - options - ServiceFooClientThreeOptions contains the optional parameters for the ServiceFooClient.Three method.
+// Three -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceFooClientThreeOptions contains the optional parameters for the ServiceFooClient.Three method.
 func (client *ServiceFooClient) Three(ctx context.Context, options *ServiceFooClientThreeOptions) (ServiceFooClientThreeResponse, error) {
 	var err error
 	const operationName = "ServiceFooClient.Three"

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicequx_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicequx_client.go
@@ -30,7 +30,9 @@ func (client *ServiceQuxClient) NewServiceQuxBarClient() *ServiceQuxBarClient {
 	}
 }
 
-// - options - ServiceQuxClientEightOptions contains the optional parameters for the ServiceQuxClient.Eight method.
+// Eight -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceQuxClientEightOptions contains the optional parameters for the ServiceQuxClient.Eight method.
 func (client *ServiceQuxClient) Eight(ctx context.Context, options *ServiceQuxClientEightOptions) (ServiceQuxClientEightResponse, error) {
 	var err error
 	const operationName = "ServiceQuxClient.Eight"

--- a/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicequxbar_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/defaultgroup/zz_servicequxbar_client.go
@@ -21,7 +21,9 @@ type ServiceQuxBarClient struct {
 	client   ClientType
 }
 
-// - options - ServiceQuxBarClientNineOptions contains the optional parameters for the ServiceQuxBarClient.Nine method.
+// Nine -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ServiceQuxBarClientNineOptions contains the optional parameters for the ServiceQuxBarClient.Nine method.
 func (client *ServiceQuxBarClient) Nine(ctx context.Context, options *ServiceQuxBarClientNineOptions) (ServiceQuxBarClientNineResponse, error) {
 	var err error
 	const operationName = "ServiceQuxBarClient.Nine"

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_clienta_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_clienta_client.go
@@ -21,7 +21,9 @@ type ClientAClient struct {
 	client   ClientType
 }
 
-// - options - ClientAClientRenamedFiveOptions contains the optional parameters for the ClientAClient.RenamedFive method.
+// RenamedFive -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientAClientRenamedFiveOptions contains the optional parameters for the ClientAClient.RenamedFive method.
 func (client *ClientAClient) RenamedFive(ctx context.Context, options *ClientAClientRenamedFiveOptions) (ClientAClientRenamedFiveResponse, error) {
 	var err error
 	const operationName = "ClientAClient.RenamedFive"
@@ -56,7 +58,9 @@ func (client *ClientAClient) renamedFiveCreateRequest(ctx context.Context, _ *Cl
 	return req, nil
 }
 
-// - options - ClientAClientRenamedOneOptions contains the optional parameters for the ClientAClient.RenamedOne method.
+// RenamedOne -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientAClientRenamedOneOptions contains the optional parameters for the ClientAClient.RenamedOne method.
 func (client *ClientAClient) RenamedOne(ctx context.Context, options *ClientAClientRenamedOneOptions) (ClientAClientRenamedOneResponse, error) {
 	var err error
 	const operationName = "ClientAClient.RenamedOne"
@@ -91,7 +95,9 @@ func (client *ClientAClient) renamedOneCreateRequest(ctx context.Context, _ *Cli
 	return req, nil
 }
 
-// - options - ClientAClientRenamedThreeOptions contains the optional parameters for the ClientAClient.RenamedThree method.
+// RenamedThree -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientAClientRenamedThreeOptions contains the optional parameters for the ClientAClient.RenamedThree method.
 func (client *ClientAClient) RenamedThree(ctx context.Context, options *ClientAClientRenamedThreeOptions) (ClientAClientRenamedThreeResponse, error) {
 	var err error
 	const operationName = "ClientAClient.RenamedThree"

--- a/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_clientb_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/multiclientgroup/zz_clientb_client.go
@@ -21,7 +21,9 @@ type ClientBClient struct {
 	client   ClientType
 }
 
-// - options - ClientBClientRenamedFourOptions contains the optional parameters for the ClientBClient.RenamedFour method.
+// RenamedFour -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientBClientRenamedFourOptions contains the optional parameters for the ClientBClient.RenamedFour method.
 func (client *ClientBClient) RenamedFour(ctx context.Context, options *ClientBClientRenamedFourOptions) (ClientBClientRenamedFourResponse, error) {
 	var err error
 	const operationName = "ClientBClient.RenamedFour"
@@ -56,7 +58,9 @@ func (client *ClientBClient) renamedFourCreateRequest(ctx context.Context, _ *Cl
 	return req, nil
 }
 
-// - options - ClientBClientRenamedSixOptions contains the optional parameters for the ClientBClient.RenamedSix method.
+// RenamedSix -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientBClientRenamedSixOptions contains the optional parameters for the ClientBClient.RenamedSix method.
 func (client *ClientBClient) RenamedSix(ctx context.Context, options *ClientBClientRenamedSixOptions) (ClientBClientRenamedSixResponse, error) {
 	var err error
 	const operationName = "ClientBClient.RenamedSix"
@@ -91,7 +95,9 @@ func (client *ClientBClient) renamedSixCreateRequest(ctx context.Context, _ *Cli
 	return req, nil
 }
 
-// - options - ClientBClientRenamedTwoOptions contains the optional parameters for the ClientBClient.RenamedTwo method.
+// RenamedTwo -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ClientBClientRenamedTwoOptions contains the optional parameters for the ClientBClient.RenamedTwo method.
 func (client *ClientBClient) RenamedTwo(ctx context.Context, options *ClientBClientRenamedTwoOptions) (ClientBClientRenamedTwoResponse, error) {
 	var err error
 	const operationName = "ClientBClient.RenamedTwo"

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_renamedoperation_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_renamedoperation_client.go
@@ -30,6 +30,8 @@ func (client *RenamedOperationClient) NewRenamedOperationGroupClient() *RenamedO
 	}
 }
 
+// RenamedFive -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationClientRenamedFiveOptions contains the optional parameters for the RenamedOperationClient.RenamedFive
 //     method.
 func (client *RenamedOperationClient) RenamedFive(ctx context.Context, options *RenamedOperationClientRenamedFiveOptions) (RenamedOperationClientRenamedFiveResponse, error) {
@@ -66,6 +68,8 @@ func (client *RenamedOperationClient) renamedFiveCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// RenamedOne -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationClientRenamedOneOptions contains the optional parameters for the RenamedOperationClient.RenamedOne
 //     method.
 func (client *RenamedOperationClient) RenamedOne(ctx context.Context, options *RenamedOperationClientRenamedOneOptions) (RenamedOperationClientRenamedOneResponse, error) {
@@ -102,6 +106,8 @@ func (client *RenamedOperationClient) renamedOneCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// RenamedThree -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationClientRenamedThreeOptions contains the optional parameters for the RenamedOperationClient.RenamedThree
 //     method.
 func (client *RenamedOperationClient) RenamedThree(ctx context.Context, options *RenamedOperationClientRenamedThreeOptions) (RenamedOperationClientRenamedThreeResponse, error) {

--- a/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_renamedoperationgroup_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/renamedopgroup/zz_renamedoperationgroup_client.go
@@ -21,6 +21,8 @@ type RenamedOperationGroupClient struct {
 	client   ClientType
 }
 
+// RenamedFour -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationGroupClientRenamedFourOptions contains the optional parameters for the RenamedOperationGroupClient.RenamedFour
 //     method.
 func (client *RenamedOperationGroupClient) RenamedFour(ctx context.Context, options *RenamedOperationGroupClientRenamedFourOptions) (RenamedOperationGroupClientRenamedFourResponse, error) {
@@ -57,6 +59,8 @@ func (client *RenamedOperationGroupClient) renamedFourCreateRequest(ctx context.
 	return req, nil
 }
 
+// RenamedSix -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationGroupClientRenamedSixOptions contains the optional parameters for the RenamedOperationGroupClient.RenamedSix
 //     method.
 func (client *RenamedOperationGroupClient) RenamedSix(ctx context.Context, options *RenamedOperationGroupClientRenamedSixOptions) (RenamedOperationGroupClientRenamedSixResponse, error) {
@@ -93,6 +97,8 @@ func (client *RenamedOperationGroupClient) renamedSixCreateRequest(ctx context.C
 	return req, nil
 }
 
+// RenamedTwo -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - RenamedOperationGroupClientRenamedTwoOptions contains the optional parameters for the RenamedOperationGroupClient.RenamedTwo
 //     method.
 func (client *RenamedOperationGroupClient) RenamedTwo(ctx context.Context, options *RenamedOperationGroupClientRenamedTwoOptions) (RenamedOperationGroupClientRenamedTwoResponse, error) {

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_twooperationgroupgroup1_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_twooperationgroupgroup1_client.go
@@ -21,6 +21,8 @@ type TwoOperationGroupGroup1Client struct {
 	client   ClientType
 }
 
+// Four -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup1ClientFourOptions contains the optional parameters for the TwoOperationGroupGroup1Client.Four
 //     method.
 func (client *TwoOperationGroupGroup1Client) Four(ctx context.Context, options *TwoOperationGroupGroup1ClientFourOptions) (TwoOperationGroupGroup1ClientFourResponse, error) {
@@ -57,6 +59,8 @@ func (client *TwoOperationGroupGroup1Client) fourCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// One -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup1ClientOneOptions contains the optional parameters for the TwoOperationGroupGroup1Client.One
 //     method.
 func (client *TwoOperationGroupGroup1Client) One(ctx context.Context, options *TwoOperationGroupGroup1ClientOneOptions) (TwoOperationGroupGroup1ClientOneResponse, error) {
@@ -93,6 +97,8 @@ func (client *TwoOperationGroupGroup1Client) oneCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Three -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup1ClientThreeOptions contains the optional parameters for the TwoOperationGroupGroup1Client.Three
 //     method.
 func (client *TwoOperationGroupGroup1Client) Three(ctx context.Context, options *TwoOperationGroupGroup1ClientThreeOptions) (TwoOperationGroupGroup1ClientThreeResponse, error) {

--- a/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_twooperationgroupgroup2_client.go
+++ b/packages/typespec-go/test/cadlranch/client/structure/twoopgroup/zz_twooperationgroupgroup2_client.go
@@ -21,6 +21,8 @@ type TwoOperationGroupGroup2Client struct {
 	client   ClientType
 }
 
+// Five -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup2ClientFiveOptions contains the optional parameters for the TwoOperationGroupGroup2Client.Five
 //     method.
 func (client *TwoOperationGroupGroup2Client) Five(ctx context.Context, options *TwoOperationGroupGroup2ClientFiveOptions) (TwoOperationGroupGroup2ClientFiveResponse, error) {
@@ -57,6 +59,8 @@ func (client *TwoOperationGroupGroup2Client) fiveCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Six -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup2ClientSixOptions contains the optional parameters for the TwoOperationGroupGroup2Client.Six
 //     method.
 func (client *TwoOperationGroupGroup2Client) Six(ctx context.Context, options *TwoOperationGroupGroup2ClientSixOptions) (TwoOperationGroupGroup2ClientSixResponse, error) {
@@ -93,6 +97,8 @@ func (client *TwoOperationGroupGroup2Client) sixCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Two -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - TwoOperationGroupGroup2ClientTwoOptions contains the optional parameters for the TwoOperationGroupGroup2Client.Two
 //     method.
 func (client *TwoOperationGroupGroup2Client) Two(ctx context.Context, options *TwoOperationGroupGroup2ClientTwoOptions) (TwoOperationGroupGroup2ClientTwoResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesheader_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesheader_client.go
@@ -20,7 +20,9 @@ type BytesHeaderClient struct {
 	internal *azcore.Client
 }
 
-// - options - BytesHeaderClientBase64Options contains the optional parameters for the BytesHeaderClient.Base64 method.
+// Base64 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesHeaderClientBase64Options contains the optional parameters for the BytesHeaderClient.Base64 method.
 func (client *BytesHeaderClient) Base64(ctx context.Context, value []byte, options *BytesHeaderClientBase64Options) (BytesHeaderClientBase64Response, error) {
 	var err error
 	const operationName = "BytesHeaderClient.Base64"
@@ -53,7 +55,9 @@ func (client *BytesHeaderClient) base64CreateRequest(ctx context.Context, value 
 	return req, nil
 }
 
-// - options - BytesHeaderClientBase64URLOptions contains the optional parameters for the BytesHeaderClient.Base64URL method.
+// Base64URL -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesHeaderClientBase64URLOptions contains the optional parameters for the BytesHeaderClient.Base64URL method.
 func (client *BytesHeaderClient) Base64URL(ctx context.Context, value []byte, options *BytesHeaderClientBase64URLOptions) (BytesHeaderClientBase64URLResponse, error) {
 	var err error
 	const operationName = "BytesHeaderClient.Base64URL"
@@ -86,6 +90,8 @@ func (client *BytesHeaderClient) base64URLCreateRequest(ctx context.Context, val
 	return req, nil
 }
 
+// Base64URLArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesHeaderClientBase64URLArrayOptions contains the optional parameters for the BytesHeaderClient.Base64URLArray
 //     method.
 func (client *BytesHeaderClient) Base64URLArray(ctx context.Context, value [][]byte, options *BytesHeaderClientBase64URLArrayOptions) (BytesHeaderClientBase64URLArrayResponse, error) {
@@ -126,7 +132,9 @@ func (client *BytesHeaderClient) base64URLArrayCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// - options - BytesHeaderClientDefaultOptions contains the optional parameters for the BytesHeaderClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesHeaderClientDefaultOptions contains the optional parameters for the BytesHeaderClient.Default method.
 func (client *BytesHeaderClient) Default(ctx context.Context, value []byte, options *BytesHeaderClientDefaultOptions) (BytesHeaderClientDefaultResponse, error) {
 	var err error
 	const operationName = "BytesHeaderClient.Default"

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesproperty_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesproperty_client.go
@@ -18,7 +18,9 @@ type BytesPropertyClient struct {
 	internal *azcore.Client
 }
 
-// - options - BytesPropertyClientBase64Options contains the optional parameters for the BytesPropertyClient.Base64 method.
+// Base64 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesPropertyClientBase64Options contains the optional parameters for the BytesPropertyClient.Base64 method.
 func (client *BytesPropertyClient) Base64(ctx context.Context, body Base64BytesProperty, options *BytesPropertyClientBase64Options) (BytesPropertyClientBase64Response, error) {
 	var err error
 	const operationName = "BytesPropertyClient.Base64"
@@ -65,7 +67,9 @@ func (client *BytesPropertyClient) base64HandleResponse(resp *http.Response) (By
 	return result, nil
 }
 
-// - options - BytesPropertyClientBase64URLOptions contains the optional parameters for the BytesPropertyClient.Base64URL method.
+// Base64URL -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesPropertyClientBase64URLOptions contains the optional parameters for the BytesPropertyClient.Base64URL method.
 func (client *BytesPropertyClient) Base64URL(ctx context.Context, body Base64URLBytesProperty, options *BytesPropertyClientBase64URLOptions) (BytesPropertyClientBase64URLResponse, error) {
 	var err error
 	const operationName = "BytesPropertyClient.Base64URL"
@@ -112,6 +116,8 @@ func (client *BytesPropertyClient) base64URLHandleResponse(resp *http.Response) 
 	return result, nil
 }
 
+// Base64URLArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesPropertyClientBase64URLArrayOptions contains the optional parameters for the BytesPropertyClient.Base64URLArray
 //     method.
 func (client *BytesPropertyClient) Base64URLArray(ctx context.Context, body Base64URLArrayBytesProperty, options *BytesPropertyClientBase64URLArrayOptions) (BytesPropertyClientBase64URLArrayResponse, error) {
@@ -160,7 +166,9 @@ func (client *BytesPropertyClient) base64URLArrayHandleResponse(resp *http.Respo
 	return result, nil
 }
 
-// - options - BytesPropertyClientDefaultOptions contains the optional parameters for the BytesPropertyClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesPropertyClientDefaultOptions contains the optional parameters for the BytesPropertyClient.Default method.
 func (client *BytesPropertyClient) Default(ctx context.Context, body DefaultBytesProperty, options *BytesPropertyClientDefaultOptions) (BytesPropertyClientDefaultResponse, error) {
 	var err error
 	const operationName = "BytesPropertyClient.Default"

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesquery_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesquery_client.go
@@ -20,7 +20,9 @@ type BytesQueryClient struct {
 	internal *azcore.Client
 }
 
-// - options - BytesQueryClientBase64Options contains the optional parameters for the BytesQueryClient.Base64 method.
+// Base64 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesQueryClientBase64Options contains the optional parameters for the BytesQueryClient.Base64 method.
 func (client *BytesQueryClient) Base64(ctx context.Context, value []byte, options *BytesQueryClientBase64Options) (BytesQueryClientBase64Response, error) {
 	var err error
 	const operationName = "BytesQueryClient.Base64"
@@ -55,7 +57,9 @@ func (client *BytesQueryClient) base64CreateRequest(ctx context.Context, value [
 	return req, nil
 }
 
-// - options - BytesQueryClientBase64URLOptions contains the optional parameters for the BytesQueryClient.Base64URL method.
+// Base64URL -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesQueryClientBase64URLOptions contains the optional parameters for the BytesQueryClient.Base64URL method.
 func (client *BytesQueryClient) Base64URL(ctx context.Context, value []byte, options *BytesQueryClientBase64URLOptions) (BytesQueryClientBase64URLResponse, error) {
 	var err error
 	const operationName = "BytesQueryClient.Base64URL"
@@ -90,6 +94,8 @@ func (client *BytesQueryClient) base64URLCreateRequest(ctx context.Context, valu
 	return req, nil
 }
 
+// Base64URLArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesQueryClientBase64URLArrayOptions contains the optional parameters for the BytesQueryClient.Base64URLArray
 //     method.
 func (client *BytesQueryClient) Base64URLArray(ctx context.Context, value [][]byte, options *BytesQueryClientBase64URLArrayOptions) (BytesQueryClientBase64URLArrayResponse, error) {
@@ -132,7 +138,9 @@ func (client *BytesQueryClient) base64URLArrayCreateRequest(ctx context.Context,
 	return req, nil
 }
 
-// - options - BytesQueryClientDefaultOptions contains the optional parameters for the BytesQueryClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesQueryClientDefaultOptions contains the optional parameters for the BytesQueryClient.Default method.
 func (client *BytesQueryClient) Default(ctx context.Context, value []byte, options *BytesQueryClientDefaultOptions) (BytesQueryClientDefaultResponse, error) {
 	var err error
 	const operationName = "BytesQueryClient.Default"

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesrequestbody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesrequestbody_client.go
@@ -19,7 +19,9 @@ type BytesRequestBodyClient struct {
 	internal *azcore.Client
 }
 
-// - options - BytesRequestBodyClientBase64Options contains the optional parameters for the BytesRequestBodyClient.Base64 method.
+// Base64 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - BytesRequestBodyClientBase64Options contains the optional parameters for the BytesRequestBodyClient.Base64 method.
 func (client *BytesRequestBodyClient) Base64(ctx context.Context, value []byte, options *BytesRequestBodyClientBase64Options) (BytesRequestBodyClientBase64Response, error) {
 	var err error
 	const operationName = "BytesRequestBodyClient.Base64"
@@ -55,6 +57,8 @@ func (client *BytesRequestBodyClient) base64CreateRequest(ctx context.Context, v
 	return req, nil
 }
 
+// Base64URL -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesRequestBodyClientBase64URLOptions contains the optional parameters for the BytesRequestBodyClient.Base64URL
 //     method.
 func (client *BytesRequestBodyClient) Base64URL(ctx context.Context, value []byte, options *BytesRequestBodyClientBase64URLOptions) (BytesRequestBodyClientBase64URLResponse, error) {
@@ -92,6 +96,8 @@ func (client *BytesRequestBodyClient) base64URLCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// CustomContentType -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesRequestBodyClientCustomContentTypeOptions contains the optional parameters for the BytesRequestBodyClient.CustomContentType
 //     method.
 func (client *BytesRequestBodyClient) CustomContentType(ctx context.Context, value io.ReadSeekCloser, options *BytesRequestBodyClientCustomContentTypeOptions) (BytesRequestBodyClientCustomContentTypeResponse, error) {
@@ -129,6 +135,8 @@ func (client *BytesRequestBodyClient) customContentTypeCreateRequest(ctx context
 	return req, nil
 }
 
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesRequestBodyClientDefaultOptions contains the optional parameters for the BytesRequestBodyClient.Default
 //     method.
 func (client *BytesRequestBodyClient) Default(ctx context.Context, value []byte, options *BytesRequestBodyClientDefaultOptions) (BytesRequestBodyClientDefaultResponse, error) {
@@ -166,6 +174,8 @@ func (client *BytesRequestBodyClient) defaultCreateRequest(ctx context.Context, 
 	return req, nil
 }
 
+// OctetStream -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesRequestBodyClientOctetStreamOptions contains the optional parameters for the BytesRequestBodyClient.OctetStream
 //     method.
 func (client *BytesRequestBodyClient) OctetStream(ctx context.Context, value io.ReadSeekCloser, options *BytesRequestBodyClientOctetStreamOptions) (BytesRequestBodyClientOctetStreamResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesresponsebody_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/bytesgroup/zz_bytesresponsebody_client.go
@@ -18,6 +18,8 @@ type BytesResponseBodyClient struct {
 	internal *azcore.Client
 }
 
+// Base64 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesResponseBodyClientBase64Options contains the optional parameters for the BytesResponseBodyClient.Base64
 //     method.
 func (client *BytesResponseBodyClient) Base64(ctx context.Context, options *BytesResponseBodyClientBase64Options) (BytesResponseBodyClientBase64Response, error) {
@@ -62,6 +64,8 @@ func (client *BytesResponseBodyClient) base64HandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Base64URL -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesResponseBodyClientBase64URLOptions contains the optional parameters for the BytesResponseBodyClient.Base64URL
 //     method.
 func (client *BytesResponseBodyClient) Base64URL(ctx context.Context, options *BytesResponseBodyClientBase64URLOptions) (BytesResponseBodyClientBase64URLResponse, error) {
@@ -106,6 +110,8 @@ func (client *BytesResponseBodyClient) base64URLHandleResponse(resp *http.Respon
 	return result, nil
 }
 
+// CustomContentType -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesResponseBodyClientCustomContentTypeOptions contains the optional parameters for the BytesResponseBodyClient.CustomContentType
 //     method.
 func (client *BytesResponseBodyClient) CustomContentType(ctx context.Context, options *BytesResponseBodyClientCustomContentTypeOptions) (BytesResponseBodyClientCustomContentTypeResponse, error) {
@@ -141,6 +147,8 @@ func (client *BytesResponseBodyClient) customContentTypeCreateRequest(ctx contex
 	return req, nil
 }
 
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesResponseBodyClientDefaultOptions contains the optional parameters for the BytesResponseBodyClient.Default
 //     method.
 func (client *BytesResponseBodyClient) Default(ctx context.Context, options *BytesResponseBodyClientDefaultOptions) (BytesResponseBodyClientDefaultResponse, error) {
@@ -185,6 +193,8 @@ func (client *BytesResponseBodyClient) defaultHandleResponse(resp *http.Response
 	return result, nil
 }
 
+// OctetStream -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BytesResponseBodyClientOctetStreamOptions contains the optional parameters for the BytesResponseBodyClient.OctetStream
 //     method.
 func (client *BytesResponseBodyClient) OctetStream(ctx context.Context, options *BytesResponseBodyClientOctetStreamOptions) (BytesResponseBodyClientOctetStreamResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeheader_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeheader_client.go
@@ -20,7 +20,9 @@ type DatetimeHeaderClient struct {
 	internal *azcore.Client
 }
 
-// - options - DatetimeHeaderClientDefaultOptions contains the optional parameters for the DatetimeHeaderClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeHeaderClientDefaultOptions contains the optional parameters for the DatetimeHeaderClient.Default method.
 func (client *DatetimeHeaderClient) Default(ctx context.Context, value time.Time, options *DatetimeHeaderClientDefaultOptions) (DatetimeHeaderClientDefaultResponse, error) {
 	var err error
 	const operationName = "DatetimeHeaderClient.Default"
@@ -53,7 +55,9 @@ func (client *DatetimeHeaderClient) defaultCreateRequest(ctx context.Context, va
 	return req, nil
 }
 
-// - options - DatetimeHeaderClientRFC3339Options contains the optional parameters for the DatetimeHeaderClient.RFC3339 method.
+// RFC3339 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeHeaderClientRFC3339Options contains the optional parameters for the DatetimeHeaderClient.RFC3339 method.
 func (client *DatetimeHeaderClient) RFC3339(ctx context.Context, value time.Time, options *DatetimeHeaderClientRFC3339Options) (DatetimeHeaderClientRFC3339Response, error) {
 	var err error
 	const operationName = "DatetimeHeaderClient.RFC3339"
@@ -86,7 +90,9 @@ func (client *DatetimeHeaderClient) rfc3339CreateRequest(ctx context.Context, va
 	return req, nil
 }
 
-// - options - DatetimeHeaderClientRFC7231Options contains the optional parameters for the DatetimeHeaderClient.RFC7231 method.
+// RFC7231 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeHeaderClientRFC7231Options contains the optional parameters for the DatetimeHeaderClient.RFC7231 method.
 func (client *DatetimeHeaderClient) RFC7231(ctx context.Context, value time.Time, options *DatetimeHeaderClientRFC7231Options) (DatetimeHeaderClientRFC7231Response, error) {
 	var err error
 	const operationName = "DatetimeHeaderClient.RFC7231"
@@ -119,6 +125,8 @@ func (client *DatetimeHeaderClient) rfc7231CreateRequest(ctx context.Context, va
 	return req, nil
 }
 
+// UnixTimestamp -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeHeaderClientUnixTimestampOptions contains the optional parameters for the DatetimeHeaderClient.UnixTimestamp
 //     method.
 func (client *DatetimeHeaderClient) UnixTimestamp(ctx context.Context, value time.Time, options *DatetimeHeaderClientUnixTimestampOptions) (DatetimeHeaderClientUnixTimestampResponse, error) {
@@ -153,6 +161,8 @@ func (client *DatetimeHeaderClient) unixTimestampCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// UnixTimestampArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeHeaderClientUnixTimestampArrayOptions contains the optional parameters for the DatetimeHeaderClient.UnixTimestampArray
 //     method.
 func (client *DatetimeHeaderClient) UnixTimestampArray(ctx context.Context, value []time.Time, options *DatetimeHeaderClientUnixTimestampArrayOptions) (DatetimeHeaderClientUnixTimestampArrayResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeproperty_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeproperty_client.go
@@ -18,6 +18,8 @@ type DatetimePropertyClient struct {
 	internal *azcore.Client
 }
 
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimePropertyClientDefaultOptions contains the optional parameters for the DatetimePropertyClient.Default
 //     method.
 func (client *DatetimePropertyClient) Default(ctx context.Context, body DefaultDatetimeProperty, options *DatetimePropertyClientDefaultOptions) (DatetimePropertyClientDefaultResponse, error) {
@@ -66,6 +68,8 @@ func (client *DatetimePropertyClient) defaultHandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// RFC3339 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimePropertyClientRFC3339Options contains the optional parameters for the DatetimePropertyClient.RFC3339
 //     method.
 func (client *DatetimePropertyClient) RFC3339(ctx context.Context, body RFC3339DatetimeProperty, options *DatetimePropertyClientRFC3339Options) (DatetimePropertyClientRFC3339Response, error) {
@@ -114,6 +118,8 @@ func (client *DatetimePropertyClient) rfc3339HandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// RFC7231 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimePropertyClientRFC7231Options contains the optional parameters for the DatetimePropertyClient.RFC7231
 //     method.
 func (client *DatetimePropertyClient) RFC7231(ctx context.Context, body RFC7231DatetimeProperty, options *DatetimePropertyClientRFC7231Options) (DatetimePropertyClientRFC7231Response, error) {
@@ -162,6 +168,8 @@ func (client *DatetimePropertyClient) rfc7231HandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// UnixTimestamp -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimePropertyClientUnixTimestampOptions contains the optional parameters for the DatetimePropertyClient.UnixTimestamp
 //     method.
 func (client *DatetimePropertyClient) UnixTimestamp(ctx context.Context, body UnixTimestampDatetimeProperty, options *DatetimePropertyClientUnixTimestampOptions) (DatetimePropertyClientUnixTimestampResponse, error) {
@@ -210,6 +218,8 @@ func (client *DatetimePropertyClient) unixTimestampHandleResponse(resp *http.Res
 	return result, nil
 }
 
+// UnixTimestampArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimePropertyClientUnixTimestampArrayOptions contains the optional parameters for the DatetimePropertyClient.UnixTimestampArray
 //     method.
 func (client *DatetimePropertyClient) UnixTimestampArray(ctx context.Context, body UnixTimestampArrayDatetimeProperty, options *DatetimePropertyClientUnixTimestampArrayOptions) (DatetimePropertyClientUnixTimestampArrayResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimequery_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimequery_client.go
@@ -20,7 +20,9 @@ type DatetimeQueryClient struct {
 	internal *azcore.Client
 }
 
-// - options - DatetimeQueryClientDefaultOptions contains the optional parameters for the DatetimeQueryClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeQueryClientDefaultOptions contains the optional parameters for the DatetimeQueryClient.Default method.
 func (client *DatetimeQueryClient) Default(ctx context.Context, value time.Time, options *DatetimeQueryClientDefaultOptions) (DatetimeQueryClientDefaultResponse, error) {
 	var err error
 	const operationName = "DatetimeQueryClient.Default"
@@ -55,7 +57,9 @@ func (client *DatetimeQueryClient) defaultCreateRequest(ctx context.Context, val
 	return req, nil
 }
 
-// - options - DatetimeQueryClientRFC3339Options contains the optional parameters for the DatetimeQueryClient.RFC3339 method.
+// RFC3339 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeQueryClientRFC3339Options contains the optional parameters for the DatetimeQueryClient.RFC3339 method.
 func (client *DatetimeQueryClient) RFC3339(ctx context.Context, value time.Time, options *DatetimeQueryClientRFC3339Options) (DatetimeQueryClientRFC3339Response, error) {
 	var err error
 	const operationName = "DatetimeQueryClient.RFC3339"
@@ -90,7 +94,9 @@ func (client *DatetimeQueryClient) rfc3339CreateRequest(ctx context.Context, val
 	return req, nil
 }
 
-// - options - DatetimeQueryClientRFC7231Options contains the optional parameters for the DatetimeQueryClient.RFC7231 method.
+// RFC7231 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DatetimeQueryClientRFC7231Options contains the optional parameters for the DatetimeQueryClient.RFC7231 method.
 func (client *DatetimeQueryClient) RFC7231(ctx context.Context, value time.Time, options *DatetimeQueryClientRFC7231Options) (DatetimeQueryClientRFC7231Response, error) {
 	var err error
 	const operationName = "DatetimeQueryClient.RFC7231"
@@ -125,6 +131,8 @@ func (client *DatetimeQueryClient) rfc7231CreateRequest(ctx context.Context, val
 	return req, nil
 }
 
+// UnixTimestamp -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeQueryClientUnixTimestampOptions contains the optional parameters for the DatetimeQueryClient.UnixTimestamp
 //     method.
 func (client *DatetimeQueryClient) UnixTimestamp(ctx context.Context, value time.Time, options *DatetimeQueryClientUnixTimestampOptions) (DatetimeQueryClientUnixTimestampResponse, error) {
@@ -161,6 +169,8 @@ func (client *DatetimeQueryClient) unixTimestampCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// UnixTimestampArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeQueryClientUnixTimestampArrayOptions contains the optional parameters for the DatetimeQueryClient.UnixTimestampArray
 //     method.
 func (client *DatetimeQueryClient) UnixTimestampArray(ctx context.Context, value []time.Time, options *DatetimeQueryClientUnixTimestampArrayOptions) (DatetimeQueryClientUnixTimestampArrayResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeresponseheader_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/datetimegroup/zz_datetimeresponseheader_client.go
@@ -21,6 +21,8 @@ type DatetimeResponseHeaderClient struct {
 	internal *azcore.Client
 }
 
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeResponseHeaderClientDefaultOptions contains the optional parameters for the DatetimeResponseHeaderClient.Default
 //     method.
 func (client *DatetimeResponseHeaderClient) Default(ctx context.Context, options *DatetimeResponseHeaderClientDefaultOptions) (DatetimeResponseHeaderClientDefaultResponse, error) {
@@ -68,6 +70,8 @@ func (client *DatetimeResponseHeaderClient) defaultHandleResponse(resp *http.Res
 	return result, nil
 }
 
+// RFC3339 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeResponseHeaderClientRFC3339Options contains the optional parameters for the DatetimeResponseHeaderClient.RFC3339
 //     method.
 func (client *DatetimeResponseHeaderClient) RFC3339(ctx context.Context, options *DatetimeResponseHeaderClientRFC3339Options) (DatetimeResponseHeaderClientRFC3339Response, error) {
@@ -115,6 +119,8 @@ func (client *DatetimeResponseHeaderClient) rfc3339HandleResponse(resp *http.Res
 	return result, nil
 }
 
+// RFC7231 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeResponseHeaderClientRFC7231Options contains the optional parameters for the DatetimeResponseHeaderClient.RFC7231
 //     method.
 func (client *DatetimeResponseHeaderClient) RFC7231(ctx context.Context, options *DatetimeResponseHeaderClientRFC7231Options) (DatetimeResponseHeaderClientRFC7231Response, error) {
@@ -162,6 +168,8 @@ func (client *DatetimeResponseHeaderClient) rfc7231HandleResponse(resp *http.Res
 	return result, nil
 }
 
+// UnixTimestamp -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DatetimeResponseHeaderClientUnixTimestampOptions contains the optional parameters for the DatetimeResponseHeaderClient.UnixTimestamp
 //     method.
 func (client *DatetimeResponseHeaderClient) UnixTimestamp(ctx context.Context, options *DatetimeResponseHeaderClientUnixTimestampOptions) (DatetimeResponseHeaderClientUnixTimestampResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationheader_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationheader_client.go
@@ -20,7 +20,9 @@ type DurationHeaderClient struct {
 	internal *azcore.Client
 }
 
-// - options - DurationHeaderClientDefaultOptions contains the optional parameters for the DurationHeaderClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DurationHeaderClientDefaultOptions contains the optional parameters for the DurationHeaderClient.Default method.
 func (client *DurationHeaderClient) Default(ctx context.Context, duration string, options *DurationHeaderClientDefaultOptions) (DurationHeaderClientDefaultResponse, error) {
 	var err error
 	const operationName = "DurationHeaderClient.Default"
@@ -53,6 +55,8 @@ func (client *DurationHeaderClient) defaultCreateRequest(ctx context.Context, du
 	return req, nil
 }
 
+// Float64Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationHeaderClientFloat64SecondsOptions contains the optional parameters for the DurationHeaderClient.Float64Seconds
 //     method.
 func (client *DurationHeaderClient) Float64Seconds(ctx context.Context, duration float64, options *DurationHeaderClientFloat64SecondsOptions) (DurationHeaderClientFloat64SecondsResponse, error) {
@@ -87,6 +91,8 @@ func (client *DurationHeaderClient) float64SecondsCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// FloatSeconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationHeaderClientFloatSecondsOptions contains the optional parameters for the DurationHeaderClient.FloatSeconds
 //     method.
 func (client *DurationHeaderClient) FloatSeconds(ctx context.Context, duration float32, options *DurationHeaderClientFloatSecondsOptions) (DurationHeaderClientFloatSecondsResponse, error) {
@@ -121,7 +127,9 @@ func (client *DurationHeaderClient) floatSecondsCreateRequest(ctx context.Contex
 	return req, nil
 }
 
-// - options - DurationHeaderClientISO8601Options contains the optional parameters for the DurationHeaderClient.ISO8601 method.
+// ISO8601 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DurationHeaderClientISO8601Options contains the optional parameters for the DurationHeaderClient.ISO8601 method.
 func (client *DurationHeaderClient) ISO8601(ctx context.Context, duration string, options *DurationHeaderClientISO8601Options) (DurationHeaderClientISO8601Response, error) {
 	var err error
 	const operationName = "DurationHeaderClient.ISO8601"
@@ -154,6 +162,8 @@ func (client *DurationHeaderClient) iso8601CreateRequest(ctx context.Context, du
 	return req, nil
 }
 
+// ISO8601Array -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationHeaderClientISO8601ArrayOptions contains the optional parameters for the DurationHeaderClient.ISO8601Array
 //     method.
 func (client *DurationHeaderClient) ISO8601Array(ctx context.Context, duration []string, options *DurationHeaderClientISO8601ArrayOptions) (DurationHeaderClientISO8601ArrayResponse, error) {
@@ -188,6 +198,8 @@ func (client *DurationHeaderClient) iso8601ArrayCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Int32Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationHeaderClientInt32SecondsOptions contains the optional parameters for the DurationHeaderClient.Int32Seconds
 //     method.
 func (client *DurationHeaderClient) Int32Seconds(ctx context.Context, duration int32, options *DurationHeaderClientInt32SecondsOptions) (DurationHeaderClientInt32SecondsResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationproperty_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationproperty_client.go
@@ -18,6 +18,8 @@ type DurationPropertyClient struct {
 	internal *azcore.Client
 }
 
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientDefaultOptions contains the optional parameters for the DurationPropertyClient.Default
 //     method.
 func (client *DurationPropertyClient) Default(ctx context.Context, body DefaultDurationProperty, options *DurationPropertyClientDefaultOptions) (DurationPropertyClientDefaultResponse, error) {
@@ -66,6 +68,8 @@ func (client *DurationPropertyClient) defaultHandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Float64Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientFloat64SecondsOptions contains the optional parameters for the DurationPropertyClient.Float64Seconds
 //     method.
 func (client *DurationPropertyClient) Float64Seconds(ctx context.Context, body Float64SecondsDurationProperty, options *DurationPropertyClientFloat64SecondsOptions) (DurationPropertyClientFloat64SecondsResponse, error) {
@@ -114,6 +118,8 @@ func (client *DurationPropertyClient) float64SecondsHandleResponse(resp *http.Re
 	return result, nil
 }
 
+// FloatSeconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientFloatSecondsOptions contains the optional parameters for the DurationPropertyClient.FloatSeconds
 //     method.
 func (client *DurationPropertyClient) FloatSeconds(ctx context.Context, body FloatSecondsDurationProperty, options *DurationPropertyClientFloatSecondsOptions) (DurationPropertyClientFloatSecondsResponse, error) {
@@ -162,6 +168,8 @@ func (client *DurationPropertyClient) floatSecondsHandleResponse(resp *http.Resp
 	return result, nil
 }
 
+// FloatSecondsArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientFloatSecondsArrayOptions contains the optional parameters for the DurationPropertyClient.FloatSecondsArray
 //     method.
 func (client *DurationPropertyClient) FloatSecondsArray(ctx context.Context, body FloatSecondsDurationArrayProperty, options *DurationPropertyClientFloatSecondsArrayOptions) (DurationPropertyClientFloatSecondsArrayResponse, error) {
@@ -210,6 +218,8 @@ func (client *DurationPropertyClient) floatSecondsArrayHandleResponse(resp *http
 	return result, nil
 }
 
+// ISO8601 -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientISO8601Options contains the optional parameters for the DurationPropertyClient.ISO8601
 //     method.
 func (client *DurationPropertyClient) ISO8601(ctx context.Context, body ISO8601DurationProperty, options *DurationPropertyClientISO8601Options) (DurationPropertyClientISO8601Response, error) {
@@ -258,6 +268,8 @@ func (client *DurationPropertyClient) iso8601HandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Int32Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationPropertyClientInt32SecondsOptions contains the optional parameters for the DurationPropertyClient.Int32Seconds
 //     method.
 func (client *DurationPropertyClient) Int32Seconds(ctx context.Context, body Int32SecondsDurationProperty, options *DurationPropertyClientInt32SecondsOptions) (DurationPropertyClientInt32SecondsResponse, error) {

--- a/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationquery_client.go
+++ b/packages/typespec-go/test/cadlranch/encode/durationgroup/zz_durationquery_client.go
@@ -21,7 +21,9 @@ type DurationQueryClient struct {
 	internal *azcore.Client
 }
 
-// - options - DurationQueryClientDefaultOptions contains the optional parameters for the DurationQueryClient.Default method.
+// Default -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DurationQueryClientDefaultOptions contains the optional parameters for the DurationQueryClient.Default method.
 func (client *DurationQueryClient) Default(ctx context.Context, input string, options *DurationQueryClientDefaultOptions) (DurationQueryClientDefaultResponse, error) {
 	var err error
 	const operationName = "DurationQueryClient.Default"
@@ -56,6 +58,8 @@ func (client *DurationQueryClient) defaultCreateRequest(ctx context.Context, inp
 	return req, nil
 }
 
+// Float64Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationQueryClientFloat64SecondsOptions contains the optional parameters for the DurationQueryClient.Float64Seconds
 //     method.
 func (client *DurationQueryClient) Float64Seconds(ctx context.Context, input float64, options *DurationQueryClientFloat64SecondsOptions) (DurationQueryClientFloat64SecondsResponse, error) {
@@ -92,6 +96,8 @@ func (client *DurationQueryClient) float64SecondsCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// FloatSeconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationQueryClientFloatSecondsOptions contains the optional parameters for the DurationQueryClient.FloatSeconds
 //     method.
 func (client *DurationQueryClient) FloatSeconds(ctx context.Context, input float32, options *DurationQueryClientFloatSecondsOptions) (DurationQueryClientFloatSecondsResponse, error) {
@@ -128,7 +134,9 @@ func (client *DurationQueryClient) floatSecondsCreateRequest(ctx context.Context
 	return req, nil
 }
 
-// - options - DurationQueryClientISO8601Options contains the optional parameters for the DurationQueryClient.ISO8601 method.
+// ISO8601 -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - DurationQueryClientISO8601Options contains the optional parameters for the DurationQueryClient.ISO8601 method.
 func (client *DurationQueryClient) ISO8601(ctx context.Context, input string, options *DurationQueryClientISO8601Options) (DurationQueryClientISO8601Response, error) {
 	var err error
 	const operationName = "DurationQueryClient.ISO8601"
@@ -163,6 +171,8 @@ func (client *DurationQueryClient) iso8601CreateRequest(ctx context.Context, inp
 	return req, nil
 }
 
+// Int32Seconds -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationQueryClientInt32SecondsOptions contains the optional parameters for the DurationQueryClient.Int32Seconds
 //     method.
 func (client *DurationQueryClient) Int32Seconds(ctx context.Context, input int32, options *DurationQueryClientInt32SecondsOptions) (DurationQueryClientInt32SecondsResponse, error) {
@@ -199,6 +209,8 @@ func (client *DurationQueryClient) int32SecondsCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// Int32SecondsArray -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DurationQueryClientInt32SecondsArrayOptions contains the optional parameters for the DurationQueryClient.Int32SecondsArray
 //     method.
 func (client *DurationQueryClient) Int32SecondsArray(ctx context.Context, input []int32, options *DurationQueryClientInt32SecondsArrayOptions) (DurationQueryClientInt32SecondsArrayResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicexplicitbody_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicexplicitbody_client.go
@@ -18,6 +18,8 @@ type BasicExplicitBodyClient struct {
 	internal *azcore.Client
 }
 
+// Simple -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BasicExplicitBodyClientSimpleOptions contains the optional parameters for the BasicExplicitBodyClient.Simple
 //     method.
 func (client *BasicExplicitBodyClient) Simple(ctx context.Context, body User, options *BasicExplicitBodyClientSimpleOptions) (BasicExplicitBodyClientSimpleResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicimplicitbody_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicimplicitbody_client.go
@@ -18,6 +18,8 @@ type BasicImplicitBodyClient struct {
 	internal *azcore.Client
 }
 
+// Simple -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BasicImplicitBodyClientSimpleOptions contains the optional parameters for the BasicImplicitBodyClient.Simple
 //     method.
 func (client *BasicImplicitBodyClient) Simple(ctx context.Context, name string, options *BasicImplicitBodyClientSimpleOptions) (BasicImplicitBodyClientSimpleResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
@@ -25,6 +25,8 @@ func (client *BodyOptionalityClient) NewBodyOptionalityOptionalExplicitClient() 
 	}
 }
 
+// RequiredExplicit -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BodyOptionalityClientRequiredExplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredExplicit
 //     method.
 func (client *BodyOptionalityClient) RequiredExplicit(ctx context.Context, body BodyModel, options *BodyOptionalityClientRequiredExplicitOptions) (BodyOptionalityClientRequiredExplicitResponse, error) {
@@ -62,6 +64,8 @@ func (client *BodyOptionalityClient) requiredExplicitCreateRequest(ctx context.C
 	return req, nil
 }
 
+// RequiredImplicit -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BodyOptionalityClientRequiredImplicitOptions contains the optional parameters for the BodyOptionalityClient.RequiredImplicit
 //     method.
 func (client *BodyOptionalityClient) RequiredImplicit(ctx context.Context, bodyModel BodyModel, options *BodyOptionalityClientRequiredImplicitOptions) (BodyOptionalityClientRequiredImplicitResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionalityoptionalexplicit_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionalityoptionalexplicit_client.go
@@ -18,6 +18,8 @@ type BodyOptionalityOptionalExplicitClient struct {
 	internal *azcore.Client
 }
 
+// Omit -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BodyOptionalityOptionalExplicitClientOmitOptions contains the optional parameters for the BodyOptionalityOptionalExplicitClient.Omit
 //     method.
 func (client *BodyOptionalityOptionalExplicitClient) Omit(ctx context.Context, options *BodyOptionalityOptionalExplicitClientOmitOptions) (BodyOptionalityOptionalExplicitClientOmitResponse, error) {
@@ -58,6 +60,8 @@ func (client *BodyOptionalityOptionalExplicitClient) omitCreateRequest(ctx conte
 	return req, nil
 }
 
+// Set -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - BodyOptionalityOptionalExplicitClientSetOptions contains the optional parameters for the BodyOptionalityOptionalExplicitClient.Set
 //     method.
 func (client *BodyOptionalityOptionalExplicitClient) Set(ctx context.Context, options *BodyOptionalityOptionalExplicitClientSetOptions) (BodyOptionalityOptionalExplicitClientSetResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_collectionformatheader_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_collectionformatheader_client.go
@@ -19,6 +19,8 @@ type CollectionFormatHeaderClient struct {
 	internal *azcore.Client
 }
 
+// CSV -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatHeaderClientCSVOptions contains the optional parameters for the CollectionFormatHeaderClient.CSV
 //     method.

--- a/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_collectionformatquery_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/collectionfmtgroup/zz_collectionformatquery_client.go
@@ -19,6 +19,8 @@ type CollectionFormatQueryClient struct {
 	internal *azcore.Client
 }
 
+// CSV -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatQueryClientCSVOptions contains the optional parameters for the CollectionFormatQueryClient.CSV
 //     method.
@@ -56,6 +58,8 @@ func (client *CollectionFormatQueryClient) csvCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Multi -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatQueryClientMultiOptions contains the optional parameters for the CollectionFormatQueryClient.Multi
 //     method.
@@ -95,6 +99,8 @@ func (client *CollectionFormatQueryClient) multiCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Pipes -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatQueryClientPipesOptions contains the optional parameters for the CollectionFormatQueryClient.Pipes
 //     method.
@@ -132,6 +138,8 @@ func (client *CollectionFormatQueryClient) pipesCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Ssv -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatQueryClientSsvOptions contains the optional parameters for the CollectionFormatQueryClient.Ssv
 //     method.
@@ -169,6 +177,8 @@ func (client *CollectionFormatQueryClient) ssvCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Tsv -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - colors - Possible values for colors are [blue,red,green]
 //   - options - CollectionFormatQueryClientTsvOptions contains the optional parameters for the CollectionFormatQueryClient.Tsv
 //     method.

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
@@ -21,6 +21,8 @@ type SpreadAliasClient struct {
 	internal *azcore.Client
 }
 
+// SpreadAsRequestBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadAliasClientSpreadAsRequestBodyOptions contains the optional parameters for the SpreadAliasClient.SpreadAsRequestBody
 //     method.
 func (client *SpreadAliasClient) SpreadAsRequestBody(ctx context.Context, name string, options *SpreadAliasClientSpreadAsRequestBodyOptions) (SpreadAliasClientSpreadAsRequestBodyResponse, error) {
@@ -63,6 +65,8 @@ func (client *SpreadAliasClient) spreadAsRequestBodyCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// SpreadAsRequestParameter -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadAliasClientSpreadAsRequestParameterOptions contains the optional parameters for the SpreadAliasClient.SpreadAsRequestParameter
 //     method.
 func (client *SpreadAliasClient) SpreadAsRequestParameter(ctx context.Context, id string, xMSTestHeader string, name string, options *SpreadAliasClientSpreadAsRequestParameterOptions) (SpreadAliasClientSpreadAsRequestParameterResponse, error) {
@@ -110,6 +114,8 @@ func (client *SpreadAliasClient) spreadAsRequestParameterCreateRequest(ctx conte
 	return req, nil
 }
 
+// SpreadWithMultipleParameters -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadAliasClientSpreadWithMultipleParametersOptions contains the optional parameters for the SpreadAliasClient.SpreadWithMultipleParameters
 //     method.
 func (client *SpreadAliasClient) SpreadWithMultipleParameters(ctx context.Context, id string, xMSTestHeader string, prop1 string, prop2 string, prop3 string, prop4 string, prop5 string, prop6 string, options *SpreadAliasClientSpreadWithMultipleParametersOptions) (SpreadAliasClientSpreadWithMultipleParametersResponse, error) {

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadmodel_client.go
@@ -21,6 +21,8 @@ type SpreadModelClient struct {
 	internal *azcore.Client
 }
 
+// SpreadAsRequestBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - bodyParameter - This is a simple model.
 //   - options - SpreadModelClientSpreadAsRequestBodyOptions contains the optional parameters for the SpreadModelClient.SpreadAsRequestBody
 //     method.
@@ -59,6 +61,8 @@ func (client *SpreadModelClient) spreadAsRequestBodyCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// SpreadCompositeRequest -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadModelClientSpreadCompositeRequestOptions contains the optional parameters for the SpreadModelClient.SpreadCompositeRequest
 //     method.
 func (client *SpreadModelClient) SpreadCompositeRequest(ctx context.Context, name string, testHeader string, body BodyParameter, options *SpreadModelClientSpreadCompositeRequestOptions) (SpreadModelClientSpreadCompositeRequestResponse, error) {
@@ -101,6 +105,8 @@ func (client *SpreadModelClient) spreadCompositeRequestCreateRequest(ctx context
 	return req, nil
 }
 
+// SpreadCompositeRequestMix -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - compositeRequestMix - This is a model with non-body http request decorator.
 //   - options - SpreadModelClientSpreadCompositeRequestMixOptions contains the optional parameters for the SpreadModelClient.SpreadCompositeRequestMix
 //     method.
@@ -144,6 +150,8 @@ func (client *SpreadModelClient) spreadCompositeRequestMixCreateRequest(ctx cont
 	return req, nil
 }
 
+// SpreadCompositeRequestOnlyWithBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadModelClientSpreadCompositeRequestOnlyWithBodyOptions contains the optional parameters for the SpreadModelClient.SpreadCompositeRequestOnlyWithBody
 //     method.
 func (client *SpreadModelClient) SpreadCompositeRequestOnlyWithBody(ctx context.Context, body BodyParameter, options *SpreadModelClientSpreadCompositeRequestOnlyWithBodyOptions) (SpreadModelClientSpreadCompositeRequestOnlyWithBodyResponse, error) {
@@ -181,6 +189,8 @@ func (client *SpreadModelClient) spreadCompositeRequestOnlyWithBodyCreateRequest
 	return req, nil
 }
 
+// SpreadCompositeRequestWithoutBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpreadModelClientSpreadCompositeRequestWithoutBodyOptions contains the optional parameters for the SpreadModelClient.SpreadCompositeRequestWithoutBody
 //     method.
 func (client *SpreadModelClient) SpreadCompositeRequestWithoutBody(ctx context.Context, name string, testHeader string, options *SpreadModelClientSpreadCompositeRequestWithoutBodyOptions) (SpreadModelClientSpreadCompositeRequestWithoutBodyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/payload/contentneggroup/zz_contentnegotiationdifferentbody_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/contentneggroup/zz_contentnegotiationdifferentbody_client.go
@@ -18,6 +18,8 @@ type ContentNegotiationDifferentBodyClient struct {
 	internal *azcore.Client
 }
 
+// GetAvatarAsJSON -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ContentNegotiationDifferentBodyClientGetAvatarAsJSONOptions contains the optional parameters for the ContentNegotiationDifferentBodyClient.GetAvatarAsJSON
 //     method.
 func (client *ContentNegotiationDifferentBodyClient) GetAvatarAsJSON(ctx context.Context, options *ContentNegotiationDifferentBodyClientGetAvatarAsJSONOptions) (ContentNegotiationDifferentBodyClientGetAvatarAsJSONResponse, error) {
@@ -62,6 +64,8 @@ func (client *ContentNegotiationDifferentBodyClient) getAvatarAsJSONHandleRespon
 	return result, nil
 }
 
+// GetAvatarAsPNG -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ContentNegotiationDifferentBodyClientGetAvatarAsPNGOptions contains the optional parameters for the ContentNegotiationDifferentBodyClient.GetAvatarAsPNG
 //     method.
 func (client *ContentNegotiationDifferentBodyClient) GetAvatarAsPNG(ctx context.Context, options *ContentNegotiationDifferentBodyClientGetAvatarAsPNGOptions) (ContentNegotiationDifferentBodyClientGetAvatarAsPNGResponse, error) {

--- a/packages/typespec-go/test/cadlranch/payload/contentneggroup/zz_contentnegotiationsamebody_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/contentneggroup/zz_contentnegotiationsamebody_client.go
@@ -18,6 +18,8 @@ type ContentNegotiationSameBodyClient struct {
 	internal *azcore.Client
 }
 
+// GetAvatarAsJPEG -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ContentNegotiationSameBodyClientGetAvatarAsJPEGOptions contains the optional parameters for the ContentNegotiationSameBodyClient.GetAvatarAsJPEG
 //     method.
 func (client *ContentNegotiationSameBodyClient) GetAvatarAsJPEG(ctx context.Context, options *ContentNegotiationSameBodyClientGetAvatarAsJPEGOptions) (ContentNegotiationSameBodyClientGetAvatarAsJPEGResponse, error) {
@@ -53,6 +55,8 @@ func (client *ContentNegotiationSameBodyClient) getAvatarAsJPEGCreateRequest(ctx
 	return req, nil
 }
 
+// GetAvatarAsPNG -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ContentNegotiationSameBodyClientGetAvatarAsPNGOptions contains the optional parameters for the ContentNegotiationSameBodyClient.GetAvatarAsPNG
 //     method.
 func (client *ContentNegotiationSameBodyClient) GetAvatarAsPNG(ctx context.Context, options *ContentNegotiationSameBodyClientGetAvatarAsPNGOptions) (ContentNegotiationSameBodyClientGetAvatarAsPNGResponse, error) {

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -19,6 +19,7 @@ type JSONMergePatchClient struct {
 }
 
 // CreateResource - Test content-type: application/merge-patch+json with required body
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - JSONMergePatchClientCreateResourceOptions contains the optional parameters for the JSONMergePatchClient.CreateResource
 //     method.
 func (client *JSONMergePatchClient) CreateResource(ctx context.Context, body Resource, options *JSONMergePatchClientCreateResourceOptions) (JSONMergePatchClientCreateResourceResponse, error) {
@@ -68,6 +69,7 @@ func (client *JSONMergePatchClient) createResourceHandleResponse(resp *http.Resp
 }
 
 // UpdateOptionalResource - Test content-type: application/merge-patch+json with optional body
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - JSONMergePatchClientUpdateOptionalResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateOptionalResource
 //     method.
 func (client *JSONMergePatchClient) UpdateOptionalResource(ctx context.Context, options *JSONMergePatchClientUpdateOptionalResourceOptions) (JSONMergePatchClientUpdateOptionalResourceResponse, error) {
@@ -120,6 +122,7 @@ func (client *JSONMergePatchClient) updateOptionalResourceHandleResponse(resp *h
 }
 
 // UpdateResource - Test content-type: application/merge-patch+json with required body
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - JSONMergePatchClientUpdateResourceOptions contains the optional parameters for the JSONMergePatchClient.UpdateResource
 //     method.
 func (client *JSONMergePatchClient) UpdateResource(ctx context.Context, body ResourcePatch, options *JSONMergePatchClientUpdateResourceOptions) (JSONMergePatchClientUpdateResourceResponse, error) {

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_mediatypestringbody_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_mediatypestringbody_client.go
@@ -20,6 +20,8 @@ type MediaTypeStringBodyClient struct {
 	internal *azcore.Client
 }
 
+// GetAsJSON -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MediaTypeStringBodyClientGetAsJSONOptions contains the optional parameters for the MediaTypeStringBodyClient.GetAsJSON
 //     method.
 func (client *MediaTypeStringBodyClient) GetAsJSON(ctx context.Context, options *MediaTypeStringBodyClientGetAsJSONOptions) (MediaTypeStringBodyClientGetAsJSONResponse, error) {
@@ -64,6 +66,8 @@ func (client *MediaTypeStringBodyClient) getAsJSONHandleResponse(resp *http.Resp
 	return result, nil
 }
 
+// GetAsText -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MediaTypeStringBodyClientGetAsTextOptions contains the optional parameters for the MediaTypeStringBodyClient.GetAsText
 //     method.
 func (client *MediaTypeStringBodyClient) GetAsText(ctx context.Context, options *MediaTypeStringBodyClientGetAsTextOptions) (MediaTypeStringBodyClientGetAsTextResponse, error) {
@@ -111,6 +115,8 @@ func (client *MediaTypeStringBodyClient) getAsTextHandleResponse(resp *http.Resp
 	return result, nil
 }
 
+// SendAsJSON -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MediaTypeStringBodyClientSendAsJSONOptions contains the optional parameters for the MediaTypeStringBodyClient.SendAsJSON
 //     method.
 func (client *MediaTypeStringBodyClient) SendAsJSON(ctx context.Context, textParam string, options *MediaTypeStringBodyClientSendAsJSONOptions) (MediaTypeStringBodyClientSendAsJSONResponse, error) {
@@ -148,6 +154,8 @@ func (client *MediaTypeStringBodyClient) sendAsJSONCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// SendAsText -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MediaTypeStringBodyClientSendAsTextOptions contains the optional parameters for the MediaTypeStringBodyClient.SendAsText
 //     method.
 func (client *MediaTypeStringBodyClient) SendAsText(ctx context.Context, textParam string, options *MediaTypeStringBodyClientSendAsTextOptions) (MediaTypeStringBodyClientSendAsTextResponse, error) {

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_multipartformdata_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_multipartformdata_client.go
@@ -20,6 +20,7 @@ type MultiPartFormDataClient struct {
 }
 
 // AnonymousModel - Test content-type: multipart/form-data
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientAnonymousModelOptions contains the optional parameters for the MultiPartFormDataClient.AnonymousModel
 //     method.
 func (client *MultiPartFormDataClient) AnonymousModel(ctx context.Context, profileImage io.ReadSeekCloser, options *MultiPartFormDataClientAnonymousModelOptions) (MultiPartFormDataClientAnonymousModelResponse, error) {
@@ -60,6 +61,7 @@ func (client *MultiPartFormDataClient) anonymousModelCreateRequest(ctx context.C
 }
 
 // Basic - Test content-type: multipart/form-data
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientBasicOptions contains the optional parameters for the MultiPartFormDataClient.Basic method.
 func (client *MultiPartFormDataClient) Basic(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientBasicOptions) (MultiPartFormDataClientBasicResponse, error) {
 	var err error
@@ -101,6 +103,7 @@ func (client *MultiPartFormDataClient) basicCreateRequest(ctx context.Context, b
 }
 
 // BinaryArrayParts - Test content-type: multipart/form-data for scenario contains multi binary parts
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientBinaryArrayPartsOptions contains the optional parameters for the MultiPartFormDataClient.BinaryArrayParts
 //     method.
 func (client *MultiPartFormDataClient) BinaryArrayParts(ctx context.Context, body BinaryArrayPartsRequest, options *MultiPartFormDataClientBinaryArrayPartsOptions) (MultiPartFormDataClientBinaryArrayPartsResponse, error) {
@@ -143,6 +146,7 @@ func (client *MultiPartFormDataClient) binaryArrayPartsCreateRequest(ctx context
 }
 
 // CheckFileNameAndContentType - Test content-type: multipart/form-data
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientCheckFileNameAndContentTypeOptions contains the optional parameters for the MultiPartFormDataClient.CheckFileNameAndContentType
 //     method.
 func (client *MultiPartFormDataClient) CheckFileNameAndContentType(ctx context.Context, body MultiPartRequest, options *MultiPartFormDataClientCheckFileNameAndContentTypeOptions) (MultiPartFormDataClientCheckFileNameAndContentTypeResponse, error) {
@@ -185,6 +189,7 @@ func (client *MultiPartFormDataClient) checkFileNameAndContentTypeCreateRequest(
 }
 
 // Complex - Test content-type: multipart/form-data for mixed scenarios
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientComplexOptions contains the optional parameters for the MultiPartFormDataClient.Complex
 //     method.
 func (client *MultiPartFormDataClient) Complex(ctx context.Context, body ComplexPartsRequest, options *MultiPartFormDataClientComplexOptions) (MultiPartFormDataClientComplexResponse, error) {
@@ -227,6 +232,7 @@ func (client *MultiPartFormDataClient) complexCreateRequest(ctx context.Context,
 }
 
 // JSONArrayParts - Test content-type: multipart/form-data for scenario contains multi json parts
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientJSONArrayPartsOptions contains the optional parameters for the MultiPartFormDataClient.JSONArrayParts
 //     method.
 func (client *MultiPartFormDataClient) JSONArrayParts(ctx context.Context, body JSONArrayPartsRequest, options *MultiPartFormDataClientJSONArrayPartsOptions) (MultiPartFormDataClientJSONArrayPartsResponse, error) {
@@ -269,6 +275,7 @@ func (client *MultiPartFormDataClient) jsonArrayPartsCreateRequest(ctx context.C
 }
 
 // JSONPart - Test content-type: multipart/form-data for scenario contains json part and binary part
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientJSONPartOptions contains the optional parameters for the MultiPartFormDataClient.JSONPart
 //     method.
 func (client *MultiPartFormDataClient) JSONPart(ctx context.Context, body JSONPartRequest, options *MultiPartFormDataClientJSONPartOptions) (MultiPartFormDataClientJSONPartResponse, error) {
@@ -311,6 +318,7 @@ func (client *MultiPartFormDataClient) jsonPartCreateRequest(ctx context.Context
 }
 
 // MultiBinaryParts - Test content-type: multipart/form-data for scenario contains multi binary parts
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultiPartFormDataClientMultiBinaryPartsOptions contains the optional parameters for the MultiPartFormDataClient.MultiBinaryParts
 //     method.
 func (client *MultiPartFormDataClient) MultiBinaryParts(ctx context.Context, body MultiBinaryPartsRequest, options *MultiPartFormDataClientMultiBinaryPartsOptions) (MultiPartFormDataClientMultiBinaryPartsResponse, error) {

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivennewgroup/zz_resiliencyservicedriven_client.go
@@ -34,6 +34,7 @@ type ResiliencyServiceDrivenClient struct {
 }
 
 // AddOperation - Added operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ResiliencyServiceDrivenClientAddOperationOptions contains the optional parameters for the ResiliencyServiceDrivenClient.AddOperation
 //     method.
 func (client *ResiliencyServiceDrivenClient) AddOperation(ctx context.Context, options *ResiliencyServiceDrivenClientAddOperationOptions) (ResiliencyServiceDrivenClientAddOperationResponse, error) {
@@ -116,6 +117,7 @@ func (client *ResiliencyServiceDrivenClient) fromNoneCreateRequest(ctx context.C
 
 // FromOneOptional - Tests that we can grow up an operation from accepting one optional parameter to accepting two optional
 // parameters.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ResiliencyServiceDrivenClientFromOneOptionalOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneOptional
 //     method.
 func (client *ResiliencyServiceDrivenClient) FromOneOptional(ctx context.Context, options *ResiliencyServiceDrivenClientFromOneOptionalOptions) (ResiliencyServiceDrivenClientFromOneOptionalResponse, error) {
@@ -163,6 +165,7 @@ func (client *ResiliencyServiceDrivenClient) fromOneOptionalCreateRequest(ctx co
 
 // FromOneRequired - Operation that grew up from accepting one required parameter to accepting a required parameter and an
 // optional parameter.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - parameter - I am a required parameter
 //   - options - ResiliencyServiceDrivenClientFromOneRequiredOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneRequired
 //     method.

--- a/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
+++ b/packages/typespec-go/test/cadlranch/resiliency/srvdrivenoldgroup/zz_resiliencyservicedriven_client.go
@@ -64,6 +64,7 @@ func (client *ResiliencyServiceDrivenClient) fromNoneCreateRequest(ctx context.C
 
 // FromOneOptional - Test that currently accepts one optional parameter, will be updated in next spec to accept a new optional
 // parameter as well
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ResiliencyServiceDrivenClientFromOneOptionalOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneOptional
 //     method.
 func (client *ResiliencyServiceDrivenClient) FromOneOptional(ctx context.Context, options *ResiliencyServiceDrivenClientFromOneOptionalOptions) (ResiliencyServiceDrivenClientFromOneOptionalResponse, error) {
@@ -108,6 +109,7 @@ func (client *ResiliencyServiceDrivenClient) fromOneOptionalCreateRequest(ctx co
 
 // FromOneRequired - Test that currently accepts one required parameter, will be updated in next spec to accept a new optional
 // parameter as well
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - parameter - I am a required parameter
 //   - options - ResiliencyServiceDrivenClientFromOneRequiredOptions contains the optional parameters for the ResiliencyServiceDrivenClient.FromOneRequired
 //     method.

--- a/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_jsonproperty_client.go
+++ b/packages/typespec-go/test/cadlranch/serialization/encoded-name/jsongroup/zz_jsonproperty_client.go
@@ -18,7 +18,9 @@ type JSONPropertyClient struct {
 	internal *azcore.Client
 }
 
-// - options - JSONPropertyClientGetOptions contains the optional parameters for the JSONPropertyClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - JSONPropertyClientGetOptions contains the optional parameters for the JSONPropertyClient.Get method.
 func (client *JSONPropertyClient) Get(ctx context.Context, options *JSONPropertyClientGetOptions) (JSONPropertyClientGetResponse, error) {
 	var err error
 	const operationName = "JSONPropertyClient.Get"
@@ -61,7 +63,9 @@ func (client *JSONPropertyClient) getHandleResponse(resp *http.Response) (JSONPr
 	return result, nil
 }
 
-// - options - JSONPropertyClientSendOptions contains the optional parameters for the JSONPropertyClient.Send method.
+// Send -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - JSONPropertyClientSendOptions contains the optional parameters for the JSONPropertyClient.Send method.
 func (client *JSONPropertyClient) Send(ctx context.Context, jsonEncodedNameModel JSONEncodedNameModel, options *JSONPropertyClientSendOptions) (JSONPropertyClientSendResponse, error) {
 	var err error
 	const operationName = "JSONPropertyClient.Send"

--- a/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_multiple_client.go
+++ b/packages/typespec-go/test/cadlranch/server/path/multiplegroup/zz_multiple_client.go
@@ -23,6 +23,8 @@ type MultipleClient struct {
 	apiVersion Versions
 }
 
+// NoOperationParams -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultipleClientNoOperationParamsOptions contains the optional parameters for the MultipleClient.NoOperationParams
 //     method.
 func (client *MultipleClient) NoOperationParams(ctx context.Context, options *MultipleClientNoOperationParamsOptions) (MultipleClientNoOperationParamsResponse, error) {
@@ -58,6 +60,8 @@ func (client *MultipleClient) noOperationParamsCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithOperationPathParam -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - MultipleClientWithOperationPathParamOptions contains the optional parameters for the MultipleClient.WithOperationPathParam
 //     method.
 func (client *MultipleClient) WithOperationPathParam(ctx context.Context, keyword string, options *MultipleClientWithOperationPathParamOptions) (MultipleClientWithOperationPathParamResponse, error) {

--- a/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_versioned_client.go
+++ b/packages/typespec-go/test/cadlranch/server/versions/versionedgroup/zz_versioned_client.go
@@ -21,6 +21,9 @@ type VersionedClient struct {
 	endpoint string
 }
 
+// WithPathAPIVersion -
+//
+// Generated from API version 2022-12-01-preview
 //   - options - VersionedClientWithPathAPIVersionOptions contains the optional parameters for the VersionedClient.WithPathAPIVersion
 //     method.
 func (client *VersionedClient) WithPathAPIVersion(ctx context.Context, options *VersionedClientWithPathAPIVersionOptions) (VersionedClientWithPathAPIVersionResponse, error) {
@@ -57,6 +60,9 @@ func (client *VersionedClient) withPathAPIVersionCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithQueryAPIVersion -
+//
+// Generated from API version 2022-12-01-preview
 //   - options - VersionedClientWithQueryAPIVersionOptions contains the optional parameters for the VersionedClient.WithQueryAPIVersion
 //     method.
 func (client *VersionedClient) WithQueryAPIVersion(ctx context.Context, options *VersionedClientWithQueryAPIVersionOptions) (VersionedClientWithQueryAPIVersionResponse, error) {
@@ -95,6 +101,9 @@ func (client *VersionedClient) withQueryAPIVersionCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithQueryOldAPIVersion -
+//
+// Generated from API version 2022-12-01-preview
 //   - options - VersionedClientWithQueryOldAPIVersionOptions contains the optional parameters for the VersionedClient.WithQueryOldAPIVersion
 //     method.
 func (client *VersionedClient) WithQueryOldAPIVersion(ctx context.Context, options *VersionedClientWithQueryOldAPIVersionOptions) (VersionedClientWithQueryOldAPIVersionResponse, error) {

--- a/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_conditionalrequest_client.go
+++ b/packages/typespec-go/test/cadlranch/special-headers/condreqgroup/zz_conditionalrequest_client.go
@@ -19,6 +19,7 @@ type ConditionalRequestClient struct {
 }
 
 // PostIfMatch - Check when only If-Match in header is defined.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ConditionalRequestClientPostIfMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfMatch
 //     method.
 func (client *ConditionalRequestClient) PostIfMatch(ctx context.Context, options *ConditionalRequestClientPostIfMatchOptions) (ConditionalRequestClientPostIfMatchResponse, error) {
@@ -56,6 +57,7 @@ func (client *ConditionalRequestClient) postIfMatchCreateRequest(ctx context.Con
 }
 
 // PostIfNoneMatch - Check when only If-None-Match in header is defined.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ConditionalRequestClientPostIfNoneMatchOptions contains the optional parameters for the ConditionalRequestClient.PostIfNoneMatch
 //     method.
 func (client *ConditionalRequestClient) PostIfNoneMatch(ctx context.Context, options *ConditionalRequestClientPostIfNoneMatchOptions) (ConditionalRequestClientPostIfNoneMatchResponse, error) {

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsmodelproperties_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsmodelproperties_client.go
@@ -18,6 +18,8 @@ type SpecialWordsModelPropertiesClient struct {
 	internal *azcore.Client
 }
 
+// SameAsModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelPropertiesClientSameAsModelOptions contains the optional parameters for the SpecialWordsModelPropertiesClient.SameAsModel
 //     method.
 func (client *SpecialWordsModelPropertiesClient) SameAsModel(ctx context.Context, body SameAsModel, options *SpecialWordsModelPropertiesClientSameAsModelOptions) (SpecialWordsModelPropertiesClientSameAsModelResponse, error) {

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsmodels_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsmodels_client.go
@@ -18,6 +18,8 @@ type SpecialWordsModelsClient struct {
 	internal *azcore.Client
 }
 
+// WithAnd -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithAndOptions contains the optional parameters for the SpecialWordsModelsClient.WithAnd
 //     method.
 func (client *SpecialWordsModelsClient) WithAnd(ctx context.Context, body And, options *SpecialWordsModelsClientWithAndOptions) (SpecialWordsModelsClientWithAndResponse, error) {
@@ -55,6 +57,8 @@ func (client *SpecialWordsModelsClient) withAndCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithAs -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithAsOptions contains the optional parameters for the SpecialWordsModelsClient.WithAs
 //     method.
 func (client *SpecialWordsModelsClient) WithAs(ctx context.Context, body As, options *SpecialWordsModelsClientWithAsOptions) (SpecialWordsModelsClientWithAsResponse, error) {
@@ -92,6 +96,8 @@ func (client *SpecialWordsModelsClient) withAsCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// WithAssert -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithAssertOptions contains the optional parameters for the SpecialWordsModelsClient.WithAssert
 //     method.
 func (client *SpecialWordsModelsClient) WithAssert(ctx context.Context, body Assert, options *SpecialWordsModelsClientWithAssertOptions) (SpecialWordsModelsClientWithAssertResponse, error) {
@@ -129,6 +135,8 @@ func (client *SpecialWordsModelsClient) withAssertCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithAsync -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithAsyncOptions contains the optional parameters for the SpecialWordsModelsClient.WithAsync
 //     method.
 func (client *SpecialWordsModelsClient) WithAsync(ctx context.Context, body Async, options *SpecialWordsModelsClientWithAsyncOptions) (SpecialWordsModelsClientWithAsyncResponse, error) {
@@ -166,6 +174,8 @@ func (client *SpecialWordsModelsClient) withAsyncCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithAwait -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithAwaitOptions contains the optional parameters for the SpecialWordsModelsClient.WithAwait
 //     method.
 func (client *SpecialWordsModelsClient) WithAwait(ctx context.Context, body Await, options *SpecialWordsModelsClientWithAwaitOptions) (SpecialWordsModelsClientWithAwaitResponse, error) {
@@ -203,6 +213,8 @@ func (client *SpecialWordsModelsClient) withAwaitCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithBreak -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithBreakOptions contains the optional parameters for the SpecialWordsModelsClient.WithBreak
 //     method.
 func (client *SpecialWordsModelsClient) WithBreak(ctx context.Context, body Break, options *SpecialWordsModelsClientWithBreakOptions) (SpecialWordsModelsClientWithBreakResponse, error) {
@@ -240,6 +252,8 @@ func (client *SpecialWordsModelsClient) withBreakCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithClass -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithClassOptions contains the optional parameters for the SpecialWordsModelsClient.WithClass
 //     method.
 func (client *SpecialWordsModelsClient) WithClass(ctx context.Context, body Class, options *SpecialWordsModelsClientWithClassOptions) (SpecialWordsModelsClientWithClassResponse, error) {
@@ -277,6 +291,8 @@ func (client *SpecialWordsModelsClient) withClassCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithConstructor -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithConstructorOptions contains the optional parameters for the SpecialWordsModelsClient.WithConstructor
 //     method.
 func (client *SpecialWordsModelsClient) WithConstructor(ctx context.Context, body Constructor, options *SpecialWordsModelsClientWithConstructorOptions) (SpecialWordsModelsClientWithConstructorResponse, error) {
@@ -314,6 +330,8 @@ func (client *SpecialWordsModelsClient) withConstructorCreateRequest(ctx context
 	return req, nil
 }
 
+// WithContinue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithContinueOptions contains the optional parameters for the SpecialWordsModelsClient.WithContinue
 //     method.
 func (client *SpecialWordsModelsClient) WithContinue(ctx context.Context, body Continue, options *SpecialWordsModelsClientWithContinueOptions) (SpecialWordsModelsClientWithContinueResponse, error) {
@@ -351,6 +369,8 @@ func (client *SpecialWordsModelsClient) withContinueCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithDef -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithDefOptions contains the optional parameters for the SpecialWordsModelsClient.WithDef
 //     method.
 func (client *SpecialWordsModelsClient) WithDef(ctx context.Context, body Def, options *SpecialWordsModelsClientWithDefOptions) (SpecialWordsModelsClientWithDefResponse, error) {
@@ -388,6 +408,8 @@ func (client *SpecialWordsModelsClient) withDefCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithDel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithDelOptions contains the optional parameters for the SpecialWordsModelsClient.WithDel
 //     method.
 func (client *SpecialWordsModelsClient) WithDel(ctx context.Context, body Del, options *SpecialWordsModelsClientWithDelOptions) (SpecialWordsModelsClientWithDelResponse, error) {
@@ -425,6 +447,8 @@ func (client *SpecialWordsModelsClient) withDelCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithElif -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithElifOptions contains the optional parameters for the SpecialWordsModelsClient.WithElif
 //     method.
 func (client *SpecialWordsModelsClient) WithElif(ctx context.Context, body Elif, options *SpecialWordsModelsClientWithElifOptions) (SpecialWordsModelsClientWithElifResponse, error) {
@@ -462,6 +486,8 @@ func (client *SpecialWordsModelsClient) withElifCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithElse -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithElseOptions contains the optional parameters for the SpecialWordsModelsClient.WithElse
 //     method.
 func (client *SpecialWordsModelsClient) WithElse(ctx context.Context, body Else, options *SpecialWordsModelsClientWithElseOptions) (SpecialWordsModelsClientWithElseResponse, error) {
@@ -499,6 +525,8 @@ func (client *SpecialWordsModelsClient) withElseCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithExcept -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithExceptOptions contains the optional parameters for the SpecialWordsModelsClient.WithExcept
 //     method.
 func (client *SpecialWordsModelsClient) WithExcept(ctx context.Context, body Except, options *SpecialWordsModelsClientWithExceptOptions) (SpecialWordsModelsClientWithExceptResponse, error) {
@@ -536,6 +564,8 @@ func (client *SpecialWordsModelsClient) withExceptCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithExec -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithExecOptions contains the optional parameters for the SpecialWordsModelsClient.WithExec
 //     method.
 func (client *SpecialWordsModelsClient) WithExec(ctx context.Context, body Exec, options *SpecialWordsModelsClientWithExecOptions) (SpecialWordsModelsClientWithExecResponse, error) {
@@ -573,6 +603,8 @@ func (client *SpecialWordsModelsClient) withExecCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithFinally -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithFinallyOptions contains the optional parameters for the SpecialWordsModelsClient.WithFinally
 //     method.
 func (client *SpecialWordsModelsClient) WithFinally(ctx context.Context, body Finally, options *SpecialWordsModelsClientWithFinallyOptions) (SpecialWordsModelsClientWithFinallyResponse, error) {
@@ -610,6 +642,8 @@ func (client *SpecialWordsModelsClient) withFinallyCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithFor -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithForOptions contains the optional parameters for the SpecialWordsModelsClient.WithFor
 //     method.
 func (client *SpecialWordsModelsClient) WithFor(ctx context.Context, body For, options *SpecialWordsModelsClientWithForOptions) (SpecialWordsModelsClientWithForResponse, error) {
@@ -647,6 +681,8 @@ func (client *SpecialWordsModelsClient) withForCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithFrom -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithFromOptions contains the optional parameters for the SpecialWordsModelsClient.WithFrom
 //     method.
 func (client *SpecialWordsModelsClient) WithFrom(ctx context.Context, body From, options *SpecialWordsModelsClientWithFromOptions) (SpecialWordsModelsClientWithFromResponse, error) {
@@ -684,6 +720,8 @@ func (client *SpecialWordsModelsClient) withFromCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithGlobal -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithGlobalOptions contains the optional parameters for the SpecialWordsModelsClient.WithGlobal
 //     method.
 func (client *SpecialWordsModelsClient) WithGlobal(ctx context.Context, body Global, options *SpecialWordsModelsClientWithGlobalOptions) (SpecialWordsModelsClientWithGlobalResponse, error) {
@@ -721,6 +759,8 @@ func (client *SpecialWordsModelsClient) withGlobalCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithIf -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithIfOptions contains the optional parameters for the SpecialWordsModelsClient.WithIf
 //     method.
 func (client *SpecialWordsModelsClient) WithIf(ctx context.Context, body If, options *SpecialWordsModelsClientWithIfOptions) (SpecialWordsModelsClientWithIfResponse, error) {
@@ -758,6 +798,8 @@ func (client *SpecialWordsModelsClient) withIfCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// WithImport -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithImportOptions contains the optional parameters for the SpecialWordsModelsClient.WithImport
 //     method.
 func (client *SpecialWordsModelsClient) WithImport(ctx context.Context, body Import, options *SpecialWordsModelsClientWithImportOptions) (SpecialWordsModelsClientWithImportResponse, error) {
@@ -795,6 +837,8 @@ func (client *SpecialWordsModelsClient) withImportCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithIn -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithInOptions contains the optional parameters for the SpecialWordsModelsClient.WithIn
 //     method.
 func (client *SpecialWordsModelsClient) WithIn(ctx context.Context, body In, options *SpecialWordsModelsClientWithInOptions) (SpecialWordsModelsClientWithInResponse, error) {
@@ -832,6 +876,8 @@ func (client *SpecialWordsModelsClient) withInCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// WithIs -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithIsOptions contains the optional parameters for the SpecialWordsModelsClient.WithIs
 //     method.
 func (client *SpecialWordsModelsClient) WithIs(ctx context.Context, body Is, options *SpecialWordsModelsClientWithIsOptions) (SpecialWordsModelsClientWithIsResponse, error) {
@@ -869,6 +915,8 @@ func (client *SpecialWordsModelsClient) withIsCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// WithLambda -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithLambdaOptions contains the optional parameters for the SpecialWordsModelsClient.WithLambda
 //     method.
 func (client *SpecialWordsModelsClient) WithLambda(ctx context.Context, body Lambda, options *SpecialWordsModelsClientWithLambdaOptions) (SpecialWordsModelsClientWithLambdaResponse, error) {
@@ -906,6 +954,8 @@ func (client *SpecialWordsModelsClient) withLambdaCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithNot -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithNotOptions contains the optional parameters for the SpecialWordsModelsClient.WithNot
 //     method.
 func (client *SpecialWordsModelsClient) WithNot(ctx context.Context, body Not, options *SpecialWordsModelsClientWithNotOptions) (SpecialWordsModelsClientWithNotResponse, error) {
@@ -943,6 +993,8 @@ func (client *SpecialWordsModelsClient) withNotCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithOr -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithOrOptions contains the optional parameters for the SpecialWordsModelsClient.WithOr
 //     method.
 func (client *SpecialWordsModelsClient) WithOr(ctx context.Context, body Or, options *SpecialWordsModelsClientWithOrOptions) (SpecialWordsModelsClientWithOrResponse, error) {
@@ -980,6 +1032,8 @@ func (client *SpecialWordsModelsClient) withOrCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// WithPass -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithPassOptions contains the optional parameters for the SpecialWordsModelsClient.WithPass
 //     method.
 func (client *SpecialWordsModelsClient) WithPass(ctx context.Context, body Pass, options *SpecialWordsModelsClientWithPassOptions) (SpecialWordsModelsClientWithPassResponse, error) {
@@ -1017,6 +1071,8 @@ func (client *SpecialWordsModelsClient) withPassCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithRaise -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithRaiseOptions contains the optional parameters for the SpecialWordsModelsClient.WithRaise
 //     method.
 func (client *SpecialWordsModelsClient) WithRaise(ctx context.Context, body Raise, options *SpecialWordsModelsClientWithRaiseOptions) (SpecialWordsModelsClientWithRaiseResponse, error) {
@@ -1054,6 +1110,8 @@ func (client *SpecialWordsModelsClient) withRaiseCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithReturn -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithReturnOptions contains the optional parameters for the SpecialWordsModelsClient.WithReturn
 //     method.
 func (client *SpecialWordsModelsClient) WithReturn(ctx context.Context, body Return, options *SpecialWordsModelsClientWithReturnOptions) (SpecialWordsModelsClientWithReturnResponse, error) {
@@ -1091,6 +1149,8 @@ func (client *SpecialWordsModelsClient) withReturnCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithTry -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithTryOptions contains the optional parameters for the SpecialWordsModelsClient.WithTry
 //     method.
 func (client *SpecialWordsModelsClient) WithTry(ctx context.Context, body Try, options *SpecialWordsModelsClientWithTryOptions) (SpecialWordsModelsClientWithTryResponse, error) {
@@ -1128,6 +1188,8 @@ func (client *SpecialWordsModelsClient) withTryCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// WithWhile -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithWhileOptions contains the optional parameters for the SpecialWordsModelsClient.WithWhile
 //     method.
 func (client *SpecialWordsModelsClient) WithWhile(ctx context.Context, body While, options *SpecialWordsModelsClientWithWhileOptions) (SpecialWordsModelsClientWithWhileResponse, error) {
@@ -1165,6 +1227,8 @@ func (client *SpecialWordsModelsClient) withWhileCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// WithWith -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithWithOptions contains the optional parameters for the SpecialWordsModelsClient.WithWith
 //     method.
 func (client *SpecialWordsModelsClient) WithWith(ctx context.Context, body With, options *SpecialWordsModelsClientWithWithOptions) (SpecialWordsModelsClientWithWithResponse, error) {
@@ -1202,6 +1266,8 @@ func (client *SpecialWordsModelsClient) withWithCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// WithYield -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsModelsClientWithYieldOptions contains the optional parameters for the SpecialWordsModelsClient.WithYield
 //     method.
 func (client *SpecialWordsModelsClient) WithYield(ctx context.Context, body Yield, options *SpecialWordsModelsClientWithYieldOptions) (SpecialWordsModelsClientWithYieldResponse, error) {

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsoperations_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsoperations_client.go
@@ -18,6 +18,8 @@ type SpecialWordsOperationsClient struct {
 	internal *azcore.Client
 }
 
+// And -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientAndOptions contains the optional parameters for the SpecialWordsOperationsClient.And
 //     method.
 func (client *SpecialWordsOperationsClient) And(ctx context.Context, options *SpecialWordsOperationsClientAndOptions) (SpecialWordsOperationsClientAndResponse, error) {
@@ -51,6 +53,8 @@ func (client *SpecialWordsOperationsClient) andCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// As -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientAsOptions contains the optional parameters for the SpecialWordsOperationsClient.As
 //     method.
 func (client *SpecialWordsOperationsClient) As(ctx context.Context, options *SpecialWordsOperationsClientAsOptions) (SpecialWordsOperationsClientAsResponse, error) {
@@ -84,6 +88,8 @@ func (client *SpecialWordsOperationsClient) asCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Assert -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientAssertOptions contains the optional parameters for the SpecialWordsOperationsClient.Assert
 //     method.
 func (client *SpecialWordsOperationsClient) Assert(ctx context.Context, options *SpecialWordsOperationsClientAssertOptions) (SpecialWordsOperationsClientAssertResponse, error) {
@@ -117,6 +123,8 @@ func (client *SpecialWordsOperationsClient) assertCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// Async -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientAsyncOptions contains the optional parameters for the SpecialWordsOperationsClient.Async
 //     method.
 func (client *SpecialWordsOperationsClient) Async(ctx context.Context, options *SpecialWordsOperationsClientAsyncOptions) (SpecialWordsOperationsClientAsyncResponse, error) {
@@ -150,6 +158,8 @@ func (client *SpecialWordsOperationsClient) asyncCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Await -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientAwaitOptions contains the optional parameters for the SpecialWordsOperationsClient.Await
 //     method.
 func (client *SpecialWordsOperationsClient) Await(ctx context.Context, options *SpecialWordsOperationsClientAwaitOptions) (SpecialWordsOperationsClientAwaitResponse, error) {
@@ -183,6 +193,8 @@ func (client *SpecialWordsOperationsClient) awaitCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Break -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientBreakOptions contains the optional parameters for the SpecialWordsOperationsClient.Break
 //     method.
 func (client *SpecialWordsOperationsClient) Break(ctx context.Context, options *SpecialWordsOperationsClientBreakOptions) (SpecialWordsOperationsClientBreakResponse, error) {
@@ -216,6 +228,8 @@ func (client *SpecialWordsOperationsClient) breakCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Class -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientClassOptions contains the optional parameters for the SpecialWordsOperationsClient.Class
 //     method.
 func (client *SpecialWordsOperationsClient) Class(ctx context.Context, options *SpecialWordsOperationsClientClassOptions) (SpecialWordsOperationsClientClassResponse, error) {
@@ -249,6 +263,8 @@ func (client *SpecialWordsOperationsClient) classCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Constructor -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientConstructorOptions contains the optional parameters for the SpecialWordsOperationsClient.Constructor
 //     method.
 func (client *SpecialWordsOperationsClient) Constructor(ctx context.Context, options *SpecialWordsOperationsClientConstructorOptions) (SpecialWordsOperationsClientConstructorResponse, error) {
@@ -282,6 +298,8 @@ func (client *SpecialWordsOperationsClient) constructorCreateRequest(ctx context
 	return req, nil
 }
 
+// Continue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientContinueOptions contains the optional parameters for the SpecialWordsOperationsClient.Continue
 //     method.
 func (client *SpecialWordsOperationsClient) Continue(ctx context.Context, options *SpecialWordsOperationsClientContinueOptions) (SpecialWordsOperationsClientContinueResponse, error) {
@@ -315,6 +333,8 @@ func (client *SpecialWordsOperationsClient) continueCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// Def -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientDefOptions contains the optional parameters for the SpecialWordsOperationsClient.Def
 //     method.
 func (client *SpecialWordsOperationsClient) Def(ctx context.Context, options *SpecialWordsOperationsClientDefOptions) (SpecialWordsOperationsClientDefResponse, error) {
@@ -348,6 +368,8 @@ func (client *SpecialWordsOperationsClient) defCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// Del -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientDelOptions contains the optional parameters for the SpecialWordsOperationsClient.Del
 //     method.
 func (client *SpecialWordsOperationsClient) Del(ctx context.Context, options *SpecialWordsOperationsClientDelOptions) (SpecialWordsOperationsClientDelResponse, error) {
@@ -381,6 +403,8 @@ func (client *SpecialWordsOperationsClient) delCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// Elif -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientElifOptions contains the optional parameters for the SpecialWordsOperationsClient.Elif
 //     method.
 func (client *SpecialWordsOperationsClient) Elif(ctx context.Context, options *SpecialWordsOperationsClientElifOptions) (SpecialWordsOperationsClientElifResponse, error) {
@@ -414,6 +438,8 @@ func (client *SpecialWordsOperationsClient) elifCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Else -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientElseOptions contains the optional parameters for the SpecialWordsOperationsClient.Else
 //     method.
 func (client *SpecialWordsOperationsClient) Else(ctx context.Context, options *SpecialWordsOperationsClientElseOptions) (SpecialWordsOperationsClientElseResponse, error) {
@@ -447,6 +473,8 @@ func (client *SpecialWordsOperationsClient) elseCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Except -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientExceptOptions contains the optional parameters for the SpecialWordsOperationsClient.Except
 //     method.
 func (client *SpecialWordsOperationsClient) Except(ctx context.Context, options *SpecialWordsOperationsClientExceptOptions) (SpecialWordsOperationsClientExceptResponse, error) {
@@ -480,6 +508,8 @@ func (client *SpecialWordsOperationsClient) exceptCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// Exec -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientExecOptions contains the optional parameters for the SpecialWordsOperationsClient.Exec
 //     method.
 func (client *SpecialWordsOperationsClient) Exec(ctx context.Context, options *SpecialWordsOperationsClientExecOptions) (SpecialWordsOperationsClientExecResponse, error) {
@@ -513,6 +543,8 @@ func (client *SpecialWordsOperationsClient) execCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Finally -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientFinallyOptions contains the optional parameters for the SpecialWordsOperationsClient.Finally
 //     method.
 func (client *SpecialWordsOperationsClient) Finally(ctx context.Context, options *SpecialWordsOperationsClientFinallyOptions) (SpecialWordsOperationsClientFinallyResponse, error) {
@@ -546,6 +578,8 @@ func (client *SpecialWordsOperationsClient) finallyCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// For -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientForOptions contains the optional parameters for the SpecialWordsOperationsClient.For
 //     method.
 func (client *SpecialWordsOperationsClient) For(ctx context.Context, options *SpecialWordsOperationsClientForOptions) (SpecialWordsOperationsClientForResponse, error) {
@@ -579,6 +613,8 @@ func (client *SpecialWordsOperationsClient) forCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// From -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientFromOptions contains the optional parameters for the SpecialWordsOperationsClient.From
 //     method.
 func (client *SpecialWordsOperationsClient) From(ctx context.Context, options *SpecialWordsOperationsClientFromOptions) (SpecialWordsOperationsClientFromResponse, error) {
@@ -612,6 +648,8 @@ func (client *SpecialWordsOperationsClient) fromCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Global -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientGlobalOptions contains the optional parameters for the SpecialWordsOperationsClient.Global
 //     method.
 func (client *SpecialWordsOperationsClient) Global(ctx context.Context, options *SpecialWordsOperationsClientGlobalOptions) (SpecialWordsOperationsClientGlobalResponse, error) {
@@ -645,6 +683,8 @@ func (client *SpecialWordsOperationsClient) globalCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// If -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientIfOptions contains the optional parameters for the SpecialWordsOperationsClient.If
 //     method.
 func (client *SpecialWordsOperationsClient) If(ctx context.Context, options *SpecialWordsOperationsClientIfOptions) (SpecialWordsOperationsClientIfResponse, error) {
@@ -678,6 +718,8 @@ func (client *SpecialWordsOperationsClient) ifCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Import -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientImportOptions contains the optional parameters for the SpecialWordsOperationsClient.Import
 //     method.
 func (client *SpecialWordsOperationsClient) Import(ctx context.Context, options *SpecialWordsOperationsClientImportOptions) (SpecialWordsOperationsClientImportResponse, error) {
@@ -711,6 +753,8 @@ func (client *SpecialWordsOperationsClient) importCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// In -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientInOptions contains the optional parameters for the SpecialWordsOperationsClient.In
 //     method.
 func (client *SpecialWordsOperationsClient) In(ctx context.Context, options *SpecialWordsOperationsClientInOptions) (SpecialWordsOperationsClientInResponse, error) {
@@ -744,6 +788,8 @@ func (client *SpecialWordsOperationsClient) inCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Is -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientIsOptions contains the optional parameters for the SpecialWordsOperationsClient.Is
 //     method.
 func (client *SpecialWordsOperationsClient) Is(ctx context.Context, options *SpecialWordsOperationsClientIsOptions) (SpecialWordsOperationsClientIsResponse, error) {
@@ -777,6 +823,8 @@ func (client *SpecialWordsOperationsClient) isCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Lambda -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientLambdaOptions contains the optional parameters for the SpecialWordsOperationsClient.Lambda
 //     method.
 func (client *SpecialWordsOperationsClient) Lambda(ctx context.Context, options *SpecialWordsOperationsClientLambdaOptions) (SpecialWordsOperationsClientLambdaResponse, error) {
@@ -810,6 +858,8 @@ func (client *SpecialWordsOperationsClient) lambdaCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// Not -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientNotOptions contains the optional parameters for the SpecialWordsOperationsClient.Not
 //     method.
 func (client *SpecialWordsOperationsClient) Not(ctx context.Context, options *SpecialWordsOperationsClientNotOptions) (SpecialWordsOperationsClientNotResponse, error) {
@@ -843,6 +893,8 @@ func (client *SpecialWordsOperationsClient) notCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// Or -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientOrOptions contains the optional parameters for the SpecialWordsOperationsClient.Or
 //     method.
 func (client *SpecialWordsOperationsClient) Or(ctx context.Context, options *SpecialWordsOperationsClientOrOptions) (SpecialWordsOperationsClientOrResponse, error) {
@@ -876,6 +928,8 @@ func (client *SpecialWordsOperationsClient) orCreateRequest(ctx context.Context,
 	return req, nil
 }
 
+// Pass -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientPassOptions contains the optional parameters for the SpecialWordsOperationsClient.Pass
 //     method.
 func (client *SpecialWordsOperationsClient) Pass(ctx context.Context, options *SpecialWordsOperationsClientPassOptions) (SpecialWordsOperationsClientPassResponse, error) {
@@ -909,6 +963,8 @@ func (client *SpecialWordsOperationsClient) passCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Raise -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientRaiseOptions contains the optional parameters for the SpecialWordsOperationsClient.Raise
 //     method.
 func (client *SpecialWordsOperationsClient) Raise(ctx context.Context, options *SpecialWordsOperationsClientRaiseOptions) (SpecialWordsOperationsClientRaiseResponse, error) {
@@ -942,6 +998,8 @@ func (client *SpecialWordsOperationsClient) raiseCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// Return -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientReturnOptions contains the optional parameters for the SpecialWordsOperationsClient.Return
 //     method.
 func (client *SpecialWordsOperationsClient) Return(ctx context.Context, options *SpecialWordsOperationsClientReturnOptions) (SpecialWordsOperationsClientReturnResponse, error) {
@@ -975,6 +1033,8 @@ func (client *SpecialWordsOperationsClient) returnCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// Try -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientTryOptions contains the optional parameters for the SpecialWordsOperationsClient.Try
 //     method.
 func (client *SpecialWordsOperationsClient) Try(ctx context.Context, options *SpecialWordsOperationsClientTryOptions) (SpecialWordsOperationsClientTryResponse, error) {
@@ -1008,6 +1068,8 @@ func (client *SpecialWordsOperationsClient) tryCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// While -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientWhileOptions contains the optional parameters for the SpecialWordsOperationsClient.While
 //     method.
 func (client *SpecialWordsOperationsClient) While(ctx context.Context, options *SpecialWordsOperationsClientWhileOptions) (SpecialWordsOperationsClientWhileResponse, error) {
@@ -1041,6 +1103,8 @@ func (client *SpecialWordsOperationsClient) whileCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// With -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientWithOptions contains the optional parameters for the SpecialWordsOperationsClient.With
 //     method.
 func (client *SpecialWordsOperationsClient) With(ctx context.Context, options *SpecialWordsOperationsClientWithOptions) (SpecialWordsOperationsClientWithResponse, error) {
@@ -1074,6 +1138,8 @@ func (client *SpecialWordsOperationsClient) withCreateRequest(ctx context.Contex
 	return req, nil
 }
 
+// Yield -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsOperationsClientYieldOptions contains the optional parameters for the SpecialWordsOperationsClient.Yield
 //     method.
 func (client *SpecialWordsOperationsClient) Yield(ctx context.Context, options *SpecialWordsOperationsClientYieldOptions) (SpecialWordsOperationsClientYieldResponse, error) {

--- a/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsparameters_client.go
+++ b/packages/typespec-go/test/cadlranch/specialwordsgroup/zz_specialwordsparameters_client.go
@@ -18,6 +18,8 @@ type SpecialWordsParametersClient struct {
 	internal *azcore.Client
 }
 
+// WithAnd -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithAndOptions contains the optional parameters for the SpecialWordsParametersClient.WithAnd
 //     method.
 func (client *SpecialWordsParametersClient) WithAnd(ctx context.Context, and string, options *SpecialWordsParametersClientWithAndOptions) (SpecialWordsParametersClientWithAndResponse, error) {
@@ -54,6 +56,8 @@ func (client *SpecialWordsParametersClient) withAndCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithAs -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithAsOptions contains the optional parameters for the SpecialWordsParametersClient.WithAs
 //     method.
 func (client *SpecialWordsParametersClient) WithAs(ctx context.Context, as string, options *SpecialWordsParametersClientWithAsOptions) (SpecialWordsParametersClientWithAsResponse, error) {
@@ -90,6 +94,8 @@ func (client *SpecialWordsParametersClient) withAsCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithAssert -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithAssertOptions contains the optional parameters for the SpecialWordsParametersClient.WithAssert
 //     method.
 func (client *SpecialWordsParametersClient) WithAssert(ctx context.Context, assert string, options *SpecialWordsParametersClientWithAssertOptions) (SpecialWordsParametersClientWithAssertResponse, error) {
@@ -126,6 +132,8 @@ func (client *SpecialWordsParametersClient) withAssertCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithAsync -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithAsyncOptions contains the optional parameters for the SpecialWordsParametersClient.WithAsync
 //     method.
 func (client *SpecialWordsParametersClient) WithAsync(ctx context.Context, async string, options *SpecialWordsParametersClientWithAsyncOptions) (SpecialWordsParametersClientWithAsyncResponse, error) {
@@ -162,6 +170,8 @@ func (client *SpecialWordsParametersClient) withAsyncCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithAwait -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithAwaitOptions contains the optional parameters for the SpecialWordsParametersClient.WithAwait
 //     method.
 func (client *SpecialWordsParametersClient) WithAwait(ctx context.Context, await string, options *SpecialWordsParametersClientWithAwaitOptions) (SpecialWordsParametersClientWithAwaitResponse, error) {
@@ -198,6 +208,8 @@ func (client *SpecialWordsParametersClient) withAwaitCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithBreak -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithBreakOptions contains the optional parameters for the SpecialWordsParametersClient.WithBreak
 //     method.
 func (client *SpecialWordsParametersClient) WithBreak(ctx context.Context, breakParam string, options *SpecialWordsParametersClientWithBreakOptions) (SpecialWordsParametersClientWithBreakResponse, error) {
@@ -234,6 +246,8 @@ func (client *SpecialWordsParametersClient) withBreakCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithCancellationToken -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithCancellationTokenOptions contains the optional parameters for the SpecialWordsParametersClient.WithCancellationToken
 //     method.
 func (client *SpecialWordsParametersClient) WithCancellationToken(ctx context.Context, cancellationToken string, options *SpecialWordsParametersClientWithCancellationTokenOptions) (SpecialWordsParametersClientWithCancellationTokenResponse, error) {
@@ -270,6 +284,8 @@ func (client *SpecialWordsParametersClient) withCancellationTokenCreateRequest(c
 	return req, nil
 }
 
+// WithClass -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithClassOptions contains the optional parameters for the SpecialWordsParametersClient.WithClass
 //     method.
 func (client *SpecialWordsParametersClient) WithClass(ctx context.Context, class string, options *SpecialWordsParametersClientWithClassOptions) (SpecialWordsParametersClientWithClassResponse, error) {
@@ -306,6 +322,8 @@ func (client *SpecialWordsParametersClient) withClassCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithConstructor -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithConstructorOptions contains the optional parameters for the SpecialWordsParametersClient.WithConstructor
 //     method.
 func (client *SpecialWordsParametersClient) WithConstructor(ctx context.Context, constructor string, options *SpecialWordsParametersClientWithConstructorOptions) (SpecialWordsParametersClientWithConstructorResponse, error) {
@@ -342,6 +360,8 @@ func (client *SpecialWordsParametersClient) withConstructorCreateRequest(ctx con
 	return req, nil
 }
 
+// WithContinue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithContinueOptions contains the optional parameters for the SpecialWordsParametersClient.WithContinue
 //     method.
 func (client *SpecialWordsParametersClient) WithContinue(ctx context.Context, continueParam string, options *SpecialWordsParametersClientWithContinueOptions) (SpecialWordsParametersClientWithContinueResponse, error) {
@@ -378,6 +398,8 @@ func (client *SpecialWordsParametersClient) withContinueCreateRequest(ctx contex
 	return req, nil
 }
 
+// WithDef -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithDefOptions contains the optional parameters for the SpecialWordsParametersClient.WithDef
 //     method.
 func (client *SpecialWordsParametersClient) WithDef(ctx context.Context, def string, options *SpecialWordsParametersClientWithDefOptions) (SpecialWordsParametersClientWithDefResponse, error) {
@@ -414,6 +436,8 @@ func (client *SpecialWordsParametersClient) withDefCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithDel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithDelOptions contains the optional parameters for the SpecialWordsParametersClient.WithDel
 //     method.
 func (client *SpecialWordsParametersClient) WithDel(ctx context.Context, del string, options *SpecialWordsParametersClientWithDelOptions) (SpecialWordsParametersClientWithDelResponse, error) {
@@ -450,6 +474,8 @@ func (client *SpecialWordsParametersClient) withDelCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithElif -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithElifOptions contains the optional parameters for the SpecialWordsParametersClient.WithElif
 //     method.
 func (client *SpecialWordsParametersClient) WithElif(ctx context.Context, elif string, options *SpecialWordsParametersClientWithElifOptions) (SpecialWordsParametersClientWithElifResponse, error) {
@@ -486,6 +512,8 @@ func (client *SpecialWordsParametersClient) withElifCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithElse -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithElseOptions contains the optional parameters for the SpecialWordsParametersClient.WithElse
 //     method.
 func (client *SpecialWordsParametersClient) WithElse(ctx context.Context, elseParam string, options *SpecialWordsParametersClientWithElseOptions) (SpecialWordsParametersClientWithElseResponse, error) {
@@ -522,6 +550,8 @@ func (client *SpecialWordsParametersClient) withElseCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithExcept -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithExceptOptions contains the optional parameters for the SpecialWordsParametersClient.WithExcept
 //     method.
 func (client *SpecialWordsParametersClient) WithExcept(ctx context.Context, except string, options *SpecialWordsParametersClientWithExceptOptions) (SpecialWordsParametersClientWithExceptResponse, error) {
@@ -558,6 +588,8 @@ func (client *SpecialWordsParametersClient) withExceptCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithExec -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithExecOptions contains the optional parameters for the SpecialWordsParametersClient.WithExec
 //     method.
 func (client *SpecialWordsParametersClient) WithExec(ctx context.Context, execParam string, options *SpecialWordsParametersClientWithExecOptions) (SpecialWordsParametersClientWithExecResponse, error) {
@@ -594,6 +626,8 @@ func (client *SpecialWordsParametersClient) withExecCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithFinally -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithFinallyOptions contains the optional parameters for the SpecialWordsParametersClient.WithFinally
 //     method.
 func (client *SpecialWordsParametersClient) WithFinally(ctx context.Context, finally string, options *SpecialWordsParametersClientWithFinallyOptions) (SpecialWordsParametersClientWithFinallyResponse, error) {
@@ -630,6 +664,8 @@ func (client *SpecialWordsParametersClient) withFinallyCreateRequest(ctx context
 	return req, nil
 }
 
+// WithFor -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithForOptions contains the optional parameters for the SpecialWordsParametersClient.WithFor
 //     method.
 func (client *SpecialWordsParametersClient) WithFor(ctx context.Context, forParam string, options *SpecialWordsParametersClientWithForOptions) (SpecialWordsParametersClientWithForResponse, error) {
@@ -666,6 +702,8 @@ func (client *SpecialWordsParametersClient) withForCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithFrom -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithFromOptions contains the optional parameters for the SpecialWordsParametersClient.WithFrom
 //     method.
 func (client *SpecialWordsParametersClient) WithFrom(ctx context.Context, from string, options *SpecialWordsParametersClientWithFromOptions) (SpecialWordsParametersClientWithFromResponse, error) {
@@ -702,6 +740,8 @@ func (client *SpecialWordsParametersClient) withFromCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithGlobal -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithGlobalOptions contains the optional parameters for the SpecialWordsParametersClient.WithGlobal
 //     method.
 func (client *SpecialWordsParametersClient) WithGlobal(ctx context.Context, global string, options *SpecialWordsParametersClientWithGlobalOptions) (SpecialWordsParametersClientWithGlobalResponse, error) {
@@ -738,6 +778,8 @@ func (client *SpecialWordsParametersClient) withGlobalCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithIf -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithIfOptions contains the optional parameters for the SpecialWordsParametersClient.WithIf
 //     method.
 func (client *SpecialWordsParametersClient) WithIf(ctx context.Context, ifParam string, options *SpecialWordsParametersClientWithIfOptions) (SpecialWordsParametersClientWithIfResponse, error) {
@@ -774,6 +816,8 @@ func (client *SpecialWordsParametersClient) withIfCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithImport -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithImportOptions contains the optional parameters for the SpecialWordsParametersClient.WithImport
 //     method.
 func (client *SpecialWordsParametersClient) WithImport(ctx context.Context, importParam string, options *SpecialWordsParametersClientWithImportOptions) (SpecialWordsParametersClientWithImportResponse, error) {
@@ -810,6 +854,8 @@ func (client *SpecialWordsParametersClient) withImportCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithIn -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithInOptions contains the optional parameters for the SpecialWordsParametersClient.WithIn
 //     method.
 func (client *SpecialWordsParametersClient) WithIn(ctx context.Context, in string, options *SpecialWordsParametersClientWithInOptions) (SpecialWordsParametersClientWithInResponse, error) {
@@ -846,6 +892,8 @@ func (client *SpecialWordsParametersClient) withInCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithIs -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithIsOptions contains the optional parameters for the SpecialWordsParametersClient.WithIs
 //     method.
 func (client *SpecialWordsParametersClient) WithIs(ctx context.Context, is string, options *SpecialWordsParametersClientWithIsOptions) (SpecialWordsParametersClientWithIsResponse, error) {
@@ -882,6 +930,8 @@ func (client *SpecialWordsParametersClient) withIsCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithLambda -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithLambdaOptions contains the optional parameters for the SpecialWordsParametersClient.WithLambda
 //     method.
 func (client *SpecialWordsParametersClient) WithLambda(ctx context.Context, lambda string, options *SpecialWordsParametersClientWithLambdaOptions) (SpecialWordsParametersClientWithLambdaResponse, error) {
@@ -918,6 +968,8 @@ func (client *SpecialWordsParametersClient) withLambdaCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithNot -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithNotOptions contains the optional parameters for the SpecialWordsParametersClient.WithNot
 //     method.
 func (client *SpecialWordsParametersClient) WithNot(ctx context.Context, not string, options *SpecialWordsParametersClientWithNotOptions) (SpecialWordsParametersClientWithNotResponse, error) {
@@ -954,6 +1006,8 @@ func (client *SpecialWordsParametersClient) withNotCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithOr -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithOrOptions contains the optional parameters for the SpecialWordsParametersClient.WithOr
 //     method.
 func (client *SpecialWordsParametersClient) WithOr(ctx context.Context, or string, options *SpecialWordsParametersClientWithOrOptions) (SpecialWordsParametersClientWithOrResponse, error) {
@@ -990,6 +1044,8 @@ func (client *SpecialWordsParametersClient) withOrCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// WithPass -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithPassOptions contains the optional parameters for the SpecialWordsParametersClient.WithPass
 //     method.
 func (client *SpecialWordsParametersClient) WithPass(ctx context.Context, pass string, options *SpecialWordsParametersClientWithPassOptions) (SpecialWordsParametersClientWithPassResponse, error) {
@@ -1026,6 +1082,8 @@ func (client *SpecialWordsParametersClient) withPassCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithRaise -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithRaiseOptions contains the optional parameters for the SpecialWordsParametersClient.WithRaise
 //     method.
 func (client *SpecialWordsParametersClient) WithRaise(ctx context.Context, raise string, options *SpecialWordsParametersClientWithRaiseOptions) (SpecialWordsParametersClientWithRaiseResponse, error) {
@@ -1062,6 +1120,8 @@ func (client *SpecialWordsParametersClient) withRaiseCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithReturn -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithReturnOptions contains the optional parameters for the SpecialWordsParametersClient.WithReturn
 //     method.
 func (client *SpecialWordsParametersClient) WithReturn(ctx context.Context, returnParam string, options *SpecialWordsParametersClientWithReturnOptions) (SpecialWordsParametersClientWithReturnResponse, error) {
@@ -1098,6 +1158,8 @@ func (client *SpecialWordsParametersClient) withReturnCreateRequest(ctx context.
 	return req, nil
 }
 
+// WithTry -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithTryOptions contains the optional parameters for the SpecialWordsParametersClient.WithTry
 //     method.
 func (client *SpecialWordsParametersClient) WithTry(ctx context.Context, try string, options *SpecialWordsParametersClientWithTryOptions) (SpecialWordsParametersClientWithTryResponse, error) {
@@ -1134,6 +1196,8 @@ func (client *SpecialWordsParametersClient) withTryCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// WithWhile -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithWhileOptions contains the optional parameters for the SpecialWordsParametersClient.WithWhile
 //     method.
 func (client *SpecialWordsParametersClient) WithWhile(ctx context.Context, while string, options *SpecialWordsParametersClientWithWhileOptions) (SpecialWordsParametersClientWithWhileResponse, error) {
@@ -1170,6 +1234,8 @@ func (client *SpecialWordsParametersClient) withWhileCreateRequest(ctx context.C
 	return req, nil
 }
 
+// WithWith -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithWithOptions contains the optional parameters for the SpecialWordsParametersClient.WithWith
 //     method.
 func (client *SpecialWordsParametersClient) WithWith(ctx context.Context, with string, options *SpecialWordsParametersClientWithWithOptions) (SpecialWordsParametersClientWithWithResponse, error) {
@@ -1206,6 +1272,8 @@ func (client *SpecialWordsParametersClient) withWithCreateRequest(ctx context.Co
 	return req, nil
 }
 
+// WithYield -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SpecialWordsParametersClientWithYieldOptions contains the optional parameters for the SpecialWordsParametersClient.WithYield
 //     method.
 func (client *SpecialWordsParametersClient) WithYield(ctx context.Context, yield string, options *SpecialWordsParametersClientWithYieldOptions) (SpecialWordsParametersClientWithYieldResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraybooleanvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraybooleanvalue_client.go
@@ -18,7 +18,9 @@ type ArrayBooleanValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayBooleanValueClientGetOptions contains the optional parameters for the ArrayBooleanValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayBooleanValueClientGetOptions contains the optional parameters for the ArrayBooleanValueClient.Get method.
 func (client *ArrayBooleanValueClient) Get(ctx context.Context, options *ArrayBooleanValueClientGetOptions) (ArrayBooleanValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayBooleanValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayBooleanValueClient) getHandleResponse(resp *http.Response) (A
 	return result, nil
 }
 
-// - options - ArrayBooleanValueClientPutOptions contains the optional parameters for the ArrayBooleanValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayBooleanValueClientPutOptions contains the optional parameters for the ArrayBooleanValueClient.Put method.
 func (client *ArrayBooleanValueClient) Put(ctx context.Context, body []bool, options *ArrayBooleanValueClientPutOptions) (ArrayBooleanValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayBooleanValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraydatetimevalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraydatetimevalue_client.go
@@ -19,7 +19,9 @@ type ArrayDatetimeValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayDatetimeValueClientGetOptions contains the optional parameters for the ArrayDatetimeValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayDatetimeValueClientGetOptions contains the optional parameters for the ArrayDatetimeValueClient.Get method.
 func (client *ArrayDatetimeValueClient) Get(ctx context.Context, options *ArrayDatetimeValueClientGetOptions) (ArrayDatetimeValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayDatetimeValueClient.Get"
@@ -68,7 +70,9 @@ func (client *ArrayDatetimeValueClient) getHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
-// - options - ArrayDatetimeValueClientPutOptions contains the optional parameters for the ArrayDatetimeValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayDatetimeValueClientPutOptions contains the optional parameters for the ArrayDatetimeValueClient.Put method.
 func (client *ArrayDatetimeValueClient) Put(ctx context.Context, body []time.Time, options *ArrayDatetimeValueClientPutOptions) (ArrayDatetimeValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayDatetimeValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraydurationvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraydurationvalue_client.go
@@ -18,7 +18,9 @@ type ArrayDurationValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayDurationValueClientGetOptions contains the optional parameters for the ArrayDurationValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayDurationValueClientGetOptions contains the optional parameters for the ArrayDurationValueClient.Get method.
 func (client *ArrayDurationValueClient) Get(ctx context.Context, options *ArrayDurationValueClientGetOptions) (ArrayDurationValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayDurationValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayDurationValueClient) getHandleResponse(resp *http.Response) (
 	return result, nil
 }
 
-// - options - ArrayDurationValueClientPutOptions contains the optional parameters for the ArrayDurationValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayDurationValueClientPutOptions contains the optional parameters for the ArrayDurationValueClient.Put method.
 func (client *ArrayDurationValueClient) Put(ctx context.Context, body []string, options *ArrayDurationValueClientPutOptions) (ArrayDurationValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayDurationValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayfloat32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayfloat32value_client.go
@@ -18,7 +18,9 @@ type ArrayFloat32ValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayFloat32ValueClientGetOptions contains the optional parameters for the ArrayFloat32ValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayFloat32ValueClientGetOptions contains the optional parameters for the ArrayFloat32ValueClient.Get method.
 func (client *ArrayFloat32ValueClient) Get(ctx context.Context, options *ArrayFloat32ValueClientGetOptions) (ArrayFloat32ValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayFloat32ValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayFloat32ValueClient) getHandleResponse(resp *http.Response) (A
 	return result, nil
 }
 
-// - options - ArrayFloat32ValueClientPutOptions contains the optional parameters for the ArrayFloat32ValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayFloat32ValueClientPutOptions contains the optional parameters for the ArrayFloat32ValueClient.Put method.
 func (client *ArrayFloat32ValueClient) Put(ctx context.Context, body []float32, options *ArrayFloat32ValueClientPutOptions) (ArrayFloat32ValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayFloat32ValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayint32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayint32value_client.go
@@ -18,7 +18,9 @@ type ArrayInt32ValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayInt32ValueClientGetOptions contains the optional parameters for the ArrayInt32ValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayInt32ValueClientGetOptions contains the optional parameters for the ArrayInt32ValueClient.Get method.
 func (client *ArrayInt32ValueClient) Get(ctx context.Context, options *ArrayInt32ValueClientGetOptions) (ArrayInt32ValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayInt32ValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayInt32ValueClient) getHandleResponse(resp *http.Response) (Arr
 	return result, nil
 }
 
-// - options - ArrayInt32ValueClientPutOptions contains the optional parameters for the ArrayInt32ValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayInt32ValueClientPutOptions contains the optional parameters for the ArrayInt32ValueClient.Put method.
 func (client *ArrayInt32ValueClient) Put(ctx context.Context, body []int32, options *ArrayInt32ValueClientPutOptions) (ArrayInt32ValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayInt32ValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayint64value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayint64value_client.go
@@ -18,7 +18,9 @@ type ArrayInt64ValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayInt64ValueClientGetOptions contains the optional parameters for the ArrayInt64ValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayInt64ValueClientGetOptions contains the optional parameters for the ArrayInt64ValueClient.Get method.
 func (client *ArrayInt64ValueClient) Get(ctx context.Context, options *ArrayInt64ValueClientGetOptions) (ArrayInt64ValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayInt64ValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayInt64ValueClient) getHandleResponse(resp *http.Response) (Arr
 	return result, nil
 }
 
-// - options - ArrayInt64ValueClientPutOptions contains the optional parameters for the ArrayInt64ValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayInt64ValueClientPutOptions contains the optional parameters for the ArrayInt64ValueClient.Put method.
 func (client *ArrayInt64ValueClient) Put(ctx context.Context, body []int64, options *ArrayInt64ValueClientPutOptions) (ArrayInt64ValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayInt64ValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraymodelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraymodelvalue_client.go
@@ -18,7 +18,9 @@ type ArrayModelValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayModelValueClientGetOptions contains the optional parameters for the ArrayModelValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayModelValueClientGetOptions contains the optional parameters for the ArrayModelValueClient.Get method.
 func (client *ArrayModelValueClient) Get(ctx context.Context, options *ArrayModelValueClientGetOptions) (ArrayModelValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayModelValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayModelValueClient) getHandleResponse(resp *http.Response) (Arr
 	return result, nil
 }
 
-// - options - ArrayModelValueClientPutOptions contains the optional parameters for the ArrayModelValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayModelValueClientPutOptions contains the optional parameters for the ArrayModelValueClient.Put method.
 func (client *ArrayModelValueClient) Put(ctx context.Context, body []InnerModel, options *ArrayModelValueClientPutOptions) (ArrayModelValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayModelValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraynullablefloatvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraynullablefloatvalue_client.go
@@ -18,6 +18,8 @@ type ArrayNullableFloatValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ArrayNullableFloatValueClientGetOptions contains the optional parameters for the ArrayNullableFloatValueClient.Get
 //     method.
 func (client *ArrayNullableFloatValueClient) Get(ctx context.Context, options *ArrayNullableFloatValueClientGetOptions) (ArrayNullableFloatValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *ArrayNullableFloatValueClient) getHandleResponse(resp *http.Respon
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ArrayNullableFloatValueClientPutOptions contains the optional parameters for the ArrayNullableFloatValueClient.Put
 //     method.
 func (client *ArrayNullableFloatValueClient) Put(ctx context.Context, body []*float32, options *ArrayNullableFloatValueClientPutOptions) (ArrayNullableFloatValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraystringvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arraystringvalue_client.go
@@ -18,7 +18,9 @@ type ArrayStringValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayStringValueClientGetOptions contains the optional parameters for the ArrayStringValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayStringValueClientGetOptions contains the optional parameters for the ArrayStringValueClient.Get method.
 func (client *ArrayStringValueClient) Get(ctx context.Context, options *ArrayStringValueClientGetOptions) (ArrayStringValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayStringValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayStringValueClient) getHandleResponse(resp *http.Response) (Ar
 	return result, nil
 }
 
-// - options - ArrayStringValueClientPutOptions contains the optional parameters for the ArrayStringValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayStringValueClientPutOptions contains the optional parameters for the ArrayStringValueClient.Put method.
 func (client *ArrayStringValueClient) Put(ctx context.Context, body []string, options *ArrayStringValueClientPutOptions) (ArrayStringValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayStringValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayunknownvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/arraygroup/zz_arrayunknownvalue_client.go
@@ -18,7 +18,9 @@ type ArrayUnknownValueClient struct {
 	internal *azcore.Client
 }
 
-// - options - ArrayUnknownValueClientGetOptions contains the optional parameters for the ArrayUnknownValueClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayUnknownValueClientGetOptions contains the optional parameters for the ArrayUnknownValueClient.Get method.
 func (client *ArrayUnknownValueClient) Get(ctx context.Context, options *ArrayUnknownValueClientGetOptions) (ArrayUnknownValueClientGetResponse, error) {
 	var err error
 	const operationName = "ArrayUnknownValueClient.Get"
@@ -61,7 +63,9 @@ func (client *ArrayUnknownValueClient) getHandleResponse(resp *http.Response) (A
 	return result, nil
 }
 
-// - options - ArrayUnknownValueClientPutOptions contains the optional parameters for the ArrayUnknownValueClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - ArrayUnknownValueClientPutOptions contains the optional parameters for the ArrayUnknownValueClient.Put method.
 func (client *ArrayUnknownValueClient) Put(ctx context.Context, body []any, options *ArrayUnknownValueClientPutOptions) (ArrayUnknownValueClientPutResponse, error) {
 	var err error
 	const operationName = "ArrayUnknownValueClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarybooleanvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarybooleanvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryBooleanValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryBooleanValueClientGetOptions contains the optional parameters for the DictionaryBooleanValueClient.Get
 //     method.
 func (client *DictionaryBooleanValueClient) Get(ctx context.Context, options *DictionaryBooleanValueClientGetOptions) (DictionaryBooleanValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryBooleanValueClient) getHandleResponse(resp *http.Respons
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryBooleanValueClientPutOptions contains the optional parameters for the DictionaryBooleanValueClient.Put
 //     method.
 func (client *DictionaryBooleanValueClient) Put(ctx context.Context, body map[string]*bool, options *DictionaryBooleanValueClientPutOptions) (DictionaryBooleanValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydatetimevalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydatetimevalue_client.go
@@ -19,6 +19,8 @@ type DictionaryDatetimeValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryDatetimeValueClientGetOptions contains the optional parameters for the DictionaryDatetimeValueClient.Get
 //     method.
 func (client *DictionaryDatetimeValueClient) Get(ctx context.Context, options *DictionaryDatetimeValueClientGetOptions) (DictionaryDatetimeValueClientGetResponse, error) {
@@ -69,6 +71,8 @@ func (client *DictionaryDatetimeValueClient) getHandleResponse(resp *http.Respon
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryDatetimeValueClientPutOptions contains the optional parameters for the DictionaryDatetimeValueClient.Put
 //     method.
 func (client *DictionaryDatetimeValueClient) Put(ctx context.Context, body map[string]*time.Time, options *DictionaryDatetimeValueClientPutOptions) (DictionaryDatetimeValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydurationvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydurationvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryDurationValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryDurationValueClientGetOptions contains the optional parameters for the DictionaryDurationValueClient.Get
 //     method.
 func (client *DictionaryDurationValueClient) Get(ctx context.Context, options *DictionaryDurationValueClientGetOptions) (DictionaryDurationValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryDurationValueClient) getHandleResponse(resp *http.Respon
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryDurationValueClientPutOptions contains the optional parameters for the DictionaryDurationValueClient.Put
 //     method.
 func (client *DictionaryDurationValueClient) Put(ctx context.Context, body map[string]*string, options *DictionaryDurationValueClientPutOptions) (DictionaryDurationValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryfloat32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryfloat32value_client.go
@@ -18,6 +18,8 @@ type DictionaryFloat32ValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryFloat32ValueClientGetOptions contains the optional parameters for the DictionaryFloat32ValueClient.Get
 //     method.
 func (client *DictionaryFloat32ValueClient) Get(ctx context.Context, options *DictionaryFloat32ValueClientGetOptions) (DictionaryFloat32ValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryFloat32ValueClient) getHandleResponse(resp *http.Respons
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryFloat32ValueClientPutOptions contains the optional parameters for the DictionaryFloat32ValueClient.Put
 //     method.
 func (client *DictionaryFloat32ValueClient) Put(ctx context.Context, body map[string]*float32, options *DictionaryFloat32ValueClientPutOptions) (DictionaryFloat32ValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryint32value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryint32value_client.go
@@ -18,6 +18,8 @@ type DictionaryInt32ValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryInt32ValueClientGetOptions contains the optional parameters for the DictionaryInt32ValueClient.Get
 //     method.
 func (client *DictionaryInt32ValueClient) Get(ctx context.Context, options *DictionaryInt32ValueClientGetOptions) (DictionaryInt32ValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryInt32ValueClient) getHandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryInt32ValueClientPutOptions contains the optional parameters for the DictionaryInt32ValueClient.Put
 //     method.
 func (client *DictionaryInt32ValueClient) Put(ctx context.Context, body map[string]*int32, options *DictionaryInt32ValueClientPutOptions) (DictionaryInt32ValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryint64value_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryint64value_client.go
@@ -18,6 +18,8 @@ type DictionaryInt64ValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryInt64ValueClientGetOptions contains the optional parameters for the DictionaryInt64ValueClient.Get
 //     method.
 func (client *DictionaryInt64ValueClient) Get(ctx context.Context, options *DictionaryInt64ValueClientGetOptions) (DictionaryInt64ValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryInt64ValueClient) getHandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryInt64ValueClientPutOptions contains the optional parameters for the DictionaryInt64ValueClient.Put
 //     method.
 func (client *DictionaryInt64ValueClient) Put(ctx context.Context, body map[string]*int64, options *DictionaryInt64ValueClientPutOptions) (DictionaryInt64ValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarymodelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarymodelvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryModelValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryModelValueClientGetOptions contains the optional parameters for the DictionaryModelValueClient.Get
 //     method.
 func (client *DictionaryModelValueClient) Get(ctx context.Context, options *DictionaryModelValueClientGetOptions) (DictionaryModelValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryModelValueClient) getHandleResponse(resp *http.Response)
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryModelValueClientPutOptions contains the optional parameters for the DictionaryModelValueClient.Put
 //     method.
 func (client *DictionaryModelValueClient) Put(ctx context.Context, body map[string]*InnerModel, options *DictionaryModelValueClientPutOptions) (DictionaryModelValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarynullablefloatvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarynullablefloatvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryNullableFloatValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryNullableFloatValueClientGetOptions contains the optional parameters for the DictionaryNullableFloatValueClient.Get
 //     method.
 func (client *DictionaryNullableFloatValueClient) Get(ctx context.Context, options *DictionaryNullableFloatValueClientGetOptions) (DictionaryNullableFloatValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryNullableFloatValueClient) getHandleResponse(resp *http.R
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryNullableFloatValueClientPutOptions contains the optional parameters for the DictionaryNullableFloatValueClient.Put
 //     method.
 func (client *DictionaryNullableFloatValueClient) Put(ctx context.Context, body map[string]*float32, options *DictionaryNullableFloatValueClientPutOptions) (DictionaryNullableFloatValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryrecursivemodelvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryrecursivemodelvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryRecursiveModelValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryRecursiveModelValueClientGetOptions contains the optional parameters for the DictionaryRecursiveModelValueClient.Get
 //     method.
 func (client *DictionaryRecursiveModelValueClient) Get(ctx context.Context, options *DictionaryRecursiveModelValueClientGetOptions) (DictionaryRecursiveModelValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryRecursiveModelValueClient) getHandleResponse(resp *http.
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryRecursiveModelValueClientPutOptions contains the optional parameters for the DictionaryRecursiveModelValueClient.Put
 //     method.
 func (client *DictionaryRecursiveModelValueClient) Put(ctx context.Context, body map[string]*InnerModel, options *DictionaryRecursiveModelValueClientPutOptions) (DictionaryRecursiveModelValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarystringvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarystringvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryStringValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryStringValueClientGetOptions contains the optional parameters for the DictionaryStringValueClient.Get
 //     method.
 func (client *DictionaryStringValueClient) Get(ctx context.Context, options *DictionaryStringValueClientGetOptions) (DictionaryStringValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryStringValueClient) getHandleResponse(resp *http.Response
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryStringValueClientPutOptions contains the optional parameters for the DictionaryStringValueClient.Put
 //     method.
 func (client *DictionaryStringValueClient) Put(ctx context.Context, body map[string]*string, options *DictionaryStringValueClientPutOptions) (DictionaryStringValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryunknownvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionaryunknownvalue_client.go
@@ -18,6 +18,8 @@ type DictionaryUnknownValueClient struct {
 	internal *azcore.Client
 }
 
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryUnknownValueClientGetOptions contains the optional parameters for the DictionaryUnknownValueClient.Get
 //     method.
 func (client *DictionaryUnknownValueClient) Get(ctx context.Context, options *DictionaryUnknownValueClientGetOptions) (DictionaryUnknownValueClientGetResponse, error) {
@@ -62,6 +64,8 @@ func (client *DictionaryUnknownValueClient) getHandleResponse(resp *http.Respons
 	return result, nil
 }
 
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - DictionaryUnknownValueClientPutOptions contains the optional parameters for the DictionaryUnknownValueClient.Put
 //     method.
 func (client *DictionaryUnknownValueClient) Put(ctx context.Context, body map[string]any, options *DictionaryUnknownValueClientPutOptions) (DictionaryUnknownValueClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_extensiblestring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/extensiblegroup/zz_extensiblestring_client.go
@@ -18,6 +18,8 @@ type ExtensibleStringClient struct {
 	internal *azcore.Client
 }
 
+// GetKnownValue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ExtensibleStringClientGetKnownValueOptions contains the optional parameters for the ExtensibleStringClient.GetKnownValue
 //     method.
 func (client *ExtensibleStringClient) GetKnownValue(ctx context.Context, options *ExtensibleStringClientGetKnownValueOptions) (ExtensibleStringClientGetKnownValueResponse, error) {
@@ -62,6 +64,8 @@ func (client *ExtensibleStringClient) getKnownValueHandleResponse(resp *http.Res
 	return result, nil
 }
 
+// GetUnknownValue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ExtensibleStringClientGetUnknownValueOptions contains the optional parameters for the ExtensibleStringClient.GetUnknownValue
 //     method.
 func (client *ExtensibleStringClient) GetUnknownValue(ctx context.Context, options *ExtensibleStringClientGetUnknownValueOptions) (ExtensibleStringClientGetUnknownValueResponse, error) {
@@ -106,6 +110,8 @@ func (client *ExtensibleStringClient) getUnknownValueHandleResponse(resp *http.R
 	return result, nil
 }
 
+// PutKnownValue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ExtensibleStringClientPutKnownValueOptions contains the optional parameters for the ExtensibleStringClient.PutKnownValue
 //     method.
 func (client *ExtensibleStringClient) PutKnownValue(ctx context.Context, body DaysOfWeekExtensibleEnum, options *ExtensibleStringClientPutKnownValueOptions) (ExtensibleStringClientPutKnownValueResponse, error) {
@@ -143,6 +149,8 @@ func (client *ExtensibleStringClient) putKnownValueCreateRequest(ctx context.Con
 	return req, nil
 }
 
+// PutUnknownValue -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ExtensibleStringClientPutUnknownValueOptions contains the optional parameters for the ExtensibleStringClient.PutUnknownValue
 //     method.
 func (client *ExtensibleStringClient) PutUnknownValue(ctx context.Context, body DaysOfWeekExtensibleEnum, options *ExtensibleStringClientPutUnknownValueOptions) (ExtensibleStringClientPutUnknownValueResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_fixedstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/enum/fixedgroup/zz_fixedstring_client.go
@@ -19,6 +19,7 @@ type FixedStringClient struct {
 }
 
 // GetKnownValue - getKnownValue
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - FixedStringClientGetKnownValueOptions contains the optional parameters for the FixedStringClient.GetKnownValue
 //     method.
 func (client *FixedStringClient) GetKnownValue(ctx context.Context, options *FixedStringClientGetKnownValueOptions) (FixedStringClientGetKnownValueResponse, error) {
@@ -64,6 +65,7 @@ func (client *FixedStringClient) getKnownValueHandleResponse(resp *http.Response
 }
 
 // PutKnownValue - putKnownValue
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - FixedStringClientPutKnownValueOptions contains the optional parameters for the FixedStringClient.PutKnownValue
 //     method.
@@ -103,6 +105,7 @@ func (client *FixedStringClient) putKnownValueCreateRequest(ctx context.Context,
 }
 
 // PutUnknownValue - putUnknownValue
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - FixedStringClientPutUnknownValueOptions contains the optional parameters for the FixedStringClient.PutUnknownValue
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_empty_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/emptygroup/zz_empty_client.go
@@ -18,7 +18,9 @@ type EmptyClient struct {
 	internal *azcore.Client
 }
 
-// - options - GetEmptyOptions contains the optional parameters for the EmptyClient.GetEmpty method.
+// GetEmpty -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - GetEmptyOptions contains the optional parameters for the EmptyClient.GetEmpty method.
 func (client *EmptyClient) GetEmpty(ctx context.Context, options *GetEmptyOptions) (GetEmptyResponse, error) {
 	var err error
 	const operationName = "EmptyClient.GetEmpty"
@@ -61,7 +63,9 @@ func (client *EmptyClient) getEmptyHandleResponse(resp *http.Response) (GetEmpty
 	return result, nil
 }
 
-// - options - PostRoundTripEmptyOptions contains the optional parameters for the EmptyClient.PostRoundTripEmpty method.
+// PostRoundTripEmpty -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - PostRoundTripEmptyOptions contains the optional parameters for the EmptyClient.PostRoundTripEmpty method.
 func (client *EmptyClient) PostRoundTripEmpty(ctx context.Context, body EmptyInputOutput, options *PostRoundTripEmptyOptions) (PostRoundTripEmptyResponse, error) {
 	var err error
 	const operationName = "EmptyClient.PostRoundTripEmpty"
@@ -108,7 +112,9 @@ func (client *EmptyClient) postRoundTripEmptyHandleResponse(resp *http.Response)
 	return result, nil
 }
 
-// - options - PutEmptyOptions contains the optional parameters for the EmptyClient.PutEmpty method.
+// PutEmpty -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - PutEmptyOptions contains the optional parameters for the EmptyClient.PutEmpty method.
 func (client *EmptyClient) PutEmpty(ctx context.Context, input EmptyInput, options *PutEmptyOptions) (PutEmptyResponse, error) {
 	var err error
 	const operationName = "EmptyClient.PutEmpty"

--- a/packages/typespec-go/test/cadlranch/type/model/flattengroup/zz_flatten_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/flattengroup/zz_flatten_client.go
@@ -18,7 +18,9 @@ type FlattenClient struct {
 	internal *azcore.Client
 }
 
-// - options - FlattenClientPutFlattenModelOptions contains the optional parameters for the FlattenClient.PutFlattenModel method.
+// PutFlattenModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - FlattenClientPutFlattenModelOptions contains the optional parameters for the FlattenClient.PutFlattenModel method.
 func (client *FlattenClient) PutFlattenModel(ctx context.Context, input FlattenModel, options *FlattenClientPutFlattenModelOptions) (FlattenClientPutFlattenModelResponse, error) {
 	var err error
 	const operationName = "FlattenClient.PutFlattenModel"
@@ -65,6 +67,8 @@ func (client *FlattenClient) putFlattenModelHandleResponse(resp *http.Response) 
 	return result, nil
 }
 
+// PutNestedFlattenModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - FlattenClientPutNestedFlattenModelOptions contains the optional parameters for the FlattenClient.PutNestedFlattenModel
 //     method.
 func (client *FlattenClient) PutNestedFlattenModel(ctx context.Context, input NestedFlattenModel, options *FlattenClientPutNestedFlattenModelOptions) (FlattenClientPutNestedFlattenModelResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/enumdiscgroup/zz_enumdiscriminator_client.go
@@ -19,6 +19,7 @@ type EnumDiscriminatorClient struct {
 }
 
 // GetExtensibleModel - Receive model with extensible enum discriminator type.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModel
 //     method.
 func (client *EnumDiscriminatorClient) GetExtensibleModel(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelOptions) (EnumDiscriminatorClientGetExtensibleModelResponse, error) {
@@ -64,6 +65,7 @@ func (client *EnumDiscriminatorClient) getExtensibleModelHandleResponse(resp *ht
 }
 
 // GetExtensibleModelMissingDiscriminator - Get a model omitting the discriminator.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions contains the optional parameters for the
 //     EnumDiscriminatorClient.GetExtensibleModelMissingDiscriminator method.
 func (client *EnumDiscriminatorClient) GetExtensibleModelMissingDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorOptions) (EnumDiscriminatorClientGetExtensibleModelMissingDiscriminatorResponse, error) {
@@ -109,6 +111,7 @@ func (client *EnumDiscriminatorClient) getExtensibleModelMissingDiscriminatorHan
 }
 
 // GetExtensibleModelWrongDiscriminator - Get a model containing discriminator value never defined.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetExtensibleModelWrongDiscriminator
 //     method.
 func (client *EnumDiscriminatorClient) GetExtensibleModelWrongDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorOptions) (EnumDiscriminatorClientGetExtensibleModelWrongDiscriminatorResponse, error) {
@@ -154,6 +157,7 @@ func (client *EnumDiscriminatorClient) getExtensibleModelWrongDiscriminatorHandl
 }
 
 // GetFixedModel - Receive model with fixed enum discriminator type.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModel
 //     method.
 func (client *EnumDiscriminatorClient) GetFixedModel(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelOptions) (EnumDiscriminatorClientGetFixedModelResponse, error) {
@@ -199,6 +203,7 @@ func (client *EnumDiscriminatorClient) getFixedModelHandleResponse(resp *http.Re
 }
 
 // GetFixedModelMissingDiscriminator - Get a model omitting the discriminator.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelMissingDiscriminator
 //     method.
 func (client *EnumDiscriminatorClient) GetFixedModelMissingDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelMissingDiscriminatorOptions) (EnumDiscriminatorClientGetFixedModelMissingDiscriminatorResponse, error) {
@@ -244,6 +249,7 @@ func (client *EnumDiscriminatorClient) getFixedModelMissingDiscriminatorHandleRe
 }
 
 // GetFixedModelWrongDiscriminator - Get a model containing discriminator value never defined.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions contains the optional parameters for the EnumDiscriminatorClient.GetFixedModelWrongDiscriminator
 //     method.
 func (client *EnumDiscriminatorClient) GetFixedModelWrongDiscriminator(ctx context.Context, options *EnumDiscriminatorClientGetFixedModelWrongDiscriminatorOptions) (EnumDiscriminatorClientGetFixedModelWrongDiscriminatorResponse, error) {
@@ -289,6 +295,7 @@ func (client *EnumDiscriminatorClient) getFixedModelWrongDiscriminatorHandleResp
 }
 
 // PutExtensibleModel - Send model with extensible enum discriminator type.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - input - Dog to create
 //   - options - EnumDiscriminatorClientPutExtensibleModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutExtensibleModel
 //     method.
@@ -328,6 +335,7 @@ func (client *EnumDiscriminatorClient) putExtensibleModelCreateRequest(ctx conte
 }
 
 // PutFixedModel - Send model with fixed enum discriminator type.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - input - Snake to create
 //   - options - EnumDiscriminatorClientPutFixedModelOptions contains the optional parameters for the EnumDiscriminatorClient.PutFixedModel
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/nodiscgroup/zz_notdiscriminated_client.go
@@ -18,6 +18,8 @@ type NotDiscriminatedClient struct {
 	internal *azcore.Client
 }
 
+// GetValid -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NotDiscriminatedClientGetValidOptions contains the optional parameters for the NotDiscriminatedClient.GetValid
 //     method.
 func (client *NotDiscriminatedClient) GetValid(ctx context.Context, options *NotDiscriminatedClientGetValidOptions) (NotDiscriminatedClientGetValidResponse, error) {
@@ -62,6 +64,8 @@ func (client *NotDiscriminatedClient) getValidHandleResponse(resp *http.Response
 	return result, nil
 }
 
+// PostValid -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NotDiscriminatedClientPostValidOptions contains the optional parameters for the NotDiscriminatedClient.PostValid
 //     method.
 func (client *NotDiscriminatedClient) PostValid(ctx context.Context, input Siamese, options *NotDiscriminatedClientPostValidOptions) (NotDiscriminatedClientPostValidResponse, error) {
@@ -99,6 +103,8 @@ func (client *NotDiscriminatedClient) postValidCreateRequest(ctx context.Context
 	return req, nil
 }
 
+// PutValid -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NotDiscriminatedClientPutValidOptions contains the optional parameters for the NotDiscriminatedClient.PutValid
 //     method.
 func (client *NotDiscriminatedClient) PutValid(ctx context.Context, input Siamese, options *NotDiscriminatedClientPutValidOptions) (NotDiscriminatedClientPutValidResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_recursive_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/recursivegroup/zz_recursive_client.go
@@ -18,7 +18,9 @@ type RecursiveClient struct {
 	internal *azcore.Client
 }
 
-// - options - RecursiveClientGetOptions contains the optional parameters for the RecursiveClient.Get method.
+// Get -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - RecursiveClientGetOptions contains the optional parameters for the RecursiveClient.Get method.
 func (client *RecursiveClient) Get(ctx context.Context, options *RecursiveClientGetOptions) (RecursiveClientGetResponse, error) {
 	var err error
 	const operationName = "RecursiveClient.Get"
@@ -61,7 +63,9 @@ func (client *RecursiveClient) getHandleResponse(resp *http.Response) (Recursive
 	return result, nil
 }
 
-// - options - RecursiveClientPutOptions contains the optional parameters for the RecursiveClient.Put method.
+// Put -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - RecursiveClientPutOptions contains the optional parameters for the RecursiveClient.Put method.
 func (client *RecursiveClient) Put(ctx context.Context, input Extension, options *RecursiveClientPutOptions) (RecursiveClientPutResponse, error) {
 	var err error
 	const operationName = "RecursiveClient.Put"

--- a/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/inheritance/singlediscgroup/zz_singlediscriminator_client.go
@@ -18,6 +18,8 @@ type SingleDiscriminatorClient struct {
 	internal *azcore.Client
 }
 
+// GetLegacyModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientGetLegacyModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetLegacyModel
 //     method.
 func (client *SingleDiscriminatorClient) GetLegacyModel(ctx context.Context, options *SingleDiscriminatorClientGetLegacyModelOptions) (SingleDiscriminatorClientGetLegacyModelResponse, error) {
@@ -62,6 +64,8 @@ func (client *SingleDiscriminatorClient) getLegacyModelHandleResponse(resp *http
 	return result, nil
 }
 
+// GetMissingDiscriminator -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientGetMissingDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetMissingDiscriminator
 //     method.
 func (client *SingleDiscriminatorClient) GetMissingDiscriminator(ctx context.Context, options *SingleDiscriminatorClientGetMissingDiscriminatorOptions) (SingleDiscriminatorClientGetMissingDiscriminatorResponse, error) {
@@ -106,6 +110,8 @@ func (client *SingleDiscriminatorClient) getMissingDiscriminatorHandleResponse(r
 	return result, nil
 }
 
+// GetModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientGetModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetModel
 //     method.
 func (client *SingleDiscriminatorClient) GetModel(ctx context.Context, options *SingleDiscriminatorClientGetModelOptions) (SingleDiscriminatorClientGetModelResponse, error) {
@@ -150,6 +156,8 @@ func (client *SingleDiscriminatorClient) getModelHandleResponse(resp *http.Respo
 	return result, nil
 }
 
+// GetRecursiveModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientGetRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.GetRecursiveModel
 //     method.
 func (client *SingleDiscriminatorClient) GetRecursiveModel(ctx context.Context, options *SingleDiscriminatorClientGetRecursiveModelOptions) (SingleDiscriminatorClientGetRecursiveModelResponse, error) {
@@ -194,6 +202,8 @@ func (client *SingleDiscriminatorClient) getRecursiveModelHandleResponse(resp *h
 	return result, nil
 }
 
+// GetWrongDiscriminator -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientGetWrongDiscriminatorOptions contains the optional parameters for the SingleDiscriminatorClient.GetWrongDiscriminator
 //     method.
 func (client *SingleDiscriminatorClient) GetWrongDiscriminator(ctx context.Context, options *SingleDiscriminatorClientGetWrongDiscriminatorOptions) (SingleDiscriminatorClientGetWrongDiscriminatorResponse, error) {
@@ -238,6 +248,8 @@ func (client *SingleDiscriminatorClient) getWrongDiscriminatorHandleResponse(res
 	return result, nil
 }
 
+// PutModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientPutModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutModel
 //     method.
 func (client *SingleDiscriminatorClient) PutModel(ctx context.Context, input BirdClassification, options *SingleDiscriminatorClientPutModelOptions) (SingleDiscriminatorClientPutModelResponse, error) {
@@ -275,6 +287,8 @@ func (client *SingleDiscriminatorClient) putModelCreateRequest(ctx context.Conte
 	return req, nil
 }
 
+// PutRecursiveModel -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - SingleDiscriminatorClientPutRecursiveModelOptions contains the optional parameters for the SingleDiscriminatorClient.PutRecursiveModel
 //     method.
 func (client *SingleDiscriminatorClient) PutRecursiveModel(ctx context.Context, input BirdClassification, options *SingleDiscriminatorClientPutRecursiveModelOptions) (SingleDiscriminatorClientPutRecursiveModelResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_usage_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/usagegroup/zz_usage_client.go
@@ -18,7 +18,9 @@ type UsageClient struct {
 	internal *azcore.Client
 }
 
-// - options - UsageClientInputOptions contains the optional parameters for the UsageClient.Input method.
+// Input -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - UsageClientInputOptions contains the optional parameters for the UsageClient.Input method.
 func (client *UsageClient) Input(ctx context.Context, input InputRecord, options *UsageClientInputOptions) (UsageClientInputResponse, error) {
 	var err error
 	const operationName = "UsageClient.Input"
@@ -54,7 +56,9 @@ func (client *UsageClient) inputCreateRequest(ctx context.Context, input InputRe
 	return req, nil
 }
 
-// - options - UsageClientInputAndOutputOptions contains the optional parameters for the UsageClient.InputAndOutput method.
+// InputAndOutput -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - UsageClientInputAndOutputOptions contains the optional parameters for the UsageClient.InputAndOutput method.
 func (client *UsageClient) InputAndOutput(ctx context.Context, body InputOutputRecord, options *UsageClientInputAndOutputOptions) (UsageClientInputAndOutputResponse, error) {
 	var err error
 	const operationName = "UsageClient.InputAndOutput"
@@ -101,7 +105,9 @@ func (client *UsageClient) inputAndOutputHandleResponse(resp *http.Response) (Us
 	return result, nil
 }
 
-// - options - UsageClientOutputOptions contains the optional parameters for the UsageClient.Output method.
+// Output -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - UsageClientOutputOptions contains the optional parameters for the UsageClient.Output method.
 func (client *UsageClient) Output(ctx context.Context, options *UsageClientOutputOptions) (UsageClientOutputResponse, error) {
 	var err error
 	const operationName = "UsageClient.Output"

--- a/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
+++ b/packages/typespec-go/test/cadlranch/type/model/visibilitygroup/zz_visibility_client.go
@@ -18,7 +18,9 @@ type VisibilityClient struct {
 	internal *azcore.Client
 }
 
-// - options - VisibilityClientDeleteModelOptions contains the optional parameters for the VisibilityClient.DeleteModel method.
+// DeleteModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - VisibilityClientDeleteModelOptions contains the optional parameters for the VisibilityClient.DeleteModel method.
 func (client *VisibilityClient) DeleteModel(ctx context.Context, input VisibilityModel, options *VisibilityClientDeleteModelOptions) (VisibilityClientDeleteModelResponse, error) {
 	var err error
 	const operationName = "VisibilityClient.DeleteModel"
@@ -54,7 +56,9 @@ func (client *VisibilityClient) deleteModelCreateRequest(ctx context.Context, in
 	return req, nil
 }
 
-// - options - VisibilityClientGetModelOptions contains the optional parameters for the VisibilityClient.GetModel method.
+// GetModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - VisibilityClientGetModelOptions contains the optional parameters for the VisibilityClient.GetModel method.
 func (client *VisibilityClient) GetModel(ctx context.Context, input VisibilityModel, options *VisibilityClientGetModelOptions) (VisibilityClientGetModelResponse, error) {
 	var err error
 	const operationName = "VisibilityClient.GetModel"
@@ -137,7 +141,9 @@ func (client *VisibilityClient) headModelCreateRequest(ctx context.Context, inpu
 	return req, nil
 }
 
-// - options - VisibilityClientPatchModelOptions contains the optional parameters for the VisibilityClient.PatchModel method.
+// PatchModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - VisibilityClientPatchModelOptions contains the optional parameters for the VisibilityClient.PatchModel method.
 func (client *VisibilityClient) PatchModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPatchModelOptions) (VisibilityClientPatchModelResponse, error) {
 	var err error
 	const operationName = "VisibilityClient.PatchModel"
@@ -173,7 +179,9 @@ func (client *VisibilityClient) patchModelCreateRequest(ctx context.Context, inp
 	return req, nil
 }
 
-// - options - VisibilityClientPostModelOptions contains the optional parameters for the VisibilityClient.PostModel method.
+// PostModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - VisibilityClientPostModelOptions contains the optional parameters for the VisibilityClient.PostModel method.
 func (client *VisibilityClient) PostModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPostModelOptions) (VisibilityClientPostModelResponse, error) {
 	var err error
 	const operationName = "VisibilityClient.PostModel"
@@ -209,7 +217,9 @@ func (client *VisibilityClient) postModelCreateRequest(ctx context.Context, inpu
 	return req, nil
 }
 
-// - options - VisibilityClientPutModelOptions contains the optional parameters for the VisibilityClient.PutModel method.
+// PutModel -
+// If the operation fails it returns an *azcore.ResponseError type.
+//   - options - VisibilityClientPutModelOptions contains the optional parameters for the VisibilityClient.PutModel method.
 func (client *VisibilityClient) PutModel(ctx context.Context, input VisibilityModel, options *VisibilityClientPutModelOptions) (VisibilityClientPutModelResponse, error) {
 	var err error
 	const operationName = "VisibilityClient.PutModel"

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablebytes_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablebytes_client.go
@@ -19,6 +19,7 @@ type NullableBytesClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableBytesClientGetNonNullOptions contains the optional parameters for the NullableBytesClient.GetNonNull
 //     method.
 func (client *NullableBytesClient) GetNonNull(ctx context.Context, options *NullableBytesClientGetNonNullOptions) (NullableBytesClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableBytesClient) getNonNullHandleResponse(resp *http.Response)
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableBytesClientGetNullOptions contains the optional parameters for the NullableBytesClient.GetNull method.
 func (client *NullableBytesClient) GetNull(ctx context.Context, options *NullableBytesClientGetNullOptions) (NullableBytesClientGetNullResponse, error) {
 	var err error
@@ -108,6 +110,7 @@ func (client *NullableBytesClient) getNullHandleResponse(resp *http.Response) (N
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableBytesClientPatchNonNullOptions contains the optional parameters for the NullableBytesClient.PatchNonNull
 //     method.
 func (client *NullableBytesClient) PatchNonNull(ctx context.Context, body BytesProperty, options *NullableBytesClientPatchNonNullOptions) (NullableBytesClientPatchNonNullResponse, error) {
@@ -146,6 +149,7 @@ func (client *NullableBytesClient) patchNonNullCreateRequest(ctx context.Context
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableBytesClientPatchNullOptions contains the optional parameters for the NullableBytesClient.PatchNull method.
 func (client *NullableBytesClient) PatchNull(ctx context.Context, body BytesProperty, options *NullableBytesClientPatchNullOptions) (NullableBytesClientPatchNullResponse, error) {
 	var err error

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablecollectionsbyte_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablecollectionsbyte_client.go
@@ -19,6 +19,7 @@ type NullableCollectionsByteClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsByteClientGetNonNullOptions contains the optional parameters for the NullableCollectionsByteClient.GetNonNull
 //     method.
 func (client *NullableCollectionsByteClient) GetNonNull(ctx context.Context, options *NullableCollectionsByteClientGetNonNullOptions) (NullableCollectionsByteClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableCollectionsByteClient) getNonNullHandleResponse(resp *http
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsByteClientGetNullOptions contains the optional parameters for the NullableCollectionsByteClient.GetNull
 //     method.
 func (client *NullableCollectionsByteClient) GetNull(ctx context.Context, options *NullableCollectionsByteClientGetNullOptions) (NullableCollectionsByteClientGetNullResponse, error) {
@@ -109,6 +111,7 @@ func (client *NullableCollectionsByteClient) getNullHandleResponse(resp *http.Re
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsByteClientPatchNonNullOptions contains the optional parameters for the NullableCollectionsByteClient.PatchNonNull
 //     method.
 func (client *NullableCollectionsByteClient) PatchNonNull(ctx context.Context, body CollectionsByteProperty, options *NullableCollectionsByteClientPatchNonNullOptions) (NullableCollectionsByteClientPatchNonNullResponse, error) {
@@ -147,6 +150,7 @@ func (client *NullableCollectionsByteClient) patchNonNullCreateRequest(ctx conte
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsByteClientPatchNullOptions contains the optional parameters for the NullableCollectionsByteClient.PatchNull
 //     method.
 func (client *NullableCollectionsByteClient) PatchNull(ctx context.Context, body CollectionsByteProperty, options *NullableCollectionsByteClientPatchNullOptions) (NullableCollectionsByteClientPatchNullResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablecollectionsmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablecollectionsmodel_client.go
@@ -19,6 +19,7 @@ type NullableCollectionsModelClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsModelClientGetNonNullOptions contains the optional parameters for the NullableCollectionsModelClient.GetNonNull
 //     method.
 func (client *NullableCollectionsModelClient) GetNonNull(ctx context.Context, options *NullableCollectionsModelClientGetNonNullOptions) (NullableCollectionsModelClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableCollectionsModelClient) getNonNullHandleResponse(resp *htt
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsModelClientGetNullOptions contains the optional parameters for the NullableCollectionsModelClient.GetNull
 //     method.
 func (client *NullableCollectionsModelClient) GetNull(ctx context.Context, options *NullableCollectionsModelClientGetNullOptions) (NullableCollectionsModelClientGetNullResponse, error) {
@@ -109,6 +111,7 @@ func (client *NullableCollectionsModelClient) getNullHandleResponse(resp *http.R
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsModelClientPatchNonNullOptions contains the optional parameters for the NullableCollectionsModelClient.PatchNonNull
 //     method.
 func (client *NullableCollectionsModelClient) PatchNonNull(ctx context.Context, body CollectionsModelProperty, options *NullableCollectionsModelClientPatchNonNullOptions) (NullableCollectionsModelClientPatchNonNullResponse, error) {
@@ -147,6 +150,7 @@ func (client *NullableCollectionsModelClient) patchNonNullCreateRequest(ctx cont
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableCollectionsModelClientPatchNullOptions contains the optional parameters for the NullableCollectionsModelClient.PatchNull
 //     method.
 func (client *NullableCollectionsModelClient) PatchNull(ctx context.Context, body CollectionsModelProperty, options *NullableCollectionsModelClientPatchNullOptions) (NullableCollectionsModelClientPatchNullResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullabledatetime_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullabledatetime_client.go
@@ -19,6 +19,7 @@ type NullableDatetimeClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDatetimeClientGetNonNullOptions contains the optional parameters for the NullableDatetimeClient.GetNonNull
 //     method.
 func (client *NullableDatetimeClient) GetNonNull(ctx context.Context, options *NullableDatetimeClientGetNonNullOptions) (NullableDatetimeClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableDatetimeClient) getNonNullHandleResponse(resp *http.Respon
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDatetimeClientGetNullOptions contains the optional parameters for the NullableDatetimeClient.GetNull
 //     method.
 func (client *NullableDatetimeClient) GetNull(ctx context.Context, options *NullableDatetimeClientGetNullOptions) (NullableDatetimeClientGetNullResponse, error) {
@@ -109,6 +111,7 @@ func (client *NullableDatetimeClient) getNullHandleResponse(resp *http.Response)
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDatetimeClientPatchNonNullOptions contains the optional parameters for the NullableDatetimeClient.PatchNonNull
 //     method.
 func (client *NullableDatetimeClient) PatchNonNull(ctx context.Context, body DatetimeProperty, options *NullableDatetimeClientPatchNonNullOptions) (NullableDatetimeClientPatchNonNullResponse, error) {
@@ -147,6 +150,7 @@ func (client *NullableDatetimeClient) patchNonNullCreateRequest(ctx context.Cont
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDatetimeClientPatchNullOptions contains the optional parameters for the NullableDatetimeClient.PatchNull
 //     method.
 func (client *NullableDatetimeClient) PatchNull(ctx context.Context, body DatetimeProperty, options *NullableDatetimeClientPatchNullOptions) (NullableDatetimeClientPatchNullResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullableduration_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullableduration_client.go
@@ -19,6 +19,7 @@ type NullableDurationClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDurationClientGetNonNullOptions contains the optional parameters for the NullableDurationClient.GetNonNull
 //     method.
 func (client *NullableDurationClient) GetNonNull(ctx context.Context, options *NullableDurationClientGetNonNullOptions) (NullableDurationClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableDurationClient) getNonNullHandleResponse(resp *http.Respon
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDurationClientGetNullOptions contains the optional parameters for the NullableDurationClient.GetNull
 //     method.
 func (client *NullableDurationClient) GetNull(ctx context.Context, options *NullableDurationClientGetNullOptions) (NullableDurationClientGetNullResponse, error) {
@@ -109,6 +111,7 @@ func (client *NullableDurationClient) getNullHandleResponse(resp *http.Response)
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDurationClientPatchNonNullOptions contains the optional parameters for the NullableDurationClient.PatchNonNull
 //     method.
 func (client *NullableDurationClient) PatchNonNull(ctx context.Context, body DurationProperty, options *NullableDurationClientPatchNonNullOptions) (NullableDurationClientPatchNonNullResponse, error) {
@@ -147,6 +150,7 @@ func (client *NullableDurationClient) patchNonNullCreateRequest(ctx context.Cont
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableDurationClientPatchNullOptions contains the optional parameters for the NullableDurationClient.PatchNull
 //     method.
 func (client *NullableDurationClient) PatchNull(ctx context.Context, body DurationProperty, options *NullableDurationClientPatchNullOptions) (NullableDurationClientPatchNullResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablestring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/nullablegroup/zz_nullablestring_client.go
@@ -19,6 +19,7 @@ type NullableStringClient struct {
 }
 
 // GetNonNull - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableStringClientGetNonNullOptions contains the optional parameters for the NullableStringClient.GetNonNull
 //     method.
 func (client *NullableStringClient) GetNonNull(ctx context.Context, options *NullableStringClientGetNonNullOptions) (NullableStringClientGetNonNullResponse, error) {
@@ -64,6 +65,7 @@ func (client *NullableStringClient) getNonNullHandleResponse(resp *http.Response
 }
 
 // GetNull - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableStringClientGetNullOptions contains the optional parameters for the NullableStringClient.GetNull method.
 func (client *NullableStringClient) GetNull(ctx context.Context, options *NullableStringClientGetNullOptions) (NullableStringClientGetNullResponse, error) {
 	var err error
@@ -108,6 +110,7 @@ func (client *NullableStringClient) getNullHandleResponse(resp *http.Response) (
 }
 
 // PatchNonNull - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableStringClientPatchNonNullOptions contains the optional parameters for the NullableStringClient.PatchNonNull
 //     method.
 func (client *NullableStringClient) PatchNonNull(ctx context.Context, body StringProperty, options *NullableStringClientPatchNonNullOptions) (NullableStringClientPatchNonNullResponse, error) {
@@ -146,6 +149,7 @@ func (client *NullableStringClient) patchNonNullCreateRequest(ctx context.Contex
 }
 
 // PatchNull - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - NullableStringClientPatchNullOptions contains the optional parameters for the NullableStringClient.PatchNull
 //     method.
 func (client *NullableStringClient) PatchNull(ctx context.Context, body StringProperty, options *NullableStringClientPatchNullOptions) (NullableStringClientPatchNullResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalbooleanliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalbooleanliteral_client.go
@@ -19,6 +19,7 @@ type OptionalBooleanLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBooleanLiteralClientGetAllOptions contains the optional parameters for the OptionalBooleanLiteralClient.GetAll
 //     method.
 func (client *OptionalBooleanLiteralClient) GetAll(ctx context.Context, options *OptionalBooleanLiteralClientGetAllOptions) (OptionalBooleanLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalBooleanLiteralClient) getAllHandleResponse(resp *http.Resp
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBooleanLiteralClientGetDefaultOptions contains the optional parameters for the OptionalBooleanLiteralClient.GetDefault
 //     method.
 func (client *OptionalBooleanLiteralClient) GetDefault(ctx context.Context, options *OptionalBooleanLiteralClientGetDefaultOptions) (OptionalBooleanLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalBooleanLiteralClient) getDefaultHandleResponse(resp *http.
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBooleanLiteralClientPutAllOptions contains the optional parameters for the OptionalBooleanLiteralClient.PutAll
 //     method.
 func (client *OptionalBooleanLiteralClient) PutAll(ctx context.Context, body BooleanLiteralProperty, options *OptionalBooleanLiteralClientPutAllOptions) (OptionalBooleanLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalBooleanLiteralClient) putAllCreateRequest(ctx context.Cont
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBooleanLiteralClientPutDefaultOptions contains the optional parameters for the OptionalBooleanLiteralClient.PutDefault
 //     method.
 func (client *OptionalBooleanLiteralClient) PutDefault(ctx context.Context, body BooleanLiteralProperty, options *OptionalBooleanLiteralClientPutDefaultOptions) (OptionalBooleanLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalbytes_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalbytes_client.go
@@ -19,6 +19,7 @@ type OptionalBytesClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBytesClientGetAllOptions contains the optional parameters for the OptionalBytesClient.GetAll method.
 func (client *OptionalBytesClient) GetAll(ctx context.Context, options *OptionalBytesClientGetAllOptions) (OptionalBytesClientGetAllResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *OptionalBytesClient) getAllHandleResponse(resp *http.Response) (Op
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBytesClientGetDefaultOptions contains the optional parameters for the OptionalBytesClient.GetDefault
 //     method.
 func (client *OptionalBytesClient) GetDefault(ctx context.Context, options *OptionalBytesClientGetDefaultOptions) (OptionalBytesClientGetDefaultResponse, error) {
@@ -108,6 +110,7 @@ func (client *OptionalBytesClient) getDefaultHandleResponse(resp *http.Response)
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBytesClientPutAllOptions contains the optional parameters for the OptionalBytesClient.PutAll method.
 func (client *OptionalBytesClient) PutAll(ctx context.Context, body BytesProperty, options *OptionalBytesClientPutAllOptions) (OptionalBytesClientPutAllResponse, error) {
 	var err error
@@ -145,6 +148,7 @@ func (client *OptionalBytesClient) putAllCreateRequest(ctx context.Context, body
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalBytesClientPutDefaultOptions contains the optional parameters for the OptionalBytesClient.PutDefault
 //     method.
 func (client *OptionalBytesClient) PutDefault(ctx context.Context, body BytesProperty, options *OptionalBytesClientPutDefaultOptions) (OptionalBytesClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalcollectionsbyte_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalcollectionsbyte_client.go
@@ -19,6 +19,7 @@ type OptionalCollectionsByteClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsByteClientGetAllOptions contains the optional parameters for the OptionalCollectionsByteClient.GetAll
 //     method.
 func (client *OptionalCollectionsByteClient) GetAll(ctx context.Context, options *OptionalCollectionsByteClientGetAllOptions) (OptionalCollectionsByteClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalCollectionsByteClient) getAllHandleResponse(resp *http.Res
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsByteClientGetDefaultOptions contains the optional parameters for the OptionalCollectionsByteClient.GetDefault
 //     method.
 func (client *OptionalCollectionsByteClient) GetDefault(ctx context.Context, options *OptionalCollectionsByteClientGetDefaultOptions) (OptionalCollectionsByteClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalCollectionsByteClient) getDefaultHandleResponse(resp *http
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsByteClientPutAllOptions contains the optional parameters for the OptionalCollectionsByteClient.PutAll
 //     method.
 func (client *OptionalCollectionsByteClient) PutAll(ctx context.Context, body CollectionsByteProperty, options *OptionalCollectionsByteClientPutAllOptions) (OptionalCollectionsByteClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalCollectionsByteClient) putAllCreateRequest(ctx context.Con
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsByteClientPutDefaultOptions contains the optional parameters for the OptionalCollectionsByteClient.PutDefault
 //     method.
 func (client *OptionalCollectionsByteClient) PutDefault(ctx context.Context, body CollectionsByteProperty, options *OptionalCollectionsByteClientPutDefaultOptions) (OptionalCollectionsByteClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalcollectionsmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalcollectionsmodel_client.go
@@ -19,6 +19,7 @@ type OptionalCollectionsModelClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsModelClientGetAllOptions contains the optional parameters for the OptionalCollectionsModelClient.GetAll
 //     method.
 func (client *OptionalCollectionsModelClient) GetAll(ctx context.Context, options *OptionalCollectionsModelClientGetAllOptions) (OptionalCollectionsModelClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalCollectionsModelClient) getAllHandleResponse(resp *http.Re
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsModelClientGetDefaultOptions contains the optional parameters for the OptionalCollectionsModelClient.GetDefault
 //     method.
 func (client *OptionalCollectionsModelClient) GetDefault(ctx context.Context, options *OptionalCollectionsModelClientGetDefaultOptions) (OptionalCollectionsModelClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalCollectionsModelClient) getDefaultHandleResponse(resp *htt
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsModelClientPutAllOptions contains the optional parameters for the OptionalCollectionsModelClient.PutAll
 //     method.
 func (client *OptionalCollectionsModelClient) PutAll(ctx context.Context, body CollectionsModelProperty, options *OptionalCollectionsModelClientPutAllOptions) (OptionalCollectionsModelClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalCollectionsModelClient) putAllCreateRequest(ctx context.Co
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalCollectionsModelClientPutDefaultOptions contains the optional parameters for the OptionalCollectionsModelClient.PutDefault
 //     method.
 func (client *OptionalCollectionsModelClient) PutDefault(ctx context.Context, body CollectionsModelProperty, options *OptionalCollectionsModelClientPutDefaultOptions) (OptionalCollectionsModelClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionaldatetime_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionaldatetime_client.go
@@ -19,6 +19,7 @@ type OptionalDatetimeClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDatetimeClientGetAllOptions contains the optional parameters for the OptionalDatetimeClient.GetAll method.
 func (client *OptionalDatetimeClient) GetAll(ctx context.Context, options *OptionalDatetimeClientGetAllOptions) (OptionalDatetimeClientGetAllResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *OptionalDatetimeClient) getAllHandleResponse(resp *http.Response) 
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDatetimeClientGetDefaultOptions contains the optional parameters for the OptionalDatetimeClient.GetDefault
 //     method.
 func (client *OptionalDatetimeClient) GetDefault(ctx context.Context, options *OptionalDatetimeClientGetDefaultOptions) (OptionalDatetimeClientGetDefaultResponse, error) {
@@ -108,6 +110,7 @@ func (client *OptionalDatetimeClient) getDefaultHandleResponse(resp *http.Respon
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDatetimeClientPutAllOptions contains the optional parameters for the OptionalDatetimeClient.PutAll method.
 func (client *OptionalDatetimeClient) PutAll(ctx context.Context, body DatetimeProperty, options *OptionalDatetimeClientPutAllOptions) (OptionalDatetimeClientPutAllResponse, error) {
 	var err error
@@ -145,6 +148,7 @@ func (client *OptionalDatetimeClient) putAllCreateRequest(ctx context.Context, b
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDatetimeClientPutDefaultOptions contains the optional parameters for the OptionalDatetimeClient.PutDefault
 //     method.
 func (client *OptionalDatetimeClient) PutDefault(ctx context.Context, body DatetimeProperty, options *OptionalDatetimeClientPutDefaultOptions) (OptionalDatetimeClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalduration_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalduration_client.go
@@ -19,6 +19,7 @@ type OptionalDurationClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDurationClientGetAllOptions contains the optional parameters for the OptionalDurationClient.GetAll method.
 func (client *OptionalDurationClient) GetAll(ctx context.Context, options *OptionalDurationClientGetAllOptions) (OptionalDurationClientGetAllResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *OptionalDurationClient) getAllHandleResponse(resp *http.Response) 
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDurationClientGetDefaultOptions contains the optional parameters for the OptionalDurationClient.GetDefault
 //     method.
 func (client *OptionalDurationClient) GetDefault(ctx context.Context, options *OptionalDurationClientGetDefaultOptions) (OptionalDurationClientGetDefaultResponse, error) {
@@ -108,6 +110,7 @@ func (client *OptionalDurationClient) getDefaultHandleResponse(resp *http.Respon
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDurationClientPutAllOptions contains the optional parameters for the OptionalDurationClient.PutAll method.
 func (client *OptionalDurationClient) PutAll(ctx context.Context, body DurationProperty, options *OptionalDurationClientPutAllOptions) (OptionalDurationClientPutAllResponse, error) {
 	var err error
@@ -145,6 +148,7 @@ func (client *OptionalDurationClient) putAllCreateRequest(ctx context.Context, b
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalDurationClientPutDefaultOptions contains the optional parameters for the OptionalDurationClient.PutDefault
 //     method.
 func (client *OptionalDurationClient) PutDefault(ctx context.Context, body DurationProperty, options *OptionalDurationClientPutDefaultOptions) (OptionalDurationClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalfloatliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalfloatliteral_client.go
@@ -19,6 +19,7 @@ type OptionalFloatLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalFloatLiteralClientGetAllOptions contains the optional parameters for the OptionalFloatLiteralClient.GetAll
 //     method.
 func (client *OptionalFloatLiteralClient) GetAll(ctx context.Context, options *OptionalFloatLiteralClientGetAllOptions) (OptionalFloatLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalFloatLiteralClient) getAllHandleResponse(resp *http.Respon
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalFloatLiteralClientGetDefaultOptions contains the optional parameters for the OptionalFloatLiteralClient.GetDefault
 //     method.
 func (client *OptionalFloatLiteralClient) GetDefault(ctx context.Context, options *OptionalFloatLiteralClientGetDefaultOptions) (OptionalFloatLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalFloatLiteralClient) getDefaultHandleResponse(resp *http.Re
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalFloatLiteralClientPutAllOptions contains the optional parameters for the OptionalFloatLiteralClient.PutAll
 //     method.
 func (client *OptionalFloatLiteralClient) PutAll(ctx context.Context, body FloatLiteralProperty, options *OptionalFloatLiteralClientPutAllOptions) (OptionalFloatLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalFloatLiteralClient) putAllCreateRequest(ctx context.Contex
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalFloatLiteralClientPutDefaultOptions contains the optional parameters for the OptionalFloatLiteralClient.PutDefault
 //     method.
 func (client *OptionalFloatLiteralClient) PutDefault(ctx context.Context, body FloatLiteralProperty, options *OptionalFloatLiteralClientPutDefaultOptions) (OptionalFloatLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalintliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalintliteral_client.go
@@ -19,6 +19,7 @@ type OptionalIntLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalIntLiteralClientGetAllOptions contains the optional parameters for the OptionalIntLiteralClient.GetAll
 //     method.
 func (client *OptionalIntLiteralClient) GetAll(ctx context.Context, options *OptionalIntLiteralClientGetAllOptions) (OptionalIntLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalIntLiteralClient) getAllHandleResponse(resp *http.Response
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalIntLiteralClientGetDefaultOptions contains the optional parameters for the OptionalIntLiteralClient.GetDefault
 //     method.
 func (client *OptionalIntLiteralClient) GetDefault(ctx context.Context, options *OptionalIntLiteralClientGetDefaultOptions) (OptionalIntLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalIntLiteralClient) getDefaultHandleResponse(resp *http.Resp
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalIntLiteralClientPutAllOptions contains the optional parameters for the OptionalIntLiteralClient.PutAll
 //     method.
 func (client *OptionalIntLiteralClient) PutAll(ctx context.Context, body IntLiteralProperty, options *OptionalIntLiteralClientPutAllOptions) (OptionalIntLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalIntLiteralClient) putAllCreateRequest(ctx context.Context,
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalIntLiteralClientPutDefaultOptions contains the optional parameters for the OptionalIntLiteralClient.PutDefault
 //     method.
 func (client *OptionalIntLiteralClient) PutDefault(ctx context.Context, body IntLiteralProperty, options *OptionalIntLiteralClientPutDefaultOptions) (OptionalIntLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalrequiredandoptional_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalrequiredandoptional_client.go
@@ -19,6 +19,7 @@ type OptionalRequiredAndOptionalClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalRequiredAndOptionalClientGetAllOptions contains the optional parameters for the OptionalRequiredAndOptionalClient.GetAll
 //     method.
 func (client *OptionalRequiredAndOptionalClient) GetAll(ctx context.Context, options *OptionalRequiredAndOptionalClientGetAllOptions) (OptionalRequiredAndOptionalClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalRequiredAndOptionalClient) getAllHandleResponse(resp *http
 }
 
 // GetRequiredOnly - Get models that will return only the required properties
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalRequiredAndOptionalClientGetRequiredOnlyOptions contains the optional parameters for the OptionalRequiredAndOptionalClient.GetRequiredOnly
 //     method.
 func (client *OptionalRequiredAndOptionalClient) GetRequiredOnly(ctx context.Context, options *OptionalRequiredAndOptionalClientGetRequiredOnlyOptions) (OptionalRequiredAndOptionalClientGetRequiredOnlyResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalRequiredAndOptionalClient) getRequiredOnlyHandleResponse(r
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalRequiredAndOptionalClientPutAllOptions contains the optional parameters for the OptionalRequiredAndOptionalClient.PutAll
 //     method.
 func (client *OptionalRequiredAndOptionalClient) PutAll(ctx context.Context, body RequiredAndOptionalProperty, options *OptionalRequiredAndOptionalClientPutAllOptions) (OptionalRequiredAndOptionalClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalRequiredAndOptionalClient) putAllCreateRequest(ctx context
 }
 
 // PutRequiredOnly - Put a body with only required properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalRequiredAndOptionalClientPutRequiredOnlyOptions contains the optional parameters for the OptionalRequiredAndOptionalClient.PutRequiredOnly
 //     method.
 func (client *OptionalRequiredAndOptionalClient) PutRequiredOnly(ctx context.Context, body RequiredAndOptionalProperty, options *OptionalRequiredAndOptionalClientPutRequiredOnlyOptions) (OptionalRequiredAndOptionalClientPutRequiredOnlyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalstring_client.go
@@ -19,6 +19,7 @@ type OptionalStringClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringClientGetAllOptions contains the optional parameters for the OptionalStringClient.GetAll method.
 func (client *OptionalStringClient) GetAll(ctx context.Context, options *OptionalStringClientGetAllOptions) (OptionalStringClientGetAllResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *OptionalStringClient) getAllHandleResponse(resp *http.Response) (O
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringClientGetDefaultOptions contains the optional parameters for the OptionalStringClient.GetDefault
 //     method.
 func (client *OptionalStringClient) GetDefault(ctx context.Context, options *OptionalStringClientGetDefaultOptions) (OptionalStringClientGetDefaultResponse, error) {
@@ -108,6 +110,7 @@ func (client *OptionalStringClient) getDefaultHandleResponse(resp *http.Response
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringClientPutAllOptions contains the optional parameters for the OptionalStringClient.PutAll method.
 func (client *OptionalStringClient) PutAll(ctx context.Context, body StringProperty, options *OptionalStringClientPutAllOptions) (OptionalStringClientPutAllResponse, error) {
 	var err error
@@ -145,6 +148,7 @@ func (client *OptionalStringClient) putAllCreateRequest(ctx context.Context, bod
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringClientPutDefaultOptions contains the optional parameters for the OptionalStringClient.PutDefault
 //     method.
 func (client *OptionalStringClient) PutDefault(ctx context.Context, body StringProperty, options *OptionalStringClientPutDefaultOptions) (OptionalStringClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalstringliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalstringliteral_client.go
@@ -19,6 +19,7 @@ type OptionalStringLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringLiteralClientGetAllOptions contains the optional parameters for the OptionalStringLiteralClient.GetAll
 //     method.
 func (client *OptionalStringLiteralClient) GetAll(ctx context.Context, options *OptionalStringLiteralClientGetAllOptions) (OptionalStringLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalStringLiteralClient) getAllHandleResponse(resp *http.Respo
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringLiteralClientGetDefaultOptions contains the optional parameters for the OptionalStringLiteralClient.GetDefault
 //     method.
 func (client *OptionalStringLiteralClient) GetDefault(ctx context.Context, options *OptionalStringLiteralClientGetDefaultOptions) (OptionalStringLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalStringLiteralClient) getDefaultHandleResponse(resp *http.R
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringLiteralClientPutAllOptions contains the optional parameters for the OptionalStringLiteralClient.PutAll
 //     method.
 func (client *OptionalStringLiteralClient) PutAll(ctx context.Context, body StringLiteralProperty, options *OptionalStringLiteralClientPutAllOptions) (OptionalStringLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalStringLiteralClient) putAllCreateRequest(ctx context.Conte
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalStringLiteralClientPutDefaultOptions contains the optional parameters for the OptionalStringLiteralClient.PutDefault
 //     method.
 func (client *OptionalStringLiteralClient) PutDefault(ctx context.Context, body StringLiteralProperty, options *OptionalStringLiteralClientPutDefaultOptions) (OptionalStringLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionfloatliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionfloatliteral_client.go
@@ -19,6 +19,7 @@ type OptionalUnionFloatLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionFloatLiteralClientGetAllOptions contains the optional parameters for the OptionalUnionFloatLiteralClient.GetAll
 //     method.
 func (client *OptionalUnionFloatLiteralClient) GetAll(ctx context.Context, options *OptionalUnionFloatLiteralClientGetAllOptions) (OptionalUnionFloatLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalUnionFloatLiteralClient) getAllHandleResponse(resp *http.R
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionFloatLiteralClientGetDefaultOptions contains the optional parameters for the OptionalUnionFloatLiteralClient.GetDefault
 //     method.
 func (client *OptionalUnionFloatLiteralClient) GetDefault(ctx context.Context, options *OptionalUnionFloatLiteralClientGetDefaultOptions) (OptionalUnionFloatLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalUnionFloatLiteralClient) getDefaultHandleResponse(resp *ht
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionFloatLiteralClientPutAllOptions contains the optional parameters for the OptionalUnionFloatLiteralClient.PutAll
 //     method.
 func (client *OptionalUnionFloatLiteralClient) PutAll(ctx context.Context, body UnionFloatLiteralProperty, options *OptionalUnionFloatLiteralClientPutAllOptions) (OptionalUnionFloatLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalUnionFloatLiteralClient) putAllCreateRequest(ctx context.C
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionFloatLiteralClientPutDefaultOptions contains the optional parameters for the OptionalUnionFloatLiteralClient.PutDefault
 //     method.
 func (client *OptionalUnionFloatLiteralClient) PutDefault(ctx context.Context, body UnionFloatLiteralProperty, options *OptionalUnionFloatLiteralClientPutDefaultOptions) (OptionalUnionFloatLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionintliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionintliteral_client.go
@@ -19,6 +19,7 @@ type OptionalUnionIntLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionIntLiteralClientGetAllOptions contains the optional parameters for the OptionalUnionIntLiteralClient.GetAll
 //     method.
 func (client *OptionalUnionIntLiteralClient) GetAll(ctx context.Context, options *OptionalUnionIntLiteralClientGetAllOptions) (OptionalUnionIntLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalUnionIntLiteralClient) getAllHandleResponse(resp *http.Res
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionIntLiteralClientGetDefaultOptions contains the optional parameters for the OptionalUnionIntLiteralClient.GetDefault
 //     method.
 func (client *OptionalUnionIntLiteralClient) GetDefault(ctx context.Context, options *OptionalUnionIntLiteralClientGetDefaultOptions) (OptionalUnionIntLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalUnionIntLiteralClient) getDefaultHandleResponse(resp *http
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionIntLiteralClientPutAllOptions contains the optional parameters for the OptionalUnionIntLiteralClient.PutAll
 //     method.
 func (client *OptionalUnionIntLiteralClient) PutAll(ctx context.Context, body UnionIntLiteralProperty, options *OptionalUnionIntLiteralClientPutAllOptions) (OptionalUnionIntLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalUnionIntLiteralClient) putAllCreateRequest(ctx context.Con
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionIntLiteralClientPutDefaultOptions contains the optional parameters for the OptionalUnionIntLiteralClient.PutDefault
 //     method.
 func (client *OptionalUnionIntLiteralClient) PutDefault(ctx context.Context, body UnionIntLiteralProperty, options *OptionalUnionIntLiteralClientPutDefaultOptions) (OptionalUnionIntLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionstringliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/optionalitygroup/zz_optionalunionstringliteral_client.go
@@ -19,6 +19,7 @@ type OptionalUnionStringLiteralClient struct {
 }
 
 // GetAll - Get models that will return all properties in the model
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionStringLiteralClientGetAllOptions contains the optional parameters for the OptionalUnionStringLiteralClient.GetAll
 //     method.
 func (client *OptionalUnionStringLiteralClient) GetAll(ctx context.Context, options *OptionalUnionStringLiteralClientGetAllOptions) (OptionalUnionStringLiteralClientGetAllResponse, error) {
@@ -64,6 +65,7 @@ func (client *OptionalUnionStringLiteralClient) getAllHandleResponse(resp *http.
 }
 
 // GetDefault - Get models that will return the default object
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionStringLiteralClientGetDefaultOptions contains the optional parameters for the OptionalUnionStringLiteralClient.GetDefault
 //     method.
 func (client *OptionalUnionStringLiteralClient) GetDefault(ctx context.Context, options *OptionalUnionStringLiteralClientGetDefaultOptions) (OptionalUnionStringLiteralClientGetDefaultResponse, error) {
@@ -109,6 +111,7 @@ func (client *OptionalUnionStringLiteralClient) getDefaultHandleResponse(resp *h
 }
 
 // PutAll - Put a body with all properties present.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionStringLiteralClientPutAllOptions contains the optional parameters for the OptionalUnionStringLiteralClient.PutAll
 //     method.
 func (client *OptionalUnionStringLiteralClient) PutAll(ctx context.Context, body UnionStringLiteralProperty, options *OptionalUnionStringLiteralClientPutAllOptions) (OptionalUnionStringLiteralClientPutAllResponse, error) {
@@ -147,6 +150,7 @@ func (client *OptionalUnionStringLiteralClient) putAllCreateRequest(ctx context.
 }
 
 // PutDefault - Put a body with default properties.
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - OptionalUnionStringLiteralClientPutDefaultOptions contains the optional parameters for the OptionalUnionStringLiteralClient.PutDefault
 //     method.
 func (client *OptionalUnionStringLiteralClient) PutDefault(ctx context.Context, body UnionStringLiteralProperty, options *OptionalUnionStringLiteralClientPutDefaultOptions) (OptionalUnionStringLiteralClientPutDefaultResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesboolean_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesboolean_client.go
@@ -19,6 +19,7 @@ type ValueTypesBooleanClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesBooleanClientGetOptions contains the optional parameters for the ValueTypesBooleanClient.Get method.
 func (client *ValueTypesBooleanClient) Get(ctx context.Context, options *ValueTypesBooleanClientGetOptions) (ValueTypesBooleanClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesBooleanClient) getHandleResponse(resp *http.Response) (V
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesBooleanClientPutOptions contains the optional parameters for the ValueTypesBooleanClient.Put method.
 func (client *ValueTypesBooleanClient) Put(ctx context.Context, body BooleanProperty, options *ValueTypesBooleanClientPutOptions) (ValueTypesBooleanClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesbooleanliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesbooleanliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesBooleanLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesBooleanLiteralClientGetOptions contains the optional parameters for the ValueTypesBooleanLiteralClient.Get
 //     method.
 func (client *ValueTypesBooleanLiteralClient) Get(ctx context.Context, options *ValueTypesBooleanLiteralClientGetOptions) (ValueTypesBooleanLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesBooleanLiteralClient) getHandleResponse(resp *http.Respo
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesBooleanLiteralClientPutOptions contains the optional parameters for the ValueTypesBooleanLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesbytes_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesbytes_client.go
@@ -19,6 +19,7 @@ type ValueTypesBytesClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesBytesClientGetOptions contains the optional parameters for the ValueTypesBytesClient.Get method.
 func (client *ValueTypesBytesClient) Get(ctx context.Context, options *ValueTypesBytesClientGetOptions) (ValueTypesBytesClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesBytesClient) getHandleResponse(resp *http.Response) (Val
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesBytesClientPutOptions contains the optional parameters for the ValueTypesBytesClient.Put method.
 func (client *ValueTypesBytesClient) Put(ctx context.Context, body BytesProperty, options *ValueTypesBytesClientPutOptions) (ValueTypesBytesClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsint_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsint_client.go
@@ -19,6 +19,7 @@ type ValueTypesCollectionsIntClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesCollectionsIntClientGetOptions contains the optional parameters for the ValueTypesCollectionsIntClient.Get
 //     method.
 func (client *ValueTypesCollectionsIntClient) Get(ctx context.Context, options *ValueTypesCollectionsIntClientGetOptions) (ValueTypesCollectionsIntClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesCollectionsIntClient) getHandleResponse(resp *http.Respo
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesCollectionsIntClientPutOptions contains the optional parameters for the ValueTypesCollectionsIntClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsmodel_client.go
@@ -19,6 +19,7 @@ type ValueTypesCollectionsModelClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesCollectionsModelClientGetOptions contains the optional parameters for the ValueTypesCollectionsModelClient.Get
 //     method.
 func (client *ValueTypesCollectionsModelClient) Get(ctx context.Context, options *ValueTypesCollectionsModelClientGetOptions) (ValueTypesCollectionsModelClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesCollectionsModelClient) getHandleResponse(resp *http.Res
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesCollectionsModelClientPutOptions contains the optional parameters for the ValueTypesCollectionsModelClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypescollectionsstring_client.go
@@ -19,6 +19,7 @@ type ValueTypesCollectionsStringClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesCollectionsStringClientGetOptions contains the optional parameters for the ValueTypesCollectionsStringClient.Get
 //     method.
 func (client *ValueTypesCollectionsStringClient) Get(ctx context.Context, options *ValueTypesCollectionsStringClientGetOptions) (ValueTypesCollectionsStringClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesCollectionsStringClient) getHandleResponse(resp *http.Re
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesCollectionsStringClientPutOptions contains the optional parameters for the ValueTypesCollectionsStringClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdatetime_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdatetime_client.go
@@ -19,6 +19,7 @@ type ValueTypesDatetimeClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesDatetimeClientGetOptions contains the optional parameters for the ValueTypesDatetimeClient.Get method.
 func (client *ValueTypesDatetimeClient) Get(ctx context.Context, options *ValueTypesDatetimeClientGetOptions) (ValueTypesDatetimeClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesDatetimeClient) getHandleResponse(resp *http.Response) (
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesDatetimeClientPutOptions contains the optional parameters for the ValueTypesDatetimeClient.Put method.
 func (client *ValueTypesDatetimeClient) Put(ctx context.Context, body DatetimeProperty, options *ValueTypesDatetimeClientPutOptions) (ValueTypesDatetimeClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdecimal128_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdecimal128_client.go
@@ -19,6 +19,7 @@ type ValueTypesDecimal128Client struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesDecimal128ClientGetOptions contains the optional parameters for the ValueTypesDecimal128Client.Get
 //     method.
 func (client *ValueTypesDecimal128Client) Get(ctx context.Context, options *ValueTypesDecimal128ClientGetOptions) (ValueTypesDecimal128ClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesDecimal128Client) getHandleResponse(resp *http.Response)
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesDecimal128ClientPutOptions contains the optional parameters for the ValueTypesDecimal128Client.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdecimal_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdecimal_client.go
@@ -19,6 +19,7 @@ type ValueTypesDecimalClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesDecimalClientGetOptions contains the optional parameters for the ValueTypesDecimalClient.Get method.
 func (client *ValueTypesDecimalClient) Get(ctx context.Context, options *ValueTypesDecimalClientGetOptions) (ValueTypesDecimalClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesDecimalClient) getHandleResponse(resp *http.Response) (V
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesDecimalClientPutOptions contains the optional parameters for the ValueTypesDecimalClient.Put method.
 func (client *ValueTypesDecimalClient) Put(ctx context.Context, body DecimalProperty, options *ValueTypesDecimalClientPutOptions) (ValueTypesDecimalClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdictionarystring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesdictionarystring_client.go
@@ -19,6 +19,7 @@ type ValueTypesDictionaryStringClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesDictionaryStringClientGetOptions contains the optional parameters for the ValueTypesDictionaryStringClient.Get
 //     method.
 func (client *ValueTypesDictionaryStringClient) Get(ctx context.Context, options *ValueTypesDictionaryStringClientGetOptions) (ValueTypesDictionaryStringClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesDictionaryStringClient) getHandleResponse(resp *http.Res
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesDictionaryStringClientPutOptions contains the optional parameters for the ValueTypesDictionaryStringClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesduration_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesduration_client.go
@@ -19,6 +19,7 @@ type ValueTypesDurationClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesDurationClientGetOptions contains the optional parameters for the ValueTypesDurationClient.Get method.
 func (client *ValueTypesDurationClient) Get(ctx context.Context, options *ValueTypesDurationClientGetOptions) (ValueTypesDurationClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesDurationClient) getHandleResponse(resp *http.Response) (
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesDurationClientPutOptions contains the optional parameters for the ValueTypesDurationClient.Put method.
 func (client *ValueTypesDurationClient) Put(ctx context.Context, body DurationProperty, options *ValueTypesDurationClientPutOptions) (ValueTypesDurationClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesenum_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesenum_client.go
@@ -19,6 +19,7 @@ type ValueTypesEnumClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesEnumClientGetOptions contains the optional parameters for the ValueTypesEnumClient.Get method.
 func (client *ValueTypesEnumClient) Get(ctx context.Context, options *ValueTypesEnumClientGetOptions) (ValueTypesEnumClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesEnumClient) getHandleResponse(resp *http.Response) (Valu
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesEnumClientPutOptions contains the optional parameters for the ValueTypesEnumClient.Put method.
 func (client *ValueTypesEnumClient) Put(ctx context.Context, body EnumProperty, options *ValueTypesEnumClientPutOptions) (ValueTypesEnumClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesextensibleenum_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesextensibleenum_client.go
@@ -19,6 +19,7 @@ type ValueTypesExtensibleEnumClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesExtensibleEnumClientGetOptions contains the optional parameters for the ValueTypesExtensibleEnumClient.Get
 //     method.
 func (client *ValueTypesExtensibleEnumClient) Get(ctx context.Context, options *ValueTypesExtensibleEnumClientGetOptions) (ValueTypesExtensibleEnumClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesExtensibleEnumClient) getHandleResponse(resp *http.Respo
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesExtensibleEnumClientPutOptions contains the optional parameters for the ValueTypesExtensibleEnumClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesfloat_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesfloat_client.go
@@ -19,6 +19,7 @@ type ValueTypesFloatClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesFloatClientGetOptions contains the optional parameters for the ValueTypesFloatClient.Get method.
 func (client *ValueTypesFloatClient) Get(ctx context.Context, options *ValueTypesFloatClientGetOptions) (ValueTypesFloatClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesFloatClient) getHandleResponse(resp *http.Response) (Val
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesFloatClientPutOptions contains the optional parameters for the ValueTypesFloatClient.Put method.
 func (client *ValueTypesFloatClient) Put(ctx context.Context, body FloatProperty, options *ValueTypesFloatClientPutOptions) (ValueTypesFloatClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesfloatliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesfloatliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesFloatLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesFloatLiteralClientGetOptions contains the optional parameters for the ValueTypesFloatLiteralClient.Get
 //     method.
 func (client *ValueTypesFloatLiteralClient) Get(ctx context.Context, options *ValueTypesFloatLiteralClientGetOptions) (ValueTypesFloatLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesFloatLiteralClient) getHandleResponse(resp *http.Respons
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesFloatLiteralClientPutOptions contains the optional parameters for the ValueTypesFloatLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesint_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesint_client.go
@@ -19,6 +19,7 @@ type ValueTypesIntClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesIntClientGetOptions contains the optional parameters for the ValueTypesIntClient.Get method.
 func (client *ValueTypesIntClient) Get(ctx context.Context, options *ValueTypesIntClientGetOptions) (ValueTypesIntClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesIntClient) getHandleResponse(resp *http.Response) (Value
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesIntClientPutOptions contains the optional parameters for the ValueTypesIntClient.Put method.
 func (client *ValueTypesIntClient) Put(ctx context.Context, body IntProperty, options *ValueTypesIntClientPutOptions) (ValueTypesIntClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesintliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesintliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesIntLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesIntLiteralClientGetOptions contains the optional parameters for the ValueTypesIntLiteralClient.Get
 //     method.
 func (client *ValueTypesIntLiteralClient) Get(ctx context.Context, options *ValueTypesIntLiteralClientGetOptions) (ValueTypesIntLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesIntLiteralClient) getHandleResponse(resp *http.Response)
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesIntLiteralClientPutOptions contains the optional parameters for the ValueTypesIntLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesmodel_client.go
@@ -19,6 +19,7 @@ type ValueTypesModelClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesModelClientGetOptions contains the optional parameters for the ValueTypesModelClient.Get method.
 func (client *ValueTypesModelClient) Get(ctx context.Context, options *ValueTypesModelClientGetOptions) (ValueTypesModelClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesModelClient) getHandleResponse(resp *http.Response) (Val
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesModelClientPutOptions contains the optional parameters for the ValueTypesModelClient.Put method.
 func (client *ValueTypesModelClient) Put(ctx context.Context, body ModelProperty, options *ValueTypesModelClientPutOptions) (ValueTypesModelClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesnever_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesnever_client.go
@@ -19,6 +19,7 @@ type ValueTypesNeverClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesNeverClientGetOptions contains the optional parameters for the ValueTypesNeverClient.Get method.
 func (client *ValueTypesNeverClient) Get(ctx context.Context, options *ValueTypesNeverClientGetOptions) (ValueTypesNeverClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesNeverClient) getHandleResponse(resp *http.Response) (Val
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesNeverClientPutOptions contains the optional parameters for the ValueTypesNeverClient.Put method.
 func (client *ValueTypesNeverClient) Put(ctx context.Context, body NeverProperty, options *ValueTypesNeverClientPutOptions) (ValueTypesNeverClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesstring_client.go
@@ -19,6 +19,7 @@ type ValueTypesStringClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesStringClientGetOptions contains the optional parameters for the ValueTypesStringClient.Get method.
 func (client *ValueTypesStringClient) Get(ctx context.Context, options *ValueTypesStringClientGetOptions) (ValueTypesStringClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ValueTypesStringClient) getHandleResponse(resp *http.Response) (Va
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesStringClientPutOptions contains the optional parameters for the ValueTypesStringClient.Put method.
 func (client *ValueTypesStringClient) Put(ctx context.Context, body StringProperty, options *ValueTypesStringClientPutOptions) (ValueTypesStringClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesstringliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesstringliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesStringLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesStringLiteralClientGetOptions contains the optional parameters for the ValueTypesStringLiteralClient.Get
 //     method.
 func (client *ValueTypesStringLiteralClient) Get(ctx context.Context, options *ValueTypesStringLiteralClientGetOptions) (ValueTypesStringLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesStringLiteralClient) getHandleResponse(resp *http.Respon
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesStringLiteralClientPutOptions contains the optional parameters for the ValueTypesStringLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionenumvalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionenumvalue_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnionEnumValueClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnionEnumValueClientGetOptions contains the optional parameters for the ValueTypesUnionEnumValueClient.Get
 //     method.
 func (client *ValueTypesUnionEnumValueClient) Get(ctx context.Context, options *ValueTypesUnionEnumValueClientGetOptions) (ValueTypesUnionEnumValueClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnionEnumValueClient) getHandleResponse(resp *http.Respo
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnionEnumValueClientPutOptions contains the optional parameters for the ValueTypesUnionEnumValueClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionfloatliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionfloatliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnionFloatLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnionFloatLiteralClientGetOptions contains the optional parameters for the ValueTypesUnionFloatLiteralClient.Get
 //     method.
 func (client *ValueTypesUnionFloatLiteralClient) Get(ctx context.Context, options *ValueTypesUnionFloatLiteralClientGetOptions) (ValueTypesUnionFloatLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnionFloatLiteralClient) getHandleResponse(resp *http.Re
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnionFloatLiteralClientPutOptions contains the optional parameters for the ValueTypesUnionFloatLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionintliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionintliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnionIntLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnionIntLiteralClientGetOptions contains the optional parameters for the ValueTypesUnionIntLiteralClient.Get
 //     method.
 func (client *ValueTypesUnionIntLiteralClient) Get(ctx context.Context, options *ValueTypesUnionIntLiteralClientGetOptions) (ValueTypesUnionIntLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnionIntLiteralClient) getHandleResponse(resp *http.Resp
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnionIntLiteralClientPutOptions contains the optional parameters for the ValueTypesUnionIntLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionstringliteral_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunionstringliteral_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnionStringLiteralClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnionStringLiteralClientGetOptions contains the optional parameters for the ValueTypesUnionStringLiteralClient.Get
 //     method.
 func (client *ValueTypesUnionStringLiteralClient) Get(ctx context.Context, options *ValueTypesUnionStringLiteralClientGetOptions) (ValueTypesUnionStringLiteralClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnionStringLiteralClient) getHandleResponse(resp *http.R
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnionStringLiteralClientPutOptions contains the optional parameters for the ValueTypesUnionStringLiteralClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownarray_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownarray_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnknownArrayClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnknownArrayClientGetOptions contains the optional parameters for the ValueTypesUnknownArrayClient.Get
 //     method.
 func (client *ValueTypesUnknownArrayClient) Get(ctx context.Context, options *ValueTypesUnknownArrayClientGetOptions) (ValueTypesUnknownArrayClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnknownArrayClient) getHandleResponse(resp *http.Respons
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnknownArrayClientPutOptions contains the optional parameters for the ValueTypesUnknownArrayClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknowndict_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknowndict_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnknownDictClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnknownDictClientGetOptions contains the optional parameters for the ValueTypesUnknownDictClient.Get
 //     method.
 func (client *ValueTypesUnknownDictClient) Get(ctx context.Context, options *ValueTypesUnknownDictClientGetOptions) (ValueTypesUnknownDictClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnknownDictClient) getHandleResponse(resp *http.Response
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnknownDictClientPutOptions contains the optional parameters for the ValueTypesUnknownDictClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownint_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownint_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnknownIntClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnknownIntClientGetOptions contains the optional parameters for the ValueTypesUnknownIntClient.Get
 //     method.
 func (client *ValueTypesUnknownIntClient) Get(ctx context.Context, options *ValueTypesUnknownIntClientGetOptions) (ValueTypesUnknownIntClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnknownIntClient) getHandleResponse(resp *http.Response)
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnknownIntClientPutOptions contains the optional parameters for the ValueTypesUnknownIntClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/property/valuetypesgroup/zz_valuetypesunknownstring_client.go
@@ -19,6 +19,7 @@ type ValueTypesUnknownStringClient struct {
 }
 
 // Get - Get call
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ValueTypesUnknownStringClientGetOptions contains the optional parameters for the ValueTypesUnknownStringClient.Get
 //     method.
 func (client *ValueTypesUnknownStringClient) Get(ctx context.Context, options *ValueTypesUnknownStringClientGetOptions) (ValueTypesUnknownStringClientGetResponse, error) {
@@ -64,6 +65,7 @@ func (client *ValueTypesUnknownStringClient) getHandleResponse(resp *http.Respon
 }
 
 // Put - Put operation
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - body
 //   - options - ValueTypesUnknownStringClientPutOptions contains the optional parameters for the ValueTypesUnknownStringClient.Put
 //     method.

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarboolean_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarboolean_client.go
@@ -19,6 +19,7 @@ type ScalarBooleanClient struct {
 }
 
 // Get - get boolean value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarBooleanClientGetOptions contains the optional parameters for the ScalarBooleanClient.Get method.
 func (client *ScalarBooleanClient) Get(ctx context.Context, options *ScalarBooleanClientGetOptions) (ScalarBooleanClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ScalarBooleanClient) getHandleResponse(resp *http.Response) (Scala
 }
 
 // Put - put boolean value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - ScalarBooleanClientPutOptions contains the optional parameters for the ScalarBooleanClient.Put method.
 func (client *ScalarBooleanClient) Put(ctx context.Context, body bool, options *ScalarBooleanClientPutOptions) (ScalarBooleanClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimal128type_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimal128type_client.go
@@ -19,6 +19,8 @@ type ScalarDecimal128TypeClient struct {
 	internal *azcore.Client
 }
 
+// RequestBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimal128TypeClientRequestBodyOptions contains the optional parameters for the ScalarDecimal128TypeClient.RequestBody
 //     method.
 func (client *ScalarDecimal128TypeClient) RequestBody(ctx context.Context, body float64, options *ScalarDecimal128TypeClientRequestBodyOptions) (ScalarDecimal128TypeClientRequestBodyResponse, error) {
@@ -56,6 +58,8 @@ func (client *ScalarDecimal128TypeClient) requestBodyCreateRequest(ctx context.C
 	return req, nil
 }
 
+// RequestParameter -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimal128TypeClientRequestParameterOptions contains the optional parameters for the ScalarDecimal128TypeClient.RequestParameter
 //     method.
 func (client *ScalarDecimal128TypeClient) RequestParameter(ctx context.Context, value float64, options *ScalarDecimal128TypeClientRequestParameterOptions) (ScalarDecimal128TypeClientRequestParameterResponse, error) {
@@ -92,6 +96,8 @@ func (client *ScalarDecimal128TypeClient) requestParameterCreateRequest(ctx cont
 	return req, nil
 }
 
+// ResponseBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimal128TypeClientResponseBodyOptions contains the optional parameters for the ScalarDecimal128TypeClient.ResponseBody
 //     method.
 func (client *ScalarDecimal128TypeClient) ResponseBody(ctx context.Context, options *ScalarDecimal128TypeClientResponseBodyOptions) (ScalarDecimal128TypeClientResponseBodyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimal128verify_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimal128verify_client.go
@@ -18,6 +18,8 @@ type ScalarDecimal128VerifyClient struct {
 	internal *azcore.Client
 }
 
+// PrepareVerify -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimal128VerifyClientPrepareVerifyOptions contains the optional parameters for the ScalarDecimal128VerifyClient.PrepareVerify
 //     method.
 func (client *ScalarDecimal128VerifyClient) PrepareVerify(ctx context.Context, options *ScalarDecimal128VerifyClientPrepareVerifyOptions) (ScalarDecimal128VerifyClientPrepareVerifyResponse, error) {
@@ -62,6 +64,8 @@ func (client *ScalarDecimal128VerifyClient) prepareVerifyHandleResponse(resp *ht
 	return result, nil
 }
 
+// Verify -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimal128VerifyClientVerifyOptions contains the optional parameters for the ScalarDecimal128VerifyClient.Verify
 //     method.
 func (client *ScalarDecimal128VerifyClient) Verify(ctx context.Context, body float64, options *ScalarDecimal128VerifyClientVerifyOptions) (ScalarDecimal128VerifyClientVerifyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimaltype_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimaltype_client.go
@@ -19,6 +19,8 @@ type ScalarDecimalTypeClient struct {
 	internal *azcore.Client
 }
 
+// RequestBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimalTypeClientRequestBodyOptions contains the optional parameters for the ScalarDecimalTypeClient.RequestBody
 //     method.
 func (client *ScalarDecimalTypeClient) RequestBody(ctx context.Context, body float64, options *ScalarDecimalTypeClientRequestBodyOptions) (ScalarDecimalTypeClientRequestBodyResponse, error) {
@@ -56,6 +58,8 @@ func (client *ScalarDecimalTypeClient) requestBodyCreateRequest(ctx context.Cont
 	return req, nil
 }
 
+// RequestParameter -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimalTypeClientRequestParameterOptions contains the optional parameters for the ScalarDecimalTypeClient.RequestParameter
 //     method.
 func (client *ScalarDecimalTypeClient) RequestParameter(ctx context.Context, value float64, options *ScalarDecimalTypeClientRequestParameterOptions) (ScalarDecimalTypeClientRequestParameterResponse, error) {
@@ -92,6 +96,8 @@ func (client *ScalarDecimalTypeClient) requestParameterCreateRequest(ctx context
 	return req, nil
 }
 
+// ResponseBody -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimalTypeClientResponseBodyOptions contains the optional parameters for the ScalarDecimalTypeClient.ResponseBody
 //     method.
 func (client *ScalarDecimalTypeClient) ResponseBody(ctx context.Context, options *ScalarDecimalTypeClientResponseBodyOptions) (ScalarDecimalTypeClientResponseBodyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimalverify_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalardecimalverify_client.go
@@ -18,6 +18,8 @@ type ScalarDecimalVerifyClient struct {
 	internal *azcore.Client
 }
 
+// PrepareVerify -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimalVerifyClientPrepareVerifyOptions contains the optional parameters for the ScalarDecimalVerifyClient.PrepareVerify
 //     method.
 func (client *ScalarDecimalVerifyClient) PrepareVerify(ctx context.Context, options *ScalarDecimalVerifyClientPrepareVerifyOptions) (ScalarDecimalVerifyClientPrepareVerifyResponse, error) {
@@ -62,6 +64,8 @@ func (client *ScalarDecimalVerifyClient) prepareVerifyHandleResponse(resp *http.
 	return result, nil
 }
 
+// Verify -
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarDecimalVerifyClientVerifyOptions contains the optional parameters for the ScalarDecimalVerifyClient.Verify
 //     method.
 func (client *ScalarDecimalVerifyClient) Verify(ctx context.Context, body float64, options *ScalarDecimalVerifyClientVerifyOptions) (ScalarDecimalVerifyClientVerifyResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarstring_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarstring_client.go
@@ -19,6 +19,7 @@ type ScalarStringClient struct {
 }
 
 // Get - get string value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarStringClientGetOptions contains the optional parameters for the ScalarStringClient.Get method.
 func (client *ScalarStringClient) Get(ctx context.Context, options *ScalarStringClientGetOptions) (ScalarStringClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ScalarStringClient) getHandleResponse(resp *http.Response) (Scalar
 }
 
 // Put - put string value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - ScalarStringClientPutOptions contains the optional parameters for the ScalarStringClient.Put method.
 func (client *ScalarStringClient) Put(ctx context.Context, body string, options *ScalarStringClientPutOptions) (ScalarStringClientPutResponse, error) {

--- a/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarunknown_client.go
+++ b/packages/typespec-go/test/cadlranch/type/scalargroup/zz_scalarunknown_client.go
@@ -19,6 +19,7 @@ type ScalarUnknownClient struct {
 }
 
 // Get - get unknown value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - options - ScalarUnknownClientGetOptions contains the optional parameters for the ScalarUnknownClient.Get method.
 func (client *ScalarUnknownClient) Get(ctx context.Context, options *ScalarUnknownClientGetOptions) (ScalarUnknownClientGetResponse, error) {
 	var err error
@@ -63,6 +64,7 @@ func (client *ScalarUnknownClient) getHandleResponse(resp *http.Response) (Scala
 }
 
 // Put - put unknown value
+// If the operation fails it returns an *azcore.ResponseError type.
 //   - body - _
 //   - options - ScalarUnknownClientPutOptions contains the optional parameters for the ScalarUnknownClient.Put method.
 func (client *ScalarUnknownClient) Put(ctx context.Context, body any, options *ScalarUnknownClientPutOptions) (ScalarUnknownClientPutResponse, error) {


### PR DESCRIPTION
Doc methods that can return an *azcore.ResponseError. Doc API version info.

Fixes https://github.com/Azure/autorest.go/issues/1342