### PR TITLE
Throw an error if no media types are defined

### DIFF
--- a/packages/autorest.go/CHANGELOG.md
+++ b/packages/autorest.go/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Release History
 
+## 4.0.0-preview.68 (Unreleased)
+
+### Bugs Fixed
+
+* Throw an error when an operation doesn't define any media types. This is indicative of an authoring error.
+
 ## 4.0.0-preview.67 (2024-07-30)
 
-## Bugs Fixed
+### Bugs Fixed
 
 * Fixed a rare issue causing some method doc comments to be omitted.
 * Fixed bad codegen for slices of raw JSON objects.

--- a/packages/autorest.go/src/m4togocodemodel/clients.ts
+++ b/packages/autorest.go/src/m4togocodemodel/clients.ts
@@ -315,6 +315,9 @@ function adaptMethodParameter(op: m4.Operation, param: m4.Parameter): go.Paramet
 
   switch (param.protocol.http?.in) {
     case 'body': {
+      if (!op.requests![0].protocol.http!.mediaTypes) {
+        throw new Error(`no media types defined for operation ${op.operationId}`);
+      }
       let contentType = `"${op.requests![0].protocol.http!.mediaTypes[0]}"`;
       if (op.requests![0].protocol.http!.mediaTypes.length > 1) {
         for (const param of values(op.requests![0].parameters)) {


### PR DESCRIPTION
The message includes the operation ID to help with debugging.