### PR TITLE
Remove wire format from model types

### DIFF
--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -261,7 +261,11 @@ function adaptResponseEnvelope(m4CodeModel: m4.CodeModel, codeModel: go.CodeMode
     if (!modelType) {
       throw new Error(`didn't find type name ${resultProp.schema.language.go!.name} for response envelope ${respEnv.name}`);
     }
-    respEnv.result = new go.ModelResult(modelType, adaptResultFormat(helpers.getSchemaResponse(op)!.protocol));
+    const resultFormat = adaptResultFormat(helpers.getSchemaResponse(op)!.protocol);
+    if (resultFormat !== 'JSON' && resultFormat !== 'XML') {
+      throw new Error(`unexpected result format ${resultFormat} for model ${modelType.name}`);
+    }
+    respEnv.result = new go.ModelResult(modelType, resultFormat);
   } else {
     throw new Error(`unhandled result type for operation ${op.language.go!.name}`);
   }

--- a/packages/autorest.go/src/m4togocodemodel/types.ts
+++ b/packages/autorest.go/src/m4togocodemodel/types.ts
@@ -112,7 +112,7 @@ export function adaptModel(obj: m4.ObjectSchema): go.ModelType | go.PolymorphicT
       (<go.PolymorphicType>modelType).discriminatorValue = getDiscriminatorLiteral(obj.discriminatorValue);
     }
   } else {
-    modelType = new go.ModelType(obj.language.go!.name, adaptModelFormat(obj), annotations, adaptUsage(obj));
+    modelType = new go.ModelType(obj.language.go!.name, annotations, adaptUsage(obj));
     // polymorphic types don't have XMLInfo
     modelType.xml = adaptXMLInfo(obj);
   }
@@ -224,16 +224,6 @@ export function adaptModelField(prop: m4.Property, obj: m4.ObjectSchema): go.Mod
   field.xml = adaptXMLInfo(prop.schema);
 
   return field;
-}
-
-function adaptModelFormat(obj: m4.ObjectSchema): go.ModelFormat {
-  if (obj.language.go!.marshallingFormat === 'json') {
-    return 'json';
-  } else if (obj.language.go!.marshallingFormat === 'xml') {
-    return 'xml';
-  } else {
-    throw new Error(`unsupported marshalling format ${obj.language.go!.marshallingFormat}`);
-  }
 }
 
 export function adaptXMLInfo(obj: m4.Schema): go.XMLInfo | undefined {

--- a/packages/codegen.go/src/time.ts
+++ b/packages/codegen.go/src/time.ts
@@ -5,7 +5,7 @@
 
 import { values } from '@azure-tools/linq';
 import * as go from '../../codemodel.go/src/index.js';
-import { contentPreamble, recursiveUnwrapMapSlice } from './helpers.js';
+import { contentPreamble, getSerDeFormat, recursiveUnwrapMapSlice } from './helpers.js';
 import { ImportManager } from './imports.js';
 
 // represents the generated content for an operation group
@@ -90,7 +90,7 @@ export async function generateTimeHelpers(codeModel: go.CodeModel, packageName?:
       if (!go.isTimeType(unwrappedField)) {
         continue;
       }
-      if (model.format === 'json') {
+      if (getSerDeFormat(model, codeModel) === 'JSON') {
         // needsSerDeHelpers helpers are for JSON only
         needsSerDeHelpers = true;
       }

--- a/packages/codegen.go/src/xmlAdditionalProps.ts
+++ b/packages/codegen.go/src/xmlAdditionalProps.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from '../../codemodel.go/src/index.js';
-import { contentPreamble } from './helpers.js';
+import { contentPreamble, getSerDeFormat } from './helpers.js';
 import { ImportManager } from './imports.js';
 
 // Creates the content for required additional properties XML marshalling helpers.
@@ -13,7 +13,7 @@ export async function generateXMLAdditionalPropsHelpers(codeModel: go.CodeModel)
   // check if any models need this helper
   let required = false;
   for (const model of codeModel.models) {
-    if (model.format !== 'xml') {
+    if (getSerDeFormat(model, codeModel) !== 'XML') {
       continue;
     }
     for (const field of model.fields) {

--- a/packages/codemodel.go/src/result.ts
+++ b/packages/codemodel.go/src/result.ts
@@ -97,9 +97,12 @@ export interface PolymorphicResult {
 
   interfaceType: type.InterfaceType;
 
-  // the format in which the result is returned
+  // the format in which the result is returned.
+  // only JSON is supported for polymorphic types.
   format: 'JSON';
 }
+
+export type ModelResultFormat = 'JSON' | 'XML';
 
 // ModelResult is a standard schema response.
 // The type is anonymously embedded in the response envelope.
@@ -109,7 +112,7 @@ export interface ModelResult {
   modelType: type.ModelType;
 
   // the format in which the result is returned
-  format: ResultFormat;
+  format: ModelResultFormat;
 }
 
 export function isAnyResult(resultType: ResultType): resultType is AnyResult {
@@ -262,7 +265,7 @@ export class PolymorphicResult implements PolymorphicResult {
 }
 
 export class ModelResult implements ModelResult {
-  constructor(type: type.ModelType, format: ResultFormat) {
+  constructor(type: type.ModelType, format: ModelResultFormat) {
     this.modelType = type;
     this.format = format;
   }

--- a/packages/codemodel.go/src/type.ts
+++ b/packages/codemodel.go/src/type.ts
@@ -14,17 +14,9 @@ export interface StructType {
   fields: Array<StructField>;
 }
 
-// ModelFormat indicates what format a model is sent/received as.
-export type ModelFormat = 'json' | 'xml';
-
 // ModelType is a struct that participates in serialization over the wire.
 export interface ModelType extends StructType {
   fields: Array<ModelField>;
-
-  // format is propagated to models purely as a convenience when determining
-  // what marshaller/unmarshaller to generate. technically, a model could
-  // participate in both JSON and XML formats. this hasn't been a problem yet
-  format: ModelFormat;
 
   annotations: ModelAnnotations;
 
@@ -55,8 +47,6 @@ export enum UsageFlags {
 // PolymorphicType is a discriminated type
 export interface PolymorphicType extends StructType {
   fields: Array<ModelField>;
-
-  format: 'json';
 
   annotations: ModelAnnotations;
 
@@ -259,7 +249,7 @@ export function isMapType(type: PossibleType): type is MapType {
 }
 
 export function isModelType(type: PossibleType): type is ModelType {
-  return (<ModelType>type).format !== undefined;
+  return (<ModelType>type).fields !== undefined;
 }
 
 export function isPolymorphicType(type: PossibleType): type is PolymorphicType {
@@ -377,9 +367,8 @@ export class LiteralValue implements LiteralValue {
 }
 
 export class ModelType extends StructType implements ModelType {
-  constructor(name: string, format: ModelFormat, annotations: ModelAnnotations, usage: UsageFlags) {
+  constructor(name: string, annotations: ModelAnnotations, usage: UsageFlags) {
     super(name);
-    this.format = format;
     this.annotations = annotations;
     this.usage = usage;
     this.fields = new Array<ModelField>();

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -575,6 +575,9 @@ export class clientAdapter {
       if (go.isPolymorphicType(modelType)) {
         respEnv.result = new go.PolymorphicResult(modelType.interface);
       } else {
+        if (contentType !== 'JSON' && contentType !== 'XML') {
+          throw new Error(`unexpected content type ${contentType} for model ${modelType.name}`);
+        }
         respEnv.result = new go.ModelResult(modelType, contentType);
       }
       respEnv.result.description = sdkResponseType.description;

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -540,8 +540,7 @@ export class typeAdapter {
       modelType = new go.PolymorphicType(modelName, iface, annotations, usage);
       (<go.PolymorphicType>modelType).discriminatorValue = discriminatorLiteral;
     } else {
-      // TODO: hard-coded format
-      modelType = new go.ModelType(modelName, 'json', annotations, usage);
+      modelType = new go.ModelType(modelName, annotations, usage);
       // polymorphic types don't have XMLInfo
       // TODO: XMLInfo
     }


### PR DESCRIPTION
The wire format is a function of the operation and isn't tied to a model. It's also possible for a model to be used with more than one wire format, although that's not a real scenario at present. When determining which SerDe methods to generate, find the operation that uses the model type to determine the wire format.

Precursor for https://github.com/Azure/autorest.go/issues/1300