### PR TITLE
Fix model fields READ-ONLY comment

### DIFF
--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -565,7 +565,7 @@ export class typeAdapter {
     if (prop.kind !== 'path' && prop.kind !== 'property') {
       throw new Error(`unexpected kind ${prop.kind} for property ${prop.name} in model ${modelType.name}`);
     }
-    const annotations = new go.ModelFieldAnnotations(prop.optional == false, false, false, false);
+    const annotations = new go.ModelFieldAnnotations(prop.optional === false, false, false, false);
     // for multipart/form data containing models, default to fields not being pointer-to-type as we
     // don't have to deal with JSON patch shenanigans. only the optional fields will be pointer-to-type.
     const isMultipartFormData = (modelType.usage & tcgc.UsageFlags.MultipartFormData) === tcgc.UsageFlags.MultipartFormData;
@@ -579,11 +579,11 @@ export class typeAdapter {
         type = this.getMultipartContent(prop.type.kind === 'array');
       }
       if (prop.visibility) {
-        for (const vis of prop.visibility) {
-          if (vis === http.Visibility.Read) {
-            annotations.readOnly = true;
-            break;
-          }
+        // the field is read-only IFF the only visibility attribute present is Read.
+        // a field can have Read & Create set which means it's required on input and
+        // returned on output.
+        if (prop.visibility.length === 1 && prop.visibility[0] === http.Visibility.Read) {
+          annotations.readOnly = true;
         }
       }
     }

--- a/packages/typespec-go/test/armapicenter/zz_models.go
+++ b/packages/typespec-go/test/armapicenter/zz_models.go
@@ -515,7 +515,7 @@ type OperationListResult struct {
 
 // Service - The service entity.
 type Service struct {
-	// READ-ONLY; The geo-location where the resource lives
+	// REQUIRED; The geo-location where the resource lives
 	Location *string
 
 	// READ-ONLY; The name of Azure API Center service.

--- a/packages/typespec-go/test/armcodesigning/zz_models.go
+++ b/packages/typespec-go/test/armcodesigning/zz_models.go
@@ -8,14 +8,14 @@ import "time"
 
 // Account - Trusted signing account resource.
 type Account struct {
+	// REQUIRED; The geo-location where the resource lives
+	Location *string
+
 	// The resource-specific properties for this resource.
 	Properties *AccountProperties
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; The geo-location where the resource lives
-	Location *string
 
 	// READ-ONLY; Trusted Signing account name.
 	Name *string

--- a/packages/typespec-go/test/armcommunitymanagement/zz_models.go
+++ b/packages/typespec-go/test/armcommunitymanagement/zz_models.go
@@ -8,6 +8,9 @@ import "time"
 
 // CommunityTraining - A CommunityProviderHub resource
 type CommunityTraining struct {
+	// REQUIRED; The geo-location where the resource lives
+	Location *string
+
 	// The resource-specific properties for this resource.
 	Properties *CommunityTrainingProperties
 
@@ -16,9 +19,6 @@ type CommunityTraining struct {
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; The geo-location where the resource lives
-	Location *string
 
 	// READ-ONLY; The name of the Community Training Resource
 	Name *string
@@ -44,25 +44,25 @@ type CommunityTrainingListResult struct {
 
 // CommunityTrainingProperties - Details of the Community CommunityTraining.
 type CommunityTrainingProperties struct {
-	// READ-ONLY; To indicate whether the Community Training instance has Disaster Recovery enabled
+	// REQUIRED; To indicate whether the Community Training instance has Disaster Recovery enabled
 	DisasterRecoveryEnabled *bool
 
-	// READ-ONLY; The identity configuration of the Community Training resource
+	// REQUIRED; The identity configuration of the Community Training resource
 	IdentityConfiguration *IdentityConfigurationProperties
 
-	// READ-ONLY; The email address of the portal admin
+	// REQUIRED; The email address of the portal admin
 	PortalAdminEmailAddress *string
 
-	// READ-ONLY; The portal name (website name) of the Community Training instance
+	// REQUIRED; The portal name (website name) of the Community Training instance
 	PortalName *string
 
-	// READ-ONLY; The email address of the portal owner. Will be used as the primary contact
+	// REQUIRED; The email address of the portal owner. Will be used as the primary contact
 	PortalOwnerEmailAddress *string
 
-	// READ-ONLY; The organization name of the portal owner
+	// REQUIRED; The organization name of the portal owner
 	PortalOwnerOrganizationName *string
 
-	// READ-ONLY; To indicate whether the Community Training instance has Zone Redundancy enabled
+	// REQUIRED; To indicate whether the Community Training instance has Zone Redundancy enabled
 	ZoneRedundancyEnabled *bool
 
 	// READ-ONLY; The status of the last operation.
@@ -82,38 +82,38 @@ type CommunityTrainingUpdate struct {
 
 // CommunityTrainingUpdateProperties - The updatable properties of the CommunityTraining.
 type CommunityTrainingUpdateProperties struct {
-	// READ-ONLY; The identity configuration of the Community Training resource
+	// The identity configuration of the Community Training resource
 	IdentityConfiguration *IdentityConfigurationProperties
 }
 
 // IdentityConfigurationProperties - Details of the Community CommunityTraining Identity Configuration
 type IdentityConfigurationProperties struct {
-	// READ-ONLY; The clientId of the application registered in the selected identity provider for the Community Training Resource
+	// REQUIRED; The clientId of the application registered in the selected identity provider for the Community Training Resource
 	ClientID *string
 
-	// READ-ONLY; The client secret of the application registered in the selected identity provider for the Community Training
+	// REQUIRED; The client secret of the application registered in the selected identity provider for the Community Training
 	// Resource
 	ClientSecret *string
 
-	// READ-ONLY; The domain name of the selected identity provider for the Community Training Resource
+	// REQUIRED; The domain name of the selected identity provider for the Community Training Resource
 	DomainName *string
 
-	// READ-ONLY; The identity type of the Community Training Resource
+	// REQUIRED; The identity type of the Community Training Resource
 	IdentityType *string
 
-	// READ-ONLY; The tenantId of the selected identity provider for the Community Training Resource
+	// REQUIRED; The tenantId of the selected identity provider for the Community Training Resource
 	TenantID *string
 
-	// READ-ONLY; The name of the authentication policy registered in ADB2C for the Community Training Resource
+	// The name of the authentication policy registered in ADB2C for the Community Training Resource
 	B2CAuthenticationPolicy *string
 
-	// READ-ONLY; The name of the password reset policy registered in ADB2C for the Community Training Resource
+	// The name of the password reset policy registered in ADB2C for the Community Training Resource
 	B2CPasswordResetPolicy *string
 
-	// READ-ONLY; The custom login parameters for the Community Training Resource
+	// The custom login parameters for the Community Training Resource
 	CustomLoginParameters *string
 
-	// READ-ONLY; To indicate whether the Community Training Resource has Teams enabled
+	// To indicate whether the Community Training Resource has Teams enabled
 	TeamsEnabled *bool
 }
 

--- a/packages/typespec-go/test/armdatabasewatcher/zz_models.go
+++ b/packages/typespec-go/test/armdatabasewatcher/zz_models.go
@@ -428,7 +428,7 @@ type VaultSecret struct {
 
 // Watcher - The DatabaseWatcherProviderHub resource.
 type Watcher struct {
-	// READ-ONLY; The geo-location where the resource lives
+	// REQUIRED; The geo-location where the resource lives
 	Location *string
 
 	// READ-ONLY; The database watcher name.

--- a/packages/typespec-go/test/armdevopsinfrastructure/zz_models.go
+++ b/packages/typespec-go/test/armdevopsinfrastructure/zz_models.go
@@ -275,7 +275,7 @@ type OsProfile struct {
 
 // Pool - Concrete tracked resource types can be created by aliasing this type using a specific property type.
 type Pool struct {
-	// READ-ONLY; The geo-location where the resource lives
+	// REQUIRED; The geo-location where the resource lives
 	Location *string
 
 	// READ-ONLY; Name of the pool. It needs to be globally unique.

--- a/packages/typespec-go/test/armlargeinstance/zz_models.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_models.go
@@ -9,14 +9,14 @@ import "time"
 // AzureLargeInstance - Azure Large Instance info on Azure (ARM properties and AzureLargeInstance
 // properties)
 type AzureLargeInstance struct {
+	// REQUIRED; The geo-location where the resource lives
+	Location *string
+
 	// The resource-specific properties for this resource.
 	Properties *Properties
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; The geo-location where the resource lives
-	Location *string
 
 	// READ-ONLY; Name of the AzureLargeInstance.
 	Name *string
@@ -34,14 +34,14 @@ type AzureLargeInstance struct {
 // AzureLargeStorageInstance info on Azure (ARM properties and
 // AzureLargeStorageInstance properties)
 type AzureLargeStorageInstance struct {
+	// REQUIRED; The geo-location where the resource lives
+	Location *string
+
 	// The resource-specific properties for this resource.
 	Properties *AzureLargeStorageInstanceProperties
 
 	// Resource tags.
 	Tags map[string]*string
-
-	// READ-ONLY; The geo-location where the resource lives
-	Location *string
 
 	// READ-ONLY; Name of the AzureLargeStorageInstance.
 	Name *string

--- a/packages/typespec-go/test/armloadtestservice/zz_models.go
+++ b/packages/typespec-go/test/armloadtestservice/zz_models.go
@@ -89,7 +89,7 @@ type LoadTestProperties struct {
 
 // LoadTestResource - LoadTest details.
 type LoadTestResource struct {
-	// READ-ONLY; The geo-location where the resource lives
+	// REQUIRED; The geo-location where the resource lives
 	Location *string
 
 	// READ-ONLY; Load Test name


### PR DESCRIPTION
Model fields are read-only if the only visibility decorator set is Read.

Fixes https://github.com/Azure/autorest.go/issues/1390