### PR TITLE
Use extends for class definitions

### DIFF
--- a/packages/codemodel.go/src/client.ts
+++ b/packages/codemodel.go/src/client.ts
@@ -165,6 +165,26 @@ export function newClientOptions(modelType: pkg.CodeModelType, clientName: strin
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// base types
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+export class Method implements Method {
+  constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
+    if (statusCodes.length === 0) {
+      throw new Error('statusCodes cannot be empty');
+    }
+    this.apiVersions = new Array<string>();
+    this.client = client;
+    this.httpMethod = httpMethod;
+    this.httpPath = httpPath;
+    this.httpStatusCodes = statusCodes;
+    this.name = name;
+    this.naming = naming;
+    this.parameters = new Array<param.Parameter>();
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class Client implements Client {
@@ -202,71 +222,25 @@ export class MethodNaming implements MethodNaming {
   }
 }
 
-export class Method implements Method {
+export class LROMethod extends Method implements LROMethod {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
-    if (statusCodes.length === 0) {
-      throw new Error('statusCodes cannot be empty');
-    }
-    this.apiVersions = new Array<string>();
-    this.client = client;
-    this.httpMethod = httpMethod;
-    this.httpPath = httpPath;
-    this.httpStatusCodes = statusCodes;
-    this.name = name;
-    this.naming = naming;
-    this.parameters = new Array<param.Parameter>();
-  }
-}
-
-export class LROMethod implements LROMethod {
-  constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
-    if (statusCodes.length === 0) {
-      throw new Error('statusCodes cannot be empty');
-    }
-    this.apiVersions = new Array<string>();
-    this.client = client;
-    this.httpMethod = httpMethod;
-    this.httpPath = httpPath;
-    this.httpStatusCodes = statusCodes;
+    super(name, client, httpPath, httpMethod, statusCodes, naming);
     this.isLRO = true;
-    this.name = name;
-    this.naming = naming;
-    this.parameters = new Array<param.Parameter>();
   }
 }
 
-export class PageableMethod implements PageableMethod {
+export class PageableMethod extends Method implements PageableMethod {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
-    if (statusCodes.length === 0) {
-      throw new Error('statusCodes cannot be empty');
-    }
-    this.apiVersions = new Array<string>();
-    this.client = client;
-    this.httpMethod = httpMethod;
-    this.httpPath = httpPath;
-    this.httpStatusCodes = statusCodes;
+    super(name, client, httpPath, httpMethod, statusCodes, naming);
     this.isPageable = true;
-    this.name = name;
-    this.naming = naming;
-    this.parameters = new Array<param.Parameter>();
   }
 }
 
-export class LROPageableMethod implements LROPageableMethod {
+export class LROPageableMethod extends Method implements LROPageableMethod {
   constructor(name: string, client: Client, httpPath: string, httpMethod: HTTPMethod, statusCodes: Array<number>, naming: MethodNaming) {
-    if (statusCodes.length === 0) {
-      throw new Error('statusCodes cannot be empty');
-    }
-    this.apiVersions = new Array<string>();
-    this.client = client;
-    this.httpMethod = httpMethod;
-    this.httpPath = httpPath;
-    this.httpStatusCodes = statusCodes;
+    super(name, client, httpPath, httpMethod, statusCodes, naming);
     this.isLRO = true;
     this.isPageable = true;
-    this.name = name;
-    this.naming = naming;
-    this.parameters = new Array<param.Parameter>();
   }
 }
 

--- a/packages/codemodel.go/src/param.ts
+++ b/packages/codemodel.go/src/param.ts
@@ -251,6 +251,7 @@ export function isLiteralParameter(param: Parameter): boolean {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// base types
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class Parameter implements Parameter {
@@ -263,168 +264,115 @@ export class Parameter implements Parameter {
   }
 }
 
-export class BodyParameter implements BodyParameter {
+///////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+export class BodyParameter extends Parameter implements BodyParameter {
   constructor(name: string, bodyFormat: BodyFormat, contentType: string, type: type.PossibleType, paramType: ParameterType, byValue: boolean) {
-    this.name = name;
+    super(name, type, paramType, byValue, 'method');
     this.bodyFormat = bodyFormat;
     this.contentType = contentType;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = 'method';
   }
 }
 
-export class PartialBodyParameter implements PartialBodyParameter{
+export class PartialBodyParameter extends Parameter implements PartialBodyParameter{
   constructor(name: string, serializedName: string, format: 'JSON' | 'XML', type: type.PossibleType, paramType: ParameterType, byValue: boolean) {
-    this.byValue = byValue;
+    super(name, type, paramType, byValue, 'method');
     this.format = format;
-    this.location = 'method';
-    this.name = name;
-    this.paramType = paramType;
     this.serializedName = serializedName;
-    this.type = type;
   }
 }
 
-export class FormBodyParameter implements FormBodyParameter {
+export class FormBodyParameter extends Parameter implements FormBodyParameter {
   constructor(name: string, formDataName: string, type: type.PossibleType, paramType: ParameterType, byValue: boolean) {
-    this.name = name;
+    super(name, type, paramType, byValue, 'method');
     this.formDataName = formDataName;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = 'method';
   }
 }
 
-export class FormBodyCollectionParameter implements FormBodyCollectionParameter {
+export class FormBodyCollectionParameter extends Parameter implements FormBodyCollectionParameter {
   constructor(name: string, formDataName: string, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, paramType: ParameterType, byValue: boolean) {
-    this.name = name;
+    super(name, type, paramType, byValue, 'method');
     this.formDataName = formDataName;
-    this.type = type;
     this.collectionFormat = collectionFormat;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = 'method';
   }
 }
 
-export class MultipartFormBodyParameter implements MultipartFormBodyParameter {
+export class MultipartFormBodyParameter extends Parameter implements MultipartFormBodyParameter {
   constructor(name: string, type: type.PossibleType, paramType: ParameterType, byValue: boolean) {
-    this.name = name;
+    super(name, type, paramType, byValue, 'method');
     this.multipartForm = true;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = 'method';
   }
 }
 
-export class HeaderParameter implements HeaderParameter {
+export class HeaderParameter extends Parameter implements HeaderParameter {
   constructor(name: string, headerName: string, type: HeaderType, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.headerName = headerName;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class HeaderCollectionParameter implements HeaderCollectionParameter {
+export class HeaderCollectionParameter extends Parameter implements HeaderCollectionParameter {
   constructor(name: string, headerName: string, type: type.SliceType, collectionFormat: CollectionFormat, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.headerName = headerName;
-    this.type = type;
     this.collectionFormat = collectionFormat;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class HeaderMapParameter implements HeaderMapParameter {
+export class HeaderMapParameter extends Parameter implements HeaderMapParameter {
   constructor(name: string, headerName: string, type: type.MapType, collectionPrefix: string, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.headerName = headerName;
-    this.type = type;
     this.collectionPrefix = collectionPrefix;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class PathParameter implements PathParameter {
+export class PathParameter extends Parameter implements PathParameter {
   constructor(name: string, pathSegment: string, isEncoded: boolean, type: PathParameterType, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.pathSegment = pathSegment;
     this.isEncoded = isEncoded;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class PathCollectionParameter implements PathCollectionParameter {
+export class PathCollectionParameter extends Parameter implements PathCollectionParameter {
   constructor(name: string, pathSegment: string, isEncoded: boolean, type: type.SliceType, collectionFormat: CollectionFormat, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.pathSegment = pathSegment;
     this.isEncoded = isEncoded;
-    this.type = type;
     this.collectionFormat = collectionFormat;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class QueryParameter implements QueryParameter {
+export class QueryParameter extends Parameter implements QueryParameter {
   constructor(name: string, queryParam: string, isEncoded: boolean, type: QueryParameterType, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.queryParameter = queryParam;
     this.isEncoded = isEncoded;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class QueryCollectionParameter implements QueryCollectionParameter {
+export class QueryCollectionParameter extends Parameter implements QueryCollectionParameter {
   constructor(name: string, queryParam: string, isEncoded: boolean, type: type.SliceType, collectionFormat: ExtendedCollectionFormat, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.queryParameter = queryParam;
     this.isEncoded = isEncoded;
-    this.type = type;
     this.collectionFormat = collectionFormat;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class URIParameter implements URIParameter {
+export class URIParameter extends Parameter implements URIParameter {
   constructor(name: string, uriPathSegment: string, type: type.ConstantType | type.PrimitiveType, paramType: ParameterType, byValue: boolean, location: ParameterLocation) {
-    this.name = name;
+    super(name, type, paramType, byValue, location);
     this.uriPathSegment = uriPathSegment;
-    this.type = type;
-    this.paramType = paramType;
-    this.byValue = byValue;
-    this.location = location;
   }
 }
 
-export class ResumeTokenParameter implements ResumeTokenParameter {
+export class ResumeTokenParameter extends Parameter implements ResumeTokenParameter {
   constructor() {
+    super('ResumeToken', new type.PrimitiveType('string'), 'optional', true, 'method');
     this.isResumeToken = true;
-    this.name = 'ResumeToken';
-    this.type = new type.PrimitiveType('string');
-    this.paramType = 'optional';
-    this.byValue = true;
-    this.location = 'method';
     this.description = 'Resumes the long-running operation from the provided token.';
   }
 }

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -171,7 +171,7 @@ export interface QualifiedType {
 export type DateTimeFormat = 'dateType' | 'dateTimeRFC1123' | 'dateTimeRFC3339' | 'timeRFC3339' | 'timeUnix';
 
 // TimeType is a time.Time type from the standard library with a format specifier.
-export interface TimeType extends QualifiedType {
+export interface TimeType {
   typeName: 'Time';
 
   packageName: 'time';
@@ -331,6 +331,25 @@ export function getTypeDeclaration(type: PossibleType, pkgName?: string): string
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+// base types
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+export class StructField implements StructField {
+  constructor(name: string, type: PossibleType, byValue: boolean) {
+    this.name = name;
+    this.type = type;
+    this.byValue = byValue;
+  }
+}
+
+export class StructType implements StructType {
+  constructor(name: string) {
+    this.fields = new Array<StructField>();
+    this.name = name;
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 export class ConstantType implements ConstantType {
@@ -357,9 +376,9 @@ export class LiteralValue implements LiteralValue {
   }
 }
 
-export class ModelType implements ModelType {
+export class ModelType extends StructType implements ModelType {
   constructor(name: string, format: ModelFormat, annotations: ModelAnnotations, usage: UsageFlags) {
-    this.name = name;
+    super(name);
     this.format = format;
     this.annotations = annotations;
     this.usage = usage;
@@ -374,11 +393,9 @@ export class ModelAnnotations implements ModelAnnotations {
   }
 }
 
-export class ModelField implements ModelField {
+export class ModelField extends StructField implements ModelField {
   constructor(name: string, type: PossibleType, byValue: boolean, serializedName: string, annotations: ModelFieldAnnotations) {
-    this.name = name;
-    this.type = type;
-    this.byValue = byValue;
+    super(name, type, byValue);
     this.serializedName = serializedName;
     this.annotations = annotations;
   }
@@ -393,28 +410,13 @@ export class ModelFieldAnnotations implements ModelFieldAnnotations {
   }
 }
 
-export class PolymorphicType implements PolymorphicType {
+export class PolymorphicType extends StructType implements PolymorphicType {
   constructor(name: string, iface: InterfaceType, annotations: ModelAnnotations, usage: UsageFlags) {
-    this.name = name;
+    super(name);
     this.interface = iface;
     this.annotations = annotations;
     this.usage = usage;
     this.fields = new Array<ModelField>();
-  }
-}
-
-export class StructType implements StructType {
-  constructor(name: string) {
-    this.fields = new Array<StructField>();
-    this.name = name;
-  }
-}
-
-export class StructField implements StructField {
-  constructor(name: string, type: PossibleType, byValue: boolean) {
-    this.name = name;
-    this.type = type;
-    this.byValue = byValue;
   }
 }
 


### PR DESCRIPTION
The enforces a call to super() which ensures the base type is properly formed and removes the duplicate constructor definitions. Don't have TimeType extend QualifiedType. While the shape is similar, they are distinct types.