### PR TITLE
Conditionally set Content-Type header

### DIFF
--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fake servers will honor the caller's context in the `*http.Request`.
 * Add missing error check when parsing multipart/form content in fakes.
+* Optional body params will only set the `Content-Type` header when a body is specified.
 
 ### Other Fixes
 

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Fake servers will honor the caller's context in the `*http.Request`.
 * Add missing error check when parsing multipart/form content in fakes.
-* Optional body params will only set the `Content-Type` header when a body is specified.
+* Optional request bodies will only set the `Content-Type` header when a body is specified.
 
 ### Other Fixes
 

--- a/packages/typespec-go/test/armlargeinstance/fake/zz_azurelargeinstance_server.go
+++ b/packages/typespec-go/test/armlargeinstance/fake/zz_azurelargeinstance_server.go
@@ -334,12 +334,10 @@ func (a *AzureLargeInstanceServerTransport) dispatchBeginRestart(req *http.Reque
 		if err != nil {
 			return nil, err
 		}
-		contentTypeParam := getOptional(getHeaderValue(req.Header, "Content-Type"))
 		var options *armlargeinstance.AzureLargeInstanceClientBeginRestartOptions
-		if !reflect.ValueOf(body).IsZero() || contentTypeParam != nil {
+		if !reflect.ValueOf(body).IsZero() {
 			options = &armlargeinstance.AzureLargeInstanceClientBeginRestartOptions{
 				ForceParameter: &body,
-				ContentType:    contentTypeParam,
 			}
 		}
 		respr, errRespr := a.srv.BeginRestart(req.Context(), resourceGroupNameParam, azureLargeInstanceNameParam, options)

--- a/packages/typespec-go/test/armlargeinstance/fake/zz_internal.go
+++ b/packages/typespec-go/test/armlargeinstance/fake/zz_internal.go
@@ -7,7 +7,6 @@ package fake
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"net/http"
-	"reflect"
 	"sync"
 )
 
@@ -31,21 +30,6 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
 }
 
 func newTracker[T any]() *tracker[T] {

--- a/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstance_client.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_azurelargeinstance_client.go
@@ -421,10 +421,8 @@ func (client *AzureLargeInstanceClient) restartCreateRequest(ctx context.Context
 	reqQP.Set("api-version", "2024-08-01-preview")
 	req.Raw().URL.RawQuery = reqQP.Encode()
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	if options != nil && options.ContentType != nil {
-		req.Raw().Header["Content-Type"] = []string{"application/json"}
-	}
 	if options != nil && options.ForceParameter != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/json"}
 		if err := runtime.MarshalAsJSON(req, *options.ForceParameter); err != nil {
 			return nil, err
 		}

--- a/packages/typespec-go/test/armlargeinstance/zz_options.go
+++ b/packages/typespec-go/test/armlargeinstance/zz_options.go
@@ -10,9 +10,6 @@ type AzureLargeInstanceClientBeginRestartOptions struct {
 	// Resumes the long-running operation from the provided token.
 	ResumeToken string
 
-	// Body parameter's content type. Known values are application/json
-	ContentType *string
-
 	// When set to 'active', this parameter empowers the server with the ability to forcefully terminate and halt any existing
 	// processes that may be running on the server
 	ForceParameter *ForceState

--- a/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicimplicitbody_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/basicparamsgroup/zz_basicimplicitbody_client.go
@@ -50,12 +50,12 @@ func (client *BasicImplicitBodyClient) simpleCreateRequest(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/fake/zz_bodyoptionalityoptionalexplicit_server.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/fake/zz_bodyoptionalityoptionalexplicit_server.go
@@ -88,12 +88,10 @@ func (b *BodyOptionalityOptionalExplicitServerTransport) dispatchOmit(req *http.
 	if err != nil {
 		return nil, err
 	}
-	contentTypeParam := getOptional(getHeaderValue(req.Header, "Content-Type"))
 	var options *bodyoptionalgroup.BodyOptionalityOptionalExplicitClientOmitOptions
-	if !reflect.ValueOf(body).IsZero() || contentTypeParam != nil {
+	if !reflect.ValueOf(body).IsZero() {
 		options = &bodyoptionalgroup.BodyOptionalityOptionalExplicitClientOmitOptions{
-			Body:        &body,
-			ContentType: contentTypeParam,
+			Body: &body,
 		}
 	}
 	respr, errRespr := b.srv.Omit(req.Context(), options)
@@ -119,12 +117,10 @@ func (b *BodyOptionalityOptionalExplicitServerTransport) dispatchSet(req *http.R
 	if err != nil {
 		return nil, err
 	}
-	contentTypeParam := getOptional(getHeaderValue(req.Header, "Content-Type"))
 	var options *bodyoptionalgroup.BodyOptionalityOptionalExplicitClientSetOptions
-	if !reflect.ValueOf(body).IsZero() || contentTypeParam != nil {
+	if !reflect.ValueOf(body).IsZero() {
 		options = &bodyoptionalgroup.BodyOptionalityOptionalExplicitClientSetOptions{
-			Body:        &body,
-			ContentType: contentTypeParam,
+			Body: &body,
 		}
 	}
 	respr, errRespr := b.srv.Set(req.Context(), options)

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/fake/zz_internal.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/fake/zz_internal.go
@@ -6,7 +6,6 @@ package fake
 
 import (
 	"net/http"
-	"reflect"
 	"sync"
 )
 
@@ -30,21 +29,6 @@ func contains[T comparable](s []T, v T) bool {
 		}
 	}
 	return false
-}
-
-func getHeaderValue(h http.Header, k string) string {
-	v := h[k]
-	if len(v) == 0 {
-		return ""
-	}
-	return v[0]
-}
-
-func getOptional[T any](v T) *T {
-	if reflect.ValueOf(v).IsZero() {
-		return nil
-	}
-	return &v
 }
 
 func initServer[T any](mu *sync.Mutex, dst **T, src func() *T) {

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionality_client.go
@@ -96,12 +96,12 @@ func (client *BodyOptionalityClient) requiredImplicitCreateRequest(ctx context.C
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionalityoptionalexplicit_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_bodyoptionalityoptionalexplicit_client.go
@@ -50,10 +50,8 @@ func (client *BodyOptionalityOptionalExplicitClient) omitCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	if options != nil && options.ContentType != nil {
-		req.Raw().Header["Content-Type"] = []string{"application/json"}
-	}
 	if options != nil && options.Body != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/json"}
 		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
 			return nil, err
 		}
@@ -94,10 +92,8 @@ func (client *BodyOptionalityOptionalExplicitClient) setCreateRequest(ctx contex
 	if err != nil {
 		return nil, err
 	}
-	if options != nil && options.ContentType != nil {
-		req.Raw().Header["Content-Type"] = []string{"application/json"}
-	}
 	if options != nil && options.Body != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/json"}
 		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
 			return nil, err
 		}

--- a/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
+++ b/packages/typespec-go/test/cadlranch/parameters/bodyoptionalgroup/zz_options.go
@@ -20,16 +20,10 @@ type BodyOptionalityClientRequiredImplicitOptions struct {
 // method.
 type BodyOptionalityOptionalExplicitClientOmitOptions struct {
 	Body *BodyModel
-
-	// Body parameter's content type. Known values are application/json
-	ContentType *string
 }
 
 // BodyOptionalityOptionalExplicitClientSetOptions contains the optional parameters for the BodyOptionalityOptionalExplicitClient.Set
 // method.
 type BodyOptionalityOptionalExplicitClientSetOptions struct {
 	Body *BodyModel
-
-	// Body parameter's content type. Known values are application/json
-	ContentType *string
 }

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadalias_client.go
@@ -53,12 +53,12 @@ func (client *SpreadAliasClient) spreadAsRequestBodyCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -101,13 +101,13 @@ func (client *SpreadAliasClient) spreadAsRequestParameterCreateRequest(ctx conte
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["x-ms-test-header"] = []string{xMSTestHeader}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -152,7 +152,6 @@ func (client *SpreadAliasClient) spreadParameterWithInnerAliasCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["x-ms-test-header"] = []string{xMSTestHeader}
 	body := struct {
 		Name string `json:"name"`
@@ -161,6 +160,7 @@ func (client *SpreadAliasClient) spreadParameterWithInnerAliasCreateRequest(ctx 
 		Name: name,
 		Age:  age,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -203,13 +203,13 @@ func (client *SpreadAliasClient) spreadParameterWithInnerModelCreateRequest(ctx 
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["x-ms-test-header"] = []string{xMSTestHeader}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -254,7 +254,6 @@ func (client *SpreadAliasClient) spreadWithMultipleParametersCreateRequest(ctx c
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["x-ms-test-header"] = []string{xMSTestHeader}
 	body := struct {
 		RequiredString     string   `json:"requiredString"`
@@ -271,6 +270,7 @@ func (client *SpreadAliasClient) spreadWithMultipleParametersCreateRequest(ctx c
 	if options != nil && options.OptionalStringList != nil {
 		body.OptionalStringList = options.OptionalStringList
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadmodel_client.go
+++ b/packages/typespec-go/test/cadlranch/parameters/spreadgroup/zz_spreadmodel_client.go
@@ -53,12 +53,12 @@ func (client *SpreadModelClient) spreadAsRequestBodyCreateRequest(ctx context.Co
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	body := struct {
 		Name string `json:"name"`
 	}{
 		Name: name,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -101,8 +101,8 @@ func (client *SpreadModelClient) spreadCompositeRequestCreateRequest(ctx context
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["test-header"] = []string{testHeader}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}
@@ -145,13 +145,13 @@ func (client *SpreadModelClient) spreadCompositeRequestMixCreateRequest(ctx cont
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	req.Raw().Header["test-header"] = []string{testHeader}
 	body := struct {
 		Prop string `json:"prop"`
 	}{
 		Prop: prop,
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, body); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/jmergepatchgroup/zz_jsonmergepatch_client.go
@@ -102,8 +102,8 @@ func (client *JSONMergePatchClient) updateOptionalResourceCreateRequest(ctx cont
 		return nil, err
 	}
 	req.Raw().Header["Accept"] = []string{"application/json"}
-	req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
 	if options != nil && options.Body != nil {
+		req.Raw().Header["Content-Type"] = []string{"application/merge-patch+json"}
 		if err := runtime.MarshalAsJSON(req, *options.Body); err != nil {
 			return nil, err
 		}

--- a/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_mediatypestringbody_client.go
+++ b/packages/typespec-go/test/cadlranch/payload/mediatypegroup/zz_mediatypestringbody_client.go
@@ -192,8 +192,8 @@ func (client *MediaTypeStringBodyClient) sendAsTextCreateRequest(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"text/plain"}
 	body := streaming.NopCloser(strings.NewReader(textParam))
+	req.Raw().Header["Content-Type"] = []string{"text/plain"}
 	if err := req.SetBody(body, "text/plain"); err != nil {
 		return nil, err
 	}

--- a/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydatetimevalue_client.go
+++ b/packages/typespec-go/test/cadlranch/type/dictionarygroup/zz_dictionarydatetimevalue_client.go
@@ -103,11 +103,11 @@ func (client *DictionaryDatetimeValueClient) putCreateRequest(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
-	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	aux := map[string]*dateTimeRFC3339{}
 	for k, v := range body {
 		aux[k] = (*dateTimeRFC3339)(v)
 	}
+	req.Raw().Header["Content-Type"] = []string{"application/json"}
 	if err := runtime.MarshalAsJSON(req, aux); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When the body param is optional, the Content-Type header should be set IFF the body param is not nil.
Don't expose optional Content-Type literal params as flags.

Fixes https://github.com/Azure/autorest.go/issues/1444