### PR TITLE
Propgate only client/host params to child clients

### DIFF
--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -107,7 +107,7 @@ export class clientAdapter {
           }
           continue;
         } else if (param.kind === 'method') {
-          // some client params, notably (only?) api-version, can be explicitly
+          // some client params, notably api-version, can be explicitly
           // defined in the operation signature:
           // e.g. op withQueryApiVersion(@query("api-version") apiVersion: string)
           // these get propagated to sdkMethod.operation.parameters thus they
@@ -123,7 +123,10 @@ export class clientAdapter {
       // to create a child client that will need to inherit our client params.
       goClient.templatedHost = parent.templatedHost;
       goClient.host = parent.host;
-      goClient.parameters = parent.parameters;
+      // make a copy of the client params. this is to prevent
+      // client method params from being shared across clients
+      // as not all client method params might be uniform.
+      goClient.parameters = new Array<go.Parameter>(...parent.parameters);
     } else {
       throw new Error(`uninstantiable client ${sdkClient.name} has no parent`);
     }

--- a/packages/typespec-go/test/armapicenter/zz_client_factory.go
+++ b/packages/typespec-go/test/armapicenter/zz_client_factory.go
@@ -91,8 +91,7 @@ func (c *ClientFactory) NewMetadataSchemasClient() *MetadataSchemasClient {
 // NewOperationsClient creates a new instance of OperationsClient.
 func (c *ClientFactory) NewOperationsClient() *OperationsClient {
 	return &OperationsClient{
-		subscriptionID: c.subscriptionID,
-		internal:       c.internal,
+		internal: c.internal,
 	}
 }
 

--- a/packages/typespec-go/test/armapicenter/zz_operations_client.go
+++ b/packages/typespec-go/test/armapicenter/zz_operations_client.go
@@ -16,22 +16,19 @@ import (
 // OperationsClient contains the methods for the Microsoft.ApiCenter namespace.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	internal       *arm.Client
-	subscriptionID string
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
-//   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
+func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		subscriptionID: subscriptionID,
-		internal:       cl,
+		internal: cl,
 	}
 	return client, nil
 }

--- a/packages/typespec-go/test/armcodesigning/zz_client_factory.go
+++ b/packages/typespec-go/test/armcodesigning/zz_client_factory.go
@@ -51,7 +51,6 @@ func (c *ClientFactory) NewCertificateProfilesClient() *CertificateProfilesClien
 // NewOperationsClient creates a new instance of OperationsClient.
 func (c *ClientFactory) NewOperationsClient() *OperationsClient {
 	return &OperationsClient{
-		subscriptionID: c.subscriptionID,
-		internal:       c.internal,
+		internal: c.internal,
 	}
 }

--- a/packages/typespec-go/test/armcodesigning/zz_operations_client.go
+++ b/packages/typespec-go/test/armcodesigning/zz_operations_client.go
@@ -16,22 +16,19 @@ import (
 // OperationsClient contains the methods for the Microsoft.CodeSigning namespace.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	internal       *arm.Client
-	subscriptionID string
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
-//   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
+func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		subscriptionID: subscriptionID,
-		internal:       cl,
+		internal: cl,
 	}
 	return client, nil
 }

--- a/packages/typespec-go/test/armdatabasewatcher/zz_client_factory.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_client_factory.go
@@ -35,8 +35,7 @@ func NewClientFactory(subscriptionID string, credential azcore.TokenCredential, 
 // NewOperationsClient creates a new instance of OperationsClient.
 func (c *ClientFactory) NewOperationsClient() *OperationsClient {
 	return &OperationsClient{
-		subscriptionID: c.subscriptionID,
-		internal:       c.internal,
+		internal: c.internal,
 	}
 }
 

--- a/packages/typespec-go/test/armdatabasewatcher/zz_operations_client.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_operations_client.go
@@ -16,22 +16,19 @@ import (
 // OperationsClient contains the methods for the Microsoft.DatabaseWatcher namespace.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	internal       *arm.Client
-	subscriptionID string
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
-//   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
+func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		subscriptionID: subscriptionID,
-		internal:       cl,
+		internal: cl,
 	}
 	return client, nil
 }

--- a/packages/typespec-go/test/armlargeinstance/zz_client_factory.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_client_factory.go
@@ -51,7 +51,6 @@ func (c *ClientFactory) NewAzureLargeStorageInstancesClient() *AzureLargeStorage
 // NewOperationsClient creates a new instance of OperationsClient.
 func (c *ClientFactory) NewOperationsClient() *OperationsClient {
 	return &OperationsClient{
-		subscriptionID: c.subscriptionID,
-		internal:       c.internal,
+		internal: c.internal,
 	}
 }

--- a/packages/typespec-go/test/armlargeinstance/zz_operations_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_operations_client.go
@@ -16,22 +16,19 @@ import (
 // OperationsClient contains the methods for the Microsoft.AzureLargeInstance namespace.
 // Don't use this type directly, use NewOperationsClient() instead.
 type OperationsClient struct {
-	internal       *arm.Client
-	subscriptionID string
+	internal *arm.Client
 }
 
 // NewOperationsClient creates a new instance of OperationsClient with the specified values.
-//   - subscriptionID - The ID of the target subscription.
 //   - credential - used to authorize requests. Usually a credential from azidentity.
 //   - options - pass nil to accept the default values.
-func NewOperationsClient(subscriptionID string, credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
+func NewOperationsClient(credential azcore.TokenCredential, options *arm.ClientOptions) (*OperationsClient, error) {
 	cl, err := arm.NewClient(moduleName, moduleVersion, credential, options)
 	if err != nil {
 		return nil, err
 	}
 	client := &OperationsClient{
-		subscriptionID: subscriptionID,
-		internal:       cl,
+		internal: cl,
 	}
 	return client, nil
 }


### PR DESCRIPTION
Don't share the array of client params, make a copy of it. This prevents client method params from being shared across clients.

Fixes https://github.com/Azure/autorest.go/issues/1330