### PR TITLE
Fix optional spread params

### DIFF
--- a/packages/codegen.go/src/fake/servers.ts
+++ b/packages/codegen.go/src/fake/servers.ts
@@ -1220,6 +1220,9 @@ function getFinalParamValue(clientPkg: string, param: go.Parameter, paramValues:
       // since headers aren't escaped, we cast required, string-based enums inline
       return `${go.getTypeDeclaration(param.type, clientPkg)}(${paramValue})`;
     }
+  } else if (go.isPartialBodyParameter(param)) {
+    // use the value from the unmarshaled, intermediate struct type
+    return `body.${capitalize(param.name)}`;
   }
 
   return paramValue;

--- a/packages/codegen.go/src/helpers.ts
+++ b/packages/codegen.go/src/helpers.ts
@@ -581,5 +581,5 @@ export function recursiveUnwrapMapSlice(item: go.PossibleType): go.PossibleType 
 
 // returns a * for optional params
 export function star(param: go.Parameter): string {
-  return go.isRequiredParameter(param) ? '' : '*';
+  return go.isRequiredParameter(param) || param.byValue ? '' : '*';
 }

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -311,8 +311,8 @@ export class clientAdapter {
 
       let adaptedParam: go.Parameter;
       if (opParam.kind === 'body' && opParam.type.kind === 'model' && opParam.type.kind !== param.type.kind) {
-        const paramKind = this.adaptParameterKind(opParam);
-        const byVal = isTypePassedByValue(opParam.type);
+        const paramKind = this.adaptParameterKind(param);
+        const byVal = isTypePassedByValue(param.type);
         const contentType = this.adaptContentType(opParam.defaultContentType);
         switch (contentType) {
           case 'JSON':
@@ -348,13 +348,22 @@ export class clientAdapter {
       adaptedParam.description = param.description;
       method.parameters.push(adaptedParam);
 
-      // we must check via param name and not reference equality. this is because a client param
-      // can be used in multiple ways. e.g. a client param "apiVersion" that's used as a path param
-      // in one method and a query param in another.
-      if (adaptedParam.location === 'client' && !method.client.parameters.find((v: go.Parameter, i: number, o: Array<go.Parameter>) => {
-        return v.name === adaptedParam.name;
-      })) {
-        method.client.parameters.push(adaptedParam);
+      if (adaptedParam.location === 'client') {
+        // we must check via param name and not reference equality. this is because a client param
+        // can be used in multiple ways. e.g. a client param "apiVersion" that's used as a path param
+        // in one method and a query param in another.
+        if (!method.client.parameters.find((v: go.Parameter, i: number, o: Array<go.Parameter>) => {
+          return v.name === adaptedParam.name;
+        })) {
+          method.client.parameters.push(adaptedParam);
+        }
+      } else if (adaptedParam.kind !== 'required' && adaptedParam.kind !== 'literal') {
+        // add optional method param to the options param group
+        if (!optionalGroup) {
+          throw new Error(`optional parameter ${param.name} has no optional parameter group`);
+        }
+        adaptedParam.group = optionalGroup;
+        optionalGroup.params.push(adaptedParam);
       }
     }
   }
@@ -456,13 +465,6 @@ export class clientAdapter {
     if (adaptedParam.location === 'client') {
       // track client parameter for later use
       this.clientParams.set(getClientParamsKey(param), adaptedParam);
-    } else if (paramKind !== 'required' && paramKind !== 'literal') {
-      // add optional method param to the options param group
-      if (!optionalGroup) {
-        throw new Error(`optional parameter ${param.name} has no optional parameter group`);
-      }
-      adaptedParam.group = optionalGroup;
-      optionalGroup.params.push(adaptedParam);
     }
 
     return adaptedParam;
@@ -634,7 +636,7 @@ export class clientAdapter {
     return type;
   }
 
-  private adaptParameterKind(param: tcgc.SdkBodyParameter | tcgc.SdkEndpointParameter | tcgc.SdkHeaderParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter): go.ParameterKind {
+  private adaptParameterKind(param: tcgc.SdkBodyParameter | tcgc.SdkEndpointParameter | tcgc.SdkHeaderParameter | tcgc.SdkMethodParameter | tcgc.SdkPathParameter | tcgc.SdkQueryParameter): go.ParameterKind {
     // NOTE: must check for constant type first as it will also set clientDefaultValue
     if (param.type.kind === 'constant') {
       if (param.optional) {

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/fake/zz_spreadalias_server.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/fake/zz_spreadalias_server.go
@@ -37,7 +37,7 @@ type SpreadAliasServer struct {
 
 	// SpreadWithMultipleParameters is the fake for method SpreadAliasClient.SpreadWithMultipleParameters
 	// HTTP status codes to indicate success: http.StatusNoContent
-	SpreadWithMultipleParameters func(ctx context.Context, id string, xMSTestHeader string, requiredString string, optionalInt int32, requiredIntList []int32, optionalStringList []string, options *spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions) (resp azfake.Responder[spreadgroup.SpreadAliasClientSpreadWithMultipleParametersResponse], errResp azfake.ErrorResponder)
+	SpreadWithMultipleParameters func(ctx context.Context, id string, xMSTestHeader string, requiredString string, requiredIntList []int32, options *spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions) (resp azfake.Responder[spreadgroup.SpreadAliasClientSpreadWithMultipleParametersResponse], errResp azfake.ErrorResponder)
 }
 
 // NewSpreadAliasServerTransport creates a new instance of SpreadAliasServerTransport with the provided implementation.
@@ -233,7 +233,7 @@ func (s *SpreadAliasServerTransport) dispatchSpreadWithMultipleParameters(req *h
 	}
 	type partialBodyParams struct {
 		RequiredString     string   `json:"requiredString"`
-		OptionalInt        int32    `json:"optionalInt"`
+		OptionalInt        *int32   `json:"optionalInt"`
 		RequiredIntList    []int32  `json:"requiredIntList"`
 		OptionalStringList []string `json:"optionalStringList"`
 	}
@@ -245,7 +245,14 @@ func (s *SpreadAliasServerTransport) dispatchSpreadWithMultipleParameters(req *h
 	if err != nil {
 		return nil, err
 	}
-	respr, errRespr := s.srv.SpreadWithMultipleParameters(req.Context(), idParam, getHeaderValue(req.Header, "x-ms-test-header"), body.RequiredString, body.OptionalInt, body.RequiredIntList, body.OptionalStringList, nil)
+	var options *spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions
+	if body.OptionalInt != nil || len(body.OptionalStringList) > 0 {
+		options = &spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions{
+			OptionalInt:        body.OptionalInt,
+			OptionalStringList: body.OptionalStringList,
+		}
+	}
+	respr, errRespr := s.srv.SpreadWithMultipleParameters(req.Context(), idParam, getHeaderValue(req.Header, "x-ms-test-header"), body.RequiredString, body.RequiredIntList, options)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/fakes_test.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/fakes_test.go
@@ -20,18 +20,20 @@ func TestFake_SpreadWithMultipleParameters(t *testing.T) {
 		idVal              = "id"
 		header             = "header"
 		requiredString     = "prop1"
-		optionalInt        = 1
+		optionalInt        = int32(1)
 		requiredIntList    = []int32{1, 2}
 		optionalStringList = []string{"a", "b"}
 	)
 	server := fake.SpreadAliasServer{
-		SpreadWithMultipleParameters: func(ctx context.Context, id string, xMSTestHeader string, requiredString string, optionalInt int32, requiredIntList []int32, optionalStringList []string, options *spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions) (resp azfake.Responder[spreadgroup.SpreadAliasClientSpreadWithMultipleParametersResponse], errResp azfake.ErrorResponder) {
+		SpreadWithMultipleParameters: func(ctx context.Context, id string, xMSTestHeader string, requiredString string, requiredIntList []int32, options *spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions) (resp azfake.Responder[spreadgroup.SpreadAliasClientSpreadWithMultipleParametersResponse], errResp azfake.ErrorResponder) {
 			require.EqualValues(t, idVal, id)
 			require.EqualValues(t, header, xMSTestHeader)
 			require.EqualValues(t, requiredString, requiredString)
-			require.EqualValues(t, optionalInt, optionalInt)
 			require.EqualValues(t, requiredIntList, requiredIntList)
-			require.EqualValues(t, optionalStringList, optionalStringList)
+			require.NotNil(t, options)
+			require.NotNil(t, options.OptionalInt)
+			require.EqualValues(t, optionalInt, *options.OptionalInt)
+			require.EqualValues(t, optionalStringList, options.OptionalStringList)
 			resp.SetResponse(http.StatusNoContent, spreadgroup.SpreadAliasClientSpreadWithMultipleParametersResponse{}, nil)
 			return
 		},
@@ -41,6 +43,9 @@ func TestFake_SpreadWithMultipleParameters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = client.NewSpreadAliasClient().SpreadWithMultipleParameters(context.Background(), idVal, header, requiredString, int32(optionalInt), requiredIntList, optionalStringList, nil)
+	_, err = client.NewSpreadAliasClient().SpreadWithMultipleParameters(context.Background(), idVal, header, requiredString, requiredIntList, &spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions{
+		OptionalInt:        &optionalInt,
+		OptionalStringList: optionalStringList,
+	})
 	require.NoError(t, err)
 }

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/spreadalias_client_test.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/spreadalias_client_test.go
@@ -8,6 +8,7 @@ import (
 	"spreadgroup"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +31,10 @@ func TestSpreadAliasClient_SpreadAsRequestParameter(t *testing.T) {
 func TestSpreadAliasClient_SpreadWithMultipleParameters(t *testing.T) {
 	client, err := spreadgroup.NewSpreadClient(nil)
 	require.NoError(t, err)
-	resp, err := client.NewSpreadAliasClient().SpreadWithMultipleParameters(context.Background(), "1", "bar", "foo", 1, []int32{1, 2}, []string{"foo", "bar"}, nil)
+	resp, err := client.NewSpreadAliasClient().SpreadWithMultipleParameters(context.Background(), "1", "bar", "foo", []int32{1, 2}, &spreadgroup.SpreadAliasClientSpreadWithMultipleParametersOptions{
+		OptionalInt:        to.Ptr[int32](1),
+		OptionalStringList: []string{"foo", "bar"},
+	})
 	require.NoError(t, err)
 	require.Zero(t, resp)
 }

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_options.go
@@ -31,7 +31,11 @@ type SpreadAliasClientSpreadParameterWithInnerModelOptions struct {
 // SpreadAliasClientSpreadWithMultipleParametersOptions contains the optional parameters for the SpreadAliasClient.SpreadWithMultipleParameters
 // method.
 type SpreadAliasClientSpreadWithMultipleParametersOptions struct {
-	// placeholder for future optional parameters
+	// optional int
+	OptionalInt *int32
+
+	// optional string
+	OptionalStringList []string
 }
 
 // SpreadModelClientSpreadAsRequestBodyOptions contains the optional parameters for the SpreadModelClient.SpreadAsRequestBody

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
@@ -219,18 +219,16 @@ func (client *SpreadAliasClient) spreadParameterWithInnerModelCreateRequest(ctx 
 // SpreadWithMultipleParameters -
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - requiredString - required string
-//   - optionalInt - optional int
 //   - requiredIntList - required int
-//   - optionalStringList - optional string
 //   - options - SpreadAliasClientSpreadWithMultipleParametersOptions contains the optional parameters for the SpreadAliasClient.SpreadWithMultipleParameters
 //     method.
-func (client *SpreadAliasClient) SpreadWithMultipleParameters(ctx context.Context, id string, xMSTestHeader string, requiredString string, optionalInt int32, requiredIntList []int32, optionalStringList []string, options *SpreadAliasClientSpreadWithMultipleParametersOptions) (SpreadAliasClientSpreadWithMultipleParametersResponse, error) {
+func (client *SpreadAliasClient) SpreadWithMultipleParameters(ctx context.Context, id string, xMSTestHeader string, requiredString string, requiredIntList []int32, options *SpreadAliasClientSpreadWithMultipleParametersOptions) (SpreadAliasClientSpreadWithMultipleParametersResponse, error) {
 	var err error
 	const operationName = "SpreadAliasClient.SpreadWithMultipleParameters"
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, operationName)
 	ctx, endSpan := runtime.StartSpan(ctx, operationName, client.internal.Tracer(), nil)
 	defer func() { endSpan(err) }()
-	req, err := client.spreadWithMultipleParametersCreateRequest(ctx, id, xMSTestHeader, requiredString, optionalInt, requiredIntList, optionalStringList, options)
+	req, err := client.spreadWithMultipleParametersCreateRequest(ctx, id, xMSTestHeader, requiredString, requiredIntList, options)
 	if err != nil {
 		return SpreadAliasClientSpreadWithMultipleParametersResponse{}, err
 	}
@@ -246,7 +244,7 @@ func (client *SpreadAliasClient) SpreadWithMultipleParameters(ctx context.Contex
 }
 
 // spreadWithMultipleParametersCreateRequest creates the SpreadWithMultipleParameters request.
-func (client *SpreadAliasClient) spreadWithMultipleParametersCreateRequest(ctx context.Context, id string, xMSTestHeader string, requiredString string, optionalInt int32, requiredIntList []int32, optionalStringList []string, _ *SpreadAliasClientSpreadWithMultipleParametersOptions) (*policy.Request, error) {
+func (client *SpreadAliasClient) spreadWithMultipleParametersCreateRequest(ctx context.Context, id string, xMSTestHeader string, requiredString string, requiredIntList []int32, options *SpreadAliasClientSpreadWithMultipleParametersOptions) (*policy.Request, error) {
 	urlPath := "/parameters/spread/alias/multiple-parameters/{id}"
 	if id == "" {
 		return nil, errors.New("parameter id cannot be empty")
@@ -260,14 +258,18 @@ func (client *SpreadAliasClient) spreadWithMultipleParametersCreateRequest(ctx c
 	req.Raw().Header["x-ms-test-header"] = []string{xMSTestHeader}
 	body := struct {
 		RequiredString     string   `json:"requiredString"`
-		OptionalInt        int32    `json:"optionalInt"`
+		OptionalInt        *int32   `json:"optionalInt"`
 		RequiredIntList    []int32  `json:"requiredIntList"`
 		OptionalStringList []string `json:"optionalStringList"`
 	}{
-		RequiredString:     requiredString,
-		OptionalInt:        optionalInt,
-		RequiredIntList:    requiredIntList,
-		OptionalStringList: optionalStringList,
+		RequiredString:  requiredString,
+		RequiredIntList: requiredIntList,
+	}
+	if options != nil && options.OptionalInt != nil {
+		body.OptionalInt = options.OptionalInt
+	}
+	if options != nil && options.OptionalStringList != nil {
+		body.OptionalStringList = options.OptionalStringList
 	}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err


### PR DESCRIPTION
Ensure that optional spread params are placed in the options type. Emit optional, primitive types, as pointer-to-type in the partial body params struct type.