### PR TITLE
Add release pipeline for typespec-go emitter

### DIFF
--- a/eng/pipelines/publish-release-typespec.yml
+++ b/eng/pipelines/publish-release-typespec.yml
@@ -1,0 +1,50 @@
+trigger: none
+pr: none
+
+
+extends: 
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: Release
+
+        variables: 
+          - template: /eng/pipelines/templates/variables/image.yml
+
+        jobs:
+          - job: Release
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+
+            steps:
+              - template: /eng/steps/set-env.yaml
+
+              - template: /eng/steps/build-test-typespec.yaml
+
+              - pwsh: |
+                  $currentVersion = node -p -e "require('./packages/typespec-go/package.json').version";
+                  cd packages/typespec-go
+                  npm version --no-git-tag-version $currentVersion
+                  npm pack;
+                  npm install -g azure-tools-typespec-go-$currentVersion.tgz
+                  if ($LASTEXITCODE) {
+                    exit $LASTEXITCODE
+                  }
+                  npx publish-release `
+                    --token $(azuresdk-github-pat) `
+                    --repo autorest.go `
+                    --owner azure `
+                    --name "TypeSpec emitter for Go SDKs v$currentVersion" `
+                    --tag v$currentVersion --notes='TypeSpec emitter for Go SDKs' `
+                    --prerelease --editRelease false `
+                    --assets azure-tools-typespec-go-$currentVersion.tgz `
+                    --target_commitish $(Build.SourceBranchName);
+                displayName: "Publish GitHub Release"
+
+              - script: |
+                  cd packages/typespec-go
+                  echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" > ./.npmrc
+                  npm publish --access public
+                displayName: "Publish to npm"


### PR DESCRIPTION
Pipeline was copied from publish-release-go.yml and slightly modified.