### PR TITLE
Move tcgc and tsp compiler to peer dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -202,24 +202,6 @@ importers:
       '@azure-tools/linq':
         specifier: ~3.1.0
         version: 3.1.263
-      '@azure-tools/typespec-azure-core':
-        specifier: '>=0.45.0 <1.0.0'
-        version: 0.45.0(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)
-      '@azure-tools/typespec-client-generator-core':
-        specifier: 0.45.4
-        version: 0.45.4(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/openapi@0.59.0)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
-      '@typespec/compiler':
-        specifier: 0.59.1
-        version: 0.59.1
-      '@typespec/http':
-        specifier: 0.59.1
-        version: 0.59.1(@typespec/compiler@0.59.1)
-      '@typespec/rest':
-        specifier: 0.59.1
-        version: 0.59.1(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)
-      '@typespec/versioning':
-        specifier: 0.59.0
-        version: 0.59.0(@typespec/compiler@0.59.1)
       js-yaml:
         specifier: ~4.1.0
         version: 4.1.0
@@ -235,13 +217,19 @@ importers:
         version: 0.14.1(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
       '@azure-tools/cadl-ranch-specs':
         specifier: 0.36.1
-        version: 0.36.1(@azure-tools/cadl-ranch-expect@0.14.1)(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
+        version: 0.36.1(@azure-tools/cadl-ranch-expect@0.14.1)(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)(@typespec/xml@0.59.0)
       '@azure-tools/typespec-autorest':
         specifier: 0.45.0
         version: 0.45.0(@azure-tools/typespec-azure-core@0.45.0)(@azure-tools/typespec-azure-resource-manager@0.45.0)(@azure-tools/typespec-client-generator-core@0.45.4)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/openapi@0.59.0)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
+      '@azure-tools/typespec-azure-core':
+        specifier: '>=0.45.0 <1.0.0'
+        version: 0.45.0(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)
       '@azure-tools/typespec-azure-resource-manager':
         specifier: 0.45.0
         version: 0.45.0(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/openapi@0.59.0)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
+      '@azure-tools/typespec-client-generator-core':
+        specifier: 0.45.4
+        version: 0.45.4(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/openapi@0.59.0)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)
       '@types/jest':
         specifier: ~26.0.24
         version: 26.0.24
@@ -257,9 +245,24 @@ importers:
       '@typescript-eslint/parser':
         specifier: ~4.1.1
         version: 4.1.1(eslint@6.6.0)(typescript@5.1.6)
+      '@typespec/compiler':
+        specifier: 0.59.1
+        version: 0.59.1
+      '@typespec/http':
+        specifier: 0.59.1
+        version: 0.59.1(@typespec/compiler@0.59.1)
       '@typespec/openapi':
         specifier: ~0.59.0
         version: 0.59.0(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)
+      '@typespec/rest':
+        specifier: 0.59.1
+        version: 0.59.1(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)
+      '@typespec/versioning':
+        specifier: 0.59.0
+        version: 0.59.0(@typespec/compiler@0.59.1)
+      '@typespec/xml':
+        specifier: 0.59.0
+        version: 0.59.0(@typespec/compiler@0.59.1)
       eslint:
         specifier: ~6.6.0
         version: 6.6.0
@@ -482,7 +485,7 @@ packages:
       '@typespec/versioning': 0.59.0(@typespec/compiler@0.59.1)
     dev: true
 
-  /@azure-tools/cadl-ranch-specs@0.36.1(@azure-tools/cadl-ranch-expect@0.14.1)(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0):
+  /@azure-tools/cadl-ranch-specs@0.36.1(@azure-tools/cadl-ranch-expect@0.14.1)(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0)(@typespec/xml@0.59.0):
     resolution: {integrity: sha512-DmgSaMeEhM6N3ZTFCDcBAy73hz8o1PYUdAKCN9P6WCj8sOVzZ8FCD9CGi2XjKBMqeJr4KHHooIgceglODJWSwQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -502,6 +505,7 @@ packages:
       '@typespec/http': 0.59.1(@typespec/compiler@0.59.1)
       '@typespec/rest': 0.59.1(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)
       '@typespec/versioning': 0.59.0(@typespec/compiler@0.59.1)
+      '@typespec/xml': 0.59.0(@typespec/compiler@0.59.1)
     transitivePeerDependencies:
       - '@types/express'
       - supports-color
@@ -646,6 +650,7 @@ packages:
       '@typespec/compiler': 0.59.1
       '@typespec/http': 0.59.1(@typespec/compiler@0.59.1)
       '@typespec/rest': 0.59.1(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)
+    dev: true
 
   /@azure-tools/typespec-azure-resource-manager@0.45.0(@azure-tools/typespec-azure-core@0.45.0)(@typespec/compiler@0.59.1)(@typespec/http@0.59.1)(@typespec/openapi@0.59.0)(@typespec/rest@0.59.1)(@typespec/versioning@0.59.0):
     resolution: {integrity: sha512-PdhB03P8PoOlUoUWd+CF5WipGzu2Q3ZjT0EAzgQe878DmXvxMq+zYaPJQtvkq9R6jCxFauDSr5gG7Yd4NINAuA==}
@@ -687,6 +692,7 @@ packages:
       '@typespec/versioning': 0.59.0(@typespec/compiler@0.59.1)
       change-case: 5.4.4
       pluralize: 8.0.0
+    dev: true
 
   /@azure/abort-controller@1.1.0:
     resolution: {integrity: sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==}
@@ -1758,10 +1764,12 @@ packages:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
+    dev: true
 
   /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
+    dev: true
 
   /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
@@ -1769,6 +1777,7 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+    dev: true
 
   /@octetstream/eslint-config@3.0.0(eslint@6.6.0):
     resolution: {integrity: sha512-VX8gZ6h9PNKrWb+N9AoWM2DA+eVBAqAL0OLHwLjh+iwLrICQRFYzJDxxHIpD7rN413PCppr2vp6cy8UGdZGd+A==}
@@ -1832,6 +1841,7 @@ packages:
   /@sindresorhus/merge-streams@2.3.0:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
+    dev: true
 
   /@sinonjs/commons@1.8.6:
     resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
@@ -2226,6 +2236,7 @@ packages:
       vscode-languageserver-textdocument: 1.0.11
       yaml: 2.4.5
       yargs: 17.7.2
+    dev: true
 
   /@typespec/http@0.58.0(@typespec/compiler@0.58.1):
     resolution: {integrity: sha512-jQpkugg9AZVrNDMkDIgZRpIoRkkU2b0LtKWqMGg33MItYj9/DYSgDtY7xb7oCBppRtFFZ/h138HyhYl3zQxZRg==}
@@ -2243,6 +2254,7 @@ packages:
       '@typespec/compiler': ~0.59.0
     dependencies:
       '@typespec/compiler': 0.59.1
+    dev: true
 
   /@typespec/openapi@0.59.0(@typespec/compiler@0.59.1)(@typespec/http@0.59.1):
     resolution: {integrity: sha512-do1Dm5w0MuK3994gYTBg6qMfgeIxmmsDqnz3zimYKMPpbnUBi4F6/o4iCfn0Fn9kaNl+H6UlOzZpsZW9xHui1Q==}
@@ -2253,6 +2265,7 @@ packages:
     dependencies:
       '@typespec/compiler': 0.59.1
       '@typespec/http': 0.59.1(@typespec/compiler@0.59.1)
+    dev: true
 
   /@typespec/rest@0.58.0(@typespec/compiler@0.58.1)(@typespec/http@0.58.0):
     resolution: {integrity: sha512-QBxkED0/KQKG22pwzis0n7BY+uLMSZZPSoVe/ESBFika9n5/yyeQ0l58xbFFwwfxAxe4xwuZ5PNwTdEXZbzr5g==}
@@ -2274,6 +2287,7 @@ packages:
     dependencies:
       '@typespec/compiler': 0.59.1
       '@typespec/http': 0.59.1(@typespec/compiler@0.59.1)
+    dev: true
 
   /@typespec/versioning@0.59.0(@typespec/compiler@0.59.1):
     resolution: {integrity: sha512-aihO/ux0lLmsuYAdGVkiBflSudcZokYG42SELk1FtMFo609G3Pd7ep7hau6unBnMIceQZejB0ow5UGRupK4X5A==}
@@ -2282,6 +2296,16 @@ packages:
       '@typespec/compiler': ~0.59.0
     dependencies:
       '@typespec/compiler': 0.59.1
+    dev: true
+
+  /@typespec/xml@0.59.0(@typespec/compiler@0.59.1):
+    resolution: {integrity: sha512-UoSsEmm7SXEtL9OXsqotu1TjruJSobqZMhUKAAlC9EP2WfQIHLRfBu7xaZB0sgwq7CM6zy/Hq1RZfQyL1KqEvg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.59.0
+    dependencies:
+      '@typespec/compiler': 0.59.1
+    dev: true
 
   /a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
@@ -2455,6 +2479,7 @@ packages:
       fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+    dev: true
 
   /amdefine@1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==}
@@ -2838,6 +2863,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
+    dev: true
 
   /brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
@@ -2959,6 +2985,7 @@ packages:
 
   /change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -3055,6 +3082,7 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+    dev: true
 
   /clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -4240,6 +4268,7 @@ packages:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.5
+    dev: true
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -4253,6 +4282,7 @@ packages:
 
   /fast-uri@3.0.1:
     resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
+    dev: true
 
   /fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
@@ -4265,6 +4295,7 @@ packages:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
     dependencies:
       reusify: 1.0.4
+    dev: true
 
   /fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -4310,6 +4341,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
+    dev: true
 
   /finalhandler@1.2.0:
     resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
@@ -4669,6 +4701,7 @@ packages:
       path-type: 5.0.0
       slash: 5.1.0
       unicorn-magic: 0.1.0
+    dev: true
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -4945,6 +4978,7 @@ packages:
   /ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
+    dev: true
 
   /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -5136,6 +5170,7 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: true
 
   /is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
@@ -6054,6 +6089,7 @@ packages:
 
   /json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+    dev: true
 
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -6189,6 +6225,7 @@ packages:
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+    dev: true
 
   /kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -6397,6 +6434,7 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+    dev: true
 
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6408,6 +6446,7 @@ packages:
     dependencies:
       braces: 3.0.2
       picomatch: 2.3.1
+    dev: true
 
   /mime-db@1.51.0:
     resolution: {integrity: sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==}
@@ -7186,6 +7225,7 @@ packages:
   /path-type@5.0.0:
     resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
     engines: {node: '>=12'}
+    dev: true
 
   /performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
@@ -7196,6 +7236,7 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+    dev: true
 
   /pirates@4.0.6:
     resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
@@ -7211,6 +7252,7 @@ packages:
   /pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+    dev: true
 
   /pn@1.1.0:
     resolution: {integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==}
@@ -7353,6 +7395,7 @@ packages:
     resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /pretty-format@26.6.2:
     resolution: {integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==}
@@ -7416,6 +7459,7 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
 
   /proper-lockfile@2.0.1:
     resolution: {integrity: sha512-rjaeGbsmhNDcDInmwi4MuI6mRwJu6zq8GjYCLuSuE7GF+4UjgzkL69sVKKJ2T2xH61kK7rXvGYpvaTu909oXaQ==}
@@ -7467,6 +7511,7 @@ packages:
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+    dev: true
 
   /quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
@@ -7627,6 +7672,7 @@ packages:
   /require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -7686,6 +7732,7 @@ packages:
   /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+    dev: true
 
   /rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
@@ -7707,6 +7754,7 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
 
   /rxjs@6.6.7:
     resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
@@ -7920,6 +7968,7 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
@@ -7933,6 +7982,7 @@ packages:
   /slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
+    dev: true
 
   /slice-ansi@2.1.0:
     resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
@@ -8285,9 +8335,11 @@ packages:
     resolution: {integrity: sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==}
     dependencies:
       temporal-spec: 0.2.4
+    dev: true
 
   /temporal-spec@0.2.4:
     resolution: {integrity: sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==}
+    dev: true
 
   /terminal-link@2.1.1:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
@@ -8337,6 +8389,7 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
 
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -8596,6 +8649,7 @@ packages:
   /unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
+    dev: true
 
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
@@ -8706,24 +8760,29 @@ packages:
   /vscode-jsonrpc@8.2.0:
     resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
     engines: {node: '>=14.0.0'}
+    dev: true
 
   /vscode-languageserver-protocol@3.17.5:
     resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
     dependencies:
       vscode-jsonrpc: 8.2.0
       vscode-languageserver-types: 3.17.5
+    dev: true
 
   /vscode-languageserver-textdocument@1.0.11:
     resolution: {integrity: sha512-X+8T3GoiwTVlJbicx/sIAF+yuJAqz8VvwJyoMVhwEMoEKE/fkDmrqUgDMyBECcM2A2frVZIUj5HI/ErRXCfOeA==}
+    dev: true
 
   /vscode-languageserver-types@3.17.5:
     resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+    dev: true
 
   /vscode-languageserver@9.0.1:
     resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
     hasBin: true
     dependencies:
       vscode-languageserver-protocol: 3.17.5
+    dev: true
 
   /w3c-hr-time@1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}
@@ -9036,6 +9095,7 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -9047,6 +9107,7 @@ packages:
     resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
     engines: {node: '>= 14'}
     hasBin: true
+    dev: true
 
   /yargs-parser@15.0.3:
     resolution: {integrity: sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==}
@@ -9071,6 +9132,7 @@ packages:
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+    dev: true
 
   /yargs@14.2.3:
     resolution: {integrity: sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==}
@@ -9129,6 +9191,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+    dev: true
 
   /yasway@1.10.7:
     resolution: {integrity: sha512-mnyGYhQIDQxbUanvD3Cc8rXCVjKyyNTCAmfZYiEHEIQ+9mlBrCf/s0H/DelY5d3b8pH4J9kC0YUPzoM5LVvwkQ==}

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -11,7 +11,7 @@ const pkgRoot = execSync('git rev-parse --show-toplevel').toString().trim() + '/
 
 const tspRoot = pkgRoot + 'node_modules/@azure-tools/cadl-ranch-specs/http/';
 
-const compiler = pkgRoot + 'node_modules/@typespec/compiler/node_modules/.bin/tsp';
+const compiler = pkgRoot + 'node_modules/@typespec/compiler/cmd/tsp.js';
 
 // the format is as follows
 // 'moduleName': [ 'input', 'emitter option 1', 'emitter option N...' ]
@@ -231,7 +231,7 @@ function generate(moduleName, input, outputDir, perTestOptions) {
       if (switches.includes('--debugger')) {
         options.push(`--option="@azure-tools/typespec-go.debugger=true"`);
       }
-      const command = `${compiler} compile ${input} --emit=${pkgRoot} ${options.join(' ')}`;
+      const command = `node ${compiler} compile ${input} --emit=${pkgRoot} ${options.join(' ')}`;
       if (switches.includes('--verbose')) {
         console.log(command);
       }

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -71,7 +71,8 @@
   },
   "peerDependencies": {
     "@azure-tools/typespec-client-generator-core": "0.45.4",
-    "@typespec/compiler": "0.59.1"
+    "@typespec/compiler": "0.59.1",
+    "@typespec/http": "0.59.1"
   },
   "dependencies": {
     "@azure-tools/codegen": "~2.9.2",

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -50,27 +50,32 @@
     "@azure-tools/cadl-ranch-expect": "~0.14.1",
     "@azure-tools/cadl-ranch-specs": "0.36.1",
     "@azure-tools/typespec-autorest": "0.45.0",
+    "@azure-tools/typespec-azure-core": ">=0.45.0 <1.0.0",
     "@azure-tools/typespec-azure-resource-manager": "0.45.0",
+    "@azure-tools/typespec-client-generator-core": "0.45.4",
     "@types/js-yaml": "~4.0.6",
     "@types/node": "^18.16.3",
     "@typescript-eslint/eslint-plugin": "~4.1.1",
     "@typescript-eslint/parser": "~4.1.1",
+    "@typespec/compiler": "0.59.1",
+    "@typespec/http": "0.59.1",
     "@typespec/openapi": "~0.59.0",
+    "@typespec/rest": "0.59.1",
+    "@typespec/versioning": "0.59.0",
+    "@typespec/xml": "0.59.0",
     "@types/jest": "~26.0.24",
     "eslint": "~6.6.0",
     "jest": "~27.0.6",
     "ts-jest": "~27.0.4",
     "typescript": "~5.1.3"
   },
+  "peerDependencies": {
+    "@azure-tools/typespec-client-generator-core": "0.45.4",
+    "@typespec/compiler": "0.59.1"
+  },
   "dependencies": {
     "@azure-tools/codegen": "~2.9.2",
     "@azure-tools/linq": "~3.1.0",
-    "@azure-tools/typespec-azure-core": ">=0.45.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": "0.45.4",
-    "@typespec/compiler": "0.59.1",
-    "@typespec/http": "0.59.1",
-    "@typespec/rest": "0.59.1",
-    "@typespec/versioning": "0.59.0",
     "js-yaml": "~4.1.0",
     "source-map-support": "0.5.21"
   }


### PR DESCRIPTION
This allows the versions to be controlled by a host. Moved other typespec dependencies to dev dependencies as they aren't directly used by the emitter, but consumed when emitting content.

No functional/version changes. Will make subsequent deltas easier to reason about.