### PR TITLE
Use tcgc usage to remove useless types

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         version: 0.39.1(@azure-tools/cadl-ranch-expect@0.15.6)(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)(@typespec/xml@0.62.0)
       '@azure-tools/typespec-autorest':
         specifier: '>=0.48.0 <1.0.0'
-        version: 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@azure-tools/typespec-azure-resource-manager@0.48.0)(@azure-tools/typespec-client-generator-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
+        version: 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@azure-tools/typespec-azure-resource-manager@0.48.0)(@azure-tools/typespec-client-generator-core@0.48.2)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
       '@azure-tools/typespec-azure-core':
         specifier: '>=0.48.0 <1.0.0'
         version: 0.48.0(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/rest@0.62.0)
@@ -228,8 +228,8 @@ importers:
         specifier: '>=0.48.0 <1.0.0'
         version: 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
       '@azure-tools/typespec-client-generator-core':
-        specifier: '>=0.48.0 <1.0.0'
-        version: 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
+        specifier: '>=0.48.2 <1.0.0'
+        version: 0.48.2(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
       '@types/jest':
         specifier: ~26.0.24
         version: 26.0.24
@@ -524,7 +524,7 @@ packages:
     engines: {node: '>=10.12.0'}
     dev: false
 
-  /@azure-tools/typespec-autorest@0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@azure-tools/typespec-azure-resource-manager@0.48.0)(@azure-tools/typespec-client-generator-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0):
+  /@azure-tools/typespec-autorest@0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@azure-tools/typespec-azure-resource-manager@0.48.0)(@azure-tools/typespec-client-generator-core@0.48.2)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0):
     resolution: {integrity: sha512-AyoNMq3EORugHynFF8bN0TJh+zYxui/ApU5DoVEL7Xr1yMD6k9p5b90VD4HiCsP0dz8470ApFnjt5Vl6xCSzig==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -539,7 +539,7 @@ packages:
     dependencies:
       '@azure-tools/typespec-azure-core': 0.48.0(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/rest@0.62.0)
       '@azure-tools/typespec-azure-resource-manager': 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
-      '@azure-tools/typespec-client-generator-core': 0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
+      '@azure-tools/typespec-client-generator-core': 0.48.2(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0)
       '@typespec/compiler': 0.62.0
       '@typespec/http': 0.62.0(@typespec/compiler@0.62.0)
       '@typespec/openapi': 0.62.0(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)
@@ -581,8 +581,8 @@ packages:
       pluralize: 8.0.0
     dev: true
 
-  /@azure-tools/typespec-client-generator-core@0.48.0(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0):
-    resolution: {integrity: sha512-+fmKjapz0kP7ONPZap8dgcIKIdQw+YBSrf89csbIyhPTcLnVAk/BKljo8FoNypKXwqKHenslLm0njBKPllkopg==}
+  /@azure-tools/typespec-client-generator-core@0.48.2(@azure-tools/typespec-azure-core@0.48.0)(@typespec/compiler@0.62.0)(@typespec/http@0.62.0)(@typespec/openapi@0.62.0)(@typespec/rest@0.62.0)(@typespec/versioning@0.62.0):
+    resolution: {integrity: sha512-5hb+J703pgn6tA3NwPCn2zJ1kWn/YJUkmDC+wfXcWmikp9sEZRE1etMktR0MekJHNO3crDHAK3egsjttnds9nw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@azure-tools/typespec-azure-core': ~0.48.0

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -52,7 +52,7 @@
     "@azure-tools/typespec-autorest": ">=0.48.0 <1.0.0",
     "@azure-tools/typespec-azure-core": ">=0.48.0 <1.0.0",
     "@azure-tools/typespec-azure-resource-manager": ">=0.48.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.48.0 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.48.2 <1.0.0",
     "@types/js-yaml": "~4.0.6",
     "@types/node": "^18.16.3",
     "@typescript-eslint/eslint-plugin": "~4.1.1",
@@ -70,7 +70,7 @@
     "typescript": "~5.1.3"
   },
   "peerDependencies": {
-    "@azure-tools/typespec-client-generator-core": ">=0.48.0 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.48.2 <1.0.0",
     "@typespec/compiler": ">=0.62.0 <1.0.0",
     "@typespec/http": ">=0.62.0 <1.0.0"
   },

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -28,6 +28,7 @@ export async function tcgcToGoCodeModel(context: EmitContext<GoEmitterOptions>):
   // to add it to the allow list of decorators
   const sdkContext = await tcgc.createSdkContext(context, '@azure-tools/typespec-go', {
     additionalDecorators: ['TypeSpec\\.@encodedName'],
+    disableUsageAccessPropagationToBase: true,
   });
   let codeModelType: go.CodeModelType = 'data-plane';
   if (sdkContext.arm === true) {

--- a/packages/typespec-go/test/azmodelsonly/zz_models.go
+++ b/packages/typespec-go/test/azmodelsonly/zz_models.go
@@ -19,3 +19,8 @@ type DerivedTwo struct {
 	// REQUIRED
 	Name *string
 }
+
+type PreservedBaseClass struct {
+	// REQUIRED
+	ID *int32
+}

--- a/packages/typespec-go/test/azmodelsonly/zz_models_serde.go
+++ b/packages/typespec-go/test/azmodelsonly/zz_models_serde.go
@@ -73,6 +73,33 @@ func (d *DerivedTwo) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// MarshalJSON implements the json.Marshaller interface for type PreservedBaseClass.
+func (p PreservedBaseClass) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]any)
+	populate(objectMap, "id", p.ID)
+	return json.Marshal(objectMap)
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface for type PreservedBaseClass.
+func (p *PreservedBaseClass) UnmarshalJSON(data []byte) error {
+	var rawMsg map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawMsg); err != nil {
+		return fmt.Errorf("unmarshalling type %T: %v", p, err)
+	}
+	for key, val := range rawMsg {
+		var err error
+		switch key {
+		case "id":
+			err = unpopulate(val, "ID", &p.ID)
+			delete(rawMsg, key)
+		}
+		if err != nil {
+			return fmt.Errorf("unmarshalling type %T: %v", p, err)
+		}
+	}
+	return nil
+}
+
 func populate(m map[string]any, k string, v any) {
 	if v == nil {
 		return


### PR DESCRIPTION
fix: https://github.com/Azure/autorest.go/issues/1466

after tcgc 0.48.2, go will rely on tcgc to figure out which type needs to be omitted. so, this pr remove all useless calculation in go emitter.