### PR TITLE
Fix multipart/form structs with optional fields

### DIFF
--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
@@ -172,7 +172,8 @@ func TestFormDataClient_MultiBinaryParts(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, resp)
 
-	jpgFile.Seek(0, io.SeekStart)
+	_, err = jpgFile.Seek(0, io.SeekStart)
+	require.NoError(t, err)
 	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer pngFile.Close()

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/formdata_client_test.go
@@ -6,6 +6,7 @@ package multipartgroup_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"multipartgroup"
 	"os"
 	"testing"
@@ -162,14 +163,24 @@ func TestFormDataClient_MultiBinaryParts(t *testing.T) {
 	jpgFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.jpg", os.O_RDONLY, 0)
 	require.NoError(t, err)
 	defer jpgFile.Close()
-	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
-	require.NoError(t, err)
-	defer pngFile.Close()
+
 	resp, err := client.NewMultiPartFormDataClient().MultiBinaryParts(context.Background(), multipartgroup.MultiBinaryPartsRequest{
 		ProfileImage: streaming.MultipartContent{
 			Body: jpgFile,
 		},
-		Picture: streaming.MultipartContent{
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+
+	jpgFile.Seek(0, io.SeekStart)
+	pngFile, err := os.OpenFile("../../../../node_modules/@azure-tools/cadl-ranch-specs/assets/image.png", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	defer pngFile.Close()
+	resp, err = client.NewMultiPartFormDataClient().MultiBinaryParts(context.Background(), multipartgroup.MultiBinaryPartsRequest{
+		ProfileImage: streaming.MultipartContent{
+			Body: jpgFile,
+		},
+		Picture: &streaming.MultipartContent{
 			Body: pngFile,
 		},
 	}, nil)

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models.go
@@ -55,7 +55,7 @@ type JSONPartRequest struct {
 type MultiBinaryPartsRequest struct {
 	// REQUIRED
 	ProfileImage streaming.MultipartContent
-	Picture      streaming.MultipartContent
+	Picture      *streaming.MultipartContent
 }
 
 type MultiPartRequest struct {

--- a/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models_serde.go
+++ b/packages/typespec-go/test/cadlranch/payload/multipartgroup/zz_models_serde.go
@@ -84,7 +84,9 @@ func (j JSONPartRequest) toMultipartFormData() (map[string]any, error) {
 // toMultipartFormData converts MultiBinaryPartsRequest to multipart/form data.
 func (m MultiBinaryPartsRequest) toMultipartFormData() (map[string]any, error) {
 	objectMap := make(map[string]any)
-	objectMap["picture"] = m.Picture
+	if m.Picture != nil {
+		objectMap["picture"] = *m.Picture
+	}
 	objectMap["profileImage"] = m.ProfileImage
 	return objectMap, nil
 }


### PR DESCRIPTION
For multipart/form structs, emit optional fields as pointer-to-type. Updated test for MultiBinaryParts to invoke it twice, once with the optional payload omitted.
Moved some SerDe imports to where they're required so it's clear when they're actually needed.