### PR TITLE
Some fixes for tsp emitter

### DIFF
--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -126,7 +126,7 @@ const armlargeinstance = pkgRoot + 'test/tsp/AzureLargeInstance.Management';
 generate('armlargeinstance', armlargeinstance, 'test/armlargeinstance', ['stutter=AzureLargeInstance']);
 
 const armdatabasewatcher = pkgRoot + 'test/tsp/DatabaseWatcher.Management';
-generate('armdatabasewatcher', armdatabasewatcher, 'test/armdatabasewatcher', ['remove-unreferenced-types=false']);
+generate('armdatabasewatcher', armdatabasewatcher, 'test/armdatabasewatcher', ['remove-unreferenced-types=false', 'fix-const-stuttering=false']);
 
 const armloadtestservice = pkgRoot + 'test/tsp/LoadTestService.Management';
 generate('armloadtestservice', armloadtestservice, 'test/armloadtestservice');
@@ -175,6 +175,7 @@ function generate(moduleName, input, outputDir, perTestOptions) {
     'inject-spans=true',
     'head-as-boolean=true',
     'remove-unreferenced-types=true',
+    'fix-const-stuttering=true',
   ];
 
   let allOptions = fixedOptions;

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -18,6 +18,7 @@ export interface GoEmitterOptions {
   'slice-elements-byval'?: boolean;
   'single-client'?: boolean;
   'stutter'?: string;
+  'fix-const-stuttering'?: boolean;
   'remove-unreferenced-types'?: boolean;
 }
 
@@ -37,6 +38,7 @@ const EmitterOptionsSchema: JSONSchemaType<GoEmitterOptions> = {
     'slice-elements-byval': { type: 'boolean', nullable: true },
     'single-client': { type: 'boolean', nullable: true },
     'stutter': { type: 'string', nullable: true },
+    'fix-const-stuttering': { type: 'boolean', nullable: true },
     'remove-unreferenced-types': { type: 'boolean', nullable: true },
   },
   required: [],

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -41,7 +41,7 @@ export function tcgcToGoCodeModel(context: EmitContext<GoEmitterOptions>): go.Co
     codeModel.options.sliceElementsByval = true;
   }
 
-  fixStutteringTypeNames(sdkContext.experimental_sdkPackage, codeModel, context.options.stutter);
+  fixStutteringTypeNames(sdkContext.experimental_sdkPackage, codeModel, context.options);
 
   const ta = new typeAdapter(codeModel);
   ta.adaptTypes(sdkContext, context.options['remove-unreferenced-types'] === true);
@@ -52,11 +52,11 @@ export function tcgcToGoCodeModel(context: EmitContext<GoEmitterOptions>): go.Co
   return codeModel;
 }
 
-function fixStutteringTypeNames(sdkPackage: tcgc.SdkPackage<tcgc.SdkHttpOperation>, codeModel: go.CodeModel, customPrefix?: string): void {
+function fixStutteringTypeNames(sdkPackage: tcgc.SdkPackage<tcgc.SdkHttpOperation>, codeModel: go.CodeModel, options: GoEmitterOptions): void {
   let stutteringPrefix = codeModel.packageName;
 
-  if (customPrefix) {
-    stutteringPrefix = customPrefix;
+  if (options.stutter) {
+    stutteringPrefix = options.stutter;
   } else {
     // if there's a well-known prefix, remove it
     if (stutteringPrefix.startsWith('arm')) {
@@ -115,8 +115,11 @@ function fixStutteringTypeNames(sdkPackage: tcgc.SdkPackage<tcgc.SdkHttpOperatio
     return newName;
   };
 
-  for (const sdkEnum of sdkPackage.enums) {
-    sdkEnum.name = renameType(sdkEnum.name);
+  // to keep compat with autorest.go, this is off by default
+  if (options['fix-const-stuttering'] === true) {
+    for (const sdkEnum of sdkPackage.enums) {
+      sdkEnum.name = renameType(sdkEnum.name);
+    }
   }
 
   for (const modelType of sdkPackage.models) {

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -150,9 +150,14 @@ export class typeAdapter {
       case 'int16':
       case 'int32':
       case 'int64':
+      case 'uint8':
+      case 'uint16':
+      case 'uint32':
+      case 'uint64':
       case 'plainDate':
       case 'plainTime':
       case 'string':
+      case 'uri':
       case 'url':
       case 'uuid':
         return this.getBuiltInType(type);

--- a/packages/typespec-go/test/armdatabasewatcher/zz_constants.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_constants.go
@@ -48,6 +48,27 @@ func PossibleCreatedByTypeValues() []CreatedByType {
 	}
 }
 
+// DatabaseWatcherProvisioningState - The status of the last provisioning operation performed on the resource.
+type DatabaseWatcherProvisioningState string
+
+const (
+	// DatabaseWatcherProvisioningStateCanceled - Resource creation was canceled.
+	DatabaseWatcherProvisioningStateCanceled DatabaseWatcherProvisioningState = "Canceled"
+	// DatabaseWatcherProvisioningStateFailed - Resource creation failed.
+	DatabaseWatcherProvisioningStateFailed DatabaseWatcherProvisioningState = "Failed"
+	// DatabaseWatcherProvisioningStateSucceeded - Resource has been created.
+	DatabaseWatcherProvisioningStateSucceeded DatabaseWatcherProvisioningState = "Succeeded"
+)
+
+// PossibleDatabaseWatcherProvisioningStateValues returns the possible values for the DatabaseWatcherProvisioningState const type.
+func PossibleDatabaseWatcherProvisioningStateValues() []DatabaseWatcherProvisioningState {
+	return []DatabaseWatcherProvisioningState{
+		DatabaseWatcherProvisioningStateCanceled,
+		DatabaseWatcherProvisioningStateFailed,
+		DatabaseWatcherProvisioningStateSucceeded,
+	}
+}
+
 // KustoOfferingType - The type of Kusto offering.
 type KustoOfferingType string
 
@@ -112,27 +133,6 @@ func PossibleOriginValues() []Origin {
 		OriginSystem,
 		OriginUser,
 		OriginUserSystem,
-	}
-}
-
-// ProvisioningState - The status of the last provisioning operation performed on the resource.
-type ProvisioningState string
-
-const (
-	// ProvisioningStateCanceled - Resource creation was canceled.
-	ProvisioningStateCanceled ProvisioningState = "Canceled"
-	// ProvisioningStateFailed - Resource creation failed.
-	ProvisioningStateFailed ProvisioningState = "Failed"
-	// ProvisioningStateSucceeded - Resource has been created.
-	ProvisioningStateSucceeded ProvisioningState = "Succeeded"
-)
-
-// PossibleProvisioningStateValues returns the possible values for the ProvisioningState const type.
-func PossibleProvisioningStateValues() []ProvisioningState {
-	return []ProvisioningState{
-		ProvisioningStateCanceled,
-		ProvisioningStateFailed,
-		ProvisioningStateSucceeded,
 	}
 }
 

--- a/packages/typespec-go/test/armdatabasewatcher/zz_models.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_models.go
@@ -474,7 +474,7 @@ type WatcherProperties struct {
 	Datastore *Datastore
 
 	// The provisioning state of the resource watcher.
-	ProvisioningState *ProvisioningState
+	ProvisioningState *DatabaseWatcherProvisioningState
 
 	// The monitoring collection status of the watcher.
 	Status *WatcherStatus


### PR DESCRIPTION
Handle types that are already handled in getBuiltInType. Add fix-const-stuttering option to keep compat with autorest.go.

Fixes:
- https://github.com/Azure/autorest.go/issues/1361
- https://github.com/Azure/autorest.go/issues/1362